### PR TITLE
Promote certificate setup and helper recovery

### DIFF
--- a/Rockxy/Core/Certificate/CertificateExportService.swift
+++ b/Rockxy/Core/Certificate/CertificateExportService.swift
@@ -1,0 +1,167 @@
+import Crypto
+import Foundation
+import NIOSSL
+import SwiftASN1
+import UniformTypeIdentifiers
+import X509
+
+// MARK: - CertificateExportFormat
+
+enum CertificateExportFormat: CaseIterable, Equatable, Hashable {
+    case privateKey
+    case rootCertificateP12
+    case rootCertificatePEM
+    case rootCertificateDER
+
+    var menuTitle: String {
+        switch self {
+        case .privateKey:
+            String(localized: "Private Key…")
+        case .rootCertificateP12:
+            String(localized: "Root Certificate as P12…")
+        case .rootCertificatePEM:
+            String(localized: "Root Certificate as PEM…")
+        case .rootCertificateDER:
+            String(localized: "Root Certificate as DER…")
+        }
+    }
+
+    var defaultFileName: String {
+        switch self {
+        case .privateKey:
+            "RockxyCA-PrivateKey.pem"
+        case .rootCertificateP12:
+            "RockxyCA.p12"
+        case .rootCertificatePEM:
+            "RockxyCA.pem"
+        case .rootCertificateDER:
+            "RockxyCA.der"
+        }
+    }
+
+    var allowedContentTypes: [UTType] {
+        switch self {
+        case .privateKey, .rootCertificatePEM:
+            [UTType(filenameExtension: "pem") ?? .data]
+        case .rootCertificateP12:
+            [UTType(filenameExtension: "p12") ?? .data]
+        case .rootCertificateDER:
+            [UTType(filenameExtension: "der") ?? .data]
+        }
+    }
+
+    var containsPrivateMaterial: Bool {
+        switch self {
+        case .privateKey, .rootCertificateP12:
+            true
+        case .rootCertificatePEM, .rootCertificateDER:
+            false
+        }
+    }
+}
+
+// MARK: - CertificateExportPayload
+
+struct CertificateExportPayload: Equatable {
+    let format: CertificateExportFormat
+    let defaultFileName: String
+    let data: Data
+    let containsPrivateMaterial: Bool
+}
+
+// MARK: - CertificateExportMaterial
+
+struct CertificateExportMaterial {
+    let certificate: Certificate?
+    let privateKey: P256.Signing.PrivateKey?
+}
+
+// MARK: - CertificateExportService
+
+struct CertificateExportService {
+    typealias MaterialProvider = @Sendable () async throws -> CertificateExportMaterial
+    typealias WriteHandler = @Sendable (Data, URL) throws -> Void
+
+    init(
+        materialProvider: @escaping MaterialProvider,
+        writeHandler: @escaping WriteHandler = { data, url in
+            try data.write(to: url, options: .atomic)
+        }
+    ) {
+        self.materialProvider = materialProvider
+        self.writeHandler = writeHandler
+    }
+
+    func payload(for format: CertificateExportFormat) async throws -> CertificateExportPayload {
+        let material = try await materialProvider()
+        guard let certificate = material.certificate else {
+            throw CertificateExportError.missingCertificate
+        }
+
+        let data: Data
+        switch format {
+        case .rootCertificatePEM:
+            data = Data(try certificatePEM(certificate).utf8)
+        case .rootCertificateDER:
+            data = try certificateDER(certificate)
+        case .privateKey:
+            guard let privateKey = material.privateKey else {
+                throw CertificateExportError.missingPrivateKey
+            }
+            data = Data(privateKey.pemRepresentation.utf8)
+        case .rootCertificateP12:
+            guard let privateKey = material.privateKey else {
+                throw CertificateExportError.missingPrivateKey
+            }
+            data = try p12Data(certificate: certificate, privateKey: privateKey)
+        }
+
+        return CertificateExportPayload(
+            format: format,
+            defaultFileName: format.defaultFileName,
+            data: data,
+            containsPrivateMaterial: format.containsPrivateMaterial
+        )
+    }
+
+    func export(_ payload: CertificateExportPayload, to url: URL) throws {
+        try writeHandler(payload.data, url)
+    }
+
+    private let materialProvider: MaterialProvider
+    private let writeHandler: WriteHandler
+
+    private func certificatePEM(_ certificate: Certificate) throws -> String {
+        let der = try certificateDER(certificate)
+        return PEMDocument(type: "CERTIFICATE", derBytes: Array(der)).pemString
+    }
+
+    private func certificateDER(_ certificate: Certificate) throws -> Data {
+        var serializer = DER.Serializer()
+        try certificate.serialize(into: &serializer)
+        return Data(serializer.serializedBytes)
+    }
+
+    private func p12Data(certificate: Certificate, privateKey: P256.Signing.PrivateKey) throws -> Data {
+        let cert = try NIOSSLCertificate(bytes: Array(certificateDER(certificate)), format: .der)
+        let key = try NIOSSLPrivateKey(bytes: Array(privateKey.pemRepresentation.utf8), format: .pem)
+        let bundle = NIOSSLPKCS12Bundle(certificateChain: [cert], privateKey: key)
+        return Data(try bundle.serialize(passphrase: [UInt8]()))
+    }
+}
+
+// MARK: - CertificateExportError
+
+enum CertificateExportError: LocalizedError, Equatable {
+    case missingCertificate
+    case missingPrivateKey
+
+    var errorDescription: String? {
+        switch self {
+        case .missingCertificate:
+            String(localized: "Rockxy has not generated a root certificate yet.")
+        case .missingPrivateKey:
+            String(localized: "Rockxy could not find the root CA private key.")
+        }
+    }
+}

--- a/Rockxy/Core/Certificate/CertificateManager.swift
+++ b/Rockxy/Core/Certificate/CertificateManager.swift
@@ -475,9 +475,45 @@ actor CertificateManager {
         return pemDocument.pemString
     }
 
+    func getRootCADER() throws -> Data? {
+        guard let certificate = rootCACertificate else {
+            return nil
+        }
+        return try certToDER(certificate)
+    }
+
+    func getRootCAPrivateKeyPEM() throws -> String? {
+        guard let privateKey = rootCAPrivateKey else {
+            return nil
+        }
+        return privateKey.pemRepresentation
+    }
+
+    func exportMaterial() throws -> CertificateExportMaterial {
+        CertificateExportMaterial(certificate: rootCACertificate, privateKey: rootCAPrivateKey)
+    }
+
     // MARK: - Host Certificates
 
     func certificateForHost(_ host: String) throws -> (certificate: Certificate, privateKey: P256.Signing.PrivateKey) {
+        if let customRoot = try CustomCertificateManager.shared.activeRootIssuer() {
+            let fingerprint = CustomCertificateManager.shared.metadata(kind: .root).last?.fingerprintSHA256 ?? "custom"
+            let cacheKey = "\(fingerprint):\(host)"
+            if let cached = hostCertCache[cacheKey] {
+                touchCacheEntry(cacheKey)
+                return (cached.certificate, cached.privateKey)
+            }
+
+            let result = try HostCertGenerator.generate(
+                host: host,
+                issuer: customRoot.certificate,
+                issuerPrivateKey: customRoot.privateKey
+            )
+            insertCacheEntry(cacheKey, entry: HostCertEntry(certificate: result.certificate, privateKey: result.privateKey))
+            Self.logger.debug("Generated certificate for host with custom root issuer: \(host)")
+            return result
+        }
+
         if let cached = hostCertCache[host] {
             touchCacheEntry(host)
             return (cached.certificate, cached.privateKey)

--- a/Rockxy/Core/Certificate/CertificateMenuActionRouter.swift
+++ b/Rockxy/Core/Certificate/CertificateMenuActionRouter.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+// MARK: - CertificateMenuAction
+
+enum CertificateMenuAction: Equatable {
+    case installOnMac
+    case installOniOSDevice
+    case installOniOSSimulator
+    case installOnAndroidDevice
+    case installOnAndroidEmulator
+    case installOnJavaVMs
+    case installOnDevelopment(SetupTarget.ID)
+    case installOnFirefox
+    case addCustomCertificates
+    case export(CertificateExportFormat)
+    case resetAll
+}
+
+// MARK: - CertificateMenuRoute
+
+enum CertificateMenuRoute: Equatable {
+    case openCertificateSetupGuide
+    case openDeveloperSetup(targetID: SetupTarget.ID, tab: SetupDetailTab)
+    case openCustomCertificates
+    case export(CertificateExportFormat)
+    case resetAll
+}
+
+// MARK: - CertificateMenuActionRouter
+
+struct CertificateMenuActionRouter {
+    func route(for action: CertificateMenuAction) -> CertificateMenuRoute {
+        switch action {
+        case .installOnMac:
+            return .openCertificateSetupGuide
+        case .installOniOSDevice:
+            return .openDeveloperSetup(targetID: .iosDevice, tab: .setup)
+        case .installOniOSSimulator:
+            return .openDeveloperSetup(targetID: .iosSimulator, tab: .setup)
+        case .installOnAndroidDevice:
+            return .openDeveloperSetup(targetID: .androidDevice, tab: .setup)
+        case .installOnAndroidEmulator:
+            return .openDeveloperSetup(targetID: .androidEmulator, tab: .setup)
+        case .installOnJavaVMs:
+            return .openDeveloperSetup(targetID: .javaVMs, tab: .setup)
+        case .installOnDevelopment(let targetID):
+            return .openDeveloperSetup(targetID: targetID, tab: .setup)
+        case .installOnFirefox:
+            return .openDeveloperSetup(targetID: .firefox, tab: .setup)
+        case .addCustomCertificates:
+            return .openCustomCertificates
+        case .export(let format):
+            return .export(format)
+        case .resetAll:
+            return .resetAll
+        }
+    }
+}

--- a/Rockxy/Core/Certificate/CertificateSetupState.swift
+++ b/Rockxy/Core/Certificate/CertificateSetupState.swift
@@ -1,0 +1,65 @@
+import Foundation
+
+// MARK: - CertificateSetupState
+
+enum CertificateSetupState: Equatable {
+    case installedAndTrusted
+    case installedNotTrusted
+    case generatedOnly
+    case missing
+
+    init(snapshot: RootCAStatusSnapshot) {
+        if snapshot.isInstalledInKeychain, snapshot.isSystemTrustValidated {
+            self = .installedAndTrusted
+        } else if snapshot.isInstalledInKeychain {
+            self = .installedNotTrusted
+        } else if snapshot.hasGeneratedCertificate {
+            self = .generatedOnly
+        } else {
+            self = .missing
+        }
+    }
+
+    var title: String {
+        switch self {
+        case .installedAndTrusted:
+            String(localized: "Installed & Trusted")
+        case .installedNotTrusted:
+            String(localized: "Installed, Trust Required")
+        case .generatedOnly:
+            String(localized: "Generated, Not Installed")
+        case .missing:
+            String(localized: "Certificate Missing")
+        }
+    }
+
+    var message: String {
+        switch self {
+        case .installedAndTrusted:
+            String(localized: "Rockxy Certificate is ready.")
+        case .installedNotTrusted:
+            String(localized: "The root CA is installed, but macOS has not fully trusted it for TLS yet.")
+        case .generatedOnly:
+            String(localized: "The root CA exists locally. Install and trust it in Keychain to decrypt HTTPS traffic.")
+        case .missing:
+            String(localized: "Generate Rockxy's root CA, then install and trust it in Keychain.")
+        }
+    }
+
+    var systemImageName: String {
+        switch self {
+        case .installedAndTrusted:
+            "checkmark.circle.fill"
+        case .installedNotTrusted:
+            "exclamationmark.triangle.fill"
+        case .generatedOnly:
+            "certificate.fill"
+        case .missing:
+            "xmark.circle.fill"
+        }
+    }
+
+    var isReady: Bool {
+        self == .installedAndTrusted
+    }
+}

--- a/Rockxy/Core/Certificate/CustomCertificateManager.swift
+++ b/Rockxy/Core/Certificate/CustomCertificateManager.swift
@@ -1,0 +1,319 @@
+import Crypto
+import Foundation
+import NIOSSL
+import SwiftASN1
+import X509
+
+// MARK: - CustomCertificateKind
+
+enum CustomCertificateKind: String, Codable, CaseIterable, Equatable {
+    case root
+    case server
+    case client
+}
+
+// MARK: - CustomCertificateMetadata
+
+struct CustomCertificateMetadata: Identifiable, Codable, Equatable {
+    var id: UUID
+    var kind: CustomCertificateKind
+    var displayName: String
+    var hostPattern: String?
+    var certificatePEM: String
+    var keychainAccount: String
+    var createdAt: Date
+    var notValidBefore: Date?
+    var notValidAfter: Date?
+    var fingerprintSHA256: String?
+}
+
+// MARK: - CustomTLSIdentity
+
+struct CustomTLSIdentity: Sendable {
+    let certificateChainPEM: [String]
+    let privateKeyPEM: String
+
+    var certificateSources: [NIOSSLCertificateSource] {
+        get throws {
+            try certificateChainPEM.map { pem in
+                try .certificate(NIOSSLCertificate(bytes: Array(pem.utf8), format: .pem))
+            }
+        }
+    }
+
+    var privateKeySource: NIOSSLPrivateKeySource {
+        get throws {
+            try .privateKey(NIOSSLPrivateKey(bytes: Array(privateKeyPEM.utf8), format: .pem))
+        }
+    }
+}
+
+// MARK: - SecureDataStore
+
+protocol SecureDataStore: Sendable {
+    func save(_ data: Data, account: String) throws
+    func load(account: String) throws -> Data?
+    func delete(account: String) throws
+}
+
+struct KeychainSecureDataStore: SecureDataStore {
+    func save(_ data: Data, account: String) throws {
+        try KeychainHelper.saveSecureData(data, service: service, account: account)
+    }
+
+    func load(account: String) throws -> Data? {
+        try KeychainHelper.loadSecureData(service: service, account: account)
+    }
+
+    func delete(account: String) throws {
+        try KeychainHelper.deleteSecureData(service: service, account: account)
+    }
+
+    private let service = RockxyIdentity.current.defaultsKey("CustomCertificates")
+}
+
+// MARK: - CustomCertificateManager
+
+final class CustomCertificateManager: @unchecked Sendable {
+    static let shared = CustomCertificateManager()
+
+    init(
+        storageURL: URL = RockxyIdentity.current.sharedSupportDirectory()
+            .appendingPathComponent("Certificates", isDirectory: true)
+            .appendingPathComponent("custom-certificates.json"),
+        secureStore: any SecureDataStore = KeychainSecureDataStore()
+    ) {
+        self.storageURL = storageURL
+        self.secureStore = secureStore
+        loadFromDisk()
+    }
+
+    func metadata(kind: CustomCertificateKind? = nil) -> [CustomCertificateMetadata] {
+        lock.withLock {
+            entries
+                .filter { kind == nil || $0.kind == kind }
+                .sorted { $0.createdAt < $1.createdAt }
+        }
+    }
+
+    @discardableResult
+    func importRoot(
+        displayName: String,
+        certificatePEM: String,
+        privateKeyPEM: String
+    ) throws -> CustomCertificateMetadata {
+        try importIdentity(kind: .root, hostPattern: nil, displayName: displayName, certificatePEM: certificatePEM, privateKeyPEM: privateKeyPEM)
+    }
+
+    @discardableResult
+    func importServerIdentity(
+        hostPattern: String,
+        displayName: String,
+        certificatePEM: String,
+        privateKeyPEM: String
+    ) throws -> CustomCertificateMetadata {
+        try importIdentity(kind: .server, hostPattern: hostPattern, displayName: displayName, certificatePEM: certificatePEM, privateKeyPEM: privateKeyPEM)
+    }
+
+    @discardableResult
+    func importClientIdentity(
+        hostPattern: String,
+        displayName: String,
+        certificatePEM: String,
+        privateKeyPEM: String
+    ) throws -> CustomCertificateMetadata {
+        try importIdentity(kind: .client, hostPattern: hostPattern, displayName: displayName, certificatePEM: certificatePEM, privateKeyPEM: privateKeyPEM)
+    }
+
+    func activeRootIssuer() throws -> (certificate: Certificate, privateKey: Certificate.PrivateKey)? {
+        guard let entry = metadata(kind: .root).last else {
+            return nil
+        }
+        guard let keyData = try secureStore.load(account: entry.keychainAccount),
+              let privateKeyPEM = String(data: keyData, encoding: .utf8) else {
+            throw CustomCertificateError.missingPrivateKey
+        }
+        return (
+            certificate: try Certificate(pemEncoded: entry.certificatePEM),
+            privateKey: try Certificate.PrivateKey(pemEncoded: privateKeyPEM)
+        )
+    }
+
+    func serverIdentity(for host: String) -> CustomTLSIdentity? {
+        identity(for: host, kind: .server)
+    }
+
+    func clientIdentity(for host: String) -> CustomTLSIdentity? {
+        identity(for: host, kind: .client)
+    }
+
+    func delete(id: UUID) throws {
+        let removed: CustomCertificateMetadata? = lock.withLock {
+            guard let index = entries.firstIndex(where: { $0.id == id }) else {
+                return nil
+            }
+            return entries.remove(at: index)
+        }
+        if let removed {
+            try secureStore.delete(account: removed.keychainAccount)
+            try persist()
+        }
+    }
+
+    func deleteAll(kind: CustomCertificateKind? = nil) throws {
+        let removed: [CustomCertificateMetadata] = lock.withLock {
+            let removed = entries.filter { kind == nil || $0.kind == kind }
+            entries.removeAll { kind == nil || $0.kind == kind }
+            return removed
+        }
+        for entry in removed {
+            try secureStore.delete(account: entry.keychainAccount)
+        }
+        try persist()
+    }
+
+    private let storageURL: URL
+    private let secureStore: any SecureDataStore
+    private let lock = NSLock()
+    private var entries: [CustomCertificateMetadata] = []
+
+    private func importIdentity(
+        kind: CustomCertificateKind,
+        hostPattern: String?,
+        displayName: String,
+        certificatePEM: String,
+        privateKeyPEM: String
+    ) throws -> CustomCertificateMetadata {
+        let certificate = try Certificate(pemEncoded: certificatePEM)
+        let privateKey = try Certificate.PrivateKey(pemEncoded: privateKeyPEM)
+        guard certificate.publicKey.subjectPublicKeyInfoBytes == privateKey.publicKey.subjectPublicKeyInfoBytes else {
+            throw CustomCertificateError.invalidCertificateKeyPair
+        }
+
+        if kind != .root {
+            try validateTLSIdentity(certificatePEM: certificatePEM, privateKeyPEM: privateKeyPEM)
+        }
+
+        let keychainAccount = "custom-certificate.\(kind.rawValue).\(UUID().uuidString)"
+        try secureStore.save(Data(privateKeyPEM.utf8), account: keychainAccount)
+
+        let entry = CustomCertificateMetadata(
+            id: UUID(),
+            kind: kind,
+            displayName: displayName,
+            hostPattern: hostPattern?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased(),
+            certificatePEM: certificatePEM,
+            keychainAccount: keychainAccount,
+            createdAt: Date(),
+            notValidBefore: certificate.notValidBefore,
+            notValidAfter: certificate.notValidAfter,
+            fingerprintSHA256: Self.fingerprint(certificate)
+        )
+
+        lock.withLock {
+            entries.removeAll {
+                $0.kind == kind && $0.hostPattern == entry.hostPattern
+            }
+            entries.append(entry)
+        }
+        try persist()
+        return entry
+    }
+
+    private func identity(for host: String, kind: CustomCertificateKind) -> CustomTLSIdentity? {
+        let normalizedHost = host.lowercased()
+        let match = lock.withLock {
+            entries.last { entry in
+                guard entry.kind == kind, let pattern = entry.hostPattern else {
+                    return false
+                }
+                return HostPatternMatcher.matches(pattern: pattern, host: normalizedHost)
+            }
+        }
+
+        guard let match,
+              let keyData = try? secureStore.load(account: match.keychainAccount),
+              let privateKeyPEM = String(data: keyData, encoding: .utf8) else {
+            return nil
+        }
+        return CustomTLSIdentity(certificateChainPEM: [match.certificatePEM], privateKeyPEM: privateKeyPEM)
+    }
+
+    private func validateTLSIdentity(certificatePEM: String, privateKeyPEM: String) throws {
+        let certificate = try NIOSSLCertificate(bytes: Array(certificatePEM.utf8), format: .pem)
+        let privateKey = try NIOSSLPrivateKey(bytes: Array(privateKeyPEM.utf8), format: .pem)
+        _ = try NIOSSLContext(configuration: TLSConfiguration.makeServerConfiguration(
+            certificateChain: [.certificate(certificate)],
+            privateKey: .privateKey(privateKey)
+        ))
+    }
+
+    private func loadFromDisk() {
+        guard let data = try? Data(contentsOf: storageURL),
+              let decoded = try? JSONDecoder().decode([CustomCertificateMetadata].self, from: data) else {
+            return
+        }
+        lock.withLock {
+            entries = decoded
+        }
+    }
+
+    private func persist() throws {
+        let snapshot = lock.withLock { entries }
+        try FileManager.default.createDirectory(
+            at: storageURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        try encoder.encode(snapshot).write(to: storageURL, options: .atomic)
+    }
+
+    private static func fingerprint(_ certificate: Certificate) -> String? {
+        var serializer = DER.Serializer()
+        guard (try? certificate.serialize(into: &serializer)) != nil else {
+            return nil
+        }
+        return KeychainHelper.computeFingerprintSHA256(Data(serializer.serializedBytes))
+    }
+}
+
+// MARK: - HostPatternMatcher
+
+enum HostPatternMatcher {
+    static func matches(pattern: String, host: String) -> Bool {
+        let normalizedPattern = pattern.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        let normalizedHost = host.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+
+        guard !normalizedPattern.isEmpty, !normalizedHost.isEmpty else {
+            return false
+        }
+
+        if normalizedPattern == normalizedHost {
+            return true
+        }
+
+        if normalizedPattern.hasPrefix("*.") {
+            let suffix = String(normalizedPattern.dropFirst(2))
+            return normalizedHost.hasSuffix(".\(suffix)") && normalizedHost != suffix
+        }
+
+        return false
+    }
+}
+
+// MARK: - CustomCertificateError
+
+enum CustomCertificateError: LocalizedError, Equatable {
+    case invalidCertificateKeyPair
+    case missingPrivateKey
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidCertificateKeyPair:
+            String(localized: "The certificate and private key do not belong to the same identity.")
+        case .missingPrivateKey:
+            String(localized: "The private key for this certificate could not be found in Keychain.")
+        }
+    }
+}

--- a/Rockxy/Core/Certificate/HostCertGenerator.swift
+++ b/Rockxy/Core/Certificate/HostCertGenerator.swift
@@ -15,6 +15,16 @@ nonisolated enum HostCertGenerator {
     )
         throws -> (certificate: Certificate, privateKey: P256.Signing.PrivateKey)
     {
+        try generate(host: host, issuer: issuer, issuerPrivateKey: .init(issuerKey))
+    }
+
+    static func generate(
+        host: String,
+        issuer: Certificate,
+        issuerPrivateKey: Certificate.PrivateKey
+    )
+        throws -> (certificate: Certificate, privateKey: P256.Signing.PrivateKey)
+    {
         let hostKey = P256.Signing.PrivateKey()
 
         let subjectName = try DistinguishedName {
@@ -61,11 +71,25 @@ nonisolated enum HostCertGenerator {
             notValidAfter: oneYearLater,
             issuer: issuer.subject,
             subject: subjectName,
-            signatureAlgorithm: .ecdsaWithSHA256,
+            signatureAlgorithm: signatureAlgorithm(for: issuerPrivateKey),
             extensions: extensions,
-            issuerPrivateKey: .init(issuerKey)
+            issuerPrivateKey: issuerPrivateKey
         )
 
         return (certificate, hostKey)
+    }
+
+    private static func signatureAlgorithm(for privateKey: Certificate.PrivateKey) -> Certificate.SignatureAlgorithm {
+        let description = privateKey.description
+        if description.hasPrefix("P384") {
+            return .ecdsaWithSHA384
+        }
+        if description.hasPrefix("P521") {
+            return .ecdsaWithSHA512
+        }
+        if description.hasPrefix("RSA") {
+            return .sha256WithRSAEncryption
+        }
+        return .ecdsaWithSHA256
     }
 }

--- a/Rockxy/Core/Certificate/KeychainHelper.swift
+++ b/Rockxy/Core/Certificate/KeychainHelper.swift
@@ -80,6 +80,63 @@ nonisolated enum KeychainHelper {
         }
     }
 
+    // MARK: - Generic Secure Data Operations
+
+    static func saveSecureData(_ data: Data, service: String, account: String) throws {
+        try deleteSecureData(service: service, account: account)
+
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecValueData as String: data,
+            kSecAttrAccessible as String: kSecAttrAccessibleWhenUnlocked
+        ]
+
+        let status = SecItemAdd(query as CFDictionary, nil)
+        guard status == errSecSuccess else {
+            logger.error("Failed to save secure data: \(status)")
+            throw KeychainError.saveFailed(status)
+        }
+    }
+
+    static func loadSecureData(service: String, account: String) throws -> Data? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne
+        ]
+
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        if status == errSecItemNotFound {
+            return nil
+        }
+
+        guard status == errSecSuccess else {
+            logger.error("Failed to load secure data: \(status)")
+            throw KeychainError.loadFailed(status)
+        }
+
+        return result as? Data
+    }
+
+    static func deleteSecureData(service: String, account: String) throws {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account
+        ]
+
+        let status = SecItemDelete(query as CFDictionary)
+        guard status == errSecSuccess || status == errSecItemNotFound else {
+            logger.error("Failed to delete secure data: \(status)")
+            throw KeychainError.deleteFailed(status)
+        }
+    }
+
     // MARK: - Certificate Operations
 
     static func installCertificate(_ certData: Data, label: String) throws {

--- a/Rockxy/Core/ProxyEngine/HTTPProxyHandler.swift
+++ b/Rockxy/Core/ProxyEngine/HTTPProxyHandler.swift
@@ -32,6 +32,7 @@ final class HTTPProxyHandler: ChannelInboundHandler, RemovableChannelHandler, @u
         ruleEngine: RuleEngine,
         scriptPluginManager: ScriptPluginManager? = nil,
         connectionLimiter: ConnectionLimiter,
+        customCertificateManager: CustomCertificateManager = .shared,
         onTransactionComplete: @escaping @Sendable (HTTPTransaction) -> Void,
         onBreakpointHit: (@Sendable (BreakpointRequestData) async -> (BreakpointDecision, BreakpointRequestData))? = nil
     ) {
@@ -39,6 +40,7 @@ final class HTTPProxyHandler: ChannelInboundHandler, RemovableChannelHandler, @u
         self.ruleEngine = ruleEngine
         self.scriptPluginManager = scriptPluginManager
         self.connectionLimiter = connectionLimiter
+        self.customCertificateManager = customCertificateManager
         self.onTransactionComplete = onTransactionComplete
         self.onBreakpointHit = onBreakpointHit
     }
@@ -99,6 +101,7 @@ final class HTTPProxyHandler: ChannelInboundHandler, RemovableChannelHandler, @u
     private let ruleEngine: RuleEngine
     private let scriptPluginManager: ScriptPluginManager?
     private let connectionLimiter: ConnectionLimiter
+    private let customCertificateManager: CustomCertificateManager
     private let onTransactionComplete: @Sendable (HTTPTransaction) -> Void
     private let onBreakpointHit: (@Sendable (BreakpointRequestData) async -> (
         BreakpointDecision,
@@ -593,6 +596,7 @@ extension HTTPProxyHandler {
                 ruleEngine: self.ruleEngine,
                 scriptPluginManager: self.scriptPluginManager,
                 connectionLimiter: self.connectionLimiter,
+                customCertificateManager: self.customCertificateManager,
                 clientSourcePort: self.clientSourcePort,
                 onTransactionComplete: self.onTransactionComplete,
                 onBreakpointHit: self.onBreakpointHit
@@ -661,8 +665,9 @@ extension HTTPProxyHandler {
             .channelInitializer { channel in
                 if useTLS {
                     do {
-                        var tlsConfig = TLSConfiguration.makeClientConfiguration()
-                        tlsConfig.certificateVerification = .fullVerification
+                        let tlsConfig = try HTTPSProxyRelayHandler.makeClientTLSConfiguration(
+                            clientIdentity: self.customCertificateManager.clientIdentity(for: host)
+                        )
                         let sslContext = try NIOSSLContext(configuration: tlsConfig)
                         let sslHandler = try NIOSSLClientHandler(
                             context: sslContext,

--- a/Rockxy/Core/ProxyEngine/HTTPSProxyRelayHandler.swift
+++ b/Rockxy/Core/ProxyEngine/HTTPSProxyRelayHandler.swift
@@ -27,6 +27,7 @@ final class HTTPSProxyRelayHandler: ChannelInboundHandler, @unchecked Sendable {
         ruleEngine: RuleEngine,
         scriptPluginManager: ScriptPluginManager? = nil,
         connectionLimiter: ConnectionLimiter,
+        customCertificateManager: CustomCertificateManager = .shared,
         clientSourcePort: UInt16? = nil,
         onTransactionComplete: @escaping @Sendable (HTTPTransaction) -> Void,
         onBreakpointHit: (@Sendable (BreakpointRequestData) async -> (BreakpointDecision, BreakpointRequestData))? = nil
@@ -36,6 +37,7 @@ final class HTTPSProxyRelayHandler: ChannelInboundHandler, @unchecked Sendable {
         self.ruleEngine = ruleEngine
         self.scriptPluginManager = scriptPluginManager
         self.connectionLimiter = connectionLimiter
+        self.customCertificateManager = customCertificateManager
         self.clientSourcePort = clientSourcePort
         self.onTransactionComplete = onTransactionComplete
         self.onBreakpointHit = onBreakpointHit
@@ -45,6 +47,16 @@ final class HTTPSProxyRelayHandler: ChannelInboundHandler, @unchecked Sendable {
 
     typealias InboundIn = HTTPServerRequestPart
     typealias OutboundOut = HTTPServerResponsePart
+
+    nonisolated static func makeClientTLSConfiguration(clientIdentity: CustomTLSIdentity?) throws -> TLSConfiguration {
+        var clientTLSConfig = TLSConfiguration.makeClientConfiguration()
+        clientTLSConfig.certificateVerification = .fullVerification
+        if let clientIdentity {
+            clientTLSConfig.certificateChain = try clientIdentity.certificateSources
+            clientTLSConfig.privateKey = try clientIdentity.privateKeySource
+        }
+        return clientTLSConfig
+    }
 
     nonisolated func channelRead(context: ChannelHandlerContext, data: NIOAny) {
         let part = unwrapInboundIn(data)
@@ -93,6 +105,7 @@ final class HTTPSProxyRelayHandler: ChannelInboundHandler, @unchecked Sendable {
     private let ruleEngine: RuleEngine
     private let scriptPluginManager: ScriptPluginManager?
     private let connectionLimiter: ConnectionLimiter
+    private let customCertificateManager: CustomCertificateManager
     private let clientSourcePort: UInt16?
     private let onTransactionComplete: @Sendable (HTTPTransaction) -> Void
     private let onBreakpointHit: (@Sendable (BreakpointRequestData) async -> (
@@ -262,8 +275,9 @@ final class HTTPSProxyRelayHandler: ChannelInboundHandler, @unchecked Sendable {
         let limiter = connectionLimiter
 
         do {
-            var clientTLSConfig = TLSConfiguration.makeClientConfiguration()
-            clientTLSConfig.certificateVerification = .fullVerification
+            let clientTLSConfig = try Self.makeClientTLSConfiguration(
+                clientIdentity: customCertificateManager.clientIdentity(for: upstreamHost)
+            )
             let sslContext = try NIOSSLContext(configuration: clientTLSConfig)
 
             ClientBootstrap(group: context.eventLoop)
@@ -660,8 +674,9 @@ final class HTTPSProxyRelayHandler: ChannelInboundHandler, @unchecked Sendable {
         if scheme == "https" {
             let connectTime = DispatchTime.now()
             do {
-                var clientTLSConfig = TLSConfiguration.makeClientConfiguration()
-                clientTLSConfig.certificateVerification = .fullVerification
+                let clientTLSConfig = try Self.makeClientTLSConfiguration(
+                    clientIdentity: customCertificateManager.clientIdentity(for: remoteHost)
+                )
                 let sslContext = try NIOSSLContext(configuration: clientTLSConfig)
 
                 ClientBootstrap(group: context.eventLoop)

--- a/Rockxy/Core/ProxyEngine/HelperManager+ForceRemove.swift
+++ b/Rockxy/Core/ProxyEngine/HelperManager+ForceRemove.swift
@@ -41,6 +41,97 @@ extension HelperManager {
         }
     }
 
+    struct ForceResetRepairResult: Equatable {
+        let removal: ForceRemoveResult
+        let finalStatus: HelperStatus
+        let isReachable: Bool
+        let lastErrorMessage: String?
+
+        var requiresApproval: Bool {
+            finalStatus == .requiresApproval
+        }
+
+        var localizedSummary: String {
+            switch finalStatus {
+            case .installedCompatible:
+                return String(
+                    localized: """
+                    \(removal.localizedSummary)
+
+                    Rockxy reinstalled the helper from the current app bundle and verified that it is reachable.
+                    """
+                )
+            case .requiresApproval:
+                return String(
+                    localized: """
+                    \(removal.localizedSummary)
+
+                    Rockxy re-registered the helper from the current app bundle. macOS still needs you to approve it in System Settings > Login Items.
+                    """
+                )
+            case .installedOutdated:
+                return String(
+                    localized: """
+                    \(removal.localizedSummary)
+
+                    Rockxy reinstalled the helper, but the installed helper still appears older than this app build.
+                    """
+                )
+            case .installedIncompatible:
+                return String(
+                    localized: """
+                    \(removal.localizedSummary)
+
+                    Rockxy reinstalled the helper, but its protocol version is not compatible with this app build.
+                    """
+                )
+            case .unreachable:
+                return String(
+                    localized: """
+                    \(removal.localizedSummary)
+
+                    Rockxy reinstalled the helper, but macOS has not made the XPC service reachable yet.
+                    """
+                )
+            case .signingMismatch:
+                return String(
+                    localized: """
+                    \(removal.localizedSummary)
+
+                    Rockxy reinstalled the helper, but the app and helper signing identities still do not match.
+                    """
+                )
+            case .notInstalled:
+                return String(
+                    localized: """
+                    \(removal.localizedSummary)
+
+                    Rockxy removed stale helper state, but the helper is not installed.
+                    """
+                )
+            }
+        }
+    }
+
+    /// Hard-reset helper state, then immediately install from the current app bundle.
+    ///
+    /// This is the user-facing recovery path for both signed release apps and local
+    /// Xcode runs. Release apps reinstall through `SMAppService`; DerivedData builds
+    /// can fall back to the legacy LaunchDaemon repair path inside `performInstall()`.
+    @discardableResult
+    func forceResetAndReinstall(resetBackgroundItems: Bool) async throws -> ForceResetRepairResult {
+        let removal = try await forceRemoveHelper(resetBackgroundItems: resetBackgroundItems)
+        try? await Task.sleep(nanoseconds: 1_000_000_000)
+        try await install()
+
+        return ForceResetRepairResult(
+            removal: removal,
+            finalStatus: status,
+            isReachable: isReachable,
+            lastErrorMessage: lastErrorMessage
+        )
+    }
+
     nonisolated static func forceRemoveShellScript(
         identity: RockxyIdentity,
         resetBackgroundItems: Bool

--- a/Rockxy/Core/ProxyEngine/TLSInterceptHandler.swift
+++ b/Rockxy/Core/ProxyEngine/TLSInterceptHandler.swift
@@ -96,6 +96,7 @@ final class TLSInterceptHandler: ChannelInboundHandler, RemovableChannelHandler,
         scriptPluginManager: ScriptPluginManager? = nil,
         connectionLimiter: ConnectionLimiter,
         sslProxyingManager: SSLProxyingManager = .shared,
+        customCertificateManager: CustomCertificateManager = .shared,
         clientSourcePort: UInt16? = nil,
         onTransactionComplete: @escaping @Sendable (HTTPTransaction) -> Void,
         onBreakpointHit: (@Sendable (BreakpointRequestData) async -> (BreakpointDecision, BreakpointRequestData))? = nil
@@ -107,6 +108,7 @@ final class TLSInterceptHandler: ChannelInboundHandler, RemovableChannelHandler,
         self.scriptPluginManager = scriptPluginManager
         self.connectionLimiter = connectionLimiter
         self.sslProxyingManager = sslProxyingManager
+        self.customCertificateManager = customCertificateManager
         self.clientSourcePort = clientSourcePort
         self.onTransactionComplete = onTransactionComplete
         self.onBreakpointHit = onBreakpointHit
@@ -231,6 +233,7 @@ final class TLSInterceptHandler: ChannelInboundHandler, RemovableChannelHandler,
     private let scriptPluginManager: ScriptPluginManager?
     private let connectionLimiter: ConnectionLimiter
     private let sslProxyingManager: SSLProxyingManager
+    private let customCertificateManager: CustomCertificateManager
     private let clientSourcePort: UInt16?
     private let onTransactionComplete: @Sendable (HTTPTransaction) -> Void
     private let onBreakpointHit: (@Sendable (BreakpointRequestData) async -> (
@@ -260,14 +263,19 @@ final class TLSInterceptHandler: ChannelInboundHandler, RemovableChannelHandler,
 
         let eventLoop = context.eventLoop
         let certManager = self.certificateManager
+        let customCertificateManager = self.customCertificateManager
         let ruleEngine = self.ruleEngine
         let callback = self.onTransactionComplete
         let scriptPluginManager = self.scriptPluginManager
         let sourcePort = self.clientSourcePort
         let breakpointHit = self.onBreakpointHit
 
-        let certFuture: EventLoopFuture<(leafPEM: String, keyPEM: String)> =
+        let certFuture: EventLoopFuture<CustomTLSIdentity> =
             eventLoop.makeFutureWithTask {
+                if let customIdentity = customCertificateManager.serverIdentity(for: host) {
+                    return customIdentity
+                }
+
                 let result = try await certManager.certificateForHost(host)
 
                 var serializer = DER.Serializer()
@@ -275,7 +283,7 @@ final class TLSInterceptHandler: ChannelInboundHandler, RemovableChannelHandler,
                 let leafPEM = PEMDocument(type: "CERTIFICATE", derBytes: serializer.serializedBytes).pemString
                 let keyPEM = result.privateKey.pemRepresentation
 
-                return (leafPEM: leafPEM, keyPEM: keyPEM)
+                return CustomTLSIdentity(certificateChainPEM: [leafPEM], privateKeyPEM: keyPEM)
             }
 
         certFuture.whenComplete { result in
@@ -287,8 +295,7 @@ final class TLSInterceptHandler: ChannelInboundHandler, RemovableChannelHandler,
             case let .success(certResult):
                 self.installTLSHandlers(
                     context: context,
-                    leafPEM: certResult.leafPEM,
-                    keyPEM: certResult.keyPEM,
+                    identity: certResult,
                     host: host,
                     port: port,
                     ruleEngine: ruleEngine,
@@ -305,8 +312,7 @@ final class TLSInterceptHandler: ChannelInboundHandler, RemovableChannelHandler,
 
     nonisolated private func installTLSHandlers(
         context: ChannelHandlerContext,
-        leafPEM: String,
-        keyPEM: String,
+        identity: CustomTLSIdentity,
         host: String,
         port: Int,
         ruleEngine: RuleEngine,
@@ -314,14 +320,14 @@ final class TLSInterceptHandler: ChannelInboundHandler, RemovableChannelHandler,
         callback: @escaping @Sendable (HTTPTransaction) -> Void,
         breakpointHit: (@Sendable (BreakpointRequestData) async -> (BreakpointDecision, BreakpointRequestData))? = nil
     ) {
-        guard !leafPEM.isEmpty, !keyPEM.isEmpty else {
+        guard !identity.certificateChainPEM.isEmpty, !identity.privateKeyPEM.isEmpty else {
             tlsLogger.warning("Empty certificate data for \(host), passing through raw bytes")
             setupRawTunnel(context: context, host: host, port: port)
             return
         }
 
         do {
-            let sslContext = try createServerSSLContext(leafPEM: leafPEM, keyPEM: keyPEM)
+            let sslContext = try NIOSSLContext(configuration: Self.makeServerTLSConfiguration(identity: identity))
             let sslHandler = NIOSSLServerHandler(context: sslContext)
 
             let postHandshake = PostHandshakeHandler(
@@ -331,6 +337,7 @@ final class TLSInterceptHandler: ChannelInboundHandler, RemovableChannelHandler,
                 scriptPluginManager: scriptPluginManager,
                 connectionLimiter: self.connectionLimiter,
                 sslProxyingManager: self.sslProxyingManager,
+                customCertificateManager: self.customCertificateManager,
                 clientSourcePort: self.clientSourcePort,
                 onTransactionComplete: callback,
                 onBreakpointHit: breakpointHit
@@ -386,25 +393,14 @@ final class TLSInterceptHandler: ChannelInboundHandler, RemovableChannelHandler,
         }
     }
 
-    nonisolated private func createServerSSLContext(
-        leafPEM: String,
-        keyPEM: String
-    )
-        throws -> NIOSSLContext
-    {
-        let certificate = try NIOSSLCertificate(bytes: Array(leafPEM.utf8), format: .pem)
-        let privateKey = try NIOSSLPrivateKey(bytes: Array(keyPEM.utf8), format: .pem)
-
-        let chain: [NIOSSLCertificateSource] = [.certificate(certificate)]
-
+    nonisolated static func makeServerTLSConfiguration(identity: CustomTLSIdentity) throws -> TLSConfiguration {
         var config = TLSConfiguration.makeServerConfiguration(
-            certificateChain: chain,
-            privateKey: .privateKey(privateKey)
+            certificateChain: try identity.certificateSources,
+            privateKey: try identity.privateKeySource
         )
         config.minimumTLSVersion = .tlsv12
         config.applicationProtocols = ["http/1.1"]
-
-        return try NIOSSLContext(configuration: config)
+        return config
     }
 
     nonisolated private func setupRawTunnel(
@@ -485,6 +481,7 @@ final class PostHandshakeHandler: ChannelInboundHandler, RemovableChannelHandler
         scriptPluginManager: ScriptPluginManager?,
         connectionLimiter: ConnectionLimiter,
         sslProxyingManager: SSLProxyingManager,
+        customCertificateManager: CustomCertificateManager = .shared,
         clientSourcePort: UInt16? = nil,
         onTransactionComplete: @escaping @Sendable (HTTPTransaction) -> Void,
         onBreakpointHit: (@Sendable (BreakpointRequestData) async -> (BreakpointDecision, BreakpointRequestData))? = nil
@@ -495,6 +492,7 @@ final class PostHandshakeHandler: ChannelInboundHandler, RemovableChannelHandler
         self.scriptPluginManager = scriptPluginManager
         self.connectionLimiter = connectionLimiter
         self.sslProxyingManager = sslProxyingManager
+        self.customCertificateManager = customCertificateManager
         self.clientSourcePort = clientSourcePort
         self.onTransactionComplete = onTransactionComplete
         self.onBreakpointHit = onBreakpointHit
@@ -518,6 +516,7 @@ final class PostHandshakeHandler: ChannelInboundHandler, RemovableChannelHandler
                 ruleEngine: ruleEngine,
                 scriptPluginManager: scriptPluginManager,
                 connectionLimiter: connectionLimiter,
+                customCertificateManager: customCertificateManager,
                 clientSourcePort: clientSourcePort,
                 onTransactionComplete: onTransactionComplete,
                 onBreakpointHit: onBreakpointHit
@@ -617,6 +616,7 @@ final class PostHandshakeHandler: ChannelInboundHandler, RemovableChannelHandler
     private let scriptPluginManager: ScriptPluginManager?
     private let connectionLimiter: ConnectionLimiter
     private let sslProxyingManager: SSLProxyingManager
+    private let customCertificateManager: CustomCertificateManager
     private let clientSourcePort: UInt16?
     private let onTransactionComplete: @Sendable (HTTPTransaction) -> Void
     private let onBreakpointHit: (@Sendable (BreakpointRequestData) async -> (

--- a/Rockxy/Models/UI/DeveloperSetupRouteStore.swift
+++ b/Rockxy/Models/UI/DeveloperSetupRouteStore.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+// MARK: - DeveloperSetupRoute
+
+struct DeveloperSetupRoute: Equatable {
+    let targetID: SetupTarget.ID
+    let tab: SetupDetailTab
+}
+
+// MARK: - DeveloperSetupRouteStore
+
+@MainActor @Observable
+final class DeveloperSetupRouteStore {
+    static let shared = DeveloperSetupRouteStore()
+
+    var pendingRoute: DeveloperSetupRoute?
+
+    func request(targetID: SetupTarget.ID, tab: SetupDetailTab = .setup) {
+        pendingRoute = DeveloperSetupRoute(targetID: targetID, tab: tab)
+    }
+
+    func consumePendingRoute() -> DeveloperSetupRoute? {
+        defer { pendingRoute = nil }
+        return pendingRoute
+    }
+
+    private init() {}
+}

--- a/Rockxy/RockxyApp.swift
+++ b/Rockxy/RockxyApp.swift
@@ -47,6 +47,22 @@ struct RockxyApp: App {
         .defaultPosition(.center)
         .windowToolbarStyle(.unifiedCompact)
 
+        Window(String(localized: "Mac Setup Guide"), id: "certificateSetup") {
+            MacCertificateSetupGuideView()
+        }
+        .commandsRemoved()
+        .defaultSize(width: 940, height: 620)
+        .defaultPosition(.center)
+        .windowToolbarStyle(.unifiedCompact)
+
+        Window(String(localized: "Custom Certificates"), id: "customCertificates") {
+            CustomCertificatesView()
+        }
+        .commandsRemoved()
+        .defaultSize(width: 940, height: 600)
+        .defaultPosition(.center)
+        .windowToolbarStyle(.unifiedCompact)
+
         Window(String(localized: "Automatic Setup"), id: "automaticSetup") {
             DeveloperSetupAutomaticWindowView(coordinator: mainCoordinator)
         }
@@ -320,8 +336,7 @@ struct RockxyMenuCommands: Commands {
 
     @AppStorage(NoCacheHeaderMutator.userDefaultsKey) private var isNoCachingEnabled = false
 
-    @State private var certificateError: String?
-    @State private var showCertificateAlert = false
+    private let certificateRouter = CertificateMenuActionRouter()
 
     @CommandsBuilder
     private var appMenu: some Commands {
@@ -677,42 +692,130 @@ struct RockxyMenuCommands: Commands {
 
     private var certificateMenu: some Commands {
         CommandMenu(String(localized: "Certificate")) {
-            Button(String(localized: "Install on This Mac…")) {
-                Task {
-                    do {
-                        try await CertificateManager.shared.installAndTrust()
-                    } catch {
-                        certificateError = error.localizedDescription
-                        showCertificateAlert = true
+            Button(String(localized: "Install Certificate on This Mac…")) {
+                dispatchCertificateAction(.installOnMac)
+            }
+
+            Divider()
+
+            Menu(String(localized: "Install Certificate on iOS")) {
+                Button(String(localized: "iOS Simulator…")) {
+                    dispatchCertificateAction(.installOniOSSimulator)
+                }
+                Button(String(localized: "Physical iPhone or iPad…")) {
+                    dispatchCertificateAction(.installOniOSDevice)
+                }
+            }
+
+            Menu(String(localized: "Install Certificate on Android")) {
+                Button(String(localized: "Android Emulator…")) {
+                    dispatchCertificateAction(.installOnAndroidEmulator)
+                }
+                Button(String(localized: "Android Device…")) {
+                    dispatchCertificateAction(.installOnAndroidDevice)
+                }
+            }
+
+            Divider()
+
+            Button(String(localized: "Install Certificate on Java VMs…")) {
+                dispatchCertificateAction(.installOnJavaVMs)
+            }
+
+            Menu(String(localized: "Install Certificate on Developments")) {
+                Button(String(localized: "Flutter…")) {
+                    dispatchCertificateAction(.installOnDevelopment(.flutter))
+                }
+                Button(String(localized: "React Native…")) {
+                    dispatchCertificateAction(.installOnDevelopment(.reactNative))
+                }
+                Button(String(localized: "Electron…")) {
+                    dispatchCertificateAction(.installOnDevelopment(.electronJS))
+                }
+                Button(String(localized: "Next.js…")) {
+                    dispatchCertificateAction(.installOnDevelopment(.nextJS))
+                }
+            }
+
+            Button(String(localized: "Install Certificate on Firefox Browsers…")) {
+                dispatchCertificateAction(.installOnFirefox)
+            }
+
+            Divider()
+
+            Button(String(localized: "Add Custom Certificates…")) {
+                dispatchCertificateAction(.addCustomCertificates)
+            }
+
+            Divider()
+
+            Menu(String(localized: "Export")) {
+                ForEach(CertificateExportFormat.allCases, id: \.self) { format in
+                    Button(format.menuTitle) {
+                        dispatchCertificateAction(.export(format))
                     }
                 }
             }
 
-            Button(String(localized: "Export Root Certificate…")) {
-                Task {
-                    do {
-                        guard let pem = try await CertificateManager.shared.getRootCAPEM() else {
-                            certificateError = String(localized: "No root certificate found. Install one first.")
-                            showCertificateAlert = true
-                            return
-                        }
-                        let panel = NSSavePanel()
-                        panel.nameFieldStringValue = "RockxyCA.pem"
-                        panel.allowedContentTypes = [.init(filenameExtension: "pem")].compactMap { $0 }
-                        let response = panel.runModal()
-                        if response == .OK, let url = panel.url {
-                            try pem.write(to: url, atomically: true, encoding: .utf8)
-                            await MainActor.run {
-                                AppSettingsManager.shared.updateLastExportedRootCAPath(url.path)
-                            }
-                        }
-                    } catch {
-                        certificateError = error.localizedDescription
-                        showCertificateAlert = true
-                    }
+            Divider()
+
+            Button(String(localized: "Reset all Rockxy Certificates")) {
+                dispatchCertificateAction(.resetAll)
+            }
+        }
+    }
+
+    private func dispatchCertificateAction(_ action: CertificateMenuAction) {
+        switch certificateRouter.route(for: action) {
+        case .openCertificateSetupGuide:
+            openWindow(id: "certificateSetup")
+        case .openDeveloperSetup(let targetID, let tab):
+            DeveloperSetupRouteStore.shared.request(targetID: targetID, tab: tab)
+            openWindow(id: "developerSetupHub")
+        case .openCustomCertificates:
+            openWindow(id: "customCertificates")
+        case .export(let format):
+            CertificateExportPanelPresenter().export(format: format)
+        case .resetAll:
+            confirmAndResetCertificates()
+        }
+    }
+
+    private func confirmAndResetCertificates() {
+        let alert = NSAlert()
+        alert.alertStyle = .warning
+        alert.messageText = String(localized: "Reset all Rockxy Certificates?")
+        alert.informativeText = String(
+            localized: "This removes Rockxy's generated root CA, trust settings, cached host certificates, and custom certificate records."
+        )
+        alert.addButton(withTitle: String(localized: "Reset"))
+        alert.addButton(withTitle: String(localized: "Cancel"))
+        guard alert.runModal() == .alertFirstButtonReturn else {
+            return
+        }
+
+        Task {
+            do {
+                try await CertificateManager.shared.reset()
+                try CustomCertificateManager.shared.deleteAll()
+                await MainActor.run {
+                    AppSettingsManager.shared.updateLastExportedRootCAPath(nil)
+                }
+            } catch {
+                await MainActor.run {
+                    showCertificateError(error.localizedDescription)
                 }
             }
         }
+    }
+
+    private func showCertificateError(_ message: String) {
+        let alert = NSAlert()
+        alert.alertStyle = .warning
+        alert.messageText = String(localized: "Certificate Action Failed")
+        alert.informativeText = message
+        alert.addButton(withTitle: String(localized: "OK"))
+        alert.runModal()
     }
 
     private var setupMenu: some Commands {

--- a/Rockxy/ViewModels/WelcomeViewModel.swift
+++ b/Rockxy/ViewModels/WelcomeViewModel.swift
@@ -112,7 +112,7 @@ final class WelcomeViewModel {
         defer { isPerformingAction = false }
 
         do {
-            try await HelperManager.shared.forceResetRegistration()
+            try await HelperManager.shared.forceResetAndReinstall(resetBackgroundItems: false)
             await refreshStatus()
         } catch {
             Self.logger.error("Failed to force-reset helper: \(error.localizedDescription)")

--- a/Rockxy/Views/Certificate/CertificateExportPanelPresenter.swift
+++ b/Rockxy/Views/Certificate/CertificateExportPanelPresenter.swift
@@ -1,0 +1,73 @@
+import AppKit
+import Foundation
+
+// MARK: - CertificateExportPanelPresenter
+
+@MainActor
+struct CertificateExportPanelPresenter {
+    func export(format: CertificateExportFormat) {
+        Task {
+            do {
+                let service = CertificateExportService {
+                    try await CertificateManager.shared.exportMaterial()
+                }
+                let payload = try await service.payload(for: format)
+
+                guard confirmPrivateExportIfNeeded(payload) else {
+                    return
+                }
+
+                guard let url = saveURL(for: format, defaultFileName: payload.defaultFileName) else {
+                    return
+                }
+
+                try service.export(payload, to: url)
+                if format == .rootCertificatePEM {
+                    AppSettingsManager.shared.updateLastExportedRootCAPath(url.path)
+                }
+                showAlert(
+                    title: String(localized: "Certificate Exported"),
+                    message: String(localized: "Rockxy saved the certificate export successfully.")
+                )
+            } catch {
+                showAlert(
+                    title: String(localized: "Export Failed"),
+                    message: error.localizedDescription
+                )
+            }
+        }
+    }
+
+    private func confirmPrivateExportIfNeeded(_ payload: CertificateExportPayload) -> Bool {
+        guard payload.containsPrivateMaterial else {
+            return true
+        }
+
+        let alert = NSAlert()
+        alert.alertStyle = .warning
+        alert.messageText = String(localized: "Export Private Certificate Material?")
+        alert.informativeText = String(
+            localized: "This export includes private key material. Store it securely and only share it with people or systems you trust."
+        )
+        alert.addButton(withTitle: String(localized: "Export"))
+        alert.addButton(withTitle: String(localized: "Cancel"))
+        return alert.runModal() == .alertFirstButtonReturn
+    }
+
+    private func saveURL(for format: CertificateExportFormat, defaultFileName: String) -> URL? {
+        let panel = NSSavePanel()
+        panel.nameFieldStringValue = defaultFileName
+        panel.allowedContentTypes = format.allowedContentTypes
+        panel.canCreateDirectories = true
+        panel.title = String(localized: "Export Certificate")
+        return panel.runModal() == .OK ? panel.url : nil
+    }
+
+    private func showAlert(title: String, message: String) {
+        let alert = NSAlert()
+        alert.messageText = title
+        alert.informativeText = message
+        alert.addButton(withTitle: String(localized: "OK"))
+        alert.runModal()
+    }
+}

--- a/Rockxy/Views/Certificate/CustomCertificatesView.swift
+++ b/Rockxy/Views/Certificate/CustomCertificatesView.swift
@@ -1,0 +1,357 @@
+import AppKit
+import SwiftUI
+import UniformTypeIdentifiers
+
+// MARK: - CustomCertificatesView
+
+struct CustomCertificatesView: View {
+    @State private var selectedTab = Tab.root
+    @State private var rootEntries: [CustomCertificateMetadata] = []
+    @State private var serverEntries: [CustomCertificateMetadata] = []
+    @State private var clientEntries: [CustomCertificateMetadata] = []
+    @State private var errorMessage: String?
+
+    var body: some View {
+        VStack(spacing: 0) {
+            toolbar
+            Divider()
+            Picker(String(localized: "Certificate Type"), selection: $selectedTab) {
+                ForEach(Tab.allCases) { tab in
+                    Text(tab.title).tag(tab)
+                }
+            }
+            .pickerStyle(.segmented)
+            .labelsHidden()
+            .frame(width: 560)
+            .padding(.top, 20)
+
+            content
+                .padding(28)
+
+            Spacer(minLength: 0)
+            bottomBar
+        }
+        .frame(minWidth: 900, minHeight: 540)
+        .onAppear(perform: reload)
+        .alert(String(localized: "Custom Certificate Failed"), isPresented: Binding(
+            get: { errorMessage != nil },
+            set: { if !$0 { errorMessage = nil } }
+        )) {
+            Button(String(localized: "OK"), role: .cancel) {}
+        } message: {
+            Text(errorMessage ?? "")
+        }
+    }
+
+    private var toolbar: some View {
+        HStack(spacing: 10) {
+            Image(systemName: "certificate")
+                .font(.title2)
+                .foregroundStyle(.secondary)
+            Text(String(localized: "Custom Certificates"))
+                .font(.headline)
+            Spacer()
+        }
+        .padding(.horizontal, 20)
+        .padding(.vertical, 12)
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        switch selectedTab {
+        case .root:
+            RootCertificateTab(entries: rootEntries)
+        case .server:
+            CertificateListTab(
+                title: String(localized: "Config Server Certificates used when establishing SSL connections to clients"),
+                subtitle: String(localized: "Suitable for apps that use certificate pinning."),
+                entries: serverEntries,
+                firstColumnTitle: String(localized: "Host"),
+                emptyMessage: String(localized: "No custom server certificates have been imported.")
+            )
+        case .client:
+            CertificateListTab(
+                title: String(localized: "Config Client Certificates used when establishing SSL connections to selected servers"),
+                subtitle: String(localized: "Suitable for upstream services that require mutual TLS."),
+                entries: clientEntries,
+                firstColumnTitle: String(localized: "Host"),
+                emptyMessage: String(localized: "No client certificates have been imported.")
+            )
+        }
+    }
+
+    private var bottomBar: some View {
+        HStack(spacing: 12) {
+            Button(selectedTab == .root ? String(localized: "Revert") : String(localized: "Delete")) {
+                deleteSelectedKind()
+            }
+                .buttonStyle(.bordered)
+                .disabled(currentEntries.isEmpty)
+
+            Button(String(localized: "How to generate self-signed certificates")) {
+                if let helpURL = URL(string: "https://github.com/RockxyApp/Rockxy/wiki") {
+                    NSWorkspace.shared.open(helpURL)
+                }
+            }
+            .buttonStyle(.bordered)
+
+            Spacer()
+
+            if let helpURL = URL(string: "https://github.com/RockxyApp/Rockxy/wiki") {
+                HelpLink(destination: helpURL)
+            }
+
+            Button(String(localized: "Preview")) {}
+                .buttonStyle(.bordered)
+                .disabled(true)
+
+            Menu {
+                Button(String(localized: "Root Certificate…")) {
+                    importCertificate(kind: .root)
+                }
+                Button(String(localized: "Server Certificate…")) {
+                    importCertificate(kind: .server)
+                }
+                Button(String(localized: "Client Certificate…")) {
+                    importCertificate(kind: .client)
+                }
+            } label: {
+                Label(String(localized: "Import"), systemImage: "chevron.down")
+            }
+            .menuStyle(.button)
+        }
+        .padding(.horizontal, 28)
+        .padding(.bottom, 22)
+    }
+
+    private var currentEntries: [CustomCertificateMetadata] {
+        switch selectedTab {
+        case .root:
+            rootEntries
+        case .server:
+            serverEntries
+        case .client:
+            clientEntries
+        }
+    }
+
+    private func reload() {
+        rootEntries = CustomCertificateManager.shared.metadata(kind: .root)
+        serverEntries = CustomCertificateManager.shared.metadata(kind: .server)
+        clientEntries = CustomCertificateManager.shared.metadata(kind: .client)
+    }
+
+    private func deleteSelectedKind() {
+        do {
+            try CustomCertificateManager.shared.deleteAll(kind: selectedTab.kind)
+            reload()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    private func importCertificate(kind: CustomCertificateKind) {
+        do {
+            guard let certificateURL = chooseFile(title: String(localized: "Choose Certificate PEM")),
+                  let privateKeyURL = chooseFile(title: String(localized: "Choose Private Key PEM")) else {
+                return
+            }
+            let certificatePEM = try String(contentsOf: certificateURL, encoding: .utf8)
+            let privateKeyPEM = try String(contentsOf: privateKeyURL, encoding: .utf8)
+            let displayName = certificateURL.deletingPathExtension().lastPathComponent
+
+            switch kind {
+            case .root:
+                try CustomCertificateManager.shared.importRoot(
+                    displayName: displayName,
+                    certificatePEM: certificatePEM,
+                    privateKeyPEM: privateKeyPEM
+                )
+                selectedTab = .root
+            case .server:
+                guard let hostPattern = promptHostPattern(
+                    title: String(localized: "Server Certificate Host"),
+                    message: String(localized: "Enter the host or wildcard pattern this server certificate should match.")
+                ) else {
+                    return
+                }
+                try CustomCertificateManager.shared.importServerIdentity(
+                    hostPattern: hostPattern,
+                    displayName: displayName,
+                    certificatePEM: certificatePEM,
+                    privateKeyPEM: privateKeyPEM
+                )
+                selectedTab = .server
+            case .client:
+                guard let hostPattern = promptHostPattern(
+                    title: String(localized: "Client Certificate Host"),
+                    message: String(localized: "Enter the upstream host or wildcard pattern that should receive this client identity.")
+                ) else {
+                    return
+                }
+                try CustomCertificateManager.shared.importClientIdentity(
+                    hostPattern: hostPattern,
+                    displayName: displayName,
+                    certificatePEM: certificatePEM,
+                    privateKeyPEM: privateKeyPEM
+                )
+                selectedTab = .client
+            }
+            reload()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    private func chooseFile(title: String) -> URL? {
+        let panel = NSOpenPanel()
+        panel.title = title
+        panel.canChooseFiles = true
+        panel.canChooseDirectories = false
+        panel.allowsMultipleSelection = false
+        panel.allowedContentTypes = [.init(filenameExtension: "pem") ?? .data]
+        return panel.runModal() == .OK ? panel.url : nil
+    }
+
+    private func promptHostPattern(title: String, message: String) -> String? {
+        let alert = NSAlert()
+        alert.messageText = title
+        alert.informativeText = message
+        alert.addButton(withTitle: String(localized: "Continue"))
+        alert.addButton(withTitle: String(localized: "Cancel"))
+
+        let field = NSTextField(frame: NSRect(x: 0, y: 0, width: 320, height: 24))
+        field.placeholderString = "api.example.com or *.example.com"
+        alert.accessoryView = field
+
+        guard alert.runModal() == .alertFirstButtonReturn else {
+            return nil
+        }
+        let value = field.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        return value.isEmpty ? nil : value
+    }
+
+    private enum Tab: CaseIterable, Identifiable {
+        case root
+        case server
+        case client
+
+        var id: Self { self }
+
+        var title: String {
+            switch self {
+            case .root:
+                String(localized: "Root Certificate")
+            case .server:
+                String(localized: "Server Certificates")
+            case .client:
+                String(localized: "Client Certificates")
+            }
+        }
+
+        var kind: CustomCertificateKind {
+            switch self {
+            case .root:
+                .root
+            case .server:
+                .server
+            case .client:
+                .client
+            }
+        }
+    }
+}
+
+// MARK: - RootCertificateTab
+
+private struct RootCertificateTab: View {
+    let entries: [CustomCertificateMetadata]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 18) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(rootTitle)
+                    .font(.title3)
+                Text(String(localized: "This certificate is used for generating proxy certificates during SSL handshakes to clients and servers."))
+                    .foregroundStyle(.secondary)
+            }
+
+            HStack(spacing: 18) {
+                Image(systemName: "certificate.fill")
+                    .font(.system(size: 54))
+                    .foregroundStyle(.yellow)
+                    .symbolRenderingMode(.hierarchical)
+
+                VStack(alignment: .leading, spacing: 6) {
+                    Text(entries.last?.displayName ?? String(localized: "Rockxy Default Root Certificate"))
+                        .font(.headline)
+                    if let entry = entries.last {
+                        Text(validityText(for: entry))
+                            .foregroundStyle(.secondary)
+                        Label(String(localized: "Custom Root Active"), systemImage: "checkmark.circle.fill")
+                            .foregroundStyle(.green)
+                    } else {
+                        Text(String(localized: "No custom root has been imported. Rockxy will use its default root CA."))
+                            .foregroundStyle(.secondary)
+                        Label(String(localized: "Default Root Active"), systemImage: "checkmark.circle.fill")
+                            .foregroundStyle(.green)
+                    }
+                }
+                Spacer()
+            }
+            .padding(18)
+            .background(.quaternary, in: RoundedRectangle(cornerRadius: 10, style: .continuous))
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var rootTitle: String {
+        if entries.isEmpty {
+            String(localized: "Rockxy is using the Default Rockxy Root Certificate")
+        } else {
+            String(localized: "Rockxy is using a Custom Root Certificate")
+        }
+    }
+
+    private func validityText(for entry: CustomCertificateMetadata) -> String {
+        let before = entry.notValidBefore?.formatted(date: .abbreviated, time: .shortened) ?? String(localized: "Unknown")
+        let after = entry.notValidAfter?.formatted(date: .abbreviated, time: .shortened) ?? String(localized: "Unknown")
+        return String(localized: "Valid from \(before) to \(after)")
+    }
+}
+
+// MARK: - CertificateListTab
+
+private struct CertificateListTab: View {
+    let title: String
+    let subtitle: String
+    let entries: [CustomCertificateMetadata]
+    let firstColumnTitle: String
+    let emptyMessage: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(title)
+                    .font(.title3)
+                Text(subtitle)
+                    .foregroundStyle(.secondary)
+            }
+
+            Table(entries) {
+                TableColumn(firstColumnTitle) { entry in
+                    Text(entry.hostPattern ?? "—")
+                }
+                TableColumn(String(localized: "Certificates")) { entry in
+                    Text(entry.displayName)
+                }
+            }
+            .overlay {
+                if entries.isEmpty {
+                    ContentUnavailableView(emptyMessage, systemImage: "certificate")
+                }
+            }
+            .frame(minHeight: 280)
+        }
+    }
+}

--- a/Rockxy/Views/Certificate/MacCertificateSetupGuideView.swift
+++ b/Rockxy/Views/Certificate/MacCertificateSetupGuideView.swift
@@ -1,0 +1,259 @@
+import SwiftUI
+
+// MARK: - MacCertificateSetupGuideView
+
+struct MacCertificateSetupGuideView: View {
+    @State private var selectedTab = Tab.automatic
+    @State private var snapshot: RootCAStatusSnapshot?
+    @State private var isWorking = false
+    @State private var errorMessage: String?
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider()
+            Picker(String(localized: "Setup Mode"), selection: $selectedTab) {
+                ForEach(Tab.allCases) { tab in
+                    Text(tab.title).tag(tab)
+                }
+            }
+            .pickerStyle(.segmented)
+            .labelsHidden()
+            .frame(width: 360)
+            .padding(.top, 20)
+
+            Group {
+                switch selectedTab {
+                case .automatic:
+                    automaticTab
+                case .manual:
+                    manualTab
+                }
+            }
+            .padding(.horizontal, 32)
+            .padding(.top, 18)
+
+            Spacer(minLength: 18)
+            footer
+        }
+        .frame(minWidth: 900, minHeight: 560)
+        .task { await refreshStatus(validate: true) }
+        .alert(String(localized: "Certificate Setup Failed"), isPresented: Binding(
+            get: { errorMessage != nil },
+            set: { if !$0 { errorMessage = nil } }
+        )) {
+            Button(String(localized: "OK"), role: .cancel) {}
+        } message: {
+            Text(errorMessage ?? "")
+        }
+    }
+
+    private var header: some View {
+        HStack(spacing: 14) {
+            Image(systemName: "laptopcomputer")
+                .font(.system(size: 40, weight: .regular))
+                .symbolRenderingMode(.hierarchical)
+                .foregroundStyle(.secondary)
+            Text(String(localized: "Mac Setup Guide"))
+                .font(.system(size: 34, weight: .regular))
+            Spacer()
+        }
+        .padding(.horizontal, 32)
+        .padding(.vertical, 22)
+    }
+
+    private var automaticTab: some View {
+        VStack(spacing: 18) {
+            statusCard
+
+            HStack(spacing: 12) {
+                Button {
+                    Task { await installAndTrust() }
+                } label: {
+                    Label(String(localized: "Install and Trust"), systemImage: "checkmark.shield")
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(isWorking || CertificateSetupState(snapshot: snapshot ?? .empty).isReady)
+
+                Button {
+                    Task { await refreshStatus(validate: true) }
+                } label: {
+                    Label(String(localized: "Recheck"), systemImage: "arrow.clockwise")
+                }
+                .buttonStyle(.bordered)
+                .disabled(isWorking)
+            }
+        }
+    }
+
+    private var statusCard: some View {
+        let state = CertificateSetupState(snapshot: snapshot ?? .empty)
+        return VStack(spacing: 12) {
+            Image(systemName: state.systemImageName)
+                .font(.system(size: 34, weight: .semibold))
+                .foregroundStyle(state.isReady ? .green : .orange)
+                .symbolRenderingMode(.hierarchical)
+
+            Text(String(localized: "Install and Trust Rockxy CA Certificate in Keychain Access"))
+                .font(.title3.weight(.semibold))
+
+            Text(state.message)
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+
+            VStack(spacing: 6) {
+                Text(state.title)
+                    .font(.headline)
+                if let fingerprint = snapshot?.fingerprintSHA256 {
+                    Text(fingerprint)
+                        .font(.caption.monospaced())
+                        .foregroundStyle(.secondary)
+                        .textSelection(.enabled)
+                }
+            }
+            .padding(.horizontal, 18)
+            .padding(.vertical, 10)
+            .background(.quaternary, in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+        }
+        .frame(maxWidth: .infinity)
+        .padding(28)
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 10, style: .continuous))
+        .overlay {
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .stroke(.separator, lineWidth: 1)
+        }
+    }
+
+    private var manualTab: some View {
+        VStack(alignment: .leading, spacing: 22) {
+            guideSection(
+                number: 1,
+                title: String(localized: "Generate and Add Rockxy CA Certificate to System Keychain"),
+                symbol: "certificate",
+                lines: [
+                    String(localized: "Choose System or login keychain in Keychain Access."),
+                    String(localized: "Use Install and Trust to generate the CA, or export the PEM file and drag it into Keychain Access.")
+                ]
+            )
+
+            guideSection(
+                number: 2,
+                title: String(localized: "Trust the Rockxy CA Certificate"),
+                symbol: "key.fill",
+                lines: [
+                    String(localized: "Open Keychain Access and search for Rockxy CA."),
+                    String(localized: "Open the certificate, expand Trust, set Secure Sockets Layer to Always Trust, then close and save.")
+                ]
+            )
+
+            guideSection(
+                number: 3,
+                title: String(localized: "Terminal Alternative"),
+                symbol: "terminal",
+                lines: [
+                    String(localized: "Export the PEM certificate, then use security add-trusted-cert with administrator approval."),
+                    String(localized: "Recheck the status above after changing trust settings.")
+                ]
+            )
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(24)
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 10, style: .continuous))
+        .overlay {
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .stroke(.separator, lineWidth: 1)
+        }
+    }
+
+    private var footer: some View {
+        HStack(spacing: 12) {
+            Button {
+                CertificateExportPanelPresenter().export(format: .rootCertificatePEM)
+            } label: {
+                Label(String(localized: "Export PEM"), systemImage: "square.and.arrow.up")
+            }
+            .buttonStyle(.bordered)
+
+            Spacer()
+
+            if let snapshot {
+                let state = CertificateSetupState(snapshot: snapshot)
+                Label(state.message, systemImage: state.systemImageName)
+                    .font(.callout)
+                    .foregroundStyle(state.isReady ? .green : .secondary)
+                    .lineLimit(1)
+            }
+
+            if let helpURL = URL(string: "https://github.com/RockxyApp/Rockxy/wiki") {
+                HelpLink(destination: helpURL)
+            }
+        }
+        .padding(.horizontal, 32)
+        .padding(.bottom, 22)
+    }
+
+    private func guideSection(number: Int, title: String, symbol: String, lines: [String]) -> some View {
+        HStack(alignment: .top, spacing: 14) {
+            Image(systemName: symbol)
+                .font(.system(size: 22, weight: .medium))
+                .frame(width: 28)
+                .foregroundStyle(.secondary)
+
+            VStack(alignment: .leading, spacing: 8) {
+                Text("\(number). \(title)")
+                    .font(.headline)
+                ForEach(lines, id: \.self) { line in
+                    Text(line)
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+    }
+
+    private func installAndTrust() async {
+        isWorking = true
+        defer { isWorking = false }
+        do {
+            try await CertificateManager.shared.installAndTrust()
+            await refreshStatus(validate: true)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    private func refreshStatus(validate: Bool) async {
+        snapshot = await CertificateManager.shared.rootCAStatusSnapshot(performValidation: validate)
+    }
+
+    private enum Tab: CaseIterable, Identifiable {
+        case automatic
+        case manual
+
+        var id: Self { self }
+
+        var title: String {
+            switch self {
+            case .automatic:
+                String(localized: "Automatic")
+            case .manual:
+                String(localized: "Manual")
+            }
+        }
+    }
+}
+
+private extension RootCAStatusSnapshot {
+    static let empty = RootCAStatusSnapshot(
+        hasGeneratedCertificate: false,
+        isInstalledInKeychain: false,
+        hasTrustSettings: false,
+        isSystemTrustValidated: false,
+        notValidBefore: nil,
+        notValidAfter: nil,
+        fingerprintSHA256: nil,
+        commonName: nil,
+        lastValidationErrorMessage: nil
+    )
+}

--- a/Rockxy/Views/DeveloperSetup/DeveloperSetupWindowView.swift
+++ b/Rockxy/Views/DeveloperSetup/DeveloperSetupWindowView.swift
@@ -27,6 +27,7 @@ struct DeveloperSetupWindowView: View {
         }
         .frame(minWidth: 1_080, minHeight: 720)
         .task {
+            applyPendingRouteIfNeeded()
             await viewModel.refreshSnapshot()
         }
         .sheet(isPresented: Binding(
@@ -71,6 +72,7 @@ struct DeveloperSetupWindowView: View {
         .onChange(of: ReadinessCoordinator.shared.certReadiness) { _, _ in refreshSnapshot() }
         .onChange(of: ReadinessCoordinator.shared.proxyMode) { _, _ in refreshSnapshot() }
         .onChange(of: ReadinessCoordinator.shared.activeWarning) { _, _ in refreshSnapshot() }
+        .onChange(of: routeStore.pendingRoute) { _, _ in applyPendingRouteIfNeeded() }
         .onDisappear {
             viewModel.cancelValidation(markCancelled: true)
             Task { await viewModel.stopValidationProbe() }
@@ -83,6 +85,7 @@ struct DeveloperSetupWindowView: View {
     @Environment(\.openSettings) private var openSettings
     @Environment(\.openWindow) private var openWindow
     @State private var viewModel: DeveloperSetupViewModel
+    @State private var routeStore = DeveloperSetupRouteStore.shared
     @StateObject private var caShareController = CAShareController()
     @State private var certificateShareStatusMessage: String?
     @State private var presentedShareSession: RootCADownloadSession?
@@ -105,6 +108,15 @@ struct DeveloperSetupWindowView: View {
         return String(
             localized: "Use this host and port when configuring a device, simulator, or client on the same network."
         )
+    }
+
+    private func applyPendingRouteIfNeeded() {
+        guard let route = routeStore.consumePendingRoute(),
+              let target = SetupTarget.target(for: route.targetID) else {
+            return
+        }
+        viewModel.selectTarget(target)
+        viewModel.selectTab(route.tab)
     }
 
     private var toolbar: some View {

--- a/Rockxy/Views/Settings/HelperRecoveryPresenter.swift
+++ b/Rockxy/Views/Settings/HelperRecoveryPresenter.swift
@@ -12,7 +12,7 @@ enum HelperRecoveryPresenter {
         confirmation.informativeText = String(
             localized: """
             Rockxy will stop capture, request administrator approval, remove stale launchd and privileged helper files, \
-            then recheck the helper. System proxy settings may be restored during the reset.
+            then reinstall the helper from the current app bundle. System proxy settings may be restored during the reset.
 
             Use this only when install, uninstall, and recheck are stuck.
             """
@@ -39,7 +39,7 @@ enum HelperRecoveryPresenter {
         Task { @MainActor in
             do {
                 try await Task.sleep(nanoseconds: 750_000_000)
-                let result = try await HelperManager.shared.forceRemoveHelper(
+                let result = try await HelperManager.shared.forceResetAndReinstall(
                     resetBackgroundItems: resetBackgroundItems
                 )
                 await ReadinessCoordinator.shared.deepRefresh()
@@ -54,35 +54,18 @@ enum HelperRecoveryPresenter {
         }
     }
 
-    private static func presentSuccess(result: HelperManager.ForceRemoveResult) {
+    private static func presentSuccess(result: HelperManager.ForceResetRepairResult) {
         let alert = NSAlert()
         alert.alertStyle = .informational
         alert.messageText = String(localized: "Helper reset complete")
-        alert.informativeText = String(
-            localized: """
-            \(result.localizedSummary)
-
-            Install the helper again, then approve Rockxy in System Settings > Login Items if macOS asks.
-            """
-        )
-        alert.addButton(withTitle: String(localized: "Install Helper"))
-        alert.addButton(withTitle: String(localized: "Open Login Items"))
+        alert.informativeText = result.localizedSummary
+        if result.requiresApproval {
+            alert.addButton(withTitle: String(localized: "Open Login Items"))
+        }
         alert.addButton(withTitle: String(localized: "OK"))
 
         switch alert.runModal() {
-        case .alertFirstButtonReturn:
-            Task { @MainActor in
-                do {
-                    try await HelperManager.shared.install()
-                    await ReadinessCoordinator.shared.deepRefresh()
-                    if HelperManager.shared.status == .requiresApproval {
-                        SMAppService.openSystemSettingsLoginItems()
-                    }
-                } catch {
-                    presentInstallFailure(error)
-                }
-            }
-        case .alertSecondButtonReturn:
+        case .alertFirstButtonReturn where result.requiresApproval:
             SMAppService.openSystemSettingsLoginItems()
         default:
             break
@@ -138,14 +121,5 @@ enum HelperRecoveryPresenter {
         }
 
         runForceReset(stopCapture: stopCapture, resetBackgroundItems: true)
-    }
-
-    private static func presentInstallFailure(_ error: Error) {
-        let alert = NSAlert()
-        alert.alertStyle = .warning
-        alert.messageText = String(localized: "Helper install failed")
-        alert.informativeText = error.localizedDescription
-        alert.addButton(withTitle: String(localized: "OK"))
-        alert.runModal()
     }
 }

--- a/Rockxy/Views/Welcome/WelcomeView.swift
+++ b/Rockxy/Views/Welcome/WelcomeView.swift
@@ -231,7 +231,7 @@ struct WelcomeView: View {
                         HStack(spacing: 4) {
                             Image(systemName: "arrow.triangle.2.circlepath")
                                 .font(.system(size: 10))
-                            Text(String(localized: "Reset Helper Registration"))
+                            Text(String(localized: "Force Reset Helper"))
                                 .font(.caption)
                         }
                     }

--- a/RockxyTests/Core/Certificate/CertificateSetupUXTests.swift
+++ b/RockxyTests/Core/Certificate/CertificateSetupUXTests.swift
@@ -1,0 +1,103 @@
+import Crypto
+import Foundation
+@testable import Rockxy
+import Testing
+import X509
+
+// MARK: - CertificateSetupUXTests
+
+struct CertificateSetupUXTests {
+    @Test("certificate status maps all setup states")
+    func certificateStatusMapping() {
+        #expect(CertificateSetupState(snapshot: snapshot(generated: true, installed: true, trusted: true)) == .installedAndTrusted)
+        #expect(CertificateSetupState(snapshot: snapshot(generated: true, installed: true, trusted: false)) == .installedNotTrusted)
+        #expect(CertificateSetupState(snapshot: snapshot(generated: true, installed: false, trusted: false)) == .generatedOnly)
+        #expect(CertificateSetupState(snapshot: snapshot(generated: false, installed: false, trusted: false)) == .missing)
+    }
+
+    @Test("certificate menu routes every action to the expected destination")
+    func menuRoutes() {
+        let router = CertificateMenuActionRouter()
+
+        #expect(router.route(for: .installOnMac) == .openCertificateSetupGuide)
+        #expect(router.route(for: .installOniOSDevice) == .openDeveloperSetup(targetID: .iosDevice, tab: .setup))
+        #expect(router.route(for: .installOniOSSimulator) == .openDeveloperSetup(targetID: .iosSimulator, tab: .setup))
+        #expect(router.route(for: .installOnAndroidDevice) == .openDeveloperSetup(targetID: .androidDevice, tab: .setup))
+        #expect(router.route(for: .installOnAndroidEmulator) == .openDeveloperSetup(targetID: .androidEmulator, tab: .setup))
+        #expect(router.route(for: .installOnJavaVMs) == .openDeveloperSetup(targetID: .javaVMs, tab: .setup))
+        #expect(router.route(for: .installOnFirefox) == .openDeveloperSetup(targetID: .firefox, tab: .setup))
+        #expect(router.route(for: .installOnDevelopment(.flutter)) == .openDeveloperSetup(targetID: .flutter, tab: .setup))
+        #expect(router.route(for: .addCustomCertificates) == .openCustomCertificates)
+        #expect(router.route(for: .export(.rootCertificatePEM)) == .export(.rootCertificatePEM))
+        #expect(router.route(for: .resetAll) == .resetAll)
+    }
+
+    @Test("export service builds PEM DER P12 and private key payloads")
+    func exportPayloadSuccess() async throws {
+        let root = try RootCAGenerator.generate()
+        let service = CertificateExportService {
+            CertificateExportMaterial(certificate: root.certificate, privateKey: root.privateKey)
+        }
+
+        let pem = try await service.payload(for: .rootCertificatePEM)
+        let der = try await service.payload(for: .rootCertificateDER)
+        let p12 = try await service.payload(for: .rootCertificateP12)
+        let privateKey = try await service.payload(for: .privateKey)
+
+        #expect(String(data: pem.data, encoding: .utf8)?.contains("BEGIN CERTIFICATE") == true)
+        #expect(der.data.isEmpty == false)
+        #expect(p12.data.isEmpty == false)
+        #expect(p12.containsPrivateMaterial)
+        #expect(String(data: privateKey.data, encoding: .utf8)?.contains("BEGIN PRIVATE KEY") == true)
+        #expect(privateKey.containsPrivateMaterial)
+    }
+
+    @Test("export service reports missing certificate and key")
+    func exportMissingMaterial() async throws {
+        let noCertificate = CertificateExportService {
+            CertificateExportMaterial(certificate: nil, privateKey: nil)
+        }
+        await #expect(throws: CertificateExportError.missingCertificate) {
+            _ = try await noCertificate.payload(for: .rootCertificatePEM)
+        }
+
+        let root = try RootCAGenerator.generate()
+        let noKey = CertificateExportService {
+            CertificateExportMaterial(certificate: root.certificate, privateKey: nil)
+        }
+        await #expect(throws: CertificateExportError.missingPrivateKey) {
+            _ = try await noKey.payload(for: .privateKey)
+        }
+    }
+
+    @Test("export service surfaces write failures")
+    func exportWriteFailure() async throws {
+        struct WriteFailure: Error {}
+        let root = try RootCAGenerator.generate()
+        let service = CertificateExportService(
+            materialProvider: {
+                CertificateExportMaterial(certificate: root.certificate, privateKey: root.privateKey)
+            },
+            writeHandler: { _, _ in throw WriteFailure() }
+        )
+        let payload = try await service.payload(for: .rootCertificatePEM)
+
+        #expect(throws: WriteFailure.self) {
+            try service.export(payload, to: URL(fileURLWithPath: "/tmp/unused.pem"))
+        }
+    }
+
+    private func snapshot(generated: Bool, installed: Bool, trusted: Bool) -> RootCAStatusSnapshot {
+        RootCAStatusSnapshot(
+            hasGeneratedCertificate: generated,
+            isInstalledInKeychain: installed,
+            hasTrustSettings: trusted,
+            isSystemTrustValidated: trusted,
+            notValidBefore: nil,
+            notValidAfter: nil,
+            fingerprintSHA256: nil,
+            commonName: nil,
+            lastValidationErrorMessage: nil
+        )
+    }
+}

--- a/RockxyTests/Core/Certificate/CustomCertificateManagerTests.swift
+++ b/RockxyTests/Core/Certificate/CustomCertificateManagerTests.swift
@@ -1,0 +1,133 @@
+import Crypto
+import Foundation
+import SwiftASN1
+@testable import Rockxy
+import Testing
+import X509
+
+// MARK: - MemorySecureDataStore
+
+private final class MemorySecureDataStore: SecureDataStore, @unchecked Sendable {
+    func save(_ data: Data, account: String) throws {
+        lock.withLock {
+            values[account] = data
+        }
+    }
+
+    func load(account: String) throws -> Data? {
+        lock.withLock { values[account] }
+    }
+
+    func delete(account: String) throws {
+        _ = lock.withLock {
+            values.removeValue(forKey: account)
+        }
+    }
+
+    private let lock = NSLock()
+    private var values: [String: Data] = [:]
+}
+
+// MARK: - CustomCertificateManagerTests
+
+struct CustomCertificateManagerTests {
+    @Test("imports custom root certificate and exposes it as active issuer")
+    func importsCustomRootIssuer() throws {
+        let manager = makeManager()
+        let root = try RootCAGenerator.generate()
+
+        _ = try manager.importRoot(
+            displayName: "Custom Root",
+            certificatePEM: try pem(root.certificate),
+            privateKeyPEM: root.privateKey.pemRepresentation
+        )
+
+        let issuer = try #require(try manager.activeRootIssuer())
+        #expect(issuer.certificate.subject == root.certificate.subject)
+        #expect(issuer.privateKey.publicKey.subjectPublicKeyInfoBytes == root.certificate.publicKey.subjectPublicKeyInfoBytes)
+    }
+
+    @Test("matches exact and wildcard server certificate hosts")
+    func matchesServerHostPatterns() throws {
+        let manager = makeManager()
+        let identity = try makeLeafIdentity(host: "api.example.com")
+
+        try manager.importServerIdentity(
+            hostPattern: "*.example.com",
+            displayName: "Pinned Server",
+            certificatePEM: identity.certificatePEM,
+            privateKeyPEM: identity.privateKeyPEM
+        )
+
+        #expect(manager.serverIdentity(for: "api.example.com") != nil)
+        #expect(manager.serverIdentity(for: "example.com") == nil)
+        #expect(manager.serverIdentity(for: "api.example.net") == nil)
+    }
+
+    @Test("matches client certificates only for configured hosts")
+    func matchesClientHostPatterns() throws {
+        let manager = makeManager()
+        let identity = try makeLeafIdentity(host: "mtls.example.com")
+
+        try manager.importClientIdentity(
+            hostPattern: "mtls.example.com",
+            displayName: "mTLS Client",
+            certificatePEM: identity.certificatePEM,
+            privateKeyPEM: identity.privateKeyPEM
+        )
+
+        #expect(manager.clientIdentity(for: "mtls.example.com") != nil)
+        #expect(manager.clientIdentity(for: "www.example.com") == nil)
+    }
+
+    @Test("rejects invalid certificate key pairs")
+    func rejectsInvalidCertificateKeyPairs() throws {
+        let manager = makeManager()
+        let first = try makeLeafIdentity(host: "one.example.com")
+        let second = try makeLeafIdentity(host: "two.example.com")
+
+        #expect(throws: CustomCertificateError.invalidCertificateKeyPair) {
+            try manager.importServerIdentity(
+                hostPattern: "one.example.com",
+                displayName: "Invalid",
+                certificatePEM: first.certificatePEM,
+                privateKeyPEM: second.privateKeyPEM
+            )
+        }
+    }
+
+    @Test("delete and revert remove custom certificate behavior")
+    func deleteAndRevert() throws {
+        let manager = makeManager()
+        let identity = try makeLeafIdentity(host: "delete.example.com")
+        let entry = try manager.importServerIdentity(
+            hostPattern: "delete.example.com",
+            displayName: "Delete Me",
+            certificatePEM: identity.certificatePEM,
+            privateKeyPEM: identity.privateKeyPEM
+        )
+
+        #expect(manager.serverIdentity(for: "delete.example.com") != nil)
+        try manager.delete(id: entry.id)
+        #expect(manager.serverIdentity(for: "delete.example.com") == nil)
+    }
+
+    private func makeManager() -> CustomCertificateManager {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("RockxyCustomCertificateTests-\(UUID().uuidString)")
+            .appendingPathComponent("custom.json")
+        return CustomCertificateManager(storageURL: url, secureStore: MemorySecureDataStore())
+    }
+
+    private func makeLeafIdentity(host: String) throws -> (certificatePEM: String, privateKeyPEM: String) {
+        let root = try RootCAGenerator.generate()
+        let leaf = try HostCertGenerator.generate(host: host, issuer: root.certificate, issuerKey: root.privateKey)
+        return (try pem(leaf.certificate), leaf.privateKey.pemRepresentation)
+    }
+
+    private func pem(_ certificate: Certificate) throws -> String {
+        var serializer = DER.Serializer()
+        try certificate.serialize(into: &serializer)
+        return PEMDocument(type: "CERTIFICATE", derBytes: serializer.serializedBytes).pemString
+    }
+}

--- a/RockxyTests/Core/ProxyEngine/CustomTLSSelectionTests.swift
+++ b/RockxyTests/Core/ProxyEngine/CustomTLSSelectionTests.swift
@@ -1,0 +1,82 @@
+import Crypto
+import Foundation
+import NIOSSL
+import SwiftASN1
+@testable import Rockxy
+import Testing
+import X509
+
+// MARK: - CustomTLSSelectionTests
+
+struct CustomTLSSelectionTests {
+    @Test("server TLS configuration accepts custom server identity")
+    func serverTLSConfigurationUsesCustomIdentity() throws {
+        let identity = try makeIdentity(host: "pinned.example.com")
+        let config = try TLSInterceptHandler.makeServerTLSConfiguration(identity: identity)
+
+        #expect(config.certificateChain.count == 1)
+        #expect(config.privateKey != nil)
+        #expect(config.applicationProtocols == ["http/1.1"])
+    }
+
+    @Test("client TLS configuration includes matching identity and keeps full verification")
+    func clientTLSConfigurationIncludesIdentity() throws {
+        let identity = try makeIdentity(host: "mtls.example.com")
+        let config = try HTTPSProxyRelayHandler.makeClientTLSConfiguration(clientIdentity: identity)
+
+        #expect(config.certificateVerification == .fullVerification)
+        #expect(config.certificateChain.count == 1)
+        #expect(config.privateKey != nil)
+    }
+
+    @Test("client TLS configuration omits identity when there is no match and keeps full verification")
+    func clientTLSConfigurationWithoutIdentity() throws {
+        let config = try HTTPSProxyRelayHandler.makeClientTLSConfiguration(clientIdentity: nil)
+
+        #expect(config.certificateVerification == .fullVerification)
+        #expect(config.certificateChain.isEmpty)
+        #expect(config.privateKey == nil)
+    }
+
+    @Test("default generated certificate remains available when no custom server match exists")
+    func defaultGeneratedCertificateFallback() throws {
+        let manager = CustomCertificateManager(
+            storageURL: FileManager.default.temporaryDirectory
+                .appendingPathComponent("RockxyTLSSelection-\(UUID().uuidString)")
+                .appendingPathComponent("custom.json"),
+            secureStore: MemorySecureDataStoreForTLS()
+        )
+
+        #expect(manager.serverIdentity(for: "fallback.example.com") == nil)
+    }
+
+    private func makeIdentity(host: String) throws -> CustomTLSIdentity {
+        let root = try RootCAGenerator.generate()
+        let leaf = try HostCertGenerator.generate(host: host, issuer: root.certificate, issuerKey: root.privateKey)
+        var serializer = DER.Serializer()
+        try leaf.certificate.serialize(into: &serializer)
+        let certificatePEM = PEMDocument(type: "CERTIFICATE", derBytes: serializer.serializedBytes).pemString
+        return CustomTLSIdentity(certificateChainPEM: [certificatePEM], privateKeyPEM: leaf.privateKey.pemRepresentation)
+    }
+}
+
+private final class MemorySecureDataStoreForTLS: SecureDataStore, @unchecked Sendable {
+    func save(_ data: Data, account: String) throws {
+        lock.withLock {
+            values[account] = data
+        }
+    }
+
+    func load(account: String) throws -> Data? {
+        lock.withLock { values[account] }
+    }
+
+    func delete(account: String) throws {
+        _ = lock.withLock {
+            values.removeValue(forKey: account)
+        }
+    }
+
+    private let lock = NSLock()
+    private var values: [String: Data] = [:]
+}

--- a/RockxyTests/Core/ProxyEngine/HelperManagerTests.swift
+++ b/RockxyTests/Core/ProxyEngine/HelperManagerTests.swift
@@ -491,6 +491,40 @@ struct HelperManagerTests {
         #expect(error.localizedDescription.contains("signal 15"))
     }
 
+    @Test("force reset repair summary reports immediate reinstall success")
+    func forceResetRepairSummaryReportsImmediateReinstallSuccess() {
+        let result = HelperManager.ForceResetRepairResult(
+            removal: HelperManager.ForceRemoveResult(
+                resetBackgroundItems: false,
+                commandOutput: "removed"
+            ),
+            finalStatus: .installedCompatible,
+            isReachable: true,
+            lastErrorMessage: nil
+        )
+
+        #expect(!result.requiresApproval)
+        #expect(result.localizedSummary.contains("reinstalled the helper"))
+        #expect(result.localizedSummary.contains("reachable"))
+    }
+
+    @Test("force reset repair summary points approval state at Login Items")
+    func forceResetRepairSummaryReportsApprovalRequired() {
+        let result = HelperManager.ForceResetRepairResult(
+            removal: HelperManager.ForceRemoveResult(
+                resetBackgroundItems: true,
+                commandOutput: "removed"
+            ),
+            finalStatus: .requiresApproval,
+            isReachable: false,
+            lastErrorMessage: "Approve in System Settings"
+        )
+
+        #expect(result.requiresApproval)
+        #expect(result.localizedSummary.contains("System Settings"))
+        #expect(result.localizedSummary.contains("Login Items"))
+    }
+
     @Test("hard force remove script only resets Background Items when explicitly requested")
     func hardForceRemoveScriptIncludesBTMResetOnlyWhenRequested() {
         let script = HelperManager.forceRemoveShellScript(

--- a/RockxyTests/Shared/CallerValidationTests.swift
+++ b/RockxyTests/Shared/CallerValidationTests.swift
@@ -66,6 +66,19 @@ struct CallerValidationTests {
         #expect(!CallerValidation.teamIdentifiersMatch("9YNS969KZE", " "))
     }
 
+    @Test("DerivedData build product detection accepts only Xcode build outputs")
+    func derivedDataBuildProductDetection() {
+        let debugApp = "/Users/test/Library/Developer/Xcode/DerivedData/Rockxy-abc/Build/Products/Debug/Rockxy.app/Contents/MacOS/Rockxy"
+        let releaseApp = "/Users/test/Library/Developer/Xcode/DerivedData/Rockxy-abc/Build/Products/Release/Rockxy.app/Contents/MacOS/Rockxy"
+        let applicationsApp = "/Applications/Rockxy.app/Contents/MacOS/Rockxy"
+        let siblingPath = "/Users/test/Library/Developer/Xcode/Archives/Rockxy.app/Contents/MacOS/Rockxy"
+
+        #expect(CallerValidation.isXcodeDerivedDataBuildProduct(path: debugApp))
+        #expect(CallerValidation.isXcodeDerivedDataBuildProduct(path: releaseApp))
+        #expect(!CallerValidation.isXcodeDerivedDataBuildProduct(path: applicationsApp))
+        #expect(!CallerValidation.isXcodeDerivedDataBuildProduct(path: siblingPath))
+    }
+
     // MARK: - Live Caller Identity (TEST_HOST = signed Rockxy app)
 
     @Test("Live test host satisfies its own configured bundle identifiers")

--- a/Shared/CallerValidation.swift
+++ b/Shared/CallerValidation.swift
@@ -38,16 +38,10 @@ enum CallerValidation {
         -> Bool
     {
         for identifier in allowedIdentifiers {
-            var requirement: SecRequirement?
-            let status = SecRequirementCreateWithString(
-                "identifier \"\(identifier)\" and anchor apple generic" as CFString,
-                [],
-                &requirement
-            )
-            guard status == errSecSuccess, let requirement else {
-                continue
+            if callerSatisfiesAppleGenericIdentifier(callerCode: callerCode, identifier: identifier) {
+                return true
             }
-            if SecCodeCheckValidity(callerCode, [], requirement) == errSecSuccess {
+            if callerSatisfiesLocalXcodeAdHocIdentifier(callerCode: callerCode, identifier: identifier) {
                 return true
             }
         }
@@ -103,6 +97,11 @@ enum CallerValidation {
         return code
     }
 
+    static func isXcodeDerivedDataBuildProduct(path: String) -> Bool {
+        path.contains("/Library/Developer/Xcode/DerivedData/")
+            && path.contains("/Build/Products/")
+    }
+
     /// Obtains a `SecCode` from raw audit token data (32-byte `audit_token_t`).
     /// Returns nil if the data size is wrong or the Security framework rejects it.
     static func secCodeFromAuditToken(_ tokenData: Data) -> SecCode? {
@@ -152,11 +151,21 @@ enum CallerValidation {
 
     // MARK: Private
 
-    private static func certificatesFromCode(_ code: SecCode) -> [SecCertificate]? {
-        guard let dict = signingInformation(from: code) else {
-            return nil
+    private struct CodeSigningProfile {
+        let identifier: String?
+        let teamIdentifier: String?
+        let certificateDERs: [Data]
+        let executablePath: String?
+
+        var isAdHoc: Bool {
+            teamIdentifier?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ?? true
+                && certificateDERs.isEmpty
         }
-        guard let certs = dict[kSecCodeInfoCertificates as String] as? [SecCertificate],
+    }
+
+    private static func certificatesFromCode(_ code: SecCode) -> [SecCertificate]? {
+        guard let dict = signingInformation(from: code),
+              let certs = certificates(from: dict),
               !certs.isEmpty else
         {
             return nil
@@ -164,24 +173,93 @@ enum CallerValidation {
         return certs
     }
 
-    private static func signingAuthoritiesMatch(_ lhs: SecCode, _ rhs: SecCode) -> Bool {
-        if teamIdentifiersMatch(teamIdentifier(from: lhs), teamIdentifier(from: rhs)) {
-            return true
+    private static func signingProfile(from code: SecCode) -> CodeSigningProfile? {
+        guard let dict = signingInformation(from: code) else {
+            return nil
         }
 
-        guard let lhsCerts = certificatesFromCode(lhs),
-              let rhsCerts = certificatesFromCode(rhs) else
-        {
-            return false
-        }
-        return certificateDataChainsMatch(
-            certificateDERData(from: lhsCerts),
-            certificateDERData(from: rhsCerts)
+        let certs = certificates(from: dict) ?? []
+        let executableURL = dict[kSecCodeInfoMainExecutable as String] as? URL
+        return CodeSigningProfile(
+            identifier: dict[kSecCodeInfoIdentifier as String] as? String,
+            teamIdentifier: dict[kSecCodeInfoTeamIdentifier as String] as? String,
+            certificateDERs: certificateDERData(from: certs),
+            executablePath: executableURL?.path
         )
     }
 
-    private static func teamIdentifier(from code: SecCode) -> String? {
-        signingInformation(from: code)?[kSecCodeInfoTeamIdentifier as String] as? String
+    private static func certificates(from signingInfo: [String: Any]) -> [SecCertificate]? {
+        signingInfo[kSecCodeInfoCertificates as String] as? [SecCertificate]
+    }
+
+    private static func callerSatisfiesAppleGenericIdentifier(
+        callerCode: SecCode,
+        identifier: String
+    )
+        -> Bool
+    {
+        var requirement: SecRequirement?
+        let status = SecRequirementCreateWithString(
+            "identifier \"\(identifier)\" and anchor apple generic" as CFString,
+            [],
+            &requirement
+        )
+        guard status == errSecSuccess, let requirement else {
+            return false
+        }
+        return SecCodeCheckValidity(callerCode, [], requirement) == errSecSuccess
+    }
+
+    private static func callerSatisfiesLocalXcodeAdHocIdentifier(
+        callerCode: SecCode,
+        identifier: String
+    )
+        -> Bool
+    {
+        guard let profile = signingProfile(from: callerCode),
+              profile.isAdHoc,
+              profile.identifier == identifier,
+              let executablePath = profile.executablePath,
+              isXcodeDerivedDataBuildProduct(path: executablePath) else
+        {
+            return false
+        }
+        return true
+    }
+
+    private static func signingAuthoritiesMatch(_ lhs: SecCode, _ rhs: SecCode) -> Bool {
+        guard let lhsProfile = signingProfile(from: lhs),
+              let rhsProfile = signingProfile(from: rhs) else
+        {
+            return false
+        }
+
+        if teamIdentifiersMatch(lhsProfile.teamIdentifier, rhsProfile.teamIdentifier) {
+            return true
+        }
+
+        if !lhsProfile.certificateDERs.isEmpty,
+           !rhsProfile.certificateDERs.isEmpty
+        {
+            return certificateDataChainsMatch(lhsProfile.certificateDERs, rhsProfile.certificateDERs)
+        }
+
+        return localXcodeAdHocPair(helper: lhsProfile, caller: rhsProfile)
+    }
+
+    private static func localXcodeAdHocPair(
+        helper: CodeSigningProfile,
+        caller: CodeSigningProfile
+    )
+        -> Bool
+    {
+        guard helper.isAdHoc,
+              caller.isAdHoc,
+              let callerPath = caller.executablePath else
+        {
+            return false
+        }
+        return isXcodeDerivedDataBuildProduct(path: callerPath)
     }
 
     private static func signingInformation(from code: SecCode) -> [String: Any]? {

--- a/docs/development/architecture.mdx
+++ b/docs/development/architecture.mdx
@@ -306,6 +306,7 @@ Rockxy uses a privileged helper daemon (`RockxyHelperTool`) registered via `SMAp
 **Security model:**
 - `NSXPCConnection` with code-signing requirements
 - Certificate-chain comparison via `ConnectionValidator` (defense-in-depth beyond bundle ID)
+- Local Xcode ad-hoc helper repair is limited to DerivedData build products
 - Rate limiting on state-changing operations
 - Port range validation (1024-65535)
 

--- a/docs/development/security.mdx
+++ b/docs/development/security.mdx
@@ -44,8 +44,9 @@ Defense-in-depth includes:
 
 - App-side privileged XPC connection setup
 - Caller validation in `Shared/ConnectionValidator.swift` checks the caller against the configured set of allowed bundle identifiers (loaded from `RockxyIdentity.current.allowedCallerIdentifiers`)
-- Code-signing requirement enforcement (`anchor apple generic`)
+- Code-signing requirement enforcement (`anchor apple generic`) for signed release and development builds
 - Certificate-chain comparison — trust is not based only on bundle ID or team ID strings
+- Local Xcode ad-hoc fallback is restricted to DerivedData build products with the configured bundle identifier, so unsigned local builds can repair their own copied helper without relaxing release validation
 - Helper-side rate limiting for state-changing operations (proxy changes, certificate installs)
 - Input validation on all helper parameters (bypass domains, service names, proxy types)
 - Atomic temp file creation with restricted permissions (0o600)


### PR DESCRIPTION
## Summary
- Promote the certificate setup workflow updates from `develop` to `main`.
- Add Mac setup guidance, certificate export formats, custom root/server/client certificate management, and menu routing into platform setup flows.
- Improve helper force reset recovery so stale helper state is removed, the helper is reinstalled from the current app bundle, and the final status is surfaced clearly.
- Tighten local development caller validation by limiting ad-hoc Xcode fallback behavior to DerivedData build products.

## Validation
- `swiftlint lint --strict`
- `git diff --check`
- `xcodebuild -project Rockxy.xcodeproj -scheme Rockxy -destination 'platform=macOS' test -only-testing:RockxyTests/CertificateSetupUXTests -only-testing:RockxyTests/CustomCertificateManagerTests -only-testing:RockxyTests/CustomTLSSelectionTests -only-testing:RockxyTests/HelperManagerTests -only-testing:RockxyTests/CallerValidationTests`

## Security Notes
- Custom certificate private keys are stored through Keychain-backed secure storage rather than plaintext metadata.
- Private key and P12 exports require an explicit warning confirmation before writing private material.
- The exact PR diff was checked for private paths, tokens, and unintended tooling references before opening this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Certificate export functionality supporting PEM, DER, and PKCS#12 formats for root certificates and private keys
  * Custom TLS certificate management allowing users to import and manage root, server, and client certificates
  * Enhanced macOS certificate setup guide with automatic installation and manual setup instructions
  * Force reset and reinstall functionality for helper tool recovery

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RockxyApp/Rockxy/pull/103?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->