### PR TITLE
Polish native status and footer bars

### DIFF
--- a/Rockxy/Core/Storage/SessionStore.swift
+++ b/Rockxy/Core/Storage/SessionStore.swift
@@ -6,12 +6,6 @@ import SQLite
 /// inline in SQLite, to keep the database size manageable and avoid large BLOB I/O.
 private let bodySizeThreshold = 1_048_576
 
-// MARK: - SessionStoreError
-
-enum SessionStoreError: Error {
-    case directoryNotFound
-}
-
 // MARK: - SessionStore
 
 /// SQLite-backed persistence layer for HTTP transactions, log entries, and WebSocket frames.
@@ -27,16 +21,7 @@ actor SessionStore {
     // MARK: - Init
 
     init() throws {
-        guard let appSupport = FileManager.default.urls(
-            for: .applicationSupportDirectory, in: .userDomainMask
-        ).first else {
-            throw SessionStoreError.directoryNotFound
-        }
-        let rockxyDir = appSupport.appendingPathComponent(
-            RockxyIdentity.current.appSupportDirectoryName,
-            isDirectory: true
-        )
-        try self.init(directory: rockxyDir)
+        try self.init(directory: RockxyIdentity.current.appSupportDirectory())
     }
 
     init(directory: URL) throws {

--- a/Rockxy/Core/Updates/AppUpdater.swift
+++ b/Rockxy/Core/Updates/AppUpdater.swift
@@ -247,6 +247,15 @@ final class AppUpdater: NSObject, ObservableObject, SPUUpdaterDelegate {
         refreshSparkleState()
     }
 
+    func showUpdatesFromStatusBadge() {
+        if sessionInProgress {
+            userDriver?.showUpdateInFocus()
+            return
+        }
+
+        checkForUpdates()
+    }
+
     func openFullChangelog() {
         NSWorkspace.shared.open(Self.fullChangelogURL)
     }

--- a/Rockxy/Core/Updates/AppUpdater.swift
+++ b/Rockxy/Core/Updates/AppUpdater.swift
@@ -79,7 +79,20 @@ final class AppUpdater: NSObject, ObservableObject, SPUUpdaterDelegate {
             guard let versionsBehind, versionsBehind > 0 else {
                 return nil
             }
-            return String(localized: "^[\(versionsBehind) version](inflect: true) behind")
+            if versionsBehind == 1 {
+                return String(localized: "1 version behind")
+            }
+            return String(localized: "\(versionsBehind) versions behind")
+        }
+
+        var badgeTitle: String {
+            guard let versionsBehind, versionsBehind > 0 else {
+                return title
+            }
+            if versionsBehind == 1 {
+                return String(localized: "1 New Update")
+            }
+            return String(localized: "\(versionsBehind) New Updates")
         }
 
         func replacingVersionsBehind(_ count: Int?) -> Self {
@@ -203,6 +216,7 @@ final class AppUpdater: NSObject, ObservableObject, SPUUpdaterDelegate {
         guard supportsAutomaticChecks else {
             if supportsManualChecks {
                 Self.logger.info("Sparkle automatic checks skipped for this build; manual checks remain available.")
+                refreshUpdateStatusFromAppcast()
             } else {
                 Self.logger.info("Sparkle updater skipped: feed or public key is not configured.")
             }
@@ -211,6 +225,7 @@ final class AppUpdater: NSObject, ObservableObject, SPUUpdaterDelegate {
 
         do {
             try ensureUpdaterStarted()
+            refreshUpdateStatusFromAppcast()
         } catch {
             presentUpdaterStartError(error)
         }
@@ -234,6 +249,32 @@ final class AppUpdater: NSObject, ObservableObject, SPUUpdaterDelegate {
 
     func openFullChangelog() {
         NSWorkspace.shared.open(Self.fullChangelogURL)
+    }
+
+    func refreshUpdateStatusFromAppcast() {
+        guard let feedURL = configuration.feedURL else {
+            return
+        }
+
+        updateStatusTask?.cancel()
+        let currentVersion = configuration.appVersion
+        updateStatusTask = Task { [weak self] in
+            do {
+                let (data, _) = try await URLSession.shared.data(from: feedURL)
+                let summary = Self.makeUpdateStatusSummary(
+                    currentVersion: currentVersion,
+                    appcastData: data
+                )
+                guard !Task.isCancelled else {
+                    return
+                }
+                await MainActor.run {
+                    self?.updateStatusSummary = summary
+                }
+            } catch {
+                Self.logger.debug("Unable to refresh update status from appcast: \(error.localizedDescription)")
+            }
+        }
     }
 
     func recordUpdateFound(_ item: SUAppcastItem) {
@@ -347,6 +388,24 @@ final class AppUpdater: NSObject, ObservableObject, SPUUpdaterDelegate {
             currentVersion: currentVersion,
             latestVersion: latestVersion,
             versionsBehind: versionsBehind
+        )
+    }
+
+    static func makeUpdateStatusSummary(
+        currentVersion: String,
+        appcastData: Data
+    ) -> UpdateStatusSummary? {
+        guard let latestVersion = AppcastVersionParser.versions(from: appcastData)?.first else {
+            return nil
+        }
+        return makeUpdateStatusSummary(
+            currentVersion: currentVersion,
+            latestVersion: latestVersion,
+            versionsBehind: versionsBehind(
+                currentVersion: currentVersion,
+                latestVersion: latestVersion,
+                appcastData: appcastData
+            )
         )
     }
 

--- a/Rockxy/Core/Updates/AppUpdater.swift
+++ b/Rockxy/Core/Updates/AppUpdater.swift
@@ -30,8 +30,67 @@ enum UpdateCheckIntervalOption: Double, CaseIterable, Identifiable {
     }
 }
 
+private final class AppcastVersionParser: NSObject, XMLParserDelegate {
+    static func versions(from data: Data) -> [String]? {
+        let delegate = AppcastVersionParser()
+        let parser = XMLParser(data: data)
+        parser.delegate = delegate
+        guard parser.parse() else {
+            return nil
+        }
+        return delegate.versions
+    }
+
+    private var versions: [String] = []
+
+    func parser(
+        _ parser: XMLParser,
+        didStartElement elementName: String,
+        namespaceURI: String?,
+        qualifiedName qName: String?,
+        attributes attributeDict: [String: String] = [:]
+    ) {
+        guard elementName == "enclosure" else {
+            return
+        }
+        let version = attributeDict["sparkle:shortVersionString"] ?? attributeDict["shortVersionString"]
+        if let version, !version.isEmpty {
+            versions.append(version)
+        }
+    }
+}
+
 @MainActor
 final class AppUpdater: NSObject, ObservableObject, SPUUpdaterDelegate {
+    struct UpdateStatusSummary: Equatable {
+        let currentVersion: String
+        let latestVersion: String
+        let versionsBehind: Int?
+
+        var title: String {
+            String(localized: "Update Available")
+        }
+
+        var versionLine: String {
+            "v\(currentVersion) -> v\(latestVersion)"
+        }
+
+        var countLine: String? {
+            guard let versionsBehind, versionsBehind > 0 else {
+                return nil
+            }
+            return String(localized: "^[\(versionsBehind) version](inflect: true) behind")
+        }
+
+        func replacingVersionsBehind(_ count: Int?) -> Self {
+            .init(
+                currentVersion: currentVersion,
+                latestVersion: latestVersion,
+                versionsBehind: count
+            )
+        }
+    }
+
     // MARK: Lifecycle
 
     init(configuration: RockxyUpdateConfiguration) {
@@ -39,6 +98,7 @@ final class AppUpdater: NSObject, ObservableObject, SPUUpdaterDelegate {
         updateCheckGate = nil
         userDriver = nil
         updater = nil
+        updateStatusTask = nil
         sparkleCancellables = []
         super.init()
 
@@ -51,6 +111,12 @@ final class AppUpdater: NSObject, ObservableObject, SPUUpdaterDelegate {
                 hostBundle: .main,
                 configuration: configuration
             )
+            userDriver.updateFoundHandler = { [weak self] item in
+                self?.recordUpdateFound(item)
+            }
+            userDriver.noUpdateHandler = { [weak self] _ in
+                self?.clearUpdateStatusSummary()
+            }
             self.userDriver = userDriver
             updater = SPUUpdater(
                 hostBundle: .main,
@@ -81,6 +147,7 @@ final class AppUpdater: NSObject, ObservableObject, SPUUpdaterDelegate {
     @Published private(set) var lastUpdateCheckDate: Date?
     @Published private(set) var updateCheckInterval: TimeInterval = UpdateCheckIntervalOption.daily.rawValue
     @Published private(set) var sessionInProgress = false
+    @Published private(set) var updateStatusSummary: UpdateStatusSummary?
 
     let configuration: RockxyUpdateConfiguration
 
@@ -169,6 +236,55 @@ final class AppUpdater: NSObject, ObservableObject, SPUUpdaterDelegate {
         NSWorkspace.shared.open(Self.fullChangelogURL)
     }
 
+    func recordUpdateFound(_ item: SUAppcastItem) {
+        recordUpdateFound(latestVersion: item.displayVersionString)
+    }
+
+    func recordUpdateFound(latestVersion: String, fetchVersionsBehind: Bool = true) {
+        updateStatusTask?.cancel()
+        guard let summary = Self.makeUpdateStatusSummary(
+            currentVersion: configuration.appVersion,
+            latestVersion: latestVersion
+        ) else {
+            updateStatusSummary = nil
+            return
+        }
+
+        updateStatusSummary = summary
+
+        guard fetchVersionsBehind, let feedURL = configuration.feedURL else {
+            return
+        }
+
+        updateStatusTask = Task { [weak self] in
+            do {
+                let (data, _) = try await URLSession.shared.data(from: feedURL)
+                let count = Self.versionsBehind(
+                    currentVersion: summary.currentVersion,
+                    latestVersion: summary.latestVersion,
+                    appcastData: data
+                )
+                guard !Task.isCancelled else {
+                    return
+                }
+                await MainActor.run {
+                    guard self?.updateStatusSummary?.latestVersion == summary.latestVersion else {
+                        return
+                    }
+                    self?.updateStatusSummary = summary.replacingVersionsBehind(count)
+                }
+            } catch {
+                Self.logger.debug("Unable to compute versions behind from appcast: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    func clearUpdateStatusSummary() {
+        updateStatusTask?.cancel()
+        updateStatusTask = nil
+        updateStatusSummary = nil
+    }
+
     func setAutomaticallyChecksForUpdates(_ enabled: Bool) {
         guard let updater, supportsAutomaticChecks else {
             return
@@ -216,7 +332,72 @@ final class AppUpdater: NSObject, ObservableObject, SPUUpdaterDelegate {
     private var updater: SPUUpdater?
     private var hasStartedUpdater = false
     private var updateCheckGate: (@MainActor (SPUUpdateCheck) -> String?)?
+    private var updateStatusTask: Task<Void, Never>?
     private var sparkleCancellables: [AnyCancellable]
+
+    static func makeUpdateStatusSummary(
+        currentVersion: String,
+        latestVersion: String,
+        versionsBehind: Int? = nil
+    ) -> UpdateStatusSummary? {
+        guard compareVersions(latestVersion, currentVersion) == .orderedDescending else {
+            return nil
+        }
+        return UpdateStatusSummary(
+            currentVersion: currentVersion,
+            latestVersion: latestVersion,
+            versionsBehind: versionsBehind
+        )
+    }
+
+    static func versionsBehind(
+        currentVersion: String,
+        latestVersion: String,
+        appcastData: Data
+    ) -> Int? {
+        guard let versions = AppcastVersionParser.versions(from: appcastData) else {
+            return nil
+        }
+
+        var seen: Set<String> = []
+        let newerVersions = versions.filter { version in
+            guard seen.insert(version).inserted else {
+                return false
+            }
+            return compareVersions(version, currentVersion) == .orderedDescending
+                && compareVersions(version, latestVersion) != .orderedDescending
+        }
+        return newerVersions.isEmpty ? nil : newerVersions.count
+    }
+
+    static func compareVersions(_ lhs: String, _ rhs: String) -> ComparisonResult {
+        let lhsComponents = versionComponents(lhs)
+        let rhsComponents = versionComponents(rhs)
+        let count = max(lhsComponents.count, rhsComponents.count)
+
+        for index in 0..<count {
+            let lhsValue = index < lhsComponents.count ? lhsComponents[index] : 0
+            let rhsValue = index < rhsComponents.count ? rhsComponents[index] : 0
+            if lhsValue < rhsValue {
+                return .orderedAscending
+            }
+            if lhsValue > rhsValue {
+                return .orderedDescending
+            }
+        }
+
+        return .orderedSame
+    }
+
+    private static func versionComponents(_ version: String) -> [Int] {
+        version
+            .trimmingCharacters(in: CharacterSet(charactersIn: "vV"))
+            .split(separator: ".")
+            .map { component in
+                let digits = component.prefix { $0.isNumber }
+                return Int(digits) ?? 0
+            }
+    }
 
     private static func installManualOnlyOverrides(defaults: UserDefaults = .standard) {
         var argumentDomain = defaults.volatileDomain(forName: UserDefaults.argumentDomain)

--- a/Rockxy/Core/Updates/RockxyUpdateUserDriver.swift
+++ b/Rockxy/Core/Updates/RockxyUpdateUserDriver.swift
@@ -11,6 +11,8 @@ final class RockxyUpdateUserDriver: NSObject, SPUUserDriver {
     }
 
     let controller: SoftwareUpdateController
+    var updateFoundHandler: ((SUAppcastItem) -> Void)?
+    var noUpdateHandler: ((NSError) -> Void)?
 
     private let standardUserDriver: SPUStandardUserDriver
 
@@ -27,6 +29,7 @@ final class RockxyUpdateUserDriver: NSObject, SPUUserDriver {
         state: SPUUserUpdateState,
         reply: @escaping (SPUUserUpdateChoice) -> Void
     ) {
+        updateFoundHandler?(appcastItem)
         controller.showAvailable(item: appcastItem, state: state, reply: reply)
     }
 
@@ -43,7 +46,9 @@ final class RockxyUpdateUserDriver: NSObject, SPUUserDriver {
     }
 
     func showUpdateNotFoundWithError(_ error: Error, acknowledgement: @escaping () -> Void) {
-        controller.showNoUpdate(error: error as NSError, acknowledgement: acknowledgement)
+        let nsError = error as NSError
+        noUpdateHandler?(nsError)
+        controller.showNoUpdate(error: nsError, acknowledgement: acknowledgement)
     }
 
     func showUpdaterError(_ error: Error, acknowledgement: @escaping () -> Void) {

--- a/Rockxy/Views/Main/Extensions/MainContentCoordinator+ProxyControl.swift
+++ b/Rockxy/Views/Main/Extensions/MainContentCoordinator+ProxyControl.swift
@@ -13,9 +13,17 @@ extension MainContentCoordinator {
     // MARK: - Proxy Lifecycle
 
     func startProxy() {
+        guard !isProxyRunning, !isProxyStarting else {
+            return
+        }
         proxyError = nil
+        isProxyStarting = true
 
         Task {
+            defer {
+                isProxyStarting = false
+            }
+
             let settings = AppSettingsStorage.load()
             do {
                 try await certificateManager.ensureRootCA()

--- a/Rockxy/Views/Main/MainContentCoordinator.swift
+++ b/Rockxy/Views/Main/MainContentCoordinator.swift
@@ -3,6 +3,28 @@ import os
 
 // Renders the main content coordinator interface for the main workspace.
 
+// MARK: - ProxyDisplayState
+
+enum ProxyDisplayState: Equatable {
+    case starting
+    case running
+    case paused
+    case stopped
+
+    var title: String {
+        switch self {
+        case .starting:
+            String(localized: "Starting")
+        case .running:
+            String(localized: "Running")
+        case .paused:
+            String(localized: "Paused")
+        case .stopped:
+            String(localized: "Stopped")
+        }
+    }
+}
+
 // MARK: - MainContentCoordinator
 
 /// Central coordinator for all Rockxy UI state, bridging the proxy engine, log engine,
@@ -71,6 +93,7 @@ final class MainContentCoordinator {
     var transactions: [HTTPTransaction] = []
     var persistedFavorites: [HTTPTransaction] = []
     var isProxyRunning = false
+    var isProxyStarting = false
     var activeProxyPort = AppSettingsManager.shared.settings.proxyPort
     var isRecording = true
     var sessionGeneration: UInt = 0
@@ -143,6 +166,16 @@ final class MainContentCoordinator {
         case nil: nil
         }
         return SystemProxyWarning(message: warning.message, action: action, isDismissible: warning.isDismissible)
+    }
+
+    var proxyDisplayState: ProxyDisplayState {
+        if isProxyStarting {
+            return .starting
+        }
+        if isProxyRunning {
+            return isRecording ? .running : .paused
+        }
+        return .stopped
     }
 
     var activeWorkspace: WorkspaceState {

--- a/Rockxy/Views/RequestList/CenterContentView.swift
+++ b/Rockxy/Views/RequestList/CenterContentView.swift
@@ -93,7 +93,9 @@ struct CenterContentView: View {
                     coordinator.isFilterBarVisible.toggle()
                     coordinator.recomputeFilteredTransactions()
                 },
-                onAutoSelect: { coordinator.isAutoSelectEnabled.toggle() }
+                onAutoSelect: {
+                    coordinator.isAutoSelectEnabled.toggle()
+                }
             )
         }
         .onChange(of: coordinator.selectedTransaction?.id) { _, newID in

--- a/Rockxy/Views/RequestList/StatusBarView.swift
+++ b/Rockxy/Views/RequestList/StatusBarView.swift
@@ -3,50 +3,178 @@ import SwiftUI
 
 // Renders the status bar interface for traffic list presentation.
 
-// MARK: - FooterButton
+// MARK: - FooterActionKind
 
-/// Styled button used in the status bar footer, with an active/inactive visual state.
-private struct FooterButton: View {
+enum FooterActionKind: String, CaseIterable {
+    case blockList
+    case allowList
+    case mapLocal
+    case scripting
+    case mapRemote
+    case breakpoint
+    case networkConditions
+}
+
+// MARK: - FooterActionDescriptor
+
+struct FooterActionDescriptor: Identifiable, Equatable {
+    let id: FooterActionKind
     let title: String
-    var isActive: Bool = false
+    let systemImage: String
+    let help: String
+    let isActive: Bool
+    let isEnabled: Bool
+
+    static func toolingActions(isAllowListActive: Bool) -> [Self] {
+        [
+            .init(
+                id: .blockList,
+                title: String(localized: "Block List"),
+                systemImage: "hand.raised.slash",
+                help: String(localized: "Open Block List"),
+                isActive: false,
+                isEnabled: true
+            ),
+            .init(
+                id: .allowList,
+                title: String(localized: "Allow List"),
+                systemImage: "checkmark.shield",
+                help: String(localized: "Open Allow List"),
+                isActive: isAllowListActive,
+                isEnabled: true
+            ),
+            .init(
+                id: .mapLocal,
+                title: String(localized: "Map Local"),
+                systemImage: "folder.badge.gearshape",
+                help: String(localized: "Open Map Local"),
+                isActive: false,
+                isEnabled: true
+            ),
+            .init(
+                id: .scripting,
+                title: String(localized: "Scripting"),
+                systemImage: "curlybraces",
+                help: String(localized: "Open Scripting"),
+                isActive: false,
+                isEnabled: true
+            ),
+            .init(
+                id: .mapRemote,
+                title: String(localized: "Map Remote"),
+                systemImage: "arrow.triangle.branch",
+                help: String(localized: "Open Map Remote"),
+                isActive: false,
+                isEnabled: true
+            ),
+            .init(
+                id: .breakpoint,
+                title: String(localized: "Breakpoint"),
+                systemImage: "pause.circle",
+                help: String(localized: "Open Breakpoint Rules"),
+                isActive: false,
+                isEnabled: true
+            ),
+            .init(
+                id: .networkConditions,
+                title: String(localized: "Network Conditions"),
+                systemImage: "speedometer",
+                help: String(localized: "Open Network Conditions"),
+                isActive: false,
+                isEnabled: true
+            ),
+        ]
+    }
+}
+
+// MARK: - FooterToolingButton
+
+private struct FooterToolingButton: View {
+    let descriptor: FooterActionDescriptor
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Text(descriptor.title)
+                .modifier(FooterToolingChrome(
+                    isActive: descriptor.isActive,
+                    isEnabled: descriptor.isEnabled,
+                    isHovered: isHovered
+                ))
+        }
+        .buttonStyle(.plain)
+        .disabled(!descriptor.isEnabled)
+        .help(descriptor.help)
+        .onHover { isHovered = $0 }
+    }
+
+    // MARK: Private
+
+    @State private var isHovered = false
+}
+
+// MARK: - FooterToolingChrome
+
+private struct FooterToolingChrome: ViewModifier {
+    let isActive: Bool
+    let isEnabled: Bool
+    let isHovered: Bool
+
+    func body(content: Content) -> some View {
+        content
+            .font(.caption2.weight(.semibold))
+            .foregroundStyle(Color.white)
+            .lineLimit(1)
+            .padding(.horizontal, 9)
+            .padding(.vertical, 3)
+            .background(backgroundColor, in: Capsule())
+            .opacity(isEnabled ? 1 : 0.45)
+    }
+
+    private var backgroundColor: Color {
+        if isActive {
+            return Color.accentColor
+        }
+        if isHovered, isEnabled {
+            return Color(nsColor: .secondaryLabelColor)
+        }
+        return Color(nsColor: .tertiaryLabelColor)
+    }
+}
+
+// MARK: - FooterPrimaryButton
+
+private struct FooterPrimaryButton: View {
+    let title: String
+    var isActive = false
     let action: () -> Void
 
     var body: some View {
         Button(action: action) {
             Text(title)
-                .font(.system(size: 11, weight: isActive ? .semibold : .regular))
-                .foregroundStyle(isActive ? .white : Color(nsColor: .secondaryLabelColor))
-                .padding(.horizontal, 11)
-                .padding(.vertical, 3)
-                .background {
-                    RoundedRectangle(cornerRadius: 4)
-                        .fill(
-                            isActive
-                                ? AnyShapeStyle(Color.accentColor)
-                                : AnyShapeStyle(
-                                    LinearGradient(
-                                        colors: [
-                                            Color(nsColor: .controlBackgroundColor),
-                                            Color(nsColor: .controlColor),
-                                        ],
-                                        startPoint: .top,
-                                        endPoint: .bottom
-                                    )
-                                )
-                        )
-                        .overlay {
-                            RoundedRectangle(cornerRadius: 4)
-                                .strokeBorder(
-                                    isActive
-                                        ? Color.accentColor
-                                        : Color(nsColor: .separatorColor),
-                                    lineWidth: 0.5
-                                )
-                        }
-                        .shadow(color: .black.opacity(0.06), radius: 0.5, y: 0.5)
-                }
+                .font(.callout)
+                .foregroundStyle(isActive ? Color.accentColor : Color(nsColor: .labelColor))
+                .lineLimit(1)
+                .padding(.horizontal, 16)
+                .padding(.vertical, 6)
+                .background(backgroundColor, in: RoundedRectangle(cornerRadius: 7, style: .continuous))
         }
         .buttonStyle(.plain)
+        .onHover { isHovered = $0 }
+    }
+
+    // MARK: Private
+
+    @State private var isHovered = false
+
+    private var backgroundColor: Color {
+        if isActive {
+            return Color.accentColor.opacity(0.12)
+        }
+        if isHovered {
+            return Color(nsColor: .controlBackgroundColor)
+        }
+        return Color(nsColor: .controlBackgroundColor).opacity(0.72)
     }
 }
 
@@ -82,23 +210,14 @@ struct StatusBarView: View {
     var body: some View {
         HStack(spacing: 0) {
             leftButtons
-            Spacer()
+            Spacer(minLength: 24)
             centerStatus
-            Spacer()
+            Spacer(minLength: 24)
             rightStats
         }
-        .padding(.horizontal, 10)
-        .frame(height: 28)
-        .background(
-            LinearGradient(
-                colors: [
-                    Color(nsColor: .windowBackgroundColor),
-                    Color(nsColor: .windowBackgroundColor).opacity(0.95),
-                ],
-                startPoint: .top,
-                endPoint: .bottom
-            )
-        )
+        .padding(.horizontal, 12)
+        .frame(height: 34)
+        .background(Theme.StatusBar.background)
         .overlay(alignment: .top) {
             Divider()
         }
@@ -121,19 +240,16 @@ struct StatusBarView: View {
     }
 
     private var leftButtons: some View {
-        HStack(spacing: 6) {
-            FooterButton(
-                title: String(localized: "Clear"),
-                action: onClear
-            )
-            FooterButton(
+        HStack(spacing: 8) {
+            FooterPrimaryButton(title: String(localized: "Clear"), action: onClear)
+            FooterPrimaryButton(
                 title: activeFilterCount > 0
-                    ? String(localized: "Filters (\(activeFilterCount))")
+                    ? String(localized: "Filter (\(activeFilterCount))")
                     : String(localized: "Filter"),
                 isActive: isFilterBarVisible || activeFilterCount > 0,
                 action: onFilter
             )
-            FooterButton(
+            FooterPrimaryButton(
                 title: String(localized: "Auto Select"),
                 isActive: isAutoSelectEnabled,
                 action: onAutoSelect
@@ -198,33 +314,21 @@ struct StatusBarView: View {
                 .foregroundStyle(Color.accentColor)
                 .help("Captured download throughput")
 
+            toolingButtons
+
             if isAllowListActive {
-                Text(String(localized: "Allow List"))
-                    .font(.system(size: 10, weight: .semibold))
-                    .foregroundStyle(.white)
-                    .padding(.horizontal, 10)
-                    .padding(.vertical, 2)
-                    .background(Color.accentColor, in: RoundedRectangle(cornerRadius: 4))
+                statusPill(String(localized: "Allow List"), color: Color.accentColor)
             }
 
             if isNoCachingActive {
-                Text(String(localized: "No Cache"))
-                    .font(.system(size: 10, weight: .semibold))
-                    .foregroundStyle(.white)
-                    .padding(.horizontal, 10)
-                    .padding(.vertical, 2)
-                    .background(Color.orange, in: RoundedRectangle(cornerRadius: 4))
+                statusPill(String(localized: "No Cache"), color: Color(nsColor: .systemOrange))
             }
 
             if isProxyOverridden {
-                Text(String(localized: "Proxy Overridden"))
-                    .font(.system(size: 10, weight: .semibold))
-                    .foregroundStyle(.white)
-                    .padding(.horizontal, 10)
-                    .padding(.vertical, 2)
-                    .background(Color.accentColor, in: RoundedRectangle(cornerRadius: 4))
+                statusPill(String(localized: "Proxy Overridden"), color: Color(nsColor: .tertiaryLabelColor))
             }
         }
+        .lineLimit(1)
     }
 
     private func formattedSpeed(_ bytesPerSecond: Int64) -> String {
@@ -235,6 +339,46 @@ struct StatusBarView: View {
         } else {
             let mb = Double(bytesPerSecond) / 1_048_576
             return String(format: "%.1f MB/s", mb)
+        }
+    }
+
+    @Environment(\.openWindow) private var openWindow
+
+    @ViewBuilder
+    private var toolingButtons: some View {
+        ForEach(FooterActionDescriptor.toolingActions(isAllowListActive: isAllowListActive)) { descriptor in
+            FooterToolingButton(descriptor: descriptor) {
+                performAction(descriptor.id)
+            }
+        }
+    }
+
+    private func statusPill(_ title: String, color: Color) -> some View {
+        Text(title)
+            .font(.caption2.weight(.semibold))
+            .foregroundStyle(.white)
+            .lineLimit(1)
+            .padding(.horizontal, 9)
+            .padding(.vertical, 3)
+            .background(color, in: Capsule())
+    }
+
+    private func performAction(_ action: FooterActionKind) {
+        switch action {
+        case .blockList:
+            openWindow(id: "blockList")
+        case .allowList:
+            openWindow(id: "allowList")
+        case .mapLocal:
+            openWindow(id: "mapLocal")
+        case .scripting:
+            openWindow(id: "scriptingList")
+        case .mapRemote:
+            openWindow(id: "mapRemote")
+        case .breakpoint:
+            openWindow(id: "breakpointRules")
+        case .networkConditions:
+            openWindow(id: "networkConditions")
         }
     }
 }

--- a/Rockxy/Views/Toolbar/ProxyStatusIndicator.swift
+++ b/Rockxy/Views/Toolbar/ProxyStatusIndicator.swift
@@ -16,47 +16,52 @@ struct ProxyStatusIndicator: View {
     let listenAddress: String
     let port: Int
     let updateStatusSummary: AppUpdater.UpdateStatusSummary?
+    let openUpdates: () -> Void
 
     @Binding var showPopover: Bool
 
     var body: some View {
-        Button {
-            showPopover.toggle()
-        } label: {
-            HStack(spacing: 7) {
-                Circle()
-                    .fill(statusColor)
-                    .frame(width: 9, height: 9)
-                    .shadow(
-                        color: statusShadowColor,
-                        radius: 4,
-                        x: 0,
-                        y: 0
-                    )
+        HStack(spacing: 0) {
+            Button {
+                showPopover.toggle()
+            } label: {
+                HStack(spacing: 7) {
+                    statusDot
 
-                Text(statusText)
-                    .font(.callout.weight(.medium))
-                    .foregroundStyle(.secondary)
-                    .lineLimit(1)
+                    Text(statusText)
+                        .font(.callout.weight(.medium))
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
 
-                if let updateStatusSummary {
-                    updateStatus(updateStatusSummary)
+                    if updateStatusSummary != nil {
+                        Text("|")
+                            .font(.caption)
+                            .foregroundStyle(Color(nsColor: .tertiaryLabelColor))
+                    }
                 }
+                .padding(.leading, 12)
+                .padding(.trailing, updateStatusSummary == nil ? 12 : 7)
+                .padding(.vertical, 6)
+                .contentShape(Rectangle())
             }
-            .padding(.horizontal, 12)
-            .padding(.vertical, 6)
-            .background(
-                Color(nsColor: .windowBackgroundColor)
-                    .opacity(0.55)
-            )
-            .clipShape(Capsule())
-            .overlay(
-                Capsule()
-                    .stroke(Color.primary.opacity(0.08), lineWidth: 1)
-            )
+            .buttonStyle(.plain)
+            .help(statusHelpText)
+
+            if let updateStatusSummary {
+                updateStatus(updateStatusSummary)
+                    .padding(.trailing, 12)
+                    .padding(.vertical, 6)
+            }
         }
-        .buttonStyle(.plain)
-        .help(statusHelpText)
+        .background(
+            Color(nsColor: .windowBackgroundColor)
+                .opacity(0.55)
+        )
+        .clipShape(Capsule())
+        .overlay(
+            Capsule()
+                .stroke(Color.primary.opacity(0.08), lineWidth: 1)
+        )
         .popover(isPresented: $showPopover) {
             ProxyStatusPopover(
                 listenAddress: listenAddress,
@@ -68,6 +73,18 @@ struct ProxyStatusIndicator: View {
     }
 
     // MARK: Private
+
+    private var statusDot: some View {
+        Circle()
+            .fill(statusColor)
+            .frame(width: 9, height: 9)
+            .shadow(
+                color: statusShadowColor,
+                radius: 4,
+                x: 0,
+                y: 0
+            )
+    }
 
     private var statusColor: Color {
         switch displayState {
@@ -114,14 +131,13 @@ struct ProxyStatusIndicator: View {
 
     @ViewBuilder
     private func updateStatus(_ summary: AppUpdater.UpdateStatusSummary) -> some View {
-        Text("|")
-            .font(.caption)
-            .foregroundStyle(Color(nsColor: .tertiaryLabelColor))
-
-        ViewThatFits(in: .horizontal) {
-            updateBadge(summary.badgeTitle)
-            updateBadge(String(localized: "Update"))
+        Button(action: openUpdates) {
+            ViewThatFits(in: .horizontal) {
+                updateBadge(summary.badgeTitle)
+                updateBadge(String(localized: "Update"))
+            }
         }
+        .buttonStyle(.plain)
         .help([
             summary.title,
             summary.versionLine,

--- a/Rockxy/Views/Toolbar/ProxyStatusIndicator.swift
+++ b/Rockxy/Views/Toolbar/ProxyStatusIndicator.swift
@@ -10,6 +10,8 @@ import SwiftUI
 struct ProxyStatusIndicator: View {
     // MARK: Internal
 
+    @Environment(\.colorScheme) private var colorScheme
+
     let displayState: ProxyDisplayState
     let listenAddress: String
     let port: Int
@@ -117,20 +119,36 @@ struct ProxyStatusIndicator: View {
             .foregroundStyle(Color(nsColor: .tertiaryLabelColor))
 
         ViewThatFits(in: .horizontal) {
-            HStack(spacing: 5) {
-                Label(summary.title, systemImage: "arrow.down.circle")
-                    .labelStyle(.titleAndIcon)
-                Text(summary.versionLine)
-                if let countLine = summary.countLine {
-                    Text(countLine)
-                }
-            }
-
-            Label(summary.title, systemImage: "arrow.down.circle")
-                .labelStyle(.titleAndIcon)
+            updateBadge(summary.badgeTitle)
+            updateBadge(String(localized: "Update"))
         }
-        .font(.caption.weight(.medium))
-        .foregroundStyle(Color.accentColor)
-        .lineLimit(1)
+        .help([
+            summary.title,
+            summary.versionLine,
+            summary.countLine,
+        ]
+        .compactMap { $0 }
+        .joined(separator: "\n"))
+    }
+
+    private func updateBadge(_ title: String) -> some View {
+        Text(title)
+            .font(.caption.weight(.semibold))
+            .foregroundStyle(.white)
+            .lineLimit(1)
+            .padding(.horizontal, 9)
+            .padding(.vertical, 3)
+            .background(
+                Capsule()
+                    .fill(updateBadgeBackground)
+            )
+            .overlay(
+                Capsule()
+                    .stroke(Color.primary.opacity(colorScheme == .dark ? 0.08 : 0.05), lineWidth: 1)
+            )
+    }
+
+    private var updateBadgeBackground: Color {
+        Color(nsColor: .systemGray).opacity(colorScheme == .dark ? 0.62 : 0.82)
     }
 }

--- a/Rockxy/Views/Toolbar/ProxyStatusIndicator.swift
+++ b/Rockxy/Views/Toolbar/ProxyStatusIndicator.swift
@@ -10,9 +10,10 @@ import SwiftUI
 struct ProxyStatusIndicator: View {
     // MARK: Internal
 
-    let isRunning: Bool
+    let displayState: ProxyDisplayState
     let listenAddress: String
     let port: Int
+    let updateStatusSummary: AppUpdater.UpdateStatusSummary?
 
     @Binding var showPopover: Bool
 
@@ -25,15 +26,20 @@ struct ProxyStatusIndicator: View {
                     .fill(statusColor)
                     .frame(width: 9, height: 9)
                     .shadow(
-                        color: isRunning ? Color.green.opacity(0.5) : Color.clear,
+                        color: statusShadowColor,
                         radius: 4,
                         x: 0,
                         y: 0
                     )
 
                 Text(statusText)
-                    .font(.system(size: 13, weight: .medium))
+                    .font(.callout.weight(.medium))
                     .foregroundStyle(.secondary)
+                    .lineLimit(1)
+
+                if let updateStatusSummary {
+                    updateStatus(updateStatusSummary)
+                }
             }
             .padding(.horizontal, 12)
             .padding(.vertical, 6)
@@ -48,6 +54,7 @@ struct ProxyStatusIndicator: View {
             )
         }
         .buttonStyle(.plain)
+        .help(statusHelpText)
         .popover(isPresented: $showPopover) {
             ProxyStatusPopover(
                 listenAddress: listenAddress,
@@ -61,14 +68,69 @@ struct ProxyStatusIndicator: View {
     // MARK: Private
 
     private var statusColor: Color {
-        isRunning ? .green : .gray
+        switch displayState {
+        case .starting:
+            Color.accentColor
+        case .running:
+            Color(nsColor: .systemGreen)
+        case .paused:
+            Color(nsColor: .systemOrange)
+        case .stopped:
+            Color(nsColor: .tertiaryLabelColor)
+        }
+    }
+
+    private var statusShadowColor: Color {
+        switch displayState {
+        case .running:
+            Color(nsColor: .systemGreen).opacity(0.45)
+        case .starting:
+            Color.accentColor.opacity(0.35)
+        default:
+            Color.clear
+        }
     }
 
     private var statusText: String {
-        if isRunning {
-            "Rockxy | Listening on \(listenAddress):\(port)"
+        "Rockxy | \(listenAddress):\(port) | \(displayState.title)"
+    }
+
+    private var statusHelpText: String {
+        if let updateStatusSummary {
+            [
+                statusText,
+                updateStatusSummary.title,
+                updateStatusSummary.versionLine,
+                updateStatusSummary.countLine,
+            ]
+            .compactMap { $0 }
+            .joined(separator: "\n")
         } else {
-            String(localized: "Rockxy | Not Running")
+            statusText
         }
+    }
+
+    @ViewBuilder
+    private func updateStatus(_ summary: AppUpdater.UpdateStatusSummary) -> some View {
+        Text("|")
+            .font(.caption)
+            .foregroundStyle(Color(nsColor: .tertiaryLabelColor))
+
+        ViewThatFits(in: .horizontal) {
+            HStack(spacing: 5) {
+                Label(summary.title, systemImage: "arrow.down.circle")
+                    .labelStyle(.titleAndIcon)
+                Text(summary.versionLine)
+                if let countLine = summary.countLine {
+                    Text(countLine)
+                }
+            }
+
+            Label(summary.title, systemImage: "arrow.down.circle")
+                .labelStyle(.titleAndIcon)
+        }
+        .font(.caption.weight(.medium))
+        .foregroundStyle(Color.accentColor)
+        .lineLimit(1)
     }
 }

--- a/Rockxy/Views/Toolbar/ProxyToolbarContent.swift
+++ b/Rockxy/Views/Toolbar/ProxyToolbarContent.swift
@@ -8,6 +8,7 @@ import SwiftUI
 /// layout toggle buttons, plus the central proxy status indicator.
 struct ProxyToolbarContent: ToolbarContent {
     @Environment(\.openWindow) private var openWindow
+    @ObservedObject private var updater = AppUpdater.shared
 
     @Bindable var coordinator: MainContentCoordinator
 
@@ -63,11 +64,12 @@ struct ProxyToolbarContent: ToolbarContent {
         // Center: status indicator
         ToolbarItem(placement: .principal) {
             ProxyStatusIndicator(
-                isRunning: coordinator.isProxyRunning,
+                displayState: coordinator.proxyDisplayState,
                 listenAddress: AppSettingsManager.shared.settings.effectiveListenAddress,
                 port: coordinator.isProxyRunning
                     ? coordinator.activeProxyPort
                     : AppSettingsManager.shared.settings.proxyPort,
+                updateStatusSummary: updater.updateStatusSummary,
                 showPopover: $coordinator.showProxyStatusPopover
             )
         }

--- a/Rockxy/Views/Toolbar/ProxyToolbarContent.swift
+++ b/Rockxy/Views/Toolbar/ProxyToolbarContent.swift
@@ -70,6 +70,9 @@ struct ProxyToolbarContent: ToolbarContent {
                     ? coordinator.activeProxyPort
                     : AppSettingsManager.shared.settings.proxyPort,
                 updateStatusSummary: updater.updateStatusSummary,
+                openUpdates: {
+                    updater.showUpdatesFromStatusBadge()
+                },
                 showPopover: $coordinator.showProxyStatusPopover
             )
         }

--- a/RockxyTests/Core/Storage/SessionStoreMigrationTests.swift
+++ b/RockxyTests/Core/Storage/SessionStoreMigrationTests.swift
@@ -7,6 +7,22 @@ import Testing
 struct SessionStoreMigrationTests {
     // MARK: Internal
 
+    @Test("Default store uses test app support namespace")
+    func defaultStoreUsesTestAppSupportNamespace() async throws {
+        let dir = RockxyIdentity.current.appSupportDirectory()
+
+        let store = try SessionStore()
+        let transaction = TestFixtures.makeTransaction(url: "https://api.example.com/test-isolation")
+        transaction.isSaved = true
+
+        try await store.saveTransaction(transaction)
+
+        let isolatedStore = try SessionStore(directory: dir)
+        let loaded = try await isolatedStore.loadPinnedAndSavedTransactions()
+
+        #expect(loaded.map(\.id).contains(transaction.id))
+    }
+
     @Test("Fresh database migrates to latest schema version")
     func freshDatabaseMigratesToLatest() async throws {
         let dir = try makeTempDir()

--- a/RockxyTests/Core/Updates/AppUpdaterStatusSummaryTests.swift
+++ b/RockxyTests/Core/Updates/AppUpdaterStatusSummaryTests.swift
@@ -1,0 +1,87 @@
+import Foundation
+@testable import Rockxy
+import Testing
+
+@MainActor
+struct AppUpdaterStatusSummaryTests {
+    @Test("Update found creates a summary")
+    func updateFoundCreatesSummary() {
+        let updater = AppUpdater(configuration: makeConfiguration(appVersion: "0.12.0"))
+
+        updater.recordUpdateFound(latestVersion: "0.17.0", fetchVersionsBehind: false)
+
+        #expect(updater.updateStatusSummary?.title == "Update Available")
+        #expect(updater.updateStatusSummary?.versionLine == "v0.12.0 -> v0.17.0")
+    }
+
+    @Test("No update clears the summary")
+    func noUpdateClearsSummary() {
+        let updater = AppUpdater(configuration: makeConfiguration(appVersion: "0.12.0"))
+        updater.recordUpdateFound(latestVersion: "0.17.0", fetchVersionsBehind: false)
+
+        updater.clearUpdateStatusSummary()
+
+        #expect(updater.updateStatusSummary == nil)
+    }
+
+    @Test("Same or older latest version hides the summary")
+    func sameOrOlderLatestVersionHidesSummary() {
+        let same = AppUpdater.makeUpdateStatusSummary(
+            currentVersion: "0.17.0",
+            latestVersion: "0.17.0"
+        )
+        let older = AppUpdater.makeUpdateStatusSummary(
+            currentVersion: "0.17.0",
+            latestVersion: "0.12.0"
+        )
+
+        #expect(same == nil)
+        #expect(older == nil)
+    }
+
+    @Test("Appcast count returns versions behind")
+    func appcastVersionsBehindCount() {
+        let data = Data(
+            """
+            <rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
+              <channel>
+                <item><enclosure sparkle:shortVersionString="0.17.0" sparkle:version="26" /></item>
+                <item><enclosure sparkle:shortVersionString="0.16.0" sparkle:version="25" /></item>
+                <item><enclosure sparkle:shortVersionString="0.15.0" sparkle:version="24" /></item>
+                <item><enclosure sparkle:shortVersionString="0.12.0" sparkle:version="15" /></item>
+              </channel>
+            </rss>
+            """.utf8
+        )
+
+        let count = AppUpdater.versionsBehind(
+            currentVersion: "0.12.0",
+            latestVersion: "0.17.0",
+            appcastData: data
+        )
+
+        #expect(count == 3)
+    }
+
+    @Test("Malformed appcast omits versions behind")
+    func malformedAppcastOmitsCount() {
+        let count = AppUpdater.versionsBehind(
+            currentVersion: "0.12.0",
+            latestVersion: "0.17.0",
+            appcastData: Data("<rss><channel>".utf8)
+        )
+
+        #expect(count == nil)
+    }
+
+    private func makeConfiguration(appVersion: String) -> RockxyUpdateConfiguration {
+        RockxyUpdateConfiguration(infoDictionary: [
+            "RockxyUpdatesEnabled": "NO",
+            "SUFeedURL": "https://example.com/appcast.xml",
+            "SUPublicEDKey": "public-key",
+            "CFBundleShortVersionString": appVersion,
+            "CFBundleVersion": "1",
+            "RockxyBuildReleaseDate": "2026-04-28T00:00:00Z",
+        ])
+    }
+}

--- a/RockxyTests/Core/Updates/AppUpdaterStatusSummaryTests.swift
+++ b/RockxyTests/Core/Updates/AppUpdaterStatusSummaryTests.swift
@@ -12,6 +12,7 @@ struct AppUpdaterStatusSummaryTests {
 
         #expect(updater.updateStatusSummary?.title == "Update Available")
         #expect(updater.updateStatusSummary?.versionLine == "v0.12.0 -> v0.17.0")
+        #expect(updater.updateStatusSummary?.badgeTitle == "Update Available")
     }
 
     @Test("No update clears the summary")
@@ -61,6 +62,54 @@ struct AppUpdaterStatusSummaryTests {
         )
 
         #expect(count == 3)
+    }
+
+    @Test("Appcast summary uses latest release and update badge")
+    func appcastSummaryUsesLatestReleaseAndBadge() {
+        let data = Data(
+            """
+            <rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
+              <channel>
+                <item><enclosure sparkle:shortVersionString="0.17.0" sparkle:version="26" /></item>
+                <item><enclosure sparkle:shortVersionString="0.16.0" sparkle:version="25" /></item>
+                <item><enclosure sparkle:shortVersionString="0.15.0" sparkle:version="24" /></item>
+                <item><enclosure sparkle:shortVersionString="0.14.0" sparkle:version="23" /></item>
+              </channel>
+            </rss>
+            """.utf8
+        )
+
+        let summary = AppUpdater.makeUpdateStatusSummary(
+            currentVersion: "0.12.0",
+            appcastData: data
+        )
+
+        #expect(summary?.latestVersion == "0.17.0")
+        #expect(summary?.versionsBehind == 4)
+        #expect(summary?.badgeTitle == "4 New Updates")
+        #expect(summary?.countLine == "4 versions behind")
+    }
+
+    @Test("Single appcast update badge uses clean singular copy")
+    func singleAppcastUpdateBadgeUsesCleanSingularCopy() {
+        let data = Data(
+            """
+            <rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
+              <channel>
+                <item><enclosure sparkle:shortVersionString="0.17.0" sparkle:version="26" /></item>
+              </channel>
+            </rss>
+            """.utf8
+        )
+
+        let summary = AppUpdater.makeUpdateStatusSummary(
+            currentVersion: "0.12.0",
+            appcastData: data
+        )
+
+        #expect(summary?.versionsBehind == 1)
+        #expect(summary?.badgeTitle == "1 New Update")
+        #expect(summary?.countLine == "1 version behind")
     }
 
     @Test("Malformed appcast omits versions behind")

--- a/RockxyTests/Views/Main/FavoriteTransactionContextMenuTests.swift
+++ b/RockxyTests/Views/Main/FavoriteTransactionContextMenuTests.swift
@@ -114,6 +114,28 @@ struct FavoriteTransactionContextMenuTests {
         #expect(coordinator.transactions.isEmpty)
     }
 
+    @Test("Deleting persisted favorite is durable across store reload")
+    func deletePersistedFavoriteDurable() async throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("RockxyTest-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let store = try SessionStore(directory: dir)
+        let transaction = TestFixtures.makeTransaction(url: "https://api.example.com/persisted-delete")
+        transaction.isSaved = true
+        try await store.saveTransaction(transaction)
+
+        let coordinator = MainContentCoordinator()
+        coordinator.cachedSessionStore = store
+        coordinator.persistedFavorites = [transaction]
+
+        coordinator.removeFavoriteTransaction(transaction, from: .saved)
+
+        let loaded = try await waitForPersistedFavorites(in: store)
+        #expect(loaded.isEmpty)
+    }
+
     @Test("Open in new tab scopes the workspace to the exact request URL")
     func openInNewTabUsesExactURLFilter() {
         let coordinator = MainContentCoordinator()
@@ -198,5 +220,14 @@ struct FavoriteTransactionContextMenuTests {
         }
 
         _ = store.consumePending()
+    }
+
+    private func waitForPersistedFavorites(in store: SessionStore) async throws -> [HTTPTransaction] {
+        var loaded = try await store.loadPinnedAndSavedTransactions()
+        for _ in 0 ..< 20 where !loaded.isEmpty {
+            try await Task.sleep(for: .milliseconds(25))
+            loaded = try await store.loadPinnedAndSavedTransactions()
+        }
+        return loaded
     }
 }

--- a/RockxyTests/Views/Main/FooterActionDescriptorTests.swift
+++ b/RockxyTests/Views/Main/FooterActionDescriptorTests.swift
@@ -1,0 +1,48 @@
+import Foundation
+@testable import Rockxy
+import Testing
+
+struct FooterActionDescriptorTests {
+    @Test("Footer tooling action order is stable")
+    func toolingActionOrder() {
+        let actions = FooterActionDescriptor.toolingActions(isAllowListActive: false)
+
+        #expect(actions.map(\.id) == [
+            .blockList,
+            .allowList,
+            .mapLocal,
+            .scripting,
+            .mapRemote,
+            .breakpoint,
+            .networkConditions,
+        ])
+    }
+
+    @Test("Footer actions use SF Symbol names")
+    func actionSymbolsArePresent() {
+        let actions = FooterActionDescriptor.toolingActions(isAllowListActive: false)
+
+        #expect(actions.allSatisfy { !$0.systemImage.isEmpty })
+        #expect(actions.first { $0.id == .blockList }?.systemImage == "hand.raised.slash")
+        #expect(actions.first { $0.id == .allowList }?.systemImage == "checkmark.shield")
+        #expect(actions.first { $0.id == .mapLocal }?.systemImage == "folder.badge.gearshape")
+        #expect(actions.first { $0.id == .scripting }?.systemImage == "curlybraces")
+        #expect(actions.first { $0.id == .mapRemote }?.systemImage == "arrow.triangle.branch")
+        #expect(actions.first { $0.id == .breakpoint }?.systemImage == "pause.circle")
+        #expect(actions.first { $0.id == .networkConditions }?.systemImage == "speedometer")
+    }
+
+    @Test("Allow List active state reflects manager state")
+    func activeStates() {
+        let tooling = FooterActionDescriptor.toolingActions(isAllowListActive: true)
+
+        #expect(tooling.first { $0.id == .allowList }?.isActive == true)
+    }
+
+    @Test("Footer tool actions render inline without overflow")
+    func toolActionsRemainInline() {
+        let actions = FooterActionDescriptor.toolingActions(isAllowListActive: false)
+
+        #expect(FooterActionKind.allCases == actions.map(\.id))
+    }
+}

--- a/RockxyTests/Views/Main/ProxyDisplayStateTests.swift
+++ b/RockxyTests/Views/Main/ProxyDisplayStateTests.swift
@@ -1,0 +1,52 @@
+import Foundation
+@testable import Rockxy
+import Testing
+
+@MainActor
+struct ProxyDisplayStateTests {
+    @Test("Coordinator reports stopped by default")
+    func stoppedByDefault() {
+        let coordinator = MainContentCoordinator()
+
+        #expect(coordinator.proxyDisplayState == .stopped)
+    }
+
+    @Test("Coordinator reports starting while proxy startup is in flight")
+    func startingDuringProxyStartup() {
+        let coordinator = MainContentCoordinator()
+
+        coordinator.isProxyStarting = true
+
+        #expect(coordinator.proxyDisplayState == .starting)
+    }
+
+    @Test("Coordinator reports running after proxy start")
+    func runningAfterProxyStart() {
+        let coordinator = MainContentCoordinator()
+
+        coordinator.isProxyRunning = true
+        coordinator.isRecording = true
+
+        #expect(coordinator.proxyDisplayState == .running)
+    }
+
+    @Test("Coordinator reports paused when proxy runs but recording is off")
+    func pausedWhenRecordingOff() {
+        let coordinator = MainContentCoordinator()
+
+        coordinator.isProxyRunning = true
+        coordinator.isRecording = false
+
+        #expect(coordinator.proxyDisplayState == .paused)
+    }
+
+    @Test("Coordinator reports stopped after failed start clears startup state")
+    func stoppedAfterFailedStart() {
+        let coordinator = MainContentCoordinator()
+
+        coordinator.isProxyStarting = false
+        coordinator.isProxyRunning = false
+
+        #expect(coordinator.proxyDisplayState == .stopped)
+    }
+}


### PR DESCRIPTION
## Summary
- Refines the native proxy status capsule with lifecycle state text and a compact Sparkle update badge.
- Routes update badge clicks to the software update window while preserving the existing proxy status popover interaction.
- Updates the footer bar with compact native quick actions and fixes sidebar pinned/saved persistence isolation.

## Validation
- xcodebuild -project Rockxy.xcodeproj -scheme Rockxy -destination 'platform=macOS' -only-testing:RockxyTests/Core/Updates/AppUpdaterStatusSummaryTests test\n- xcodebuild -project Rockxy.xcodeproj -scheme Rockxy -destination 'platform=macOS' -only-testing:RockxyTests/Core/Storage/SessionStoreMigrationTests test\n- xcodebuild -project Rockxy.xcodeproj -scheme Rockxy -destination 'platform=macOS' -only-testing:RockxyTests/Views/Main/FavoriteTransactionContextMenuTests test\n- swiftlint lint --strict --quiet

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Update availability now displays the latest version and how many versions behind you are.
  * New "starting" state added to proxy status indicator for better visual feedback during startup.
  * Enhanced footer actions with improved UI rendering and organization.

* **Improvements**
  * Proxy status indicator now integrates update information directly in the toolbar.
  * Better state management during proxy initialization and startup operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->