### PR TITLE
Improve rule management and scripting workflows

### DIFF
--- a/Rockxy/ContentView.swift
+++ b/Rockxy/ContentView.swift
@@ -84,6 +84,7 @@ struct ContentView: View {
             coordinator.setupRulesObserver()
             coordinator.setupSSLProxyingObserver()
             coordinator.loadInitialRules()
+            coordinator.refreshProxyOverrideStatus()
         }
         .modifier(ConditionalScriptingWindowOpeners(isEnabled: managesLifecycle, openWindow: openWindow))
         .alert(
@@ -254,6 +255,9 @@ private struct ContentWindowNotificationHandlers: ViewModifier {
             }
             .onReceive(NotificationCenter.default.publisher(for: .stopProxyRequested)) { _ in
                 coordinator.stopProxy()
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .systemProxyDidChange)) { _ in
+                coordinator.refreshProxyOverrideStatus()
             }
             .onReceive(NotificationCenter.default.publisher(
                 for: RockxyIdentity.current.notificationName("openCustomColumnsWindow")

--- a/Rockxy/Core/ProxyEngine/HTTPProxyHandler.swift
+++ b/Rockxy/Core/ProxyEngine/HTTPProxyHandler.swift
@@ -303,24 +303,38 @@ final class HTTPProxyHandler: ChannelInboundHandler, RemovableChannelHandler, @u
         case let .block(statusCode):
             sendErrorResponse(context: context, status: statusCode, requestData: requestData, callback: callback)
 
-        case let .mapLocal(filePath, statusCode, isDirectory) where isDirectory:
-            handleMapLocalDirectory(
-                context: context,
-                directoryPath: filePath,
-                statusCode: statusCode,
-                requestData: requestData,
-                callback: callback,
-                urlPattern: urlPattern ?? ""
-            )
-
-        case let .mapLocal(filePath, statusCode, _):
-            handleMapLocal(
-                context: context,
-                filePath: filePath,
-                statusCode: statusCode,
-                requestData: requestData,
-                callback: callback
-            )
+        case let .mapLocal(filePath, statusCode, isDirectory, delayMs):
+            let performMapLocal = { [weak self] in
+                guard let self else {
+                    return
+                }
+                if isDirectory {
+                    self.handleMapLocalDirectory(
+                        context: context,
+                        directoryPath: filePath,
+                        statusCode: statusCode,
+                        requestData: requestData,
+                        callback: callback,
+                        urlPattern: urlPattern ?? ""
+                    )
+                } else {
+                    self.handleMapLocal(
+                        context: context,
+                        filePath: filePath,
+                        statusCode: statusCode,
+                        requestData: requestData,
+                        callback: callback
+                    )
+                }
+            }
+            let effectiveDelayMs = delayMs < 0 ? Int.random(in: 1_000 ... 15_000) : delayMs
+            if effectiveDelayMs > 0 {
+                pendingThrottleTask = context.eventLoop.scheduleTask(in: .milliseconds(Int64(effectiveDelayMs))) {
+                    performMapLocal()
+                }
+            } else {
+                performMapLocal()
+            }
 
         case let .modifyHeader(operations):
             let requestOps = HeaderOperation.requestPhase(from: operations)

--- a/Rockxy/Core/ProxyEngine/HTTPProxyHandler.swift
+++ b/Rockxy/Core/ProxyEngine/HTTPProxyHandler.swift
@@ -369,13 +369,19 @@ final class HTTPProxyHandler: ChannelInboundHandler, RemovableChannelHandler, @u
                 self.forwardRequest(context: context, head: head, requestData: requestData, callback: callback)
             }
 
-        case let .networkCondition(_, delayMs):
-            let delay = TimeAmount.milliseconds(Int64(delayMs))
-            pendingThrottleTask = context.eventLoop.scheduleTask(in: delay) { [weak self] in
+        case let .networkCondition(preset, delayMs):
+            let profile = NetworkConditionProfile(preset: preset, latencyMs: delayMs)
+            pendingThrottleTask = context.eventLoop.scheduleTask(in: profile.latencyDelay) { [weak self] in
                 guard let self else {
                     return
                 }
-                self.forwardRequest(context: context, head: head, requestData: requestData, callback: callback)
+                self.forwardRequest(
+                    context: context,
+                    head: head,
+                    requestData: requestData,
+                    networkConditionProfile: profile,
+                    callback: callback
+                )
             }
 
         case let .breakpoint(phase):
@@ -411,7 +417,7 @@ final class HTTPProxyHandler: ChannelInboundHandler, RemovableChannelHandler, @u
         let uri = query.map { "\(effectivePath)?\($0)" } ?? effectivePath
 
         var modifiedHead = head
-        modifiedHead.uri = uri
+        modifiedHead.uri = configuration.preserveOriginalURL ? head.uri : uri
 
         let hostHeaderValue: String = if configuration.preserveHostHeader {
             originalURL.host ?? upstreamHost
@@ -628,13 +634,15 @@ extension HTTPProxyHandler {
         context: ChannelHandlerContext,
         head: HTTPRequestHead,
         requestData: HTTPRequestData,
-        responseHeaderOperations: [HeaderOperation]? = nil
+        responseHeaderOperations: [HeaderOperation]? = nil,
+        networkConditionProfile: NetworkConditionProfile? = nil
     ) {
         forwardRequest(
             context: context,
             head: head,
             requestData: requestData,
             responseHeaderOperations: responseHeaderOperations,
+            networkConditionProfile: networkConditionProfile,
             callback: onTransactionComplete
         )
     }
@@ -644,6 +652,7 @@ extension HTTPProxyHandler {
         head: HTTPRequestHead,
         requestData: HTTPRequestData,
         responseHeaderOperations: [HeaderOperation]? = nil,
+        networkConditionProfile: NetworkConditionProfile? = nil,
         callback: @escaping @Sendable (HTTPTransaction) -> Void
     ) {
         var head = head
@@ -718,6 +727,7 @@ extension HTTPProxyHandler {
                         connectTime: connectTime,
                         tcpTime: tcpTime,
                         responseHeaderOperations: responseHeaderOperations,
+                        networkConditionProfile: networkConditionProfile,
                         onUpstreamClosed: { limiter.release(host: host, port: port) },
                         callback: callback
                     )
@@ -739,6 +749,7 @@ extension HTTPProxyHandler {
         connectTime: DispatchTime,
         tcpTime: DispatchTime,
         responseHeaderOperations: [HeaderOperation]? = nil,
+        networkConditionProfile: NetworkConditionProfile? = nil,
         onUpstreamClosed: @escaping @Sendable () -> Void,
         callback: @escaping @Sendable (HTTPTransaction) -> Void
     ) {
@@ -752,6 +763,7 @@ extension HTTPProxyHandler {
             sourcePort: clientSourcePort,
             breakpointPhase: pendingBreakpointPhase,
             headerResponseOperations: responseHeaderOperations,
+            networkConditionProfile: networkConditionProfile,
             scriptPluginManager: scriptPluginManager,
             onBreakpointHit: onBreakpointHit,
             onTransactionComplete: callback,
@@ -772,21 +784,18 @@ extension HTTPProxyHandler {
                 )
                 clientChannel.write(NIOAny(HTTPClientRequestPart.head(forwardHead)), promise: nil)
                 if let bodyData = requestData.body, !bodyData.isEmpty {
-                    var bodyBuffer = clientChannel.allocator.buffer(capacity: bodyData.count)
-                    bodyBuffer.writeBytes(bodyData)
-                    clientChannel.write(
-                        NIOAny(HTTPClientRequestPart.body(.byteBuffer(bodyBuffer))),
-                        promise: nil
+                    NetworkConditionIOThrottle.writeClientRequestBodyAndEnd(
+                        bodyData: bodyData,
+                        to: clientChannel,
+                        uploadBytesPerSecond: networkConditionProfile?.uploadBytesPerSecond
+                    )
+                } else {
+                    NetworkConditionIOThrottle.writeClientRequestBodyAndEnd(
+                        bodyData: nil,
+                        to: clientChannel,
+                        uploadBytesPerSecond: networkConditionProfile?.uploadBytesPerSecond
                     )
                 }
-                let endPromise = clientChannel.eventLoop.makePromise(of: Void.self)
-                endPromise.futureResult.whenFailure { _ in
-                    clientChannel.close(promise: nil)
-                }
-                clientChannel.writeAndFlush(
-                    NIOAny(HTTPClientRequestPart.end(nil)),
-                    promise: endPromise
-                )
             case let .failure(error):
                 proxyHandlerLogger.error(
                     "Failed to add response handler to upstream: \(error.localizedDescription)"

--- a/Rockxy/Core/ProxyEngine/HTTPSProxyRelayHandler.swift
+++ b/Rockxy/Core/ProxyEngine/HTTPSProxyRelayHandler.swift
@@ -260,6 +260,7 @@ final class HTTPSProxyRelayHandler: ChannelInboundHandler, @unchecked Sendable {
         graphQLInfo: GraphQLInfo?,
         startTime: DispatchTime,
         responseHeaderOperations: [HeaderOperation]? = nil,
+        networkConditionProfile: NetworkConditionProfile? = nil,
         callback: @escaping @Sendable (HTTPTransaction) -> Void
     ) {
         let upstreamHost = self.host
@@ -308,6 +309,7 @@ final class HTTPSProxyRelayHandler: ChannelInboundHandler, @unchecked Sendable {
                         upstreamHost: upstreamHost,
                         upstreamPort: upstreamPort,
                         responseHeaderOperations: responseHeaderOperations,
+                        networkConditionProfile: networkConditionProfile,
                         callback: callback
                     )
                 }
@@ -329,6 +331,7 @@ final class HTTPSProxyRelayHandler: ChannelInboundHandler, @unchecked Sendable {
         upstreamHost: String,
         upstreamPort: Int,
         responseHeaderOperations: [HeaderOperation]? = nil,
+        networkConditionProfile: NetworkConditionProfile? = nil,
         callback: @escaping @Sendable (HTTPTransaction) -> Void
     ) {
         let limiter = connectionLimiter
@@ -346,6 +349,7 @@ final class HTTPSProxyRelayHandler: ChannelInboundHandler, @unchecked Sendable {
                 sourcePort: self.clientSourcePort,
                 breakpointPhase: self.pendingBreakpointPhase,
                 headerResponseOperations: responseHeaderOperations,
+                networkConditionProfile: networkConditionProfile,
                 scriptPluginManager: self.scriptPluginManager,
                 onBreakpointHit: self.onBreakpointHit,
                 onTransactionComplete: callback,
@@ -361,21 +365,18 @@ final class HTTPSProxyRelayHandler: ChannelInboundHandler, @unchecked Sendable {
                     )
                     clientChannel.write(NIOAny(HTTPClientRequestPart.head(forwardHead)), promise: nil)
                     if let bodyData = requestData.body, !bodyData.isEmpty {
-                        var bodyBuffer = clientChannel.allocator.buffer(capacity: bodyData.count)
-                        bodyBuffer.writeBytes(bodyData)
-                        clientChannel.write(
-                            NIOAny(HTTPClientRequestPart.body(.byteBuffer(bodyBuffer))),
-                            promise: nil
+                        NetworkConditionIOThrottle.writeClientRequestBodyAndEnd(
+                            bodyData: bodyData,
+                            to: clientChannel,
+                            uploadBytesPerSecond: networkConditionProfile?.uploadBytesPerSecond
+                        )
+                    } else {
+                        NetworkConditionIOThrottle.writeClientRequestBodyAndEnd(
+                            bodyData: nil,
+                            to: clientChannel,
+                            uploadBytesPerSecond: networkConditionProfile?.uploadBytesPerSecond
                         )
                     }
-                    let endPromise = clientChannel.eventLoop.makePromise(of: Void.self)
-                    endPromise.futureResult.whenFailure { _ in
-                        clientChannel.close(promise: nil)
-                    }
-                    clientChannel.writeAndFlush(
-                        NIOAny(HTTPClientRequestPart.end(nil)),
-                        promise: endPromise
-                    )
                 case let .failure(error):
                     httpsRelayLogger.error(
                         "Failed to add response handler to upstream: \(error.localizedDescription)"
@@ -469,15 +470,16 @@ final class HTTPSProxyRelayHandler: ChannelInboundHandler, @unchecked Sendable {
                 )
             }
 
-        case let .networkCondition(_, delayMs):
-            let delay = TimeAmount.milliseconds(Int64(delayMs))
-            context.eventLoop.scheduleTask(in: delay) { [weak self] in
+        case let .networkCondition(preset, delayMs):
+            let profile = NetworkConditionProfile(preset: preset, latencyMs: delayMs)
+            context.eventLoop.scheduleTask(in: profile.latencyDelay) { [weak self] in
                 self?.connectToUpstream(
                     context: context,
                     head: head,
                     requestData: requestData,
                     graphQLInfo: graphQLInfo,
                     startTime: startTime,
+                    networkConditionProfile: profile,
                     callback: callback
                 )
             }
@@ -652,7 +654,7 @@ final class HTTPSProxyRelayHandler: ChannelInboundHandler, @unchecked Sendable {
         let uri = remoteQuery.map { "\(effectivePath)?\($0)" } ?? effectivePath
 
         var modifiedHead = head
-        modifiedHead.uri = uri
+        modifiedHead.uri = configuration.preserveOriginalURL ? head.uri : uri
 
         let hostHeaderValue: String = if configuration.preserveHostHeader {
             originalURL.host ?? remoteHost

--- a/Rockxy/Core/ProxyEngine/HTTPSProxyRelayHandler.swift
+++ b/Rockxy/Core/ProxyEngine/HTTPSProxyRelayHandler.swift
@@ -412,24 +412,38 @@ final class HTTPSProxyRelayHandler: ChannelInboundHandler, @unchecked Sendable {
                 callback: callback
             )
 
-        case let .mapLocal(filePath, statusCode, isDirectory) where isDirectory:
-            handleMapLocalDirectory(
-                context: context,
-                directoryPath: filePath,
-                statusCode: statusCode,
-                requestData: requestData,
-                callback: callback,
-                urlPattern: urlPattern ?? ""
-            )
-
-        case let .mapLocal(filePath, statusCode, _):
-            handleMapLocal(
-                context: context,
-                filePath: filePath,
-                statusCode: statusCode,
-                requestData: requestData,
-                callback: callback
-            )
+        case let .mapLocal(filePath, statusCode, isDirectory, delayMs):
+            let performMapLocal = { [weak self] in
+                guard let self else {
+                    return
+                }
+                if isDirectory {
+                    self.handleMapLocalDirectory(
+                        context: context,
+                        directoryPath: filePath,
+                        statusCode: statusCode,
+                        requestData: requestData,
+                        callback: callback,
+                        urlPattern: urlPattern ?? ""
+                    )
+                } else {
+                    self.handleMapLocal(
+                        context: context,
+                        filePath: filePath,
+                        statusCode: statusCode,
+                        requestData: requestData,
+                        callback: callback
+                    )
+                }
+            }
+            let effectiveDelayMs = delayMs < 0 ? Int.random(in: 1_000 ... 15_000) : delayMs
+            if effectiveDelayMs > 0 {
+                context.eventLoop.scheduleTask(in: .milliseconds(Int64(effectiveDelayMs))) {
+                    performMapLocal()
+                }
+            } else {
+                performMapLocal()
+            }
 
         case let .mapRemote(configuration):
             handleMapRemote(

--- a/Rockxy/Core/ProxyEngine/NetworkConditionProfile.swift
+++ b/Rockxy/Core/ProxyEngine/NetworkConditionProfile.swift
@@ -1,0 +1,204 @@
+import Foundation
+import NIOCore
+import NIOHTTP1
+
+// MARK: - NetworkConditionProfile
+
+/// Runtime profile derived from the persisted `RuleAction.networkCondition`
+/// payload. The rule action remains latency-compatible on disk; preset bandwidth
+/// metadata is resolved here when the action is enforced.
+struct NetworkConditionProfile: Equatable, Sendable {
+    // MARK: Lifecycle
+
+    init(preset: NetworkConditionPreset, latencyMs: Int) {
+        self.preset = preset
+        self.latencyMs = max(0, latencyMs)
+        downloadBytesPerSecond = preset.downloadBytesPerSecond
+        uploadBytesPerSecond = preset.uploadBytesPerSecond
+        packetLossRate = preset.packetLossRate
+    }
+
+    // MARK: Internal
+
+    let preset: NetworkConditionPreset
+    let latencyMs: Int
+    let downloadBytesPerSecond: Int?
+    let uploadBytesPerSecond: Int?
+    let packetLossRate: Double
+
+    var latencyDelay: TimeAmount {
+        .milliseconds(Int64(latencyMs))
+    }
+}
+
+// MARK: - NetworkThrottleChunkPlan
+
+struct NetworkThrottleChunkPlan: Equatable {
+    let offset: Int
+    let length: Int
+    let delayMs: Int64
+}
+
+// MARK: - NetworkThrottlePlan
+
+struct NetworkThrottlePlan: Equatable {
+    let chunks: [NetworkThrottleChunkPlan]
+    let readyAtNanos: UInt64
+
+    var totalDelayMs: Int64 {
+        chunks.last?.delayMs ?? 0
+    }
+}
+
+// MARK: - NetworkThrottlePlanner
+
+enum NetworkThrottlePlanner {
+    static let targetChunkIntervalMs = 250
+    static let minimumChunkSize = 4 * 1_024
+    static let maximumChunkSize = 64 * 1_024
+
+    static func chunkSize(bytesPerSecond: Int) -> Int {
+        guard bytesPerSecond > 0 else {
+            return 0
+        }
+        let intervalChunk = max(1, (bytesPerSecond * targetChunkIntervalMs) / 1_000)
+        return min(max(intervalChunk, minimumChunkSize), maximumChunkSize)
+    }
+
+    static func makePlan(
+        byteCount: Int,
+        bytesPerSecond: Int?,
+        nowNanos: UInt64 = DispatchTime.now().uptimeNanoseconds,
+        earliestReadyAtNanos: UInt64? = nil
+    )
+        -> NetworkThrottlePlan?
+    {
+        guard byteCount > 0, let bytesPerSecond, bytesPerSecond > 0 else {
+            return nil
+        }
+
+        let chunkSize = chunkSize(bytesPerSecond: bytesPerSecond)
+        guard chunkSize > 0 else {
+            return nil
+        }
+
+        let startNanos = max(nowNanos, earliestReadyAtNanos ?? nowNanos)
+        var chunks: [NetworkThrottleChunkPlan] = []
+        chunks.reserveCapacity(Int(ceil(Double(byteCount) / Double(chunkSize))))
+
+        var offset = 0
+        var transmittedBytes = 0
+        while offset < byteCount {
+            let length = min(chunkSize, byteCount - offset)
+            transmittedBytes += length
+            let elapsedNanos = nanoseconds(forByteCount: transmittedBytes, bytesPerSecond: bytesPerSecond)
+            let scheduledAtNanos = startNanos.saturatingAdd(elapsedNanos)
+            chunks.append(NetworkThrottleChunkPlan(
+                offset: offset,
+                length: length,
+                delayMs: millisecondsCeiling(from: nowNanos, to: scheduledAtNanos)
+            ))
+            offset += length
+        }
+
+        return NetworkThrottlePlan(
+            chunks: chunks,
+            readyAtNanos: startNanos.saturatingAdd(nanoseconds(forByteCount: byteCount, bytesPerSecond: bytesPerSecond))
+        )
+    }
+
+    static func millisecondsUntil(
+        nowNanos: UInt64 = DispatchTime.now().uptimeNanoseconds,
+        readyAtNanos: UInt64?
+    )
+        -> Int64
+    {
+        guard let readyAtNanos else {
+            return 0
+        }
+        return millisecondsCeiling(from: nowNanos, to: readyAtNanos)
+    }
+
+    private static func nanoseconds(forByteCount byteCount: Int, bytesPerSecond: Int) -> UInt64 {
+        let seconds = Double(byteCount) / Double(bytesPerSecond)
+        return UInt64((seconds * 1_000_000_000).rounded(.up))
+    }
+
+    private static func millisecondsCeiling(from nowNanos: UInt64, to scheduledAtNanos: UInt64) -> Int64 {
+        guard scheduledAtNanos > nowNanos else {
+            return 0
+        }
+        let nanos = scheduledAtNanos - nowNanos
+        return Int64((nanos + 999_999) / 1_000_000)
+    }
+}
+
+// MARK: - NetworkConditionIOThrottle
+
+enum NetworkConditionIOThrottle {
+    static func writeClientRequestBodyAndEnd(
+        bodyData: Data?,
+        to channel: Channel,
+        uploadBytesPerSecond: Int?
+    ) {
+        guard let bodyData, !bodyData.isEmpty else {
+            writeClientRequestEnd(to: channel)
+            return
+        }
+
+        guard let plan = NetworkThrottlePlanner.makePlan(
+            byteCount: bodyData.count,
+            bytesPerSecond: uploadBytesPerSecond
+        ) else {
+            var bodyBuffer = channel.allocator.buffer(capacity: bodyData.count)
+            bodyBuffer.writeBytes(bodyData)
+            channel.write(NIOAny(HTTPClientRequestPart.body(.byteBuffer(bodyBuffer))), promise: nil)
+            writeClientRequestEnd(to: channel)
+            return
+        }
+
+        for chunk in plan.chunks {
+            let isLastChunk = chunk == plan.chunks.last
+            channel.eventLoop.scheduleTask(in: .milliseconds(chunk.delayMs)) {
+                guard channel.isActive else {
+                    return
+                }
+                var bodyBuffer = channel.allocator.buffer(capacity: chunk.length)
+                let startIndex = bodyData.index(bodyData.startIndex, offsetBy: chunk.offset)
+                let endIndex = bodyData.index(startIndex, offsetBy: chunk.length)
+                bodyBuffer.writeBytes(bodyData[startIndex ..< endIndex])
+                let bodyPromise = channel.eventLoop.makePromise(of: Void.self)
+                channel.writeAndFlush(
+                    NIOAny(HTTPClientRequestPart.body(.byteBuffer(bodyBuffer))),
+                    promise: bodyPromise
+                )
+                if isLastChunk {
+                    bodyPromise.futureResult.whenComplete { _ in
+                        guard channel.isActive else {
+                            return
+                        }
+                        writeClientRequestEnd(to: channel)
+                    }
+                }
+            }
+        }
+    }
+
+    private static func writeClientRequestEnd(to channel: Channel) {
+        let endPromise = channel.eventLoop.makePromise(of: Void.self)
+        endPromise.futureResult.whenFailure { _ in
+            channel.close(promise: nil)
+        }
+        channel.writeAndFlush(
+            NIOAny(HTTPClientRequestPart.end(nil)),
+            promise: endPromise
+        )
+    }
+}
+
+private extension UInt64 {
+    func saturatingAdd(_ value: UInt64) -> UInt64 {
+        let (result, overflow) = addingReportingOverflow(value)
+        return overflow ? UInt64.max : result
+    }
+}

--- a/Rockxy/Core/ProxyEngine/UpstreamResponseHandler.swift
+++ b/Rockxy/Core/ProxyEngine/UpstreamResponseHandler.swift
@@ -35,6 +35,7 @@ final class UpstreamResponseHandler: ChannelInboundHandler, @unchecked Sendable 
         sourcePort: UInt16? = nil,
         breakpointPhase: BreakpointRulePhase? = nil,
         headerResponseOperations: [HeaderOperation]? = nil,
+        networkConditionProfile: NetworkConditionProfile? = nil,
         scriptPluginManager: ScriptPluginManager? = nil,
         onBreakpointHit: (@Sendable (BreakpointRequestData) async -> (BreakpointDecision, BreakpointRequestData))? =
             nil,
@@ -51,6 +52,7 @@ final class UpstreamResponseHandler: ChannelInboundHandler, @unchecked Sendable 
         self.sourcePort = sourcePort
         self.breakpointPhase = breakpointPhase
         self.headerResponseOperations = headerResponseOperations
+        self.networkConditionProfile = networkConditionProfile
         self.scriptPluginManager = scriptPluginManager
         self.onBreakpointHit = onBreakpointHit
         self.onTransactionComplete = onTransactionComplete
@@ -307,6 +309,7 @@ final class UpstreamResponseHandler: ChannelInboundHandler, @unchecked Sendable 
     private let sourcePort: UInt16?
     private let breakpointPhase: BreakpointRulePhase?
     private let headerResponseOperations: [HeaderOperation]?
+    private let networkConditionProfile: NetworkConditionProfile?
     private let scriptPluginManager: ScriptPluginManager?
     private let hasResponseScript: Bool
     private let onBreakpointHit: (@Sendable (BreakpointRequestData) async -> (
@@ -323,6 +326,8 @@ final class UpstreamResponseHandler: ChannelInboundHandler, @unchecked Sendable 
     private var firstByteTime: DispatchTime?
     private var completed = false
     private var readTimeoutTask: Scheduled<Void>?
+    private var downloadReadyAtNanos: UInt64?
+    private var downloadTailFuture: EventLoopFuture<Void>?
 
     /// True while we are buffering the response before relaying, because a
     /// matching response-side script is expected to mutate it. Flipped to false
@@ -353,30 +358,86 @@ final class UpstreamResponseHandler: ChannelInboundHandler, @unchecked Sendable 
             return
         }
         let proxyHead = HTTPResponseHead(version: head.version, status: head.status, headers: head.headers)
-        clientContext.write(
-            NIOAny(HTTPServerResponsePart.head(proxyHead)),
-            promise: nil
-        )
+        let part = NIOAny(HTTPServerResponsePart.head(proxyHead))
+        if networkConditionProfile?.downloadBytesPerSecond != nil {
+            clientContext.writeAndFlush(part, promise: nil)
+        } else {
+            clientContext.write(part, promise: nil)
+        }
     }
 
     nonisolated private func relayResponseBody(_ buffer: ByteBuffer) {
         guard clientContext.channel.isActive else {
             return
         }
-        clientContext.write(
-            NIOAny(HTTPServerResponsePart.body(.byteBuffer(buffer))),
-            promise: nil
-        )
+        guard let plan = NetworkThrottlePlanner.makePlan(
+            byteCount: buffer.readableBytes,
+            bytesPerSecond: networkConditionProfile?.downloadBytesPerSecond,
+            earliestReadyAtNanos: downloadReadyAtNanos
+        ) else {
+            clientContext.write(
+                NIOAny(HTTPServerResponsePart.body(.byteBuffer(buffer))),
+                promise: nil
+            )
+            return
+        }
+
+        downloadReadyAtNanos = plan.readyAtNanos
+        for chunk in plan.chunks {
+            let isLastChunk = chunk == plan.chunks.last
+            let tailPromise = isLastChunk ? clientContext.eventLoop.makePromise(of: Void.self) : nil
+            if let tailPromise {
+                downloadTailFuture = tailPromise.futureResult
+            }
+            clientContext.eventLoop.scheduleTask(in: .milliseconds(chunk.delayMs)) { [clientContext] in
+                guard clientContext.channel.isActive else {
+                    tailPromise?.fail(ChannelError.ioOnClosedChannel)
+                    return
+                }
+                var chunkBuffer = buffer
+                chunkBuffer.moveReaderIndex(forwardBy: chunk.offset)
+                let slice = chunkBuffer.readSlice(length: chunk.length) ?? chunkBuffer
+                let bodyPromise = clientContext.eventLoop.makePromise(of: Void.self)
+                clientContext.writeAndFlush(
+                    NIOAny(HTTPServerResponsePart.body(.byteBuffer(slice))),
+                    promise: bodyPromise
+                )
+                if let tailPromise {
+                    bodyPromise.futureResult.whenComplete { result in
+                        tailPromise.completeWith(result)
+                    }
+                }
+            }
+        }
     }
 
     nonisolated private func relayResponseEnd() {
         guard clientContext.channel.isActive else {
             return
         }
-        clientContext.writeAndFlush(
-            NIOAny(HTTPServerResponsePart.end(nil)),
-            promise: nil
-        )
+        if let downloadTailFuture {
+            self.downloadTailFuture = nil
+            downloadTailFuture.whenComplete { [clientContext] _ in
+                guard clientContext.channel.isActive else {
+                    return
+                }
+                clientContext.writeAndFlush(
+                    NIOAny(HTTPServerResponsePart.end(nil)),
+                    promise: nil
+                )
+            }
+            return
+        }
+        let delayMs = NetworkThrottlePlanner.millisecondsUntil(readyAtNanos: downloadReadyAtNanos)
+        clientContext.eventLoop.scheduleTask(in: .milliseconds(delayMs)) { [clientContext] in
+            guard clientContext.channel.isActive else {
+                return
+            }
+            clientContext.writeAndFlush(
+                NIOAny(HTTPServerResponsePart.end(nil)),
+                promise: nil
+            )
+        }
     }
 
     // MARK: - Response Script

--- a/Rockxy/Core/RuleEngine/BlockListSettingsCodec.swift
+++ b/Rockxy/Core/RuleEngine/BlockListSettingsCodec.swift
@@ -1,0 +1,279 @@
+import Foundation
+import os
+
+// MARK: - BlockListSettingsCodec
+
+/// Encodes and imports Block List settings without touching non-block rules.
+enum BlockListSettingsCodec {
+    // MARK: Internal
+
+    enum ImportError: LocalizedError {
+        case invalidFormat
+        case noRulesFound
+        case invalidRegex(pattern: String, reason: String)
+
+        // MARK: Internal
+
+        var errorDescription: String? {
+            switch self {
+            case .invalidFormat:
+                String(localized: "The file is not a valid Block List settings export.")
+            case .noRulesFound:
+                String(localized: "No Block List rules found in the file.")
+            case let .invalidRegex(pattern, reason):
+                String(localized: "Invalid matching rule '\(pattern)': \(reason)")
+            }
+        }
+    }
+
+    static func exportRules(_ rules: [ProxyRule]) throws -> Data {
+        let blockRules = rules.filter(\.isBlockRule)
+        let payload = ExportPayload(version: 1, blockRules: blockRules)
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        return try encoder.encode(payload)
+    }
+
+    static func importFromProxyman(_ data: Data) throws -> [ProxyRule] {
+        if let payload = try? JSONDecoder().decode(ExportPayload.self, from: data) {
+            let rules = try validate(payload.blockRules.filter(\.isBlockRule))
+            guard !rules.isEmpty else {
+                throw ImportError.noRulesFound
+            }
+            return rules
+        }
+
+        if let rules = try? JSONDecoder().decode([ProxyRule].self, from: data) {
+            let blockRules = try validate(rules.filter(\.isBlockRule))
+            guard !blockRules.isEmpty else {
+                throw ImportError.noRulesFound
+            }
+            return blockRules
+        }
+
+        guard let json = try? JSONSerialization.jsonObject(with: data) else {
+            throw ImportError.invalidFormat
+        }
+        let entries = extractJSONEntries(from: json)
+        let rules = try buildRules(from: entries)
+        guard !rules.isEmpty else {
+            throw ImportError.noRulesFound
+        }
+        Self.logger.info("Imported \(rules.count) Block List rules from JSON settings")
+        return rules
+    }
+
+    static func importFromCharlesProxy(_ data: Data) throws -> [ProxyRule] {
+        guard let plist = try? PropertyListSerialization.propertyList(from: data, format: nil) else {
+            throw ImportError.invalidFormat
+        }
+        let entries = extractPlistEntries(from: plist)
+        let rules = try buildRules(from: entries)
+        guard !rules.isEmpty else {
+            throw ImportError.noRulesFound
+        }
+        Self.logger.info("Imported \(rules.count) Block List rules from Charles Proxy settings")
+        return rules
+    }
+
+    // MARK: Private
+
+    private struct ExportPayload: Codable {
+        let format = "rockxy.block-list"
+        let version: Int
+        let blockRules: [ProxyRule]
+
+        private enum CodingKeys: String, CodingKey {
+            case format
+            case version
+            case blockRules
+        }
+    }
+
+    private struct Entry {
+        var name: String?
+        var pattern: String
+        var method: String?
+        var matchType: RuleMatchType
+        var statusCode: Int
+        var isEnabled: Bool
+        var includeSubpaths: Bool
+    }
+
+    private static let logger = Logger(
+        subsystem: RockxyIdentity.current.logSubsystem,
+        category: "BlockListSettingsCodec"
+    )
+
+    private static func extractJSONEntries(from value: Any) -> [Entry] {
+        if let strings = value as? [String] {
+            return strings.compactMap { entry(pattern: $0, source: [:]) }
+        }
+        if let dictionaries = value as? [[String: Any]] {
+            return dictionaries.compactMap { entry(from: $0) }
+        }
+        guard let dictionary = value as? [String: Any] else {
+            return []
+        }
+
+        let arrayKeys = ["blockRules", "rules", "entries", "locations", "location", "items"]
+        for key in arrayKeys {
+            if let strings = dictionary[key] as? [String] {
+                return strings.compactMap { entry(pattern: $0, source: [:]) }
+            }
+            if let dictionaries = dictionary[key] as? [[String: Any]] {
+                return dictionaries.compactMap { entry(from: $0) }
+            }
+        }
+
+        return entry(from: dictionary).map { [$0] } ?? []
+    }
+
+    private static func extractPlistEntries(from value: Any) -> [Entry] {
+        if let dictionaries = value as? [[String: Any]] {
+            return dictionaries.compactMap { entry(from: $0) }
+        }
+        guard let dictionary = value as? [String: Any] else {
+            return []
+        }
+
+        let arrayKeys = ["blockRules", "rules", "entries", "locations", "location", "items"]
+        for key in arrayKeys {
+            if let dictionaries = dictionary[key] as? [[String: Any]] {
+                let entries = dictionaries.compactMap { entry(from: $0) }
+                if !entries.isEmpty {
+                    return entries
+                }
+            }
+        }
+
+        return entry(from: dictionary).map { [$0] } ?? []
+    }
+
+    private static func entry(from source: [String: Any]) -> Entry? {
+        if let url = stringValue(source, keys: ["url", "urlPattern", "pattern", "matchingRule", "matching_rule"]) {
+            return entry(pattern: url, source: source)
+        }
+
+        guard let host = stringValue(source, keys: ["host", "domain", "hostname"]) else {
+            return nil
+        }
+        let path = stringValue(source, keys: ["path", "urlPath"]) ?? "/"
+        let normalizedPath = path.hasPrefix("/") ? path : "/\(path)"
+        let pattern = host == "*" ? "*" : "*\(host)\(normalizedPath)"
+        return entry(pattern: pattern, source: source)
+    }
+
+    private static func entry(pattern rawPattern: String, source: [String: Any]) -> Entry? {
+        let trimmedPattern = rawPattern.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedPattern.isEmpty else {
+            return nil
+        }
+
+        let method = stringValue(source, keys: ["method", "httpMethod", "http_method"])?.uppercased()
+        let normalizedMethod = method == "ANY" ? nil : method
+        let action = stringValue(source, keys: ["action", "blockAction", "block_action"])?.lowercased() ?? ""
+        let statusCode = intValue(source, keys: ["statusCode", "status", "code"]) ?? (action.contains("drop") ? 0 : 403)
+        let matchText = stringValue(source, keys: ["matchType", "match_type", "type"])?.lowercased() ?? ""
+        let matchType: RuleMatchType = matchText.contains("regex") ? .regex : .wildcard
+
+        return Entry(
+            name: stringValue(source, keys: ["name", "title"]),
+            pattern: trimmedPattern,
+            method: normalizedMethod,
+            matchType: matchType,
+            statusCode: statusCode,
+            isEnabled: boolValue(source, keys: ["enabled", "isEnabled", "active"]) ?? true,
+            includeSubpaths: boolValue(source, keys: ["includeSubpaths", "include_subpaths"]) ?? true
+        )
+    }
+
+    private static func buildRules(from entries: [Entry]) throws -> [ProxyRule] {
+        var seen = Set<String>()
+        var rules: [ProxyRule] = []
+
+        for entry in entries {
+            let regex = RulePatternBuilder.regexSource(
+                rawPattern: entry.pattern,
+                matchType: entry.matchType,
+                includeSubpaths: entry.includeSubpaths
+            )
+            let method = entry.method?.isEmpty == false ? entry.method : nil
+            let key = "\(regex)|\(method ?? "ANY")|\(entry.statusCode)".lowercased()
+            guard !seen.contains(key) else {
+                continue
+            }
+            try validate(regex)
+            seen.insert(key)
+            let trimmedName = entry.name?.trimmingCharacters(in: .whitespacesAndNewlines)
+            rules.append(ProxyRule(
+                name: trimmedName?.isEmpty == false ? trimmedName ?? entry.pattern : entry.pattern,
+                isEnabled: entry.isEnabled,
+                matchCondition: RuleMatchCondition(urlPattern: regex, method: method),
+                action: .block(statusCode: entry.statusCode)
+            ))
+        }
+
+        return rules
+    }
+
+    private static func validate(_ rules: [ProxyRule]) throws -> [ProxyRule] {
+        try rules.forEach { rule in
+            if let pattern = rule.matchCondition.urlPattern {
+                try validate(pattern)
+            }
+        }
+        return rules
+    }
+
+    private static func validate(_ pattern: String) throws {
+        if case let .failure(error) = RegexValidator.compile(pattern) {
+            throw ImportError.invalidRegex(pattern: pattern, reason: error.localizedDescription)
+        }
+    }
+
+    private static func stringValue(_ source: [String: Any], keys: [String]) -> String? {
+        for key in keys {
+            if let value = source[key] as? String {
+                return value
+            }
+            if let value = source[key] {
+                return String(describing: value)
+            }
+        }
+        return nil
+    }
+
+    private static func intValue(_ source: [String: Any], keys: [String]) -> Int? {
+        for key in keys {
+            if let value = source[key] as? Int {
+                return value
+            }
+            if let value = source[key] as? String, let int = Int(value) {
+                return int
+            }
+        }
+        return nil
+    }
+
+    private static func boolValue(_ source: [String: Any], keys: [String]) -> Bool? {
+        for key in keys {
+            if let value = source[key] as? Bool {
+                return value
+            }
+            if let value = source[key] as? String {
+                return Bool(value)
+            }
+        }
+        return nil
+    }
+}
+
+private extension ProxyRule {
+    var isBlockRule: Bool {
+        if case .block = action {
+            return true
+        }
+        return false
+    }
+}

--- a/Rockxy/Core/RuleEngine/RuleEngine.swift
+++ b/Rockxy/Core/RuleEngine/RuleEngine.swift
@@ -29,7 +29,13 @@ actor RuleEngine {
     /// Used by Map Local Directory to extract the URL pattern for subpath resolution.
     func evaluateRule(method: String, url: URL, headers: [HTTPHeader]) -> ProxyRule? {
         for rule in rules where rule.isEnabled {
+            if !blockListToolEnabled, case .block = rule.action {
+                continue
+            }
             if !breakpointToolEnabled, case .breakpoint = rule.action {
+                continue
+            }
+            if !mapLocalToolEnabled, case .mapLocal = rule.action {
                 continue
             }
             let compiled = compiledPatterns[rule.id]
@@ -140,6 +146,14 @@ actor RuleEngine {
         breakpointToolEnabled = enabled
     }
 
+    func setBlockListToolEnabled(_ enabled: Bool) {
+        blockListToolEnabled = enabled
+    }
+
+    func setMapLocalToolEnabled(_ enabled: Bool) {
+        mapLocalToolEnabled = enabled
+    }
+
     // MARK: - Atomic Quota-Checked Operations
 
     func addRuleIfAllowed(_ rule: ProxyRule, maxPerCategory: Int) -> Bool {
@@ -209,7 +223,9 @@ actor RuleEngine {
     private static let logger = Logger(subsystem: RockxyIdentity.current.logSubsystem, category: "RuleEngine")
 
     private var rules: [ProxyRule] = []
+    private var blockListToolEnabled: Bool = true
     private var breakpointToolEnabled: Bool = true
+    private var mapLocalToolEnabled: Bool = true
     private var compiledPatterns: [UUID: NSRegularExpression] = [:]
 
     private func compilePatterns() {

--- a/Rockxy/Core/RuleEngine/RuleEngine.swift
+++ b/Rockxy/Core/RuleEngine/RuleEngine.swift
@@ -38,6 +38,12 @@ actor RuleEngine {
             if !mapLocalToolEnabled, case .mapLocal = rule.action {
                 continue
             }
+            if !mapRemoteToolEnabled, case .mapRemote = rule.action {
+                continue
+            }
+            if !networkConditionsToolEnabled, case .networkCondition = rule.action {
+                continue
+            }
             let compiled = compiledPatterns[rule.id]
             if rule.matchCondition.matches(method: method, url: url, headers: headers, compiledPattern: compiled) {
                 Self.logger.debug("Rule matched: \(rule.name)")
@@ -154,6 +160,14 @@ actor RuleEngine {
         mapLocalToolEnabled = enabled
     }
 
+    func setMapRemoteToolEnabled(_ enabled: Bool) {
+        mapRemoteToolEnabled = enabled
+    }
+
+    func setNetworkConditionsToolEnabled(_ enabled: Bool) {
+        networkConditionsToolEnabled = enabled
+    }
+
     // MARK: - Atomic Quota-Checked Operations
 
     func addRuleIfAllowed(_ rule: ProxyRule, maxPerCategory: Int) -> Bool {
@@ -226,6 +240,8 @@ actor RuleEngine {
     private var blockListToolEnabled: Bool = true
     private var breakpointToolEnabled: Bool = true
     private var mapLocalToolEnabled: Bool = true
+    private var mapRemoteToolEnabled: Bool = true
+    private var networkConditionsToolEnabled: Bool = true
     private var compiledPatterns: [UUID: NSRegularExpression] = [:]
 
     private func compilePatterns() {

--- a/Rockxy/Core/RuleEngine/RuleSyncService.swift
+++ b/Rockxy/Core/RuleEngine/RuleSyncService.swift
@@ -169,7 +169,9 @@ enum RuleSyncService {
     private static func syncAll() async {
         let allRules = await RuleEngine.shared.allRules
         await persistenceQueue.save(allRules)
-        NotificationCenter.default.post(name: .rulesDidChange, object: allRules)
+        await MainActor.run {
+            NotificationCenter.default.post(name: .rulesDidChange, object: allRules)
+        }
         logger.debug("Rules synced: \(allRules.count) rules")
     }
 }

--- a/Rockxy/Core/RuleEngine/RuleSyncService.swift
+++ b/Rockxy/Core/RuleEngine/RuleSyncService.swift
@@ -121,12 +121,26 @@ enum RuleSyncService {
         await RuleEngine.shared.setBreakpointToolEnabled(enabled)
     }
 
+    static func setBlockListToolEnabled(_ enabled: Bool) async {
+        UserDefaults.standard.set(enabled, forKey: "blockListToolEnabled")
+        await RuleEngine.shared.setBlockListToolEnabled(enabled)
+    }
+
+    static func setMapLocalToolEnabled(_ enabled: Bool) async {
+        UserDefaults.standard.set(enabled, forKey: "mapLocalToolEnabled")
+        await RuleEngine.shared.setMapLocalToolEnabled(enabled)
+    }
+
     static func loadFromDisk() async {
         // Read and apply the breakpoint-tool flag BEFORE loading rules so the
         // rule engine has the correct evaluation gate in place when rules are
         // first compiled and become live.
+        let blockListEnabled = UserDefaults.standard.object(forKey: "blockListToolEnabled") as? Bool ?? true
+        await RuleEngine.shared.setBlockListToolEnabled(blockListEnabled)
         let bpEnabled = UserDefaults.standard.object(forKey: "breakpointToolEnabled") as? Bool ?? true
         await RuleEngine.shared.setBreakpointToolEnabled(bpEnabled)
+        let mapLocalEnabled = UserDefaults.standard.object(forKey: "mapLocalToolEnabled") as? Bool ?? true
+        await RuleEngine.shared.setMapLocalToolEnabled(mapLocalEnabled)
         try? await RuleEngine.shared.loadRules(from: RuleStore())
         await syncAll()
     }

--- a/Rockxy/Core/RuleEngine/RuleSyncService.swift
+++ b/Rockxy/Core/RuleEngine/RuleSyncService.swift
@@ -131,6 +131,16 @@ enum RuleSyncService {
         await RuleEngine.shared.setMapLocalToolEnabled(enabled)
     }
 
+    static func setMapRemoteToolEnabled(_ enabled: Bool) async {
+        UserDefaults.standard.set(enabled, forKey: "mapRemoteToolEnabled")
+        await RuleEngine.shared.setMapRemoteToolEnabled(enabled)
+    }
+
+    static func setNetworkConditionsToolEnabled(_ enabled: Bool) async {
+        UserDefaults.standard.set(enabled, forKey: "networkConditionsToolEnabled")
+        await RuleEngine.shared.setNetworkConditionsToolEnabled(enabled)
+    }
+
     static func loadFromDisk() async {
         // Read and apply the breakpoint-tool flag BEFORE loading rules so the
         // rule engine has the correct evaluation gate in place when rules are
@@ -141,6 +151,12 @@ enum RuleSyncService {
         await RuleEngine.shared.setBreakpointToolEnabled(bpEnabled)
         let mapLocalEnabled = UserDefaults.standard.object(forKey: "mapLocalToolEnabled") as? Bool ?? true
         await RuleEngine.shared.setMapLocalToolEnabled(mapLocalEnabled)
+        let mapRemoteEnabled = UserDefaults.standard.object(forKey: "mapRemoteToolEnabled") as? Bool ?? true
+        await RuleEngine.shared.setMapRemoteToolEnabled(mapRemoteEnabled)
+        let networkConditionsEnabled = UserDefaults.standard.object(
+            forKey: "networkConditionsToolEnabled"
+        ) as? Bool ?? true
+        await RuleEngine.shared.setNetworkConditionsToolEnabled(networkConditionsEnabled)
         try? await RuleEngine.shared.loadRules(from: RuleStore())
         await syncAll()
     }

--- a/Rockxy/Core/TrafficCapture/AllowListSettingsCodec.swift
+++ b/Rockxy/Core/TrafficCapture/AllowListSettingsCodec.swift
@@ -1,0 +1,249 @@
+import Foundation
+import os
+
+// MARK: - AllowListSettingsCodec
+
+/// Encodes and imports Allow List settings from Rockxy and compatible proxy-tool exports.
+enum AllowListSettingsCodec {
+    // MARK: Internal
+
+    enum ImportError: LocalizedError {
+        case invalidFormat
+        case noRulesFound
+        case invalidRegex(pattern: String, reason: String)
+        case patternTooLong(pattern: String, limit: Int)
+
+        // MARK: Internal
+
+        var errorDescription: String? {
+            switch self {
+            case .invalidFormat:
+                String(localized: "The file is not a valid Allow List settings export.")
+            case .noRulesFound:
+                String(localized: "No Allow List rules found in the file.")
+            case let .invalidRegex(pattern, reason):
+                String(localized: "Invalid matching rule '\(pattern)': \(reason)")
+            case let .patternTooLong(pattern, limit):
+                String(localized: "Matching rule '\(pattern)' exceeds \(limit) characters.")
+            }
+        }
+    }
+
+    static func importFromProxyman(_ data: Data) throws -> [AllowListRule] {
+        guard let json = try? JSONSerialization.jsonObject(with: data) else {
+            throw ImportError.invalidFormat
+        }
+        let entries = extractJSONEntries(from: json)
+        let rules = try buildRules(from: entries)
+        guard !rules.isEmpty else {
+            throw ImportError.noRulesFound
+        }
+        logger.info("Imported \(rules.count) Allow List rules from JSON settings")
+        return rules
+    }
+
+    static func importFromCharlesProxy(_ data: Data) throws -> [AllowListRule] {
+        guard let plist = try? PropertyListSerialization.propertyList(from: data, format: nil) else {
+            throw ImportError.invalidFormat
+        }
+        let entries = extractPlistEntries(from: plist)
+        let rules = try buildRules(from: entries)
+        guard !rules.isEmpty else {
+            throw ImportError.noRulesFound
+        }
+        logger.info("Imported \(rules.count) Allow List rules from Charles Proxy settings")
+        return rules
+    }
+
+    // MARK: Private
+
+    private struct Entry {
+        var name: String?
+        var pattern: String
+        var method: String?
+        var matchType: RuleMatchType
+        var isEnabled: Bool
+        var includeSubpaths: Bool
+    }
+
+    private static let logger = Logger(
+        subsystem: RockxyIdentity.current.logSubsystem,
+        category: "AllowListSettingsCodec"
+    )
+
+    private static let maxRegexLength = 2_048
+
+    private static func extractJSONEntries(from value: Any) -> [Entry] {
+        if let strings = value as? [String] {
+            return strings.compactMap { entry(pattern: $0, source: [:]) }
+        }
+        if let dictionaries = value as? [[String: Any]] {
+            return dictionaries.compactMap { entry(from: $0) }
+        }
+        guard let dictionary = value as? [String: Any] else {
+            return []
+        }
+
+        let arrayKeys = [
+            "allowRules",
+            "allowList",
+            "allowlist",
+            "includeDomains",
+            "domains",
+            "rules",
+            "entries",
+            "locations",
+            "location",
+            "items",
+        ]
+        for key in arrayKeys {
+            if let strings = dictionary[key] as? [String] {
+                let entries = strings.compactMap { entry(pattern: $0, source: [:]) }
+                if !entries.isEmpty {
+                    return entries
+                }
+            }
+            if let dictionaries = dictionary[key] as? [[String: Any]] {
+                let entries = dictionaries.compactMap { entry(from: $0) }
+                if !entries.isEmpty {
+                    return entries
+                }
+            }
+        }
+
+        return entry(from: dictionary).map { [$0] } ?? []
+    }
+
+    private static func extractPlistEntries(from value: Any) -> [Entry] {
+        if let dictionaries = value as? [[String: Any]] {
+            return dictionaries.compactMap { entry(from: $0) }
+        }
+        guard let dictionary = value as? [String: Any] else {
+            return []
+        }
+
+        let arrayKeys = ["allowRules", "allowList", "allowlist", "rules", "entries", "locations", "location", "items"]
+        for key in arrayKeys {
+            if let dictionaries = dictionary[key] as? [[String: Any]] {
+                let entries = dictionaries.compactMap { entry(from: $0) }
+                if !entries.isEmpty {
+                    return entries
+                }
+            }
+        }
+
+        return entry(from: dictionary).map { [$0] } ?? []
+    }
+
+    private static func entry(from source: [String: Any]) -> Entry? {
+        if let url = stringValue(
+            source,
+            keys: ["url", "urlPattern", "pattern", "matchingRule", "matching_rule", "match", "value"]
+        ) {
+            return entry(pattern: url, source: source)
+        }
+
+        guard let rawHost = stringValue(source, keys: ["host", "domain", "hostname"]) else {
+            return nil
+        }
+        let host = rawHost.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !host.isEmpty else {
+            return nil
+        }
+        let path = stringValue(source, keys: ["path", "urlPath", "url_path"])?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? "/"
+        let normalizedPath = path.hasPrefix("/") ? path : "/\(path)"
+        let pattern = host == "*" ? "*" : "*\(host)\(normalizedPath)"
+        return entry(pattern: pattern, source: source)
+    }
+
+    private static func entry(pattern rawPattern: String, source: [String: Any]) -> Entry? {
+        let trimmedPattern = rawPattern.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedPattern.isEmpty else {
+            return nil
+        }
+
+        let method = stringValue(source, keys: ["method", "httpMethod", "http_method"])?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .uppercased()
+        let normalizedMethod = method == "ANY" ? nil : method
+        let matchText = stringValue(source, keys: ["matchType", "match_type", "type"])?.lowercased() ?? ""
+        let matchType: RuleMatchType = matchText.contains("regex") ? .regex : .wildcard
+
+        return Entry(
+            name: stringValue(source, keys: ["name", "title"]),
+            pattern: trimmedPattern,
+            method: normalizedMethod?.isEmpty == false ? normalizedMethod : nil,
+            matchType: matchType,
+            isEnabled: boolValue(source, keys: ["enabled", "isEnabled", "active"]) ?? true,
+            includeSubpaths: boolValue(source, keys: ["includeSubpaths", "include_subpaths"]) ?? true
+        )
+    }
+
+    private static func buildRules(from entries: [Entry]) throws -> [AllowListRule] {
+        var seen = Set<String>()
+        var rules: [AllowListRule] = []
+
+        for entry in entries {
+            try validate(entry)
+            let method = entry.method?.isEmpty == false ? entry.method : nil
+            let key = "\(entry.pattern)|\(method ?? "ANY")|\(entry.matchType.rawValue)|\(entry.includeSubpaths)"
+                .lowercased()
+            guard !seen.contains(key) else {
+                continue
+            }
+            seen.insert(key)
+            let name = entry.name?.trimmingCharacters(in: .whitespacesAndNewlines)
+            rules.append(AllowListRule(
+                name: name?.isEmpty == false ? name ?? entry.pattern : entry.pattern,
+                isEnabled: entry.isEnabled,
+                rawPattern: entry.pattern,
+                method: method,
+                matchType: entry.matchType,
+                includeSubpaths: entry.matchType == .wildcard ? entry.includeSubpaths : false
+            ))
+        }
+
+        return rules
+    }
+
+    private static func validate(_ entry: Entry) throws {
+        if entry.matchType == .regex, entry.pattern.count > maxRegexLength {
+            throw ImportError.patternTooLong(pattern: entry.pattern, limit: maxRegexLength)
+        }
+        let source = RulePatternBuilder.regexSource(
+            rawPattern: entry.pattern,
+            matchType: entry.matchType,
+            includeSubpaths: entry.includeSubpaths
+        )
+        do {
+            _ = try NSRegularExpression(pattern: source)
+        } catch {
+            throw ImportError.invalidRegex(pattern: entry.pattern, reason: error.localizedDescription)
+        }
+    }
+
+    private static func stringValue(_ source: [String: Any], keys: [String]) -> String? {
+        for key in keys {
+            if let value = source[key] as? String {
+                return value
+            }
+            if let value = source[key] {
+                return String(describing: value)
+            }
+        }
+        return nil
+    }
+
+    private static func boolValue(_ source: [String: Any], keys: [String]) -> Bool? {
+        for key in keys {
+            if let value = source[key] as? Bool {
+                return value
+            }
+            if let value = source[key] as? String {
+                return Bool(value)
+            }
+        }
+        return nil
+    }
+}

--- a/Rockxy/Models/Rules/BreakpointTemplate.swift
+++ b/Rockxy/Models/Rules/BreakpointTemplate.swift
@@ -1,0 +1,518 @@
+import Foundation
+
+// MARK: - BreakpointTemplateKind
+
+enum BreakpointTemplateKind: String, CaseIterable, Codable, Identifiable {
+    case request
+    case response
+
+    // MARK: Internal
+
+    var id: String {
+        rawValue
+    }
+
+    var singularTitle: String {
+        switch self {
+        case .request: String(localized: "Request Template")
+        case .response: String(localized: "Response Template")
+        }
+    }
+
+    var pluralTitle: String {
+        switch self {
+        case .request: String(localized: "Request Templates")
+        case .response: String(localized: "Response Templates")
+        }
+    }
+
+    var groupTitle: String {
+        pluralTitle
+    }
+
+    var defaultName: String {
+        switch self {
+        case .request: String(localized: "JSON Request")
+        case .response: String(localized: "JSON Response")
+        }
+    }
+
+    var emptyName: String {
+        switch self {
+        case .request: String(localized: "Untitled Request Template")
+        case .response: String(localized: "Untitled Response Template")
+        }
+    }
+
+    var sampleMessage: String {
+        switch self {
+        case .request:
+            """
+            GET /api/example HTTP/1.1
+            Host: example.com
+            Accept: application/json
+
+            """
+        case .response:
+            """
+            HTTP/1.1 200 OK
+            Content-Type: application/json
+
+            {"ok":true}
+            """
+        }
+    }
+}
+
+// MARK: - BreakpointTemplate
+
+struct BreakpointTemplate: Identifiable, Codable, Equatable {
+    // MARK: Lifecycle
+
+    init(
+        id: UUID = UUID(),
+        kind: BreakpointTemplateKind,
+        name: String? = nil,
+        rawMessage: String? = nil,
+        createdAt: Date = Date(),
+        updatedAt: Date = Date()
+    ) {
+        self.id = id
+        self.kind = kind
+        self.name = name?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty ?? kind.defaultName
+        self.rawMessage = rawMessage ?? kind.sampleMessage
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let decodedKind = try container.decodeIfPresent(BreakpointTemplateKind.self, forKey: .kind) ?? .request
+        id = try container.decodeIfPresent(UUID.self, forKey: .id) ?? UUID()
+        kind = decodedKind
+        name = try container.decodeIfPresent(String.self, forKey: .name)?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .nilIfEmpty ?? decodedKind.emptyName
+        rawMessage = try container.decodeIfPresent(String.self, forKey: .rawMessage)?
+            .nilIfEmpty ?? decodedKind.sampleMessage
+        createdAt = try container.decodeIfPresent(Date.self, forKey: .createdAt) ?? Date()
+        updatedAt = try container.decodeIfPresent(Date.self, forKey: .updatedAt) ?? createdAt
+    }
+
+    // MARK: Internal
+
+    let id: UUID
+    let kind: BreakpointTemplateKind
+    var name: String
+    var rawMessage: String
+    let createdAt: Date
+    var updatedAt: Date
+
+    var validation: BreakpointTemplateValidation {
+        BreakpointTemplateValidator.validate(rawMessage: rawMessage, kind: kind)
+    }
+
+    var applicationPayload: BreakpointTemplateApplication? {
+        BreakpointTemplateApplication(template: self)
+    }
+
+    static let defaultTemplates: [BreakpointTemplate] = [
+        BreakpointTemplate(
+            kind: .request,
+            name: String(localized: "JSON Request"),
+            rawMessage: BreakpointTemplateKind.request.sampleMessage
+        ),
+        BreakpointTemplate(
+            kind: .response,
+            name: String(localized: "JSON Response"),
+            rawMessage: BreakpointTemplateKind.response.sampleMessage
+        ),
+    ]
+
+    static func defaultRawMessage(for kind: BreakpointTemplateKind) -> String {
+        kind.sampleMessage
+    }
+}
+
+// MARK: - BreakpointTemplateValidation
+
+enum BreakpointTemplateValidation: Equatable {
+    case valid(summary: String)
+    case invalid(message: String)
+
+    // MARK: Internal
+
+    var isValid: Bool {
+        if case .valid = self {
+            return true
+        }
+        return false
+    }
+
+    var message: String {
+        switch self {
+        case let .valid(summary): summary
+        case let .invalid(message): message
+        }
+    }
+}
+
+// MARK: - BreakpointTemplateHeader
+
+struct BreakpointTemplateHeader: Codable, Equatable {
+    let name: String
+    let value: String
+}
+
+// MARK: - BreakpointTemplateParsedMessage
+
+enum BreakpointTemplateParsedMessage: Equatable {
+    case request(BreakpointTemplateParsedRequest)
+    case response(BreakpointTemplateParsedResponse)
+}
+
+struct BreakpointTemplateParsedRequest: Equatable {
+    let method: String
+    let target: String
+    let httpVersion: String
+    let headers: [BreakpointTemplateHeader]
+    let body: String
+}
+
+struct BreakpointTemplateParsedResponse: Equatable {
+    let httpVersion: String
+    let statusCode: Int
+    let reasonPhrase: String
+    let headers: [BreakpointTemplateHeader]
+    let body: String
+}
+
+// MARK: - BreakpointTemplateApplication
+
+struct BreakpointTemplateApplication: Equatable {
+    // MARK: Lifecycle
+
+    init?(template: BreakpointTemplate) {
+        guard case let .valid(_, parsed) = BreakpointTemplateValidator.parse(
+            rawMessage: template.rawMessage,
+            kind: template.kind
+        ) else {
+            return nil
+        }
+        id = template.id
+        name = template.name
+        kind = template.kind
+        rawMessage = template.rawMessage
+        parsedMessage = parsed
+    }
+
+    // MARK: Internal
+
+    let id: UUID
+    let name: String
+    let kind: BreakpointTemplateKind
+    let rawMessage: String
+    let parsedMessage: BreakpointTemplateParsedMessage
+
+    func applying(to draft: BreakpointRequestData) -> BreakpointRequestData {
+        var next = draft
+        switch parsedMessage {
+        case let .request(request):
+            next.method = request.method
+            next.url = request.target
+            next.headers = request.headers.map { EditableHeader(name: $0.name, value: $0.value) }
+            next.body = request.body
+            next.phase = .request
+        case let .response(response):
+            next.statusCode = response.statusCode
+            next.headers = response.headers.map { EditableHeader(name: $0.name, value: $0.value) }
+            next.body = response.body
+            next.phase = .response
+        }
+        return next
+    }
+}
+
+// MARK: - BreakpointTemplateValidator
+
+enum BreakpointTemplateValidator {
+    // MARK: Internal
+
+    static func validate(rawMessage: String, kind: BreakpointTemplateKind) -> BreakpointTemplateValidation {
+        switch parse(rawMessage: rawMessage, kind: kind) {
+        case let .valid(summary, _):
+            .valid(summary: summary)
+        case let .invalid(message):
+            .invalid(message: message)
+        }
+    }
+
+    static func parse(rawMessage: String, kind: BreakpointTemplateKind) -> ParseResult {
+        let normalized = normalize(rawMessage)
+        guard !normalized.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return .invalid(String(localized: "Message is empty."))
+        }
+
+        let split = splitHeadAndBody(normalized)
+        var headerLines = split.head.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+        guard let startLine = headerLines.first?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !startLine.isEmpty else
+        {
+            return .invalid(String(localized: "Missing HTTP start line."))
+        }
+        headerLines.removeFirst()
+
+        switch kind {
+        case .request:
+            return parseRequest(startLine: startLine, headerLines: headerLines, body: split.body)
+        case .response:
+            return parseResponse(startLine: startLine, headerLines: headerLines, body: split.body)
+        }
+    }
+
+    // MARK: Private
+
+    enum ParseResult: Equatable {
+        case valid(summary: String, parsed: BreakpointTemplateParsedMessage)
+        case invalid(String)
+    }
+
+    private static func parseRequest(
+        startLine: String,
+        headerLines: [String],
+        body: String
+    )
+        -> ParseResult
+    {
+        let parts = startLine.split(separator: " ", omittingEmptySubsequences: true).map(String.init)
+        guard parts.count == 3 else {
+            return .invalid(String(localized: "Request line must be METHOD target HTTP/version."))
+        }
+        let method = parts[0].uppercased()
+        guard method.range(of: #"^[A-Z]+$"#, options: .regularExpression) != nil else {
+            return .invalid(String(localized: "Request method must contain only letters."))
+        }
+        guard parts[2].hasPrefix("HTTP/") else {
+            return .invalid(String(localized: "Request line must end with an HTTP version."))
+        }
+        guard !parts[1].isEmpty else {
+            return .invalid(String(localized: "Request target is empty."))
+        }
+
+        let headers = parseHeaders(headerLines)
+        guard case let .valid(parsedHeaders) = headers else {
+            if case let .invalid(message) = headers {
+                return .invalid(message)
+            }
+            return .invalid(String(localized: "Invalid headers."))
+        }
+
+        let parsed = BreakpointTemplateParsedRequest(
+            method: method,
+            target: parts[1],
+            httpVersion: parts[2],
+            headers: parsedHeaders,
+            body: body
+        )
+        return .valid(
+            summary: String(localized: "Valid request message"),
+            parsed: .request(parsed)
+        )
+    }
+
+    private static func parseResponse(
+        startLine: String,
+        headerLines: [String],
+        body: String
+    )
+        -> ParseResult
+    {
+        let parts = startLine.split(separator: " ", maxSplits: 2, omittingEmptySubsequences: true).map(String.init)
+        guard parts.count >= 2 else {
+            return .invalid(String(localized: "Response line must be HTTP/version status."))
+        }
+        guard parts[0].hasPrefix("HTTP/") else {
+            return .invalid(String(localized: "Response line must start with an HTTP version."))
+        }
+        guard let statusCode = Int(parts[1]), (100...999).contains(statusCode) else {
+            return .invalid(String(localized: "Response status must be a three-digit code."))
+        }
+
+        let headers = parseHeaders(headerLines)
+        guard case let .valid(parsedHeaders) = headers else {
+            if case let .invalid(message) = headers {
+                return .invalid(message)
+            }
+            return .invalid(String(localized: "Invalid headers."))
+        }
+
+        let parsed = BreakpointTemplateParsedResponse(
+            httpVersion: parts[0],
+            statusCode: statusCode,
+            reasonPhrase: parts.count == 3 ? parts[2] : "",
+            headers: parsedHeaders,
+            body: body
+        )
+        return .valid(
+            summary: String(localized: "Valid response message"),
+            parsed: .response(parsed)
+        )
+    }
+
+    private static func parseHeaders(_ lines: [String]) -> HeaderParseResult {
+        var headers: [BreakpointTemplateHeader] = []
+        for line in lines where !line.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            guard let colon = line.firstIndex(of: ":") else {
+                return .invalid(String(localized: "Header lines must contain a colon."))
+            }
+            let name = String(line[..<colon]).trimmingCharacters(in: .whitespacesAndNewlines)
+            let valueStart = line.index(after: colon)
+            let value = String(line[valueStart...]).trimmingCharacters(in: .whitespaces)
+            guard !name.isEmpty else {
+                return .invalid(String(localized: "Header name is empty."))
+            }
+            guard name.rangeOfCharacter(from: .whitespacesAndNewlines) == nil else {
+                return .invalid(String(localized: "Header names cannot contain spaces."))
+            }
+            headers.append(BreakpointTemplateHeader(name: name, value: value))
+        }
+        return .valid(headers)
+    }
+
+    private static func normalize(_ rawMessage: String) -> String {
+        rawMessage
+            .replacingOccurrences(of: "\r\n", with: "\n")
+            .replacingOccurrences(of: "\r", with: "\n")
+    }
+
+    private static func splitHeadAndBody(_ message: String) -> (head: String, body: String) {
+        guard let separator = message.range(of: "\n\n") else {
+            return (message, "")
+        }
+        let head = String(message[..<separator.lowerBound])
+        let body = String(message[separator.upperBound...])
+        return (head, body)
+    }
+
+    private enum HeaderParseResult {
+        case valid([BreakpointTemplateHeader])
+        case invalid(String)
+    }
+}
+
+// MARK: - BreakpointRawMessage
+
+enum BreakpointRawMessage {
+    // MARK: Internal
+
+    enum Error: Swift.Error {
+        case invalid(String)
+    }
+
+    static func validation(for rawMessage: String, kind: BreakpointTemplateKind) -> BreakpointTemplateValidation {
+        BreakpointTemplateValidator.validate(rawMessage: rawMessage, kind: kind)
+    }
+
+    static func rawMessage(from draft: BreakpointRequestData, kind: BreakpointTemplateKind) -> String {
+        let headers = draft.headers
+            .filter { !$0.name.isEmpty }
+            .map { "\($0.name): \($0.value)" }
+            .joined(separator: "\n")
+
+        switch kind {
+        case .request:
+            return join(
+                startLine: "\(draft.method) \(requestTarget(from: draft.url)) HTTP/1.1",
+                headers: headers,
+                body: draft.body
+            )
+        case .response:
+            return join(
+                startLine: "HTTP/1.1 \(draft.statusCode) \(reasonPhrase(for: draft.statusCode))",
+                headers: headers,
+                body: draft.body
+            )
+        }
+    }
+
+    static func applying(
+        _ rawMessage: String,
+        kind: BreakpointTemplateKind,
+        to draft: BreakpointRequestData
+    ) throws -> BreakpointRequestData {
+        switch BreakpointTemplateValidator.parse(rawMessage: rawMessage, kind: kind) {
+        case let .valid(_, parsed):
+            return apply(parsed, to: draft)
+        case let .invalid(message):
+            throw Error.invalid(message)
+        }
+    }
+
+    // MARK: Private
+
+    private static func apply(
+        _ parsed: BreakpointTemplateParsedMessage,
+        to draft: BreakpointRequestData
+    )
+        -> BreakpointRequestData
+    {
+        var next = draft
+        switch parsed {
+        case let .request(request):
+            next.method = request.method
+            next.url = request.target
+            next.headers = request.headers.map { EditableHeader(name: $0.name, value: $0.value) }
+            next.body = request.body
+            next.phase = .request
+        case let .response(response):
+            next.statusCode = response.statusCode
+            next.headers = response.headers.map { EditableHeader(name: $0.name, value: $0.value) }
+            next.body = response.body
+            next.phase = .response
+        }
+        return next
+    }
+
+    private static func join(startLine: String, headers: String, body: String) -> String {
+        if headers.isEmpty {
+            return "\(startLine)\n\n\(body)"
+        }
+        return "\(startLine)\n\(headers)\n\n\(body)"
+    }
+
+    private static func requestTarget(from urlString: String) -> String {
+        guard let components = URLComponents(string: urlString) else {
+            return urlString.isEmpty ? "/" : urlString
+        }
+        let path = components.path.isEmpty ? "/" : components.path
+        if let query = components.query, !query.isEmpty {
+            return "\(path)?\(query)"
+        }
+        return path
+    }
+
+    private static func reasonPhrase(for statusCode: Int) -> String {
+        switch statusCode {
+        case 200: "OK"
+        case 201: "Created"
+        case 204: "No Content"
+        case 301: "Moved Permanently"
+        case 302: "Found"
+        case 304: "Not Modified"
+        case 400: "Bad Request"
+        case 401: "Unauthorized"
+        case 403: "Forbidden"
+        case 404: "Not Found"
+        case 500: "Internal Server Error"
+        case 502: "Bad Gateway"
+        case 503: "Service Unavailable"
+        default: ""
+        }
+    }
+}
+
+private extension String {
+    var nilIfEmpty: String? {
+        isEmpty ? nil : self
+    }
+}

--- a/Rockxy/Models/Rules/BreakpointTemplateStore.swift
+++ b/Rockxy/Models/Rules/BreakpointTemplateStore.swift
@@ -1,0 +1,253 @@
+import Foundation
+import os
+
+// Persists and coordinates breakpoint request/response templates.
+
+@MainActor @Observable
+final class BreakpointTemplateStore {
+    // MARK: Lifecycle
+
+    init(
+        defaults: UserDefaults = .standard,
+        storageKey: String = RockxyIdentity.current.defaultsKey("breakpointTemplates"),
+        seedDefaults: Bool = true
+    ) {
+        self.defaults = defaults
+        self.storageKey = storageKey
+        self.seedDefaults = seedDefaults
+        load()
+        if selectedTemplateID == nil {
+            selectedTemplateID = templates(for: selectedKind).first?.id
+        }
+    }
+
+    // MARK: Internal
+
+    static let shared = BreakpointTemplateStore()
+
+    var selectedKind: BreakpointTemplateKind = .request {
+        didSet {
+            guard selectedKind != oldValue else {
+                return
+            }
+            selectedTemplateID = templates(for: selectedKind).first?.id
+        }
+    }
+
+    var selectedTemplateID: UUID?
+    private(set) var templates: [BreakpointTemplate] = []
+
+    var requestTemplates: [BreakpointTemplate] {
+        templates(for: .request)
+    }
+
+    var responseTemplates: [BreakpointTemplate] {
+        templates(for: .response)
+    }
+
+    var selectedTemplates: [BreakpointTemplate] {
+        templates(for: selectedKind)
+    }
+
+    var selectedTemplate: BreakpointTemplate? {
+        guard let selectedTemplateID else {
+            return nil
+        }
+        return templates.first { $0.id == selectedTemplateID }
+    }
+
+    var selectedValidation: BreakpointTemplateValidation {
+        selectedTemplate?.validation ?? .invalid(message: String(localized: "No template selected."))
+    }
+
+    @discardableResult
+    func addTemplate(kind: BreakpointTemplateKind? = nil) -> BreakpointTemplate {
+        let templateKind = kind ?? selectedKind
+        let template = BreakpointTemplate(
+            kind: templateKind,
+            name: uniqueName(for: templateKind),
+            rawMessage: templateKind.sampleMessage
+        )
+        templates.append(template)
+        selectedKind = templateKind
+        selectedTemplateID = template.id
+        save()
+        Self.logger.info("Added breakpoint \(templateKind.rawValue) template")
+        return template
+    }
+
+    func deleteSelectedTemplate() {
+        guard let selectedTemplateID else {
+            return
+        }
+        deleteTemplate(id: selectedTemplateID)
+    }
+
+    func deleteTemplate(id: UUID) {
+        guard let index = templates.firstIndex(where: { $0.id == id }) else {
+            return
+        }
+        let kind = templates[index].kind
+        templates.remove(at: index)
+        if selectedTemplateID == id {
+            selectedTemplateID = templates(for: kind).first?.id
+        }
+        save()
+    }
+
+    func updateTemplate(id: UUID, name: String? = nil, rawMessage: String? = nil) {
+        guard let index = templates.firstIndex(where: { $0.id == id }) else {
+            return
+        }
+        if let name {
+            templates[index].name = sanitizedName(name, fallback: templates[index].kind.emptyName)
+        }
+        if let rawMessage {
+            templates[index].rawMessage = rawMessage
+        }
+        templates[index].updatedAt = Date()
+        save()
+    }
+
+    func renameSelectedTemplate(to name: String) {
+        guard let selectedTemplateID else {
+            return
+        }
+        updateTemplate(id: selectedTemplateID, name: name)
+    }
+
+    func updateSelectedRawMessage(_ rawMessage: String) {
+        guard let selectedTemplateID else {
+            return
+        }
+        updateTemplate(id: selectedTemplateID, rawMessage: rawMessage)
+    }
+
+    @discardableResult
+    func duplicateSelectedTemplate() -> BreakpointTemplate? {
+        guard let selectedTemplate else {
+            return nil
+        }
+        var duplicate = BreakpointTemplate(
+            kind: selectedTemplate.kind,
+            name: String(localized: "Copy of \(selectedTemplate.name)"),
+            rawMessage: selectedTemplate.rawMessage
+        )
+        duplicate.updatedAt = Date()
+        templates.append(duplicate)
+        selectedKind = duplicate.kind
+        selectedTemplateID = duplicate.id
+        save()
+        return duplicate
+    }
+
+    func resetSelectedTemplateToSample() {
+        guard let selectedTemplate else {
+            return
+        }
+        updateTemplate(id: selectedTemplate.id, rawMessage: selectedTemplate.kind.sampleMessage)
+    }
+
+    func validation(for templateID: UUID) -> BreakpointTemplateValidation {
+        templates.first { $0.id == templateID }?.validation
+            ?? .invalid(message: String(localized: "Template is missing."))
+    }
+
+    func applicationPayload(for templateID: UUID) -> BreakpointTemplateApplication? {
+        templates.first { $0.id == templateID }?.applicationPayload
+    }
+
+    func selectedApplicationPayload() -> BreakpointTemplateApplication? {
+        guard let selectedTemplateID else {
+            return nil
+        }
+        return applicationPayload(for: selectedTemplateID)
+    }
+
+    func reload() {
+        load()
+    }
+
+    func templates(for kind: BreakpointTemplateKind) -> [BreakpointTemplate] {
+        templates.filter { $0.kind == kind }
+    }
+
+    func removeSelectedTemplate() {
+        deleteSelectedTemplate()
+    }
+
+    func updateSelected(name: String? = nil, rawMessage: String? = nil) {
+        if let name {
+            renameSelectedTemplate(to: name)
+        }
+        if let rawMessage {
+            updateSelectedRawMessage(rawMessage)
+        }
+    }
+
+    func resetSelectedTemplate() {
+        resetSelectedTemplateToSample()
+    }
+
+    // MARK: Private
+
+    private static let logger = Logger(subsystem: RockxyIdentity.current.logSubsystem, category: "BreakpointTemplateStore")
+
+    private let defaults: UserDefaults
+    private let storageKey: String
+    private let seedDefaults: Bool
+
+    private func uniqueName(for kind: BreakpointTemplateKind) -> String {
+        let base = kind.emptyName
+        let names = Set(templates(for: kind).map(\.name))
+        guard names.contains(base) else {
+            return base
+        }
+        var index = 2
+        while names.contains("\(base) \(index)") {
+            index += 1
+        }
+        return "\(base) \(index)"
+    }
+
+    private func sanitizedName(_ name: String, fallback: String) -> String {
+        name.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty ?? fallback
+    }
+
+    private func save() {
+        do {
+            let data = try JSONEncoder().encode(templates)
+            defaults.set(data, forKey: storageKey)
+        } catch {
+            Self.logger.error("Failed to save breakpoint templates: \(error.localizedDescription)")
+        }
+    }
+
+    private func load() {
+        guard let data = defaults.data(forKey: storageKey) else {
+            templates = seedDefaults ? BreakpointTemplate.defaultTemplates : []
+            if seedDefaults {
+                save()
+            }
+            return
+        }
+
+        do {
+            let decoded = try JSONDecoder().decode([BreakpointTemplate].self, from: data)
+            templates = decoded
+            if templates.isEmpty, seedDefaults {
+                templates = BreakpointTemplate.defaultTemplates
+                save()
+            }
+        } catch {
+            Self.logger.error("Failed to load breakpoint templates: \(error.localizedDescription)")
+            templates = seedDefaults ? BreakpointTemplate.defaultTemplates : []
+        }
+    }
+}
+
+private extension String {
+    var nilIfEmpty: String? {
+        isEmpty ? nil : self
+    }
+}

--- a/Rockxy/Models/Rules/MapRemoteConfiguration.swift
+++ b/Rockxy/Models/Rules/MapRemoteConfiguration.swift
@@ -11,6 +11,7 @@ struct MapRemoteConfiguration: Codable, Hashable {
         port: Int? = nil,
         path: String? = nil,
         query: String? = nil,
+        preserveOriginalURL: Bool = false,
         preserveHostHeader: Bool = false
     ) {
         self.scheme = scheme
@@ -18,6 +19,7 @@ struct MapRemoteConfiguration: Codable, Hashable {
         self.port = port
         self.path = path
         self.query = query
+        self.preserveOriginalURL = preserveOriginalURL
         self.preserveHostHeader = preserveHostHeader
     }
 
@@ -28,6 +30,7 @@ struct MapRemoteConfiguration: Codable, Hashable {
         port = try container.decodeIfPresent(Int.self, forKey: .port)
         path = try container.decodeIfPresent(String.self, forKey: .path)
         query = try container.decodeIfPresent(String.self, forKey: .query)
+        preserveOriginalURL = try container.decodeIfPresent(Bool.self, forKey: .preserveOriginalURL) ?? false
         preserveHostHeader = try container.decodeIfPresent(Bool.self, forKey: .preserveHostHeader) ?? false
     }
 
@@ -43,6 +46,7 @@ struct MapRemoteConfiguration: Codable, Hashable {
             port: components.port,
             path: components.path.isEmpty ? nil : components.path,
             query: components.query,
+            preserveOriginalURL: false,
             preserveHostHeader: false
         )
     }
@@ -54,6 +58,7 @@ struct MapRemoteConfiguration: Codable, Hashable {
     var port: Int?
     var path: String?
     var query: String?
+    var preserveOriginalURL: Bool
     var preserveHostHeader: Bool
 
     /// Whether any destination override is set.

--- a/Rockxy/Models/Rules/NetworkConditionPreset.swift
+++ b/Rockxy/Models/Rules/NetworkConditionPreset.swift
@@ -1,6 +1,7 @@
 import Foundation
 
-/// Named latency presets for Network Conditions, modeled after Apple's Network Link Conditioner.
+/// Named presets for Network Conditions, modeled after Apple's Network Link Conditioner
+/// naming and Proxyman-style bandwidth profile ranges.
 enum NetworkConditionPreset: String, CaseIterable, Codable {
     case threeG
     case edge
@@ -31,6 +32,58 @@ enum NetworkConditionPreset: String, CaseIterable, Codable {
         case .wifi: 2
         case .custom: 0
         }
+    }
+
+    /// Download bandwidth cap in kilobits per second. `nil` means the profile does
+    /// not apply a bandwidth cap, which is currently only true for Custom.
+    var downloadBandwidthKbps: Int? {
+        switch self {
+        case .threeG: 780
+        case .edge: 240
+        case .lte: 50_000
+        case .veryBadNetwork: 1_000
+        case .wifi: 40_000
+        case .custom: nil
+        }
+    }
+
+    /// Upload bandwidth cap in kilobits per second. `nil` means the profile does
+    /// not apply a bandwidth cap, which is currently only true for Custom.
+    var uploadBandwidthKbps: Int? {
+        switch self {
+        case .threeG: 330
+        case .edge: 200
+        case .lte: 10_000
+        case .veryBadNetwork: 1_000
+        case .wifi: 30_000
+        case .custom: nil
+        }
+    }
+
+    var downloadBandwidthLabel: String {
+        Self.bandwidthLabel(for: downloadBandwidthKbps)
+    }
+
+    var uploadBandwidthLabel: String {
+        Self.bandwidthLabel(for: uploadBandwidthKbps)
+    }
+
+    var packetLossLabel: String {
+        String(format: "%.1f%%", packetLossRate)
+    }
+
+    var downloadBytesPerSecond: Int? {
+        downloadBandwidthKbps.map { ($0 * 1_000) / 8 }
+    }
+
+    var uploadBytesPerSecond: Int? {
+        uploadBandwidthKbps.map { ($0 * 1_000) / 8 }
+    }
+
+    /// Packet loss remains disabled until the proxy engine has packet-dropping
+    /// semantics for HTTP body chunks and WebSocket frames.
+    var packetLossRate: Double {
+        0.0
     }
 
     var systemImage: String {
@@ -66,5 +119,17 @@ enum NetworkConditionPreset: String, CaseIterable, Codable {
             matchCondition: matchCondition,
             action: .networkCondition(preset: preset, delayMs: latencyMs)
         )
+    }
+
+    // MARK: Private
+
+    private static func bandwidthLabel(for kbps: Int?) -> String {
+        guard let kbps else {
+            return "Unlimited"
+        }
+        if kbps >= 1_000, kbps.isMultiple(of: 1_000) {
+            return "< \(kbps / 1_000) Mbps"
+        }
+        return "< \(kbps) kbps"
     }
 }

--- a/Rockxy/Models/Rules/RuleAction.swift
+++ b/Rockxy/Models/Rules/RuleAction.swift
@@ -24,7 +24,7 @@ enum HeaderModifyPhase: String, Codable, CaseIterable {
 /// The action to perform when a `ProxyRule` matches a request.
 enum RuleAction {
     case breakpoint(phase: BreakpointRulePhase = .both)
-    case mapLocal(filePath: String, statusCode: Int = 200, isDirectory: Bool = false)
+    case mapLocal(filePath: String, statusCode: Int = 200, isDirectory: Bool = false, delayMs: Int = 0)
     case mapRemote(configuration: MapRemoteConfiguration)
     case block(statusCode: Int)
     case throttle(delayMs: Int)
@@ -49,7 +49,7 @@ extension RuleAction {
         switch self {
         case let .breakpoint(phase):
             "Breakpoint (\(phase.rawValue.capitalized))"
-        case let .mapLocal(filePath, _, isDirectory):
+        case let .mapLocal(filePath, _, isDirectory, _):
             isDirectory ? "Map Local Directory" : "Map Local (\((filePath as NSString).lastPathComponent))"
         case .mapRemote:
             "Map Remote"
@@ -104,7 +104,8 @@ extension RuleAction: Codable {
             let filePath = try container.decode(String.self, forKey: .filePath)
             let statusCode = try container.decodeIfPresent(Int.self, forKey: .statusCode) ?? 200
             let isDirectory = try container.decodeIfPresent(Bool.self, forKey: .isDirectory) ?? false
-            self = .mapLocal(filePath: filePath, statusCode: statusCode, isDirectory: isDirectory)
+            let delayMs = try container.decodeIfPresent(Int.self, forKey: .delayMs) ?? 0
+            self = .mapLocal(filePath: filePath, statusCode: statusCode, isDirectory: isDirectory, delayMs: delayMs)
         case .mapRemote:
             if let config = try container.decodeIfPresent(MapRemoteConfiguration.self, forKey: .configuration) {
                 self = .mapRemote(configuration: config)
@@ -141,12 +142,15 @@ extension RuleAction: Codable {
         case let .breakpoint(phase):
             try container.encode(ActionType.breakpoint, forKey: .type)
             try container.encode(phase, forKey: .phase)
-        case let .mapLocal(filePath, statusCode, isDirectory):
+        case let .mapLocal(filePath, statusCode, isDirectory, delayMs):
             try container.encode(ActionType.mapLocal, forKey: .type)
             try container.encode(filePath, forKey: .filePath)
             try container.encode(statusCode, forKey: .statusCode)
             if isDirectory {
                 try container.encode(isDirectory, forKey: .isDirectory)
+            }
+            if delayMs > 0 {
+                try container.encode(delayMs, forKey: .delayMs)
             }
         case let .mapRemote(configuration):
             try container.encode(ActionType.mapRemote, forKey: .type)

--- a/Rockxy/Models/Rules/RulePolicyGate.swift
+++ b/Rockxy/Models/Rules/RulePolicyGate.swift
@@ -173,6 +173,14 @@ final class RulePolicyGate: @unchecked Sendable {
         await RuleSyncService.setBreakpointToolEnabled(enabled)
     }
 
+    func setBlockListToolEnabled(_ enabled: Bool) async {
+        await RuleSyncService.setBlockListToolEnabled(enabled)
+    }
+
+    func setMapLocalToolEnabled(_ enabled: Bool) async {
+        await RuleSyncService.setMapLocalToolEnabled(enabled)
+    }
+
     // MARK: Private
 
     private static let logger = Logger(

--- a/Rockxy/Models/Rules/RulePolicyGate.swift
+++ b/Rockxy/Models/Rules/RulePolicyGate.swift
@@ -181,6 +181,14 @@ final class RulePolicyGate: @unchecked Sendable {
         await RuleSyncService.setMapLocalToolEnabled(enabled)
     }
 
+    func setMapRemoteToolEnabled(_ enabled: Bool) async {
+        await RuleSyncService.setMapRemoteToolEnabled(enabled)
+    }
+
+    func setNetworkConditionsToolEnabled(_ enabled: Bool) async {
+        await RuleSyncService.setNetworkConditionsToolEnabled(enabled)
+    }
+
     // MARK: Private
 
     private static let logger = Logger(

--- a/Rockxy/RockxyApp.swift
+++ b/Rockxy/RockxyApp.swift
@@ -108,7 +108,7 @@ struct RockxyApp: App {
             MapRemoteEditorWindowView()
         }
         .commandsRemoved()
-        .defaultSize(width: 834, height: 668)
+        .defaultSize(width: 834, height: 584)
         .defaultPosition(.center)
         .windowResizability(.contentSize)
 

--- a/Rockxy/RockxyApp.swift
+++ b/Rockxy/RockxyApp.swift
@@ -88,6 +88,14 @@ struct RockxyApp: App {
         .windowResizability(.contentSize)
         .defaultPosition(.center)
 
+        Window(String(localized: "Map Local Editor"), id: "mapLocalEditor") {
+            MapLocalEditorWindowView()
+        }
+        .commandsRemoved()
+        .defaultSize(width: 960, height: 640)
+        .defaultPosition(.center)
+        .windowResizability(.contentSize)
+
         Window(String(localized: "Map Remote"), id: "mapRemote") {
             MapRemoteWindowView()
         }

--- a/Rockxy/RockxyApp.swift
+++ b/Rockxy/RockxyApp.swift
@@ -104,6 +104,14 @@ struct RockxyApp: App {
         .defaultPosition(.center)
         .windowToolbarStyle(.unifiedCompact)
 
+        Window(String(localized: "Map Remote Editor"), id: "mapRemoteEditor") {
+            MapRemoteEditorWindowView()
+        }
+        .commandsRemoved()
+        .defaultSize(width: 834, height: 668)
+        .defaultPosition(.center)
+        .windowResizability(.contentSize)
+
         Window(String(localized: "Block List"), id: "blockList") {
             BlockListWindowView()
         }
@@ -163,13 +171,13 @@ struct RockxyApp: App {
         .commandsRemoved()
         .windowResizability(.contentSize)
         .defaultPosition(.center)
-        .defaultSize(width: 900, height: 640)
+        .defaultSize(width: 1_200, height: 672)
 
         Window(String(localized: "Script Editor"), id: "scriptEditor") {
             ScriptEditorWindowView()
         }
         .commandsRemoved()
-        .defaultSize(width: 1_120, height: 740)
+        .defaultSize(width: 1_120, height: 690)
         .defaultPosition(.center)
 
         Window(String(localized: "Body Previewer Tabs"), id: "bodyPreviewerTabs") {
@@ -188,6 +196,22 @@ struct RockxyApp: App {
 
         Window(String(localized: "Breakpoint Rules"), id: "breakpointRules") {
             BreakpointRulesWindowView()
+        }
+        .commandsRemoved()
+        .windowResizability(.contentSize)
+        .defaultPosition(.center)
+        .windowToolbarStyle(.unifiedCompact)
+
+        Window(String(localized: "Breakpoint Rule Editor"), id: "breakpointRuleEditor") {
+            BreakpointRuleEditorWindowView()
+        }
+        .commandsRemoved()
+        .windowResizability(.contentSize)
+        .defaultPosition(.center)
+        .windowToolbarStyle(.unifiedCompact)
+
+        Window(String(localized: "Breakpoint Template"), id: "breakpointTemplates") {
+            BreakpointTemplateWindowView()
         }
         .commandsRemoved()
         .windowResizability(.contentSize)
@@ -584,6 +608,12 @@ struct RockxyMenuCommands: Commands {
             }
             .keyboardShortcut("d", modifiers: [.command, .shift])
 
+            Button(String(localized: "Toggle System Proxy")) {
+                actions?.toggleSystemProxyOverride()
+            }
+            .keyboardShortcut("o", modifiers: [.command, .option])
+            .disabled(actions?.canToggleSystemProxyOverride != true)
+
             Divider()
 
             Button(String(localized: "Debug My App…")) {
@@ -615,6 +645,10 @@ struct RockxyMenuCommands: Commands {
 
             Button(String(localized: "Breakpoint Queue…")) {
                 openWindow(id: "breakpoints")
+            }
+
+            Button(String(localized: "Breakpoint Templates…")) {
+                openWindow(id: "breakpointTemplates")
             }
 
             Divider()

--- a/Rockxy/ViewModels/ScriptingListViewModel.swift
+++ b/Rockxy/ViewModels/ScriptingListViewModel.swift
@@ -70,10 +70,12 @@ final class ScriptingListViewModel {
 
     init(
         pluginManager: ScriptPluginManager = PluginManager.shared.scriptManager,
-        folderStore: ScriptFolderStore = .shared
+        folderStore: ScriptFolderStore = .shared,
+        pluginsDirectory: URL? = nil
     ) {
         self.pluginManager = pluginManager
         self.folderStore = folderStore
+        self.pluginsDirectoryOverride = pluginsDirectory
     }
 
     // MARK: Internal
@@ -162,9 +164,7 @@ final class ScriptingListViewModel {
     func createNewScript() async -> String? {
         let id = UUID().uuidString.lowercased()
         let name = "Untitled Script \(plugins.count + 1)"
-        let pluginsDir = RockxyIdentity.current
-            .appSupportPath("Plugins")
-            .appendingPathComponent(id, isDirectory: true)
+        let pluginsDir = pluginDir(for: id)
         var createdDirectory = false
         do {
             try FileManager.default.createDirectory(at: pluginsDir, withIntermediateDirectories: true)
@@ -271,12 +271,8 @@ final class ScriptingListViewModel {
             return
         }
         let newID = UUID().uuidString.lowercased()
-        let sourceDir = RockxyIdentity.current
-            .appSupportPath("Plugins")
-            .appendingPathComponent(id, isDirectory: true)
-        let destDir = RockxyIdentity.current
-            .appSupportPath("Plugins")
-            .appendingPathComponent(newID, isDirectory: true)
+        let sourceDir = pluginDir(for: id)
+        let destDir = pluginDir(for: newID)
         var createdDestination = false
         do {
             try FileManager.default.copyItem(at: sourceDir, to: destDir)
@@ -385,6 +381,12 @@ final class ScriptingListViewModel {
 
     private let pluginManager: ScriptPluginManager
     private let folderStore: ScriptFolderStore
+    private let pluginsDirectoryOverride: URL?
+
+    private func pluginDir(for id: String) -> URL {
+        let root = pluginsDirectoryOverride ?? RockxyIdentity.current.appSupportPath("Plugins")
+        return root.appendingPathComponent(id, isDirectory: true)
+    }
 
     private static func snapshot(from info: PluginInfo) -> PluginInfoSnapshot {
         let behavior = info.manifest.scriptBehavior ?? ScriptBehavior.defaults()

--- a/Rockxy/ViewModels/ScriptingListViewModel.swift
+++ b/Rockxy/ViewModels/ScriptingListViewModel.swift
@@ -493,7 +493,7 @@ final class ScriptingListViewModel {
         case .name:
             script.name.lowercased().contains(needle)
         case .method:
-            (script.method ?? "").lowercased().contains(needle)
+            (script.method ?? "ANY").lowercased().contains(needle)
         case .urlPattern:
             (script.urlPattern ?? "").lowercased().contains(needle)
         }

--- a/Rockxy/Views/Breakpoint/BreakpointEditorView.swift
+++ b/Rockxy/Views/Breakpoint/BreakpointEditorView.swift
@@ -46,6 +46,9 @@ struct BreakpointEditorView: View {
     @State private var selectedTab: BreakpointEditorTab = .headers
     @State private var queryItems: [EditableQueryItem] = []
     @State private var lastSyncedURL: String = ""
+    @State private var rawMessage: String = ""
+    @State private var rawMessageItemID: UUID?
+    @State private var templateStore = BreakpointTemplateStore.shared
 
     private var emptyState: some View {
         VStack(spacing: 4) {
@@ -170,6 +173,8 @@ struct BreakpointEditorView: View {
                     headersEditor(itemId: itemId)
                 case .body:
                     bodyEditor(itemId: itemId)
+                case .raw:
+                    rawEditor(itemId: itemId)
                 case .query:
                     queryDisplay(itemId: itemId)
                 }
@@ -266,6 +271,48 @@ struct BreakpointEditorView: View {
         .padding(8)
     }
 
+    private func rawEditor(itemId: UUID) -> some View {
+        let kind = rawKind(for: itemId)
+        let validation = BreakpointRawMessage.validation(for: rawMessage, kind: kind)
+        return VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 8) {
+                Label(validation.message, systemImage: "circle.fill")
+                    .font(.caption)
+                    .foregroundStyle(validation.isValid ? Color.green : Color.red)
+                Spacer()
+                Menu {
+                    ForEach(templateStore.templates(for: kind)) { template in
+                        Button(template.name.isEmpty ? String(localized: "Untitled") : template.name) {
+                            applyTemplate(template, to: itemId)
+                        }
+                    }
+                } label: {
+                    Label(String(localized: "Template"), systemImage: "doc.text")
+                }
+                .disabled(templateStore.templates(for: kind).isEmpty)
+            }
+            .padding(.horizontal, 12)
+            .padding(.top, 8)
+
+            MapLocalHTTPMessageEditor(text: Binding(
+                get: { rawMessage },
+                set: { updateRawMessage($0, itemId: itemId) }
+            ))
+            .overlay(Rectangle().stroke(Color(nsColor: .separatorColor).opacity(0.35)))
+            .padding(.horizontal, 12)
+            .padding(.bottom, 12)
+        }
+        .onAppear { syncRawMessageFromDraft(itemId: itemId, force: true) }
+        .onChange(of: manager.selectedItemId) { _, _ in
+            syncRawMessageFromDraft(itemId: itemId, force: true)
+        }
+        .onChange(of: selectedTab) { _, newValue in
+            if newValue == .raw {
+                syncRawMessageFromDraft(itemId: itemId, force: rawMessageItemID != itemId)
+            }
+        }
+    }
+
     private func queryDisplay(itemId: UUID) -> some View {
         VStack(spacing: 0) {
             HStack {
@@ -348,9 +395,9 @@ struct BreakpointEditorView: View {
 
     private func availableTabs(for itemId: UUID) -> [BreakpointEditorTab] {
         if itemPhase(itemId: itemId) == .response {
-            return [.headers, .body]
+            return [.headers, .body, .raw]
         }
-        return [.headers, .body, .query]
+        return [.headers, .body, .raw, .query]
     }
 
     private func syncQueryItemsFromURL(itemId: UUID) {
@@ -384,6 +431,40 @@ struct BreakpointEditorView: View {
     private func headerValue(itemId: UUID, headerId: UUID) -> EditableHeader? {
         draftFor(itemId)?.headers.first(where: { $0.id == headerId })
     }
+
+    private func rawKind(for itemId: UUID) -> BreakpointTemplateKind {
+        itemPhase(itemId: itemId) == .response ? .response : .request
+    }
+
+    private func syncRawMessageFromDraft(itemId: UUID, force: Bool = false) {
+        guard force || rawMessageItemID != itemId,
+              let draft = draftFor(itemId)
+        else {
+            return
+        }
+        rawMessageItemID = itemId
+        rawMessage = BreakpointRawMessage.rawMessage(from: draft, kind: rawKind(for: itemId))
+    }
+
+    private func updateRawMessage(_ newValue: String, itemId: UUID) {
+        rawMessageItemID = itemId
+        rawMessage = newValue
+        let kind = rawKind(for: itemId)
+        guard BreakpointRawMessage.validation(for: newValue, kind: kind).isValid else {
+            return
+        }
+        manager.updateDraft(id: itemId) { draft in
+            if let updated = try? BreakpointRawMessage.applying(newValue, kind: kind, to: draft) {
+                draft = updated
+            }
+        }
+    }
+
+    private func applyTemplate(_ template: BreakpointTemplate, to itemId: UUID) {
+        rawMessageItemID = itemId
+        rawMessage = template.rawMessage
+        updateRawMessage(template.rawMessage, itemId: itemId)
+    }
 }
 
 // MARK: - BreakpointEditorTab
@@ -391,6 +472,7 @@ struct BreakpointEditorView: View {
 private enum BreakpointEditorTab: String, CaseIterable, Identifiable {
     case headers
     case body
+    case raw
     case query
 
     // MARK: Internal
@@ -403,6 +485,7 @@ private enum BreakpointEditorTab: String, CaseIterable, Identifiable {
         switch self {
         case .headers: String(localized: "Headers")
         case .body: String(localized: "Body")
+        case .raw: String(localized: "Raw")
         case .query: String(localized: "Query")
         }
     }

--- a/Rockxy/Views/Breakpoint/BreakpointRuleEditorWindowView.swift
+++ b/Rockxy/Views/Breakpoint/BreakpointRuleEditorWindowView.swift
@@ -1,0 +1,221 @@
+import SwiftUI
+
+// MARK: - BreakpointRuleEditorStore
+
+@MainActor @Observable
+final class BreakpointRuleEditorStore {
+    // MARK: Internal
+
+    typealias SaveHandler = (String, String, HTTPMethodFilter, RuleMatchType, Bool, Bool, Bool) -> Void
+
+    static let shared = BreakpointRuleEditorStore()
+
+    private(set) var editorContext: BreakpointEditorContext?
+    private(set) var editingRule: ProxyRule?
+    private(set) var draftVersion: UInt64 = 0
+
+    var onSave: SaveHandler?
+
+    func openNew(context: BreakpointEditorContext? = nil, onSave: @escaping SaveHandler) {
+        editorContext = context
+        editingRule = nil
+        self.onSave = onSave
+        draftVersion &+= 1
+    }
+
+    func openExisting(_ rule: ProxyRule, onSave: @escaping SaveHandler) {
+        editorContext = nil
+        editingRule = rule
+        self.onSave = onSave
+        draftVersion &+= 1
+    }
+
+    // MARK: Private
+
+    private init() {}
+}
+
+// MARK: - BreakpointRuleEditorWindowView
+
+struct BreakpointRuleEditorWindowView: View {
+    // MARK: Internal
+
+    var body: some View {
+        VStack(spacing: 10) {
+            formRows
+            Spacer(minLength: 8)
+            actionRow
+        }
+        .padding(.horizontal, 18)
+        .padding(.top, 14)
+        .padding(.bottom, 18)
+        .frame(width: 785, height: 238)
+        .onAppear { loadFromStore() }
+        .onChange(of: store.draftVersion) { _, _ in loadFromStore() }
+    }
+
+    // MARK: Private
+
+    private static let labelWidth: CGFloat = 92
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var store = BreakpointRuleEditorStore.shared
+
+    @State private var ruleName = "Untitled"
+    @State private var urlPattern = ""
+    @State private var httpMethod: HTTPMethodFilter = .any
+    @State private var matchType: RuleMatchType = .wildcard
+    @State private var includeSubpaths = true
+    @State private var breakpointRequest = true
+    @State private var breakpointResponse = true
+
+    private var isEditing: Bool {
+        store.editingRule != nil
+    }
+
+    private var canSave: Bool {
+        !urlPattern.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            && (breakpointRequest || breakpointResponse)
+    }
+
+    private var formRows: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            formRow(String(localized: "Name:")) {
+                TextField(String(localized: "Untitled"), text: $ruleName)
+                    .textFieldStyle(.roundedBorder)
+            }
+
+            formRow(String(localized: "Matching Rule:")) {
+                TextField("/v1/*", text: $urlPattern)
+                    .textFieldStyle(.roundedBorder)
+                    .font(.system(.body, design: .monospaced))
+            }
+
+            HStack(spacing: 8) {
+                Spacer()
+                    .frame(width: Self.labelWidth)
+                Picker("", selection: $httpMethod) {
+                    ForEach(HTTPMethodFilter.allCases, id: \.self) { method in
+                        Text(method.rawValue).tag(method)
+                    }
+                }
+                .labelsHidden()
+                .frame(width: 100)
+
+                Picker("", selection: $matchType) {
+                    ForEach(RuleMatchType.allCases, id: \.self) { type in
+                        Text(type.rawValue).tag(type)
+                    }
+                }
+                .labelsHidden()
+                .frame(width: 132)
+
+                Text(String(localized: "Support wildcard * and ?."))
+                    .font(.system(size: 13))
+                    .foregroundStyle(.secondary)
+
+                Button(String(localized: "Test your Rule")) {
+                    NSSound.beep()
+                }
+                .buttonStyle(.link)
+                .foregroundStyle(.secondary)
+            }
+
+            HStack(spacing: 8) {
+                Spacer()
+                    .frame(width: Self.labelWidth)
+                Toggle(String(localized: "Include all subpaths of this URL"), isOn: $includeSubpaths)
+                    .toggleStyle(.checkbox)
+                    .font(.system(size: 13))
+                    .disabled(matchType != .wildcard)
+            }
+
+            formRow(String(localized: "Breakpoint:")) {
+                Toggle(String(localized: "Request"), isOn: $breakpointRequest)
+                    .toggleStyle(.checkbox)
+                    .font(.system(size: 13))
+                Toggle(String(localized: "Response"), isOn: $breakpointResponse)
+                    .toggleStyle(.checkbox)
+                    .font(.system(size: 13))
+            }
+
+            HStack {
+                Spacer()
+                    .frame(width: Self.labelWidth)
+                Text(String(localized: "Start the breakpoint for out-going request or in-coming response."))
+                    .font(.system(size: 13))
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    private var actionRow: some View {
+        HStack(spacing: 8) {
+            Spacer()
+            Button(String(localized: "Cancel")) {
+                dismiss()
+            }
+            .keyboardShortcut(.cancelAction)
+            .frame(width: 100)
+
+            Button(isEditing ? String(localized: "Save (⌘↵)") : String(localized: "Add (⌘↵)")) {
+                store.onSave?(
+                    ruleName,
+                    urlPattern,
+                    httpMethod,
+                    matchType,
+                    breakpointRequest,
+                    breakpointResponse,
+                    includeSubpaths
+                )
+                dismiss()
+            }
+            .keyboardShortcut(.defaultAction)
+            .disabled(!canSave)
+            .frame(width: 100)
+        }
+    }
+
+    private func formRow(
+        _ label: String,
+        @ViewBuilder content: () -> some View
+    )
+        -> some View
+    {
+        HStack(alignment: .firstTextBaseline, spacing: 8) {
+            Text(label)
+                .font(.system(size: 13))
+                .frame(width: Self.labelWidth, alignment: .trailing)
+            content()
+        }
+    }
+
+    private func loadFromStore() {
+        if let editingRule = store.editingRule {
+            let decoded = AddBreakpointRuleSheet.decode(rule: editingRule)
+            ruleName = editingRule.name
+            urlPattern = decoded.displayPattern
+            httpMethod = decoded.httpMethod
+            matchType = decoded.matchType
+            includeSubpaths = decoded.includeSubpaths
+            breakpointRequest = decoded.breakpointRequest
+            breakpointResponse = decoded.breakpointResponse
+        } else if let context = store.editorContext {
+            ruleName = context.suggestedName.isEmpty ? "Untitled" : context.suggestedName
+            urlPattern = context.defaultPattern
+            httpMethod = context.httpMethod
+            matchType = context.defaultMatchType
+            includeSubpaths = context.includeSubpaths
+            breakpointRequest = context.breakpointRequest
+            breakpointResponse = context.breakpointResponse
+        } else {
+            ruleName = "Untitled"
+            urlPattern = ""
+            httpMethod = .any
+            matchType = .wildcard
+            includeSubpaths = true
+            breakpointRequest = true
+            breakpointResponse = true
+        }
+    }
+}

--- a/Rockxy/Views/Breakpoint/BreakpointRulesWindowView.swift
+++ b/Rockxy/Views/Breakpoint/BreakpointRulesWindowView.swift
@@ -10,14 +10,12 @@ final class BreakpointRulesViewModel {
     // MARK: Internal
 
     var selectedRuleID: UUID?
-    var showAddSheet = false
-    var editingRule: ProxyRule?
-    var pendingContext: BreakpointEditorContext?
     private(set) var allRules: [ProxyRule] = []
 
     var isFilterBarVisible = false
     var filterColumn: BreakpointFilterColumn = .name
     var filterText = ""
+    var alertMessage: String?
 
     var isBreakpointToolEnabled: Bool = UserDefaults.standard.object(
         forKey: "breakpointToolEnabled"
@@ -50,6 +48,13 @@ final class BreakpointRulesViewModel {
 
     var ruleCount: Int {
         breakpointRules.count
+    }
+
+    var selectedRule: ProxyRule? {
+        guard let id = selectedRuleID else {
+            return nil
+        }
+        return breakpointRules.first { $0.id == id }
     }
 
     func refreshFromEngine() async {
@@ -184,6 +189,39 @@ final class BreakpointRulesViewModel {
         Task { await RulePolicyGate.shared.setBreakpointToolEnabled(isBreakpointToolEnabled) }
     }
 
+    func setBreakpointToolEnabled(_ enabled: Bool) {
+        isBreakpointToolEnabled = enabled
+        Task { await RulePolicyGate.shared.setBreakpointToolEnabled(enabled) }
+    }
+
+    func methodLabel(for rule: ProxyRule) -> String {
+        rule.matchCondition.method?.uppercased() ?? "ANY"
+    }
+
+    func matchingRuleLabel(for rule: ProxyRule) -> String {
+        let decoded = AddBreakpointRuleSheet.decode(rule: rule)
+        switch decoded.matchType {
+        case .wildcard:
+            return "Wildcard: \(decoded.displayPattern)"
+        case .regex:
+            return "Regex: \(rule.matchCondition.urlPattern ?? "")"
+        }
+    }
+
+    func breaksOnRequest(_ rule: ProxyRule) -> Bool {
+        guard case let .breakpoint(phase) = rule.action else {
+            return false
+        }
+        return phase == .request || phase == .both
+    }
+
+    func breaksOnResponse(_ rule: ProxyRule) -> Bool {
+        guard case let .breakpoint(phase) = rule.action else {
+            return false
+        }
+        return phase == .response || phase == .both
+    }
+
     // MARK: Private
 
     private static func compilePattern(
@@ -227,25 +265,13 @@ struct BreakpointRulesWindowView: View {
     // MARK: Internal
 
     var body: some View {
-        VStack(spacing: 0) {
-            toolbar
-            Divider()
-            infoBanner
-            Divider()
-            content
-            if viewModel.isFilterBarVisible {
-                Divider()
-                BreakpointFilterBar(
-                    filterColumn: $viewModel.filterColumn,
-                    filterText: $viewModel.filterText,
-                    onDismiss: hideFilterBar
-                )
-                .transition(.move(edge: .bottom).combined(with: .opacity))
-            }
-            Divider()
+        VStack(alignment: .leading, spacing: 0) {
+            header
+            tableContent
+            shortcutStrip
             bottomBar
         }
-        .frame(width: 860, height: 620)
+        .frame(width: 1_200, height: 675)
         .task { await viewModel.refreshFromEngine() }
         .onAppear { consumePendingContext() }
         .onReceive(NotificationCenter.default.publisher(for: .openBreakpointRulesWindow)) { _ in
@@ -254,38 +280,17 @@ struct BreakpointRulesWindowView: View {
         .onReceive(NotificationCenter.default.publisher(for: .rulesDidChange)) { notification in
             viewModel.handleRulesDidChange(notification)
         }
-        .sheet(isPresented: $viewModel.showAddSheet) {
-            viewModel.pendingContext = nil
-            viewModel.editingRule = nil
-        } content: {
-            AddBreakpointRuleSheet(
-                editorContext: viewModel.editingRule == nil ? viewModel.pendingContext : nil,
-                editingRule: viewModel.editingRule
-            ) { name, pattern, method, matchType, phaseReq, phaseRes, includeSubpaths in
-                if let editing = viewModel.editingRule {
-                    viewModel.updateRule(
-                        id: editing.id,
-                        ruleName: name,
-                        urlPattern: pattern,
-                        httpMethod: method,
-                        matchType: matchType,
-                        phaseRequest: phaseReq,
-                        phaseResponse: phaseRes,
-                        includeSubpaths: includeSubpaths
-                    )
-                } else {
-                    viewModel.addBreakpointRule(
-                        ruleName: name,
-                        urlPattern: pattern,
-                        httpMethod: method,
-                        matchType: matchType,
-                        phaseRequest: phaseReq,
-                        phaseResponse: phaseRes,
-                        includeSubpaths: includeSubpaths
-                    )
-                }
-                viewModel.pendingContext = nil
-                viewModel.editingRule = nil
+        .alert(
+            String(localized: "Breakpoint Rules"),
+            isPresented: Binding(
+                get: { viewModel.alertMessage != nil },
+                set: { if !$0 { viewModel.alertMessage = nil } }
+            )
+        ) {
+            Button(String(localized: "OK")) { viewModel.alertMessage = nil }
+        } message: {
+            if let message = viewModel.alertMessage {
+                Text(message)
             }
         }
         .animation(.easeInOut(duration: 0.2), value: viewModel.isFilterBarVisible)
@@ -298,12 +303,11 @@ struct BreakpointRulesWindowView: View {
         category: "BreakpointRulesWindowView"
     )
 
+    @Environment(\.openWindow) private var openWindow
     @State private var viewModel = BreakpointRulesViewModel()
 
     private var enableDisableLabel: String {
-        guard let id = viewModel.selectedRuleID,
-              let rule = viewModel.breakpointRules.first(where: { $0.id == id }) else
-        {
+        guard let rule = viewModel.selectedRule else {
             return String(localized: "Enable Rule")
         }
         return rule.isEnabled
@@ -311,168 +315,193 @@ struct BreakpointRulesWindowView: View {
             : String(localized: "Enable Rule")
     }
 
-    private var toolbar: some View {
-        HStack {
-            Text(String(localized: "Breakpoint Rules"))
-                .font(.headline)
-            Spacer()
-            Toggle(
-                String(localized: "Enable Breakpoint Tool"),
-                isOn: Binding(
-                    get: { viewModel.isBreakpointToolEnabled },
-                    set: { _ in viewModel.toggleBreakpointTool() }
-                )
-            )
-            .toggleStyle(.switch)
-            .controlSize(.small)
-        }
-        .padding(.horizontal, 16)
-        .padding(.vertical, 10)
-    }
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Toggle(isOn: Binding(
+                get: { viewModel.isBreakpointToolEnabled },
+                set: { viewModel.setBreakpointToolEnabled($0) }
+            )) {
+                Text(String(localized: "Enable Breakpoint Tool"))
+                    .font(.system(size: 13))
+            }
+            .toggleStyle(.checkbox)
+            .padding(.top, 16)
 
-    private var infoBanner: some View {
-        HStack(spacing: 6) {
-            Image(systemName: "info.circle")
+            Text(String(localized: "Modify the Request/Response on the fly. Support URL, Method, Status Code, Headers, and Body."))
+                .font(.system(size: 13))
+            Text(String(localized: "Each request is checked against the rules from top to bottom, stopping when a match is found."))
+                .font(.system(size: 13))
                 .foregroundStyle(.secondary)
-            Text(
-                String(
-                    localized:
-                    "Modify the Request/Response on the fly. Each request is checked against the rules from top to bottom, stopping when a match is found."
-                )
-            )
-            .font(.caption)
-            .foregroundStyle(.secondary)
-            Spacer()
-        }
-        .padding(.horizontal, 16)
-        .padding(.vertical, 8)
-        .background(.quaternary.opacity(0.5))
-    }
 
-    @ViewBuilder private var content: some View {
-        if viewModel.breakpointRules.isEmpty {
-            emptyState
-        } else {
-            VStack(spacing: 0) {
-                columnHeader
-                Divider()
-                List(selection: $viewModel.selectedRuleID) {
-                    ForEach(viewModel.filteredBreakpointRules) { rule in
-                        BreakpointRulesRow(rule: rule) {
-                            viewModel.toggleRule(id: rule.id)
-                        }
-                        .tag(rule.id)
-                    }
-                }
-                .listStyle(.inset(alternatesRowBackgrounds: true))
+            if viewModel.isFilterBarVisible {
+                BreakpointFilterBar(
+                    filterColumn: $viewModel.filterColumn,
+                    filterText: $viewModel.filterText,
+                    onDismiss: hideFilterBar
+                )
+                .transition(.move(edge: .top).combined(with: .opacity))
             }
         }
+        .padding(.horizontal, 22)
+        .padding(.bottom, 10)
     }
 
-    private var columnHeader: some View {
-        HStack(spacing: 10) {
-            Spacer().frame(width: 24)
-            Text(String(localized: "Name"))
-                .font(.caption.weight(.semibold))
-                .foregroundStyle(.secondary)
-                .frame(width: 180, alignment: .leading)
-            Text(String(localized: "Method"))
-                .font(.caption.weight(.semibold))
-                .foregroundStyle(.secondary)
-                .frame(width: 60, alignment: .leading)
-            Text(String(localized: "Matching Rule"))
-                .font(.caption.weight(.semibold))
-                .foregroundStyle(.secondary)
-                .frame(maxWidth: .infinity, alignment: .leading)
-            Text(String(localized: "Request"))
-                .font(.caption.weight(.semibold))
-                .foregroundStyle(.secondary)
-                .frame(width: 60)
-            Text(String(localized: "Response"))
-                .font(.caption.weight(.semibold))
-                .foregroundStyle(.secondary)
-                .frame(width: 60)
-        }
-        .padding(.horizontal, 16)
-        .padding(.vertical, 6)
-        .background(.background.tertiary)
-    }
+    private var tableContent: some View {
+        Table(viewModel.filteredBreakpointRules, selection: $viewModel.selectedRuleID) {
+            TableColumn(String(localized: "Name")) { rule in
+                HStack(spacing: 7) {
+                    Toggle("", isOn: Binding(
+                        get: { rule.isEnabled },
+                        set: { _ in viewModel.toggleRule(id: rule.id) }
+                    ))
+                    .toggleStyle(.checkbox)
+                    .labelsHidden()
 
-    private var emptyState: some View {
-        VStack(alignment: .center, spacing: 8) {
-            Image(systemName: "pause.circle")
-                .font(.system(size: 20))
-                .foregroundStyle(.tertiary)
-            Text(String(localized: "No Breakpoint Rules"))
-                .font(.system(size: 13, weight: .medium))
-                .foregroundStyle(.secondary)
-            Text(String(localized: "Add URL patterns to pause matching requests for inspection."))
-                .font(.caption)
-                .foregroundStyle(.tertiary)
-                .multilineTextAlignment(.center)
+                    Text(rule.name.isEmpty ? String(localized: "Untitled") : rule.name)
+                        .lineLimit(1)
+                }
+                .opacity(rule.isEnabled ? 1.0 : 0.5)
+            }
+            .width(min: 190, ideal: 240)
+
+            TableColumn(String(localized: "Method")) { rule in
+                Text(viewModel.methodLabel(for: rule))
+                    .lineLimit(1)
+                    .opacity(rule.isEnabled ? 1.0 : 0.5)
+            }
+            .width(86)
+
+            TableColumn(String(localized: "Matching Rule")) { rule in
+                Text(viewModel.matchingRuleLabel(for: rule))
+                    .lineLimit(1)
+                    .help(viewModel.matchingRuleLabel(for: rule))
+                    .opacity(rule.isEnabled ? 1.0 : 0.5)
+            }
+            .width(min: 420, ideal: 520)
+
+            TableColumn(String(localized: "Request")) { rule in
+                phaseIndicator(isActive: viewModel.breaksOnRequest(rule))
+                    .opacity(rule.isEnabled ? 1.0 : 0.5)
+            }
+            .width(78)
+
+            TableColumn(String(localized: "Response")) { rule in
+                phaseIndicator(isActive: viewModel.breaksOnResponse(rule))
+                    .opacity(rule.isEnabled ? 1.0 : 0.5)
+            }
+            .width(86)
         }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .padding(.horizontal, 24)
-        .padding(.top, 12)
+        .contextMenu(forSelectionType: UUID.self) { ids in
+            tableContextMenu(ids: ids)
+        } primaryAction: { ids in
+            guard let id = ids.first,
+                  let rule = viewModel.breakpointRules.first(where: { $0.id == id }) else
+            {
+                return
+            }
+            openEditor(for: rule)
+        }
+        .overlay {
+            if viewModel.filteredBreakpointRules.isEmpty {
+                ContentUnavailableView(
+                    String(localized: "No Breakpoint Rules"),
+                    systemImage: "pause.circle",
+                    description: Text(String(localized: "Click + or create a rule from a captured request."))
+                )
+            }
+        }
+        .padding(.horizontal, 22)
     }
 
     private var bottomBar: some View {
         HStack(spacing: 8) {
-            Button {
-                viewModel.showAddSheet = true
-            } label: {
-                Image(systemName: "plus")
+            HStack(spacing: 0) {
+                Button {
+                    openNewEditor()
+                } label: {
+                    Image(systemName: "plus")
+                        .font(.system(size: 12, weight: .regular))
+                        .frame(width: 18, height: 18)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .keyboardShortcut("n", modifiers: .command)
+
+                Rectangle()
+                    .fill(Color(nsColor: .separatorColor))
+                    .frame(width: 1, height: 18)
+
+                Button {
+                    viewModel.removeSelected()
+                } label: {
+                    Image(systemName: "minus")
+                        .font(.system(size: 12, weight: .regular))
+                        .frame(width: 18, height: 18)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .keyboardShortcut(.delete, modifiers: .command)
+                .disabled(viewModel.selectedRuleID == nil)
             }
-            .buttonStyle(.borderless)
+            .foregroundStyle(.primary)
+            .background(Color(nsColor: .controlBackgroundColor))
+            .overlay(Rectangle().stroke(Color(nsColor: .separatorColor), lineWidth: 1))
+            .frame(width: 37, height: 19)
+
+            Button(String(localized: "New Folder")) {}
+                .disabled(true)
+                .help(String(localized: "Breakpoint folders are not supported yet."))
 
             Button {
-                viewModel.removeSelected()
+                viewModel.alertMessage = String(
+                    localized: "Breakpoint rules pause matching traffic so requests or responses can be inspected and modified before forwarding."
+                )
             } label: {
-                Image(systemName: "minus")
+                Image(systemName: "questionmark.circle")
             }
-            .buttonStyle(.borderless)
-            .disabled(viewModel.selectedRuleID == nil)
-
-            Divider()
-                .frame(height: 16)
-
-            Text(
-                "\(viewModel.ruleCount) \(viewModel.ruleCount == 1 ? String(localized: "rule") : String(localized: "rules"))"
-            )
-            .font(.caption)
-            .foregroundStyle(.secondary)
+            .buttonStyle(.bordered)
 
             Spacer()
 
             Button {
-                showFilterBar()
+                withAnimation {
+                    viewModel.isFilterBarVisible.toggle()
+                }
             } label: {
-                Label(String(localized: "Filter"), systemImage: "line.3.horizontal.decrease.circle")
+                Label(String(localized: "Filter"), systemImage: "magnifyingglass")
             }
-            .buttonStyle(.borderless)
             .keyboardShortcut("f", modifiers: .command)
+
+            Button(String(localized: "Templates...")) {
+                openWindow(id: "breakpointTemplates")
+            }
 
             moreMenu
         }
-        .padding(.horizontal, 12)
-        .padding(.vertical, 8)
+        .padding(.horizontal, 22)
+        .padding(.bottom, 14)
+        .padding(.top, 8)
+    }
+
+    private var shortcutStrip: some View {
+        Text("New: ⌘N    Edit: ⌘↵    Delete: ⌘⌫    Duplicate: ⌘D    Toggle: ↵")
+            .font(.system(size: 11))
+            .foregroundStyle(.secondary)
+            .padding(.horizontal, 22)
+            .padding(.top, 8)
+            .padding(.bottom, 4)
     }
 
     private var moreMenu: some View {
         Menu {
-            Button(String(localized: "New Rule...")) {
-                viewModel.showAddSheet = true
+            Button(String(localized: "New")) {
+                openNewEditor()
             }
             .keyboardShortcut("n", modifiers: .command)
 
-            Divider()
-
             Button(String(localized: "Edit")) {
-                if let id = viewModel.selectedRuleID,
-                   let rule = viewModel.breakpointRules.first(where: { $0.id == id })
-                {
-                    viewModel.editingRule = rule
-                    viewModel.showAddSheet = true
+                if let rule = viewModel.selectedRule {
+                    openEditor(for: rule)
                 }
             }
             .keyboardShortcut(.return, modifiers: .command)
@@ -501,15 +530,15 @@ struct BreakpointRulesWindowView: View {
             .keyboardShortcut(.delete, modifiers: .command)
             .disabled(viewModel.selectedRuleID == nil)
         } label: {
-            Text(String(localized: "More"))
-            Image(systemName: "chevron.down")
-                .font(.caption2)
+            HStack(spacing: 6) {
+                Text(String(localized: "More"))
+                Image(systemName: "chevron.down")
+                    .font(.system(size: 9, weight: .semibold))
+            }
         }
-        .menuStyle(.borderlessButton)
-    }
-
-    private func showFilterBar() {
-        viewModel.isFilterBarVisible = true
+        .menuIndicator(.hidden)
+        .buttonStyle(.bordered)
+        .fixedSize()
     }
 
     private func hideFilterBar() {
@@ -517,87 +546,71 @@ struct BreakpointRulesWindowView: View {
         viewModel.filterText = ""
     }
 
+    @ViewBuilder
+    private func tableContextMenu(ids: Set<UUID>) -> some View {
+        if let id = ids.first {
+            Button(String(localized: "Edit Rule")) {
+                if let rule = viewModel.breakpointRules.first(where: { $0.id == id }) {
+                    openEditor(for: rule)
+                }
+            }
+            Button(String(localized: "Duplicate")) {
+                viewModel.selectedRuleID = id
+                viewModel.duplicateRule(id: id)
+            }
+            Divider()
+            Button(String(localized: "Delete Rule"), role: .destructive) {
+                viewModel.selectedRuleID = id
+                viewModel.removeSelected()
+            }
+        }
+    }
+
+    private func phaseIndicator(isActive: Bool) -> some View {
+        HStack {
+            Spacer()
+            Image(systemName: isActive ? "checkmark.square.fill" : "square")
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(isActive ? Color.accentColor : Color.secondary)
+            Spacer()
+        }
+    }
+
+    private func openNewEditor(context: BreakpointEditorContext? = nil) {
+        BreakpointRuleEditorStore.shared.openNew(context: context) { name, pattern, method, matchType, phaseReq, phaseRes, includeSubpaths in
+            viewModel.addBreakpointRule(
+                ruleName: name,
+                urlPattern: pattern,
+                httpMethod: method,
+                matchType: matchType,
+                phaseRequest: phaseReq,
+                phaseResponse: phaseRes,
+                includeSubpaths: includeSubpaths
+            )
+        }
+        openWindow(id: "breakpointRuleEditor")
+    }
+
+    private func openEditor(for rule: ProxyRule) {
+        BreakpointRuleEditorStore.shared.openExisting(rule) { name, pattern, method, matchType, phaseReq, phaseRes, includeSubpaths in
+            viewModel.updateRule(
+                id: rule.id,
+                ruleName: name,
+                urlPattern: pattern,
+                httpMethod: method,
+                matchType: matchType,
+                phaseRequest: phaseReq,
+                phaseResponse: phaseRes,
+                includeSubpaths: includeSubpaths
+            )
+        }
+        openWindow(id: "breakpointRuleEditor")
+    }
+
     private func consumePendingContext() {
         guard let context = BreakpointEditorContextStore.shared.consumePending() else {
             return
         }
-        viewModel.pendingContext = context
-        viewModel.showAddSheet = true
-    }
-}
-
-// MARK: - BreakpointRulesRow
-
-private struct BreakpointRulesRow: View {
-    // MARK: Internal
-
-    let rule: ProxyRule
-    let onToggle: () -> Void
-
-    var body: some View {
-        HStack(spacing: 10) {
-            Toggle("", isOn: Binding(
-                get: { rule.isEnabled },
-                set: { _ in onToggle() }
-            ))
-            .toggleStyle(.switch)
-            .labelsHidden()
-            .controlSize(.small)
-
-            Text(rule.name)
-                .font(.system(size: 12, weight: .medium))
-                .lineLimit(1)
-                .truncationMode(.tail)
-                .frame(width: 180, alignment: .leading)
-
-            Text(rule.matchCondition.method ?? "ANY")
-                .font(.caption)
-                .foregroundStyle(.secondary)
-                .frame(width: 60, alignment: .leading)
-
-            Text(rule.matchCondition.urlPattern ?? "")
-                .font(.system(.caption, design: .monospaced))
-                .foregroundStyle(.secondary)
-                .lineLimit(1)
-                .truncationMode(.middle)
-                .frame(maxWidth: .infinity, alignment: .leading)
-
-            requestBadge
-                .frame(width: 60)
-            responseBadge
-                .frame(width: 60)
-        }
-        .padding(.vertical, 2)
-        .opacity(rule.isEnabled ? 1.0 : 0.5)
-    }
-
-    // MARK: Private
-
-    @ViewBuilder private var requestBadge: some View {
-        if case let .breakpoint(phase) = rule.action,
-           phase == .request || phase == .both
-        {
-            Image(systemName: "checkmark.circle.fill")
-                .foregroundStyle(.green)
-                .font(.caption)
-        } else {
-            Image(systemName: "circle")
-                .foregroundStyle(.quaternary)
-                .font(.caption)
-        }
-    }
-
-    @ViewBuilder private var responseBadge: some View {
-        if case let .breakpoint(phase) = rule.action,
-           phase == .response || phase == .both
-        {
-            Image(systemName: "checkmark.circle.fill")
-                .foregroundStyle(.green)
-                .font(.caption)
-        } else {
-            Image(systemName: "circle")
-                .foregroundStyle(.quaternary)
-                .font(.caption)
-        }
+        openNewEditor(context: context)
     }
 }

--- a/Rockxy/Views/Breakpoint/BreakpointTemplateWindowView.swift
+++ b/Rockxy/Views/Breakpoint/BreakpointTemplateWindowView.swift
@@ -1,0 +1,207 @@
+import SwiftUI
+
+// MARK: - BreakpointTemplateWindowView
+
+struct BreakpointTemplateWindowView: View {
+    // MARK: Internal
+
+    var body: some View {
+        HStack(spacing: 0) {
+            sidebar
+            Divider()
+            editor
+        }
+        .frame(width: 802, height: 631)
+    }
+
+    // MARK: Private
+
+    @State private var store = BreakpointTemplateStore.shared
+
+    private var sidebar: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Text(String(localized: "Breakpoint Templates"))
+                .font(.system(size: 13))
+                .padding(.top, 20)
+                .padding(.horizontal, 20)
+
+            List(selection: $store.selectedTemplateID) {
+                templateSection(kind: .request)
+                templateSection(kind: .response)
+            }
+            .listStyle(.sidebar)
+            .scrollContentBackground(.hidden)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .padding(.top, 6)
+
+            bottomControls
+        }
+        .frame(width: 238)
+        .background(Color(nsColor: .windowBackgroundColor))
+    }
+
+    private func templateSection(kind: BreakpointTemplateKind) -> some View {
+        Section {
+            ForEach(store.templates(for: kind)) { template in
+                Text(template.name.isEmpty ? String(localized: "Untitled") : template.name)
+                    .font(.system(size: 13))
+                    .tag(template.id)
+            }
+        } header: {
+            Label(kind.groupTitle, systemImage: "folder")
+                .font(.system(size: 13))
+                .foregroundStyle(.primary)
+        }
+    }
+
+    private var bottomControls: some View {
+        HStack(spacing: 12) {
+            HStack(spacing: 0) {
+                Button {
+                    store.addTemplate()
+                } label: {
+                    Image(systemName: "plus")
+                        .font(.system(size: 12))
+                        .frame(width: 20, height: 20)
+                }
+                .buttonStyle(.plain)
+                .keyboardShortcut("n", modifiers: .command)
+
+                Divider()
+                    .frame(height: 18)
+
+                Button {
+                    store.removeSelectedTemplate()
+                } label: {
+                    Image(systemName: "minus")
+                        .font(.system(size: 12))
+                        .frame(width: 20, height: 20)
+                }
+                .buttonStyle(.plain)
+                .keyboardShortcut(.delete, modifiers: .command)
+                .disabled(store.selectedTemplate == nil || store.templates.count <= 1)
+            }
+            .background(Color(nsColor: .controlBackgroundColor))
+            .overlay(Rectangle().stroke(Color(nsColor: .separatorColor), lineWidth: 1))
+            .frame(width: 42, height: 22)
+
+            Button {
+                NSSound.beep()
+            } label: {
+                Image(systemName: "questionmark.circle")
+            }
+            .buttonStyle(.borderless)
+            .help(String(localized: "Templates can be applied from the Breakpoint Queue Raw tab."))
+
+            Spacer()
+
+            Menu {
+                Button(String(localized: "New Request Template")) {
+                    store.addTemplate(kind: .request)
+                }
+                Button(String(localized: "New Response Template")) {
+                    store.addTemplate(kind: .response)
+                }
+                Button(String(localized: "Duplicate")) {
+                    store.duplicateSelectedTemplate()
+                }
+                .disabled(store.selectedTemplate == nil)
+                Button(String(localized: "Reset Raw Message")) {
+                    store.resetSelectedTemplate()
+                }
+                .disabled(store.selectedTemplate == nil)
+                Divider()
+                Button(String(localized: "Delete"), role: .destructive) {
+                    store.removeSelectedTemplate()
+                }
+                .disabled(store.selectedTemplate == nil || store.templates.count <= 1)
+            } label: {
+                HStack(spacing: 6) {
+                    Text(String(localized: "More"))
+                    Image(systemName: "chevron.down")
+                        .font(.system(size: 9, weight: .semibold))
+                }
+            }
+            .menuIndicator(.hidden)
+            .buttonStyle(.bordered)
+            .fixedSize()
+        }
+        .padding(.horizontal, 20)
+        .padding(.bottom, 18)
+    }
+
+    @ViewBuilder private var editor: some View {
+        if let template = store.selectedTemplate {
+            VStack(alignment: .leading, spacing: 12) {
+                Text(template.kind == .request
+                    ? String(localized: "Request Template")
+                    : String(localized: "Response Template"))
+                    .font(.system(size: 13))
+                    .padding(.top, 20)
+
+                HStack(spacing: 8) {
+                    Text(String(localized: "Name:"))
+                        .frame(width: 58, alignment: .trailing)
+                    TextField(String(localized: "Untitled"), text: Binding(
+                        get: { template.name },
+                        set: { store.updateSelected(name: $0) }
+                    ))
+                    .textFieldStyle(.roundedBorder)
+                }
+                .padding(8)
+                .background(Color(nsColor: .controlBackgroundColor).opacity(0.65))
+                .clipShape(RoundedRectangle(cornerRadius: 10))
+
+                Text(template.kind == .request
+                    ? String(localized: "Request Raw Message")
+                    : String(localized: "Response Raw Message"))
+                    .font(.system(size: 13))
+                    .padding(.top, 2)
+
+                rawEditor(template: template)
+
+                Text(
+                    String(
+                        localized:
+                        "To apply Breakpoint Template: In the Breakpoint Window -> Select Raw Tab -> Template"
+                    )
+                )
+                .font(.system(size: 13))
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+                .minimumScaleFactor(0.85)
+            }
+            .padding(.horizontal, 20)
+            .padding(.bottom, 18)
+        } else {
+            ContentUnavailableView(
+                String(localized: "No Template Selected"),
+                systemImage: "doc.text",
+                description: Text(String(localized: "Create a request or response template to continue."))
+            )
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+    }
+
+    private func rawEditor(template: BreakpointTemplate) -> some View {
+        let validation = BreakpointRawMessage.validation(for: template.rawMessage, kind: template.kind)
+        return VStack(alignment: .leading, spacing: 8) {
+            Label(validation.message, systemImage: "circle.fill")
+                .font(.system(size: 12))
+                .foregroundStyle(validation.isValid ? Color.green : Color.red)
+                .labelStyle(.titleAndIcon)
+
+            MapLocalHTTPMessageEditor(text: Binding(
+                get: { template.rawMessage },
+                set: { store.updateSelected(rawMessage: $0) }
+            ))
+            .frame(minHeight: 382)
+            .overlay(Rectangle().stroke(Color(nsColor: .separatorColor).opacity(0.45)))
+        }
+        .padding(.horizontal, 20)
+        .padding(.top, 10)
+        .padding(.bottom, 12)
+        .background(Color(nsColor: .controlBackgroundColor).opacity(0.55))
+        .clipShape(RoundedRectangle(cornerRadius: 10))
+    }
+}

--- a/Rockxy/Views/Breakpoint/BreakpointWindowView.swift
+++ b/Rockxy/Views/Breakpoint/BreakpointWindowView.swift
@@ -30,14 +30,21 @@ struct BreakpointWindowView: View {
     // MARK: Private
 
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.openWindow) private var openWindow
 
     private let manager = BreakpointManager.shared
     private let windowModel = BreakpointWindowModel.shared
 
     private var actionBar: some View {
-        HStack {
+        HStack(spacing: 10) {
             Button(String(localized: "Cancel")) { dismiss() }
                 .keyboardShortcut(.cancelAction)
+
+            Button {
+                openWindow(id: "breakpointTemplates")
+            } label: {
+                Label(String(localized: "Templates"), systemImage: "doc.text")
+            }
 
             Spacer()
 

--- a/Rockxy/Views/Inspector/InspectorBodyTextEditor.swift
+++ b/Rockxy/Views/Inspector/InspectorBodyTextEditor.swift
@@ -63,6 +63,7 @@ struct InspectorBodyTextEditor: NSViewRepresentable {
                 }
                 textView.textStorage?.setAttributedString(attributed)
                 textView.setSelectedRange(clamped(range: selectedRange, length: attributed.length))
+                (scrollView.verticalRulerView as? ScriptCodeEditorRulerView)?.invalidateLineNumbers()
             }
         }
 
@@ -190,6 +191,7 @@ struct InspectorBodyTextEditor: NSViewRepresentable {
         if let coordinator {
             coordinator.scheduleHighlight(text: text, fontSize: fontSize, in: scrollView)
         }
+        (scrollView.verticalRulerView as? ScriptCodeEditorRulerView)?.invalidateLineNumbers()
     }
 
     private struct HighlightSpan: Sendable {

--- a/Rockxy/Views/Main/Extensions/MainContentCoordinator+ProxyControl.swift
+++ b/Rockxy/Views/Main/Extensions/MainContentCoordinator+ProxyControl.swift
@@ -82,7 +82,9 @@ extension MainContentCoordinator {
                         return
                     }
                     let count = notification.userInfo?["count"] as? Int ?? Int(5e3)
-                    self.evictOldestTransactions(count: count)
+                    Task { @MainActor in
+                        self.evictOldestTransactions(count: count)
+                    }
                 }
 
                 readiness.startObserving()
@@ -92,9 +94,11 @@ extension MainContentCoordinator {
                 do {
                     try await SystemProxyManager.shared.enableSystemProxy(port: resolvedPort)
                     isSystemProxyConfigured = true
+                    isProxyOverridden = true
                     Self.logger.info("System proxy enabled on port \(resolvedPort)")
                 } catch {
                     isSystemProxyConfigured = false
+                    isProxyOverridden = false
                     readiness.setProxyEnableFailed(message: error.localizedDescription)
                     Self.logger.warning(
                         "System proxy not configured: \(error.localizedDescription). Proxy still running on 127.0.0.1:\(resolvedPort)"
@@ -130,6 +134,7 @@ extension MainContentCoordinator {
                 Self.logger.error("Failed to restore proxy: \(error.localizedDescription)")
             }
             isSystemProxyConfigured = false
+            isProxyOverridden = false
             readiness.setCaptureActive(false)
             SSLProxyingManager.shared.forceGlobalPassthrough = false
 
@@ -158,12 +163,73 @@ extension MainContentCoordinator {
             do {
                 try await SystemProxyManager.shared.enableSystemProxy(port: self.activeProxyPort)
                 isSystemProxyConfigured = true
+                isProxyOverridden = true
                 Self.logger.info("System proxy enabled on retry")
             } catch {
                 isSystemProxyConfigured = false
+                isProxyOverridden = false
                 readiness.setProxyEnableFailed(message: error.localizedDescription)
                 Self.logger.warning("System proxy retry failed: \(error.localizedDescription)")
             }
+        }
+    }
+
+    func refreshProxyOverrideStatus() {
+        Task { @MainActor in
+            let owner = await SystemProxyManager.shared.effectiveOverrideOwner()
+            let overridden = switch owner {
+            case .none:
+                false
+            case .direct, .helper:
+                true
+            }
+            isProxyOverridden = overridden
+            isSystemProxyConfigured = overridden
+        }
+    }
+
+    func switchOffSystemProxyOverride() {
+        Task { @MainActor in
+            do {
+                try await SystemProxyManager.shared.disableSystemProxy()
+                isSystemProxyConfigured = false
+                isProxyOverridden = false
+                await readiness.refresh()
+                Self.logger.info("System proxy override switched off")
+            } catch {
+                readiness.setProxyEnableFailed(message: error.localizedDescription)
+                Self.logger.error("Failed to switch off system proxy override: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    func switchOnSystemProxyOverride() {
+        guard isProxyRunning else {
+            return
+        }
+        readiness.clearProxyEnableFailure()
+
+        Task { @MainActor in
+            do {
+                try await SystemProxyManager.shared.enableSystemProxy(port: self.activeProxyPort)
+                isSystemProxyConfigured = true
+                isProxyOverridden = true
+                await readiness.refresh()
+                Self.logger.info("System proxy override switched on")
+            } catch {
+                isSystemProxyConfigured = false
+                isProxyOverridden = false
+                readiness.setProxyEnableFailed(message: error.localizedDescription)
+                Self.logger.error("Failed to switch on system proxy override: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    func toggleSystemProxyOverride() {
+        if isProxyOverridden {
+            switchOffSystemProxyOverride()
+        } else {
+            switchOnSystemProxyOverride()
         }
     }
 

--- a/Rockxy/Views/Main/Extensions/MainContentCoordinator+Rules.swift
+++ b/Rockxy/Views/Main/Extensions/MainContentCoordinator+Rules.swift
@@ -12,8 +12,9 @@ extension MainContentCoordinator {
     // MARK: - Rule Management
 
     func addRule(_ rule: ProxyRule) {
-        Task {
-            let accepted = await RulePolicyGate.shared.addRule(rule)
+        let gate = RulePolicyGate.shared
+        ruleMutationTask = Task {
+            let accepted = await gate.addRule(rule)
             if !accepted {
                 Self.logger.info("Rule add rejected — quota reached for \(rule.action.toolCategory)")
                 activeToast = ToastMessage(
@@ -25,12 +26,14 @@ extension MainContentCoordinator {
     }
 
     func removeRule(id: UUID) {
-        Task { await RulePolicyGate.shared.removeRule(id: id) }
+        let gate = RulePolicyGate.shared
+        ruleMutationTask = Task { await gate.removeRule(id: id) }
     }
 
     func toggleRule(id: UUID) {
-        Task {
-            let accepted = await RulePolicyGate.shared.toggleRule(id: id)
+        let gate = RulePolicyGate.shared
+        ruleMutationTask = Task {
+            let accepted = await gate.toggleRule(id: id)
             if !accepted {
                 Self.logger.info("Rule toggle rejected — quota reached")
                 activeToast = ToastMessage(

--- a/Rockxy/Views/Main/MainContentCommandActions.swift
+++ b/Rockxy/Views/Main/MainContentCommandActions.swift
@@ -16,6 +16,10 @@ struct MainContentCommandActions {
         coordinator.isProxyRunning
     }
 
+    var canToggleSystemProxyOverride: Bool {
+        coordinator.isProxyRunning
+    }
+
     var hasSelectedTransaction: Bool {
         coordinator.selectedTransaction != nil
     }
@@ -54,6 +58,10 @@ struct MainContentCommandActions {
 
     func toggleRecording() {
         coordinator.toggleRecording()
+    }
+
+    func toggleSystemProxyOverride() {
+        coordinator.toggleSystemProxyOverride()
     }
 
     // MARK: - Session I/O

--- a/Rockxy/Views/Main/MainContentCoordinator.swift
+++ b/Rockxy/Views/Main/MainContentCoordinator.swift
@@ -153,6 +153,7 @@ final class MainContentCoordinator {
     var observedDomainsByApp: [String: Set<String>] = [:]
 
     private(set) var ruleLoadTask: Task<Void, Never>?
+    var ruleMutationTask: Task<Void, Never>?
 
     var systemProxyWarning: SystemProxyWarning? {
         guard let warning = readiness.activeWarning else {

--- a/Rockxy/Views/RequestList/CenterContentView.swift
+++ b/Rockxy/Views/RequestList/CenterContentView.swift
@@ -69,6 +69,8 @@ struct CenterContentView: View {
                 totalCount: coordinator.filteredTransactions.count,
                 selectedCount: selectedIDs.count,
                 isProxyRunning: coordinator.isProxyRunning,
+                proxyHost: AppSettingsManager.shared.settings.effectiveListenAddress,
+                proxyPort: coordinator.activeProxyPort,
                 totalDataSize: coordinator.totalDataSize,
                 uploadSpeed: coordinator.uploadSpeed,
                 downloadSpeed: coordinator.downloadSpeed,
@@ -95,6 +97,9 @@ struct CenterContentView: View {
                 },
                 onAutoSelect: {
                     coordinator.isAutoSelectEnabled.toggle()
+                },
+                onSwitchOffProxyOverride: {
+                    coordinator.switchOffSystemProxyOverride()
                 }
             )
         }

--- a/Rockxy/Views/RequestList/StatusBarView.swift
+++ b/Rockxy/Views/RequestList/StatusBarView.swift
@@ -13,6 +13,7 @@ enum FooterActionKind: String, CaseIterable {
     case mapRemote
     case breakpoint
     case networkConditions
+    case proxyOverride
 }
 
 // MARK: - FooterActionDescriptor
@@ -25,8 +26,8 @@ struct FooterActionDescriptor: Identifiable, Equatable {
     let isActive: Bool
     let isEnabled: Bool
 
-    static func toolingActions(isAllowListActive: Bool) -> [Self] {
-        [
+    static func toolingActions(isAllowListActive: Bool, isProxyOverridden: Bool = false) -> [Self] {
+        var actions: [Self] = [
             .init(
                 id: .blockList,
                 title: String(localized: "Block List"),
@@ -84,6 +85,19 @@ struct FooterActionDescriptor: Identifiable, Equatable {
                 isEnabled: true
             ),
         ]
+
+        if isProxyOverridden {
+            actions.append(.init(
+                id: .proxyOverride,
+                title: String(localized: "Proxy Overridden"),
+                systemImage: "checkmark.circle.fill",
+                help: String(localized: "Show system proxy override details. Toggle by: ⌥⌘O"),
+                isActive: true,
+                isEnabled: true
+            ))
+        }
+
+        return actions
     }
 }
 
@@ -111,6 +125,69 @@ private struct FooterToolingButton: View {
     // MARK: Private
 
     @State private var isHovered = false
+}
+
+// MARK: - FooterProxyOverrideButton
+
+private struct FooterProxyOverrideButton: View {
+    let descriptor: FooterActionDescriptor
+    let proxyHost: String
+    let proxyPort: Int
+    let onSwitchOff: () -> Void
+
+    var body: some View {
+        FooterToolingButton(descriptor: descriptor) {
+            showPopover.toggle()
+        }
+        .popover(isPresented: $showPopover, arrowEdge: .bottom) {
+            FooterProxyOverridePopover(
+                proxyHost: proxyHost,
+                proxyPort: proxyPort,
+                isPresented: $showPopover,
+                onSwitchOff: onSwitchOff
+            )
+        }
+    }
+
+    // MARK: Private
+
+    @State private var showPopover = false
+}
+
+// MARK: - FooterProxyOverridePopover
+
+private struct FooterProxyOverridePopover: View {
+    let proxyHost: String
+    let proxyPort: Int
+    @Binding var isPresented: Bool
+    let onSwitchOff: () -> Void
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "checkmark.circle.fill")
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundStyle(Color(nsColor: .systemGreen))
+
+            Text(statusText)
+                .font(.system(size: 13))
+                .foregroundStyle(Color(nsColor: .labelColor))
+                .lineLimit(1)
+                .truncationMode(.middle)
+
+            Button(String(localized: "Switch Off")) {
+                isPresented = false
+                onSwitchOff()
+            }
+            .controlSize(.small)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .frame(width: 660, alignment: .leading)
+    }
+
+    private var statusText: String {
+        String(localized: "System Proxy is Overridden by Rockxy (IP=\(proxyHost) Port=\(proxyPort)) (Toggle by: ⌥⌘O)")
+    }
 }
 
 // MARK: - FooterToolingChrome
@@ -188,6 +265,7 @@ struct StatusBarView: View {
     let totalCount: Int
     let selectedCount: Int
     var isProxyRunning: Bool = false
+    var proxyHost: String = "127.0.0.1"
     var proxyPort: Int = 9_090
     var totalDataSize: Int64 = 0
     var uploadSpeed: Int64 = 0
@@ -206,6 +284,7 @@ struct StatusBarView: View {
     var onClear: () -> Void = {}
     var onFilter: () -> Void = {}
     var onAutoSelect: () -> Void = {}
+    var onSwitchOffProxyOverride: () -> Void = {}
 
     var body: some View {
         HStack(spacing: 0) {
@@ -323,10 +402,6 @@ struct StatusBarView: View {
             if isNoCachingActive {
                 statusPill(String(localized: "No Cache"), color: Color(nsColor: .systemOrange))
             }
-
-            if isProxyOverridden {
-                statusPill(String(localized: "Proxy Overridden"), color: Color(nsColor: .tertiaryLabelColor))
-            }
         }
         .lineLimit(1)
     }
@@ -346,9 +421,21 @@ struct StatusBarView: View {
 
     @ViewBuilder
     private var toolingButtons: some View {
-        ForEach(FooterActionDescriptor.toolingActions(isAllowListActive: isAllowListActive)) { descriptor in
-            FooterToolingButton(descriptor: descriptor) {
-                performAction(descriptor.id)
+        ForEach(FooterActionDescriptor.toolingActions(
+            isAllowListActive: isAllowListActive,
+            isProxyOverridden: isProxyOverridden
+        )) { descriptor in
+            if descriptor.id == .proxyOverride {
+                FooterProxyOverrideButton(
+                    descriptor: descriptor,
+                    proxyHost: proxyHost,
+                    proxyPort: proxyPort,
+                    onSwitchOff: onSwitchOffProxyOverride
+                )
+            } else {
+                FooterToolingButton(descriptor: descriptor) {
+                    performAction(descriptor.id)
+                }
             }
         }
     }
@@ -379,6 +466,8 @@ struct StatusBarView: View {
             openWindow(id: "breakpointRules")
         case .networkConditions:
             openWindow(id: "networkConditions")
+        case .proxyOverride:
+            break
         }
     }
 }

--- a/Rockxy/Views/Rules/AllowListWindowView.swift
+++ b/Rockxy/Views/Rules/AllowListWindowView.swift
@@ -385,25 +385,7 @@ struct AllowListWindowView: View {
 
     private var footer: some View {
         HStack(spacing: 0) {
-            Button {
-                viewModel.presentNewRuleEditor()
-            } label: {
-                Image(systemName: "plus")
-                    .frame(width: 18, height: 18)
-            }
-            .buttonStyle(.borderless)
-            .keyboardShortcut("n", modifiers: .command)
-            .help(String(localized: "New Rule"))
-
-            Button {
-                viewModel.removeSelected()
-            } label: {
-                Image(systemName: "minus")
-                    .frame(width: 18, height: 18)
-            }
-            .buttonStyle(.borderless)
-            .disabled(viewModel.selectedRuleID == nil)
-            .help(String(localized: "Delete Rule"))
+            addRemoveControl
 
             Button {
                 // Help content is intentionally deferred; this mirrors the reference affordance.
@@ -424,6 +406,46 @@ struct AllowListWindowView: View {
         .padding(.horizontal, 20)
         .padding(.top, 10)
         .padding(.bottom, 18)
+    }
+
+    private var addRemoveControl: some View {
+        HStack(spacing: 0) {
+            Button {
+                viewModel.presentNewRuleEditor()
+            } label: {
+                Image(systemName: "plus")
+                    .font(.system(size: 13, weight: .regular))
+                    .foregroundStyle(.primary)
+                    .frame(width: 21, height: 21)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .keyboardShortcut("n", modifiers: .command)
+            .help(String(localized: "New Rule"))
+
+            Rectangle()
+                .fill(Color(nsColor: .separatorColor).opacity(0.7))
+                .frame(width: 1, height: 21)
+
+            Button {
+                viewModel.removeSelected()
+            } label: {
+                Image(systemName: "minus")
+                    .font(.system(size: 13, weight: .regular))
+                    .foregroundStyle(viewModel.selectedRuleID == nil ? .tertiary : .primary)
+                    .frame(width: 21, height: 21)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .disabled(viewModel.selectedRuleID == nil)
+            .help(String(localized: "Delete Rule"))
+        }
+        .frame(height: 23)
+        .background(Color(nsColor: .windowBackgroundColor))
+        .overlay(
+            Rectangle()
+                .stroke(Color(nsColor: .separatorColor), lineWidth: 1)
+        )
     }
 
     private var moreMenu: some View {
@@ -487,15 +509,13 @@ struct AllowListWindowView: View {
             .keyboardShortcut(.delete, modifiers: .command)
             .disabled(viewModel.selectedRuleID == nil)
         } label: {
-            HStack(spacing: 8) {
+            HStack(spacing: 6) {
                 Text(String(localized: "More"))
                 Image(systemName: "chevron.down")
-                    .font(.caption2)
+                    .font(.system(size: 8, weight: .semibold))
             }
-            .padding(.horizontal, 12)
-            .padding(.vertical, 3)
         }
-        .menuStyle(.borderlessButton)
+        .menuIndicator(.hidden)
     }
 
     @ViewBuilder

--- a/Rockxy/Views/Rules/AllowListWindowView.swift
+++ b/Rockxy/Views/Rules/AllowListWindowView.swift
@@ -512,10 +512,12 @@ struct AllowListWindowView: View {
             HStack(spacing: 6) {
                 Text(String(localized: "More"))
                 Image(systemName: "chevron.down")
-                    .font(.system(size: 8, weight: .semibold))
+                    .font(.system(size: 9, weight: .semibold))
             }
         }
         .menuIndicator(.hidden)
+        .buttonStyle(.bordered)
+        .fixedSize()
     }
 
     @ViewBuilder

--- a/Rockxy/Views/Rules/AllowListWindowView.swift
+++ b/Rockxy/Views/Rules/AllowListWindowView.swift
@@ -34,6 +34,14 @@ struct AllowListEditorSession: Identifiable {
     let mode: Mode
 }
 
+// MARK: - AllowListImportSource
+
+private enum AllowListImportSource {
+    case rockxyJSON
+    case proxyman
+    case charlesProxy
+}
+
 // MARK: - AllowListWindowViewModel
 
 @MainActor @Observable
@@ -184,6 +192,18 @@ final class AllowListWindowViewModel {
         manager.setActive(active)
     }
 
+    func exportRulesJSON() throws -> Data {
+        guard let data = manager.exportRulesJSON() else {
+            throw CocoaError(.fileWriteUnknown)
+        }
+        return data
+    }
+
+    func importRules(_ rules: [AllowListRule]) {
+        manager.replaceAll(rules)
+        selectedRuleID = rules.first?.id
+    }
+
     /// Called from the view layer's `.onChange(of: manager.rules)` to keep the
     /// table selection in sync when rules change externally (import, migration).
     func reconcileSelectionAfterRulesChange() {
@@ -202,14 +222,16 @@ struct AllowListWindowView: View {
     // MARK: Internal
 
     var body: some View {
-        VStack(spacing: 0) {
-            toolbar
-            Divider()
-            infoBanner
-            Divider()
-            content
+        VStack(alignment: .leading, spacing: 0) {
+            header
+            AllowListTableView(
+                rules: viewModel.filteredRules,
+                selectedRuleID: $viewModel.selectedRuleID,
+                onToggle: { viewModel.toggleRule(id: $0) },
+                onEdit: openEditorForRule,
+                contextMenuItems: contextMenuItems
+            )
             if viewModel.isFilterBarVisible {
-                Divider()
                 AllowListFilterBar(
                     filterColumn: $viewModel.filterColumn,
                     filterText: $viewModel.filterText,
@@ -217,10 +239,10 @@ struct AllowListWindowView: View {
                 )
                 .transition(.move(edge: .bottom).combined(with: .opacity))
             }
-            Divider()
-            bottomBar
+            shortcutHelp
+            footer
         }
-        .frame(width: 860, height: 620)
+        .frame(width: 1_200, height: 642)
         .onAppear { consumePendingContext() }
         .onReceive(NotificationCenter.default.publisher(for: .openAllowListWindow)) { _ in
             consumePendingContext()
@@ -265,7 +287,7 @@ struct AllowListWindowView: View {
         }
         .fileImporter(
             isPresented: $showImporter,
-            allowedContentTypes: [.json],
+            allowedContentTypes: [.json, .xml, .propertyList],
             allowsMultipleSelection: false
         ) { result in
             handleImport(result)
@@ -288,6 +310,9 @@ struct AllowListWindowView: View {
             }
         }
         .animation(.easeInOut(duration: 0.2), value: viewModel.isFilterBarVisible)
+        .onDeleteCommand {
+            viewModel.removeSelected()
+        }
     }
 
     // MARK: Private
@@ -306,6 +331,7 @@ struct AllowListWindowView: View {
     @State private var showImporter = false
     @State private var exportDocument: AllowListJSONDocument?
     @State private var importError: String?
+    @State private var importSource: AllowListImportSource = .rockxyJSON
 
     private var enableDisableLabel: String {
         guard let id = viewModel.selectedRuleID,
@@ -318,11 +344,8 @@ struct AllowListWindowView: View {
             : String(localized: "Enable Rule")
     }
 
-    private var toolbar: some View {
-        HStack {
-            Text(String(localized: "Allow List"))
-                .font(.headline)
-            Spacer()
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 12) {
             Toggle(
                 String(localized: "Enable Allow List Tool"),
                 isOn: Binding(
@@ -330,173 +353,82 @@ struct AllowListWindowView: View {
                     set: { viewModel.setActive($0) }
                 )
             )
-            .toggleStyle(.switch)
-            .controlSize(.small)
-        }
-        .padding(.horizontal, 16)
-        .padding(.vertical, 10)
-    }
+            .toggleStyle(.checkbox)
+            .controlSize(.large)
+            .font(.system(size: 13, weight: .medium))
 
-    private var infoBanner: some View {
-        HStack(spacing: 6) {
-            Image(systemName: "info.circle")
-                .foregroundStyle(.secondary)
+            Text(String(localized: "Define Rules for capturing only specific domains. Ignore others domains."))
+                .font(.system(size: 13))
+                .foregroundStyle(.primary)
+
             Text(
                 String(
                     localized:
-                    "Define URL patterns for capturing only matching requests. Each request is checked against the rules from top to bottom, stopping when a match is found."
+                    "Each request is checked against the rules from top to bottom, stopping when a match is found."
                 )
             )
-            .font(.caption)
+            .font(.system(size: 12.5))
             .foregroundStyle(.secondary)
-            Spacer()
         }
-        .padding(.horizontal, 16)
-        .padding(.vertical, 8)
-        .background(.quaternary.opacity(0.5))
+        .padding(.horizontal, 20)
+        .padding(.top, 20)
+        .padding(.bottom, 14)
     }
 
-    @ViewBuilder private var content: some View {
-        if viewModel.manager.rules.isEmpty {
-            emptyState
-        } else {
-            VStack(spacing: 0) {
-                columnHeader
-                Divider()
-                List(selection: $viewModel.selectedRuleID) {
-                    ForEach(viewModel.filteredRules) { rule in
-                        AllowListRulesRow(rule: rule) {
-                            viewModel.toggleRule(id: rule.id)
-                        }
-                        .tag(rule.id)
-                    }
-                }
-                .listStyle(.inset(alternatesRowBackgrounds: true))
-                .contextMenu(forSelectionType: UUID.self) { _ in
-                    contextMenuItems
-                } primaryAction: { _ in
-                    openEditorForSelection()
-                }
-            }
-        }
+    private var shortcutHelp: some View {
+        Text(String(localized: "New: ⌘N    Edit: ⌘↩    Delete: ⌘⌫    Duplicate: ⌘D    Toggle: Space"))
+            .font(.system(size: 10.5))
+            .foregroundStyle(.secondary)
+            .padding(.horizontal, 20)
+            .padding(.top, 12)
     }
 
-    private var columnHeader: some View {
-        HStack(spacing: 10) {
-            Spacer().frame(width: 24)
-            Text(String(localized: "Name"))
-                .font(.caption.weight(.semibold))
-                .foregroundStyle(.secondary)
-                .frame(width: 220, alignment: .leading)
-            Text(String(localized: "Method"))
-                .font(.caption.weight(.semibold))
-                .foregroundStyle(.secondary)
-                .frame(width: 70, alignment: .leading)
-            Text(String(localized: "Matching Rule"))
-                .font(.caption.weight(.semibold))
-                .foregroundStyle(.secondary)
-                .frame(maxWidth: .infinity, alignment: .leading)
-        }
-        .padding(.horizontal, 16)
-        .padding(.vertical, 6)
-        .background(.background.tertiary)
-    }
-
-    private var emptyState: some View {
-        VStack(alignment: .center, spacing: 8) {
-            Image(systemName: "line.3.horizontal.decrease.circle")
-                .font(.system(size: 20))
-                .foregroundStyle(.tertiary)
-            Text(String(localized: "No Allow List Rules"))
-                .font(.system(size: 13, weight: .medium))
-                .foregroundStyle(.secondary)
-            Text(
-                String(
-                    localized:
-                    "Add URL patterns to capture only matching requests.\nWhen active, unmatched traffic is forwarded but not recorded."
-                )
-            )
-            .font(.caption)
-            .foregroundStyle(.tertiary)
-            .multilineTextAlignment(.center)
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .padding(.horizontal, 24)
-        .padding(.top, 12)
-    }
-
-    private var bottomBar: some View {
-        HStack(spacing: 8) {
+    private var footer: some View {
+        HStack(spacing: 0) {
             Button {
                 viewModel.presentNewRuleEditor()
             } label: {
                 Image(systemName: "plus")
+                    .frame(width: 18, height: 18)
             }
             .buttonStyle(.borderless)
+            .keyboardShortcut("n", modifiers: .command)
             .help(String(localized: "New Rule"))
 
             Button {
                 viewModel.removeSelected()
             } label: {
                 Image(systemName: "minus")
+                    .frame(width: 18, height: 18)
             }
             .buttonStyle(.borderless)
             .disabled(viewModel.selectedRuleID == nil)
             .help(String(localized: "Delete Rule"))
 
-            Divider()
-                .frame(height: 16)
-
-            Text(
-                "\(viewModel.ruleCount) \(viewModel.ruleCount == 1 ? String(localized: "rule") : String(localized: "rules"))"
-            )
-            .font(.caption)
-            .foregroundStyle(.secondary)
+            Button {
+                // Help content is intentionally deferred; this mirrors the reference affordance.
+            } label: {
+                Image(systemName: "questionmark.circle.fill")
+                    .font(.system(size: 22))
+                    .foregroundStyle(.secondary.opacity(0.35), .clear)
+                    .overlay(Text("?").font(.system(size: 15, weight: .medium)).foregroundStyle(.primary))
+                    .frame(width: 34, height: 22)
+            }
+            .buttonStyle(.borderless)
+            .padding(.leading, 10)
 
             Spacer()
 
-            Button {
-                showFilterBar()
-            } label: {
-                Label(String(localized: "Filter"), systemImage: "line.3.horizontal.decrease.circle")
-            }
-            .buttonStyle(.borderless)
-            .keyboardShortcut("f", modifiers: .command)
-
             moreMenu
         }
-        .padding(.horizontal, 12)
-        .padding(.vertical, 8)
-    }
-
-    @ViewBuilder private var contextMenuItems: some View {
-        Button(String(localized: "Edit…")) {
-            openEditorForSelection()
-        }
-        .keyboardShortcut(.return, modifiers: .command)
-
-        Button(String(localized: "Duplicate")) {
-            viewModel.duplicateSelected()
-        }
-        .keyboardShortcut("d", modifiers: .command)
-
-        Button(enableDisableLabel) {
-            if let id = viewModel.selectedRuleID {
-                viewModel.toggleRule(id: id)
-            }
-        }
-
-        Divider()
-
-        Button(String(localized: "Delete"), role: .destructive) {
-            viewModel.removeSelected()
-        }
-        .keyboardShortcut(.delete, modifiers: .command)
+        .padding(.horizontal, 20)
+        .padding(.top, 10)
+        .padding(.bottom, 18)
     }
 
     private var moreMenu: some View {
         Menu {
-            Button(String(localized: "New Rule…")) {
+            Button(String(localized: "New…")) {
                 viewModel.presentNewRuleEditor()
             }
             .keyboardShortcut("n", modifiers: .command)
@@ -520,6 +452,7 @@ struct AllowListWindowView: View {
                     viewModel.toggleRule(id: id)
                 }
             }
+            .keyboardShortcut(.space, modifiers: [])
             .disabled(viewModel.selectedRuleID == nil)
 
             Divider()
@@ -527,9 +460,23 @@ struct AllowListWindowView: View {
             Button(String(localized: "Export Settings…")) {
                 prepareExport()
             }
+            .disabled(viewModel.manager.rules.isEmpty)
 
-            Button(String(localized: "Import Settings…")) {
-                showImporter = true
+            Menu(String(localized: "Import Settings")) {
+                Button(String(localized: "From Rockxy JSON…")) {
+                    importSource = .rockxyJSON
+                    showImporter = true
+                }
+
+                Button(String(localized: "From Proxyman…")) {
+                    importSource = .proxyman
+                    showImporter = true
+                }
+
+                Button(String(localized: "From Charles Proxy…")) {
+                    importSource = .charlesProxy
+                    showImporter = true
+                }
             }
 
             Divider()
@@ -540,11 +487,49 @@ struct AllowListWindowView: View {
             .keyboardShortcut(.delete, modifiers: .command)
             .disabled(viewModel.selectedRuleID == nil)
         } label: {
-            Text(String(localized: "More"))
-            Image(systemName: "chevron.down")
-                .font(.caption2)
+            HStack(spacing: 8) {
+                Text(String(localized: "More"))
+                Image(systemName: "chevron.down")
+                    .font(.caption2)
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 3)
         }
         .menuStyle(.borderlessButton)
+    }
+
+    @ViewBuilder
+    private func contextMenuItems(for id: UUID) -> some View {
+        Button(String(localized: "Edit…")) {
+            openEditorForRule(id)
+        }
+        .keyboardShortcut(.return, modifiers: .command)
+
+        Button(String(localized: "Duplicate")) {
+            viewModel.selectedRuleID = id
+            viewModel.duplicateSelected()
+        }
+        .keyboardShortcut("d", modifiers: .command)
+
+        Button(enableDisableLabel(for: id)) {
+            viewModel.toggleRule(id: id)
+        }
+        .keyboardShortcut(.space, modifiers: [])
+
+        Divider()
+
+        Button(String(localized: "Delete"), role: .destructive) {
+            viewModel.selectedRuleID = id
+            viewModel.removeSelected()
+        }
+        .keyboardShortcut(.delete, modifiers: .command)
+    }
+
+    private func enableDisableLabel(for id: UUID) -> String {
+        guard let rule = viewModel.manager.rules.first(where: { $0.id == id }) else {
+            return String(localized: "Enable Rule")
+        }
+        return rule.isEnabled ? String(localized: "Disable Rule") : String(localized: "Enable Rule")
     }
 
     private func openEditorForSelection() {
@@ -556,8 +541,12 @@ struct AllowListWindowView: View {
         viewModel.presentEditorForEditing(rule)
     }
 
-    private func showFilterBar() {
-        viewModel.isFilterBarVisible = true
+    private func openEditorForRule(_ id: UUID) {
+        guard let rule = viewModel.manager.rules.first(where: { $0.id == id }) else {
+            return
+        }
+        viewModel.selectedRuleID = id
+        viewModel.presentEditorForEditing(rule)
     }
 
     private func hideFilterBar() {
@@ -576,11 +565,13 @@ struct AllowListWindowView: View {
     }
 
     private func prepareExport() {
-        guard let data = viewModel.manager.exportRulesJSON() else {
-            return
+        do {
+            exportDocument = try AllowListJSONDocument(data: viewModel.exportRulesJSON())
+            showExporter = true
+        } catch {
+            importError = error.localizedDescription
+            Self.logger.error("Allow list export failed: \(error.localizedDescription)")
         }
-        exportDocument = AllowListJSONDocument(data: data)
-        showExporter = true
     }
 
     private func handleImport(_ result: Result<[URL], Error>) {
@@ -604,7 +595,14 @@ struct AllowListWindowView: View {
                     return
                 }
                 let data = try Data(contentsOf: url)
-                try viewModel.manager.importRulesJSON(data)
+                switch importSource {
+                case .rockxyJSON:
+                    try viewModel.manager.importRulesJSON(data)
+                case .proxyman:
+                    try viewModel.importRules(AllowListSettingsCodec.importFromProxyman(data))
+                case .charlesProxy:
+                    try viewModel.importRules(AllowListSettingsCodec.importFromCharlesProxy(data))
+                }
             } catch {
                 importError = error.localizedDescription
                 Self.logger.error("Allow list import failed: \(error.localizedDescription)")
@@ -615,42 +613,160 @@ struct AllowListWindowView: View {
     }
 }
 
-// MARK: - AllowListRulesRow
+// MARK: - AllowListTableView
 
-private struct AllowListRulesRow: View {
+private struct AllowListTableView<ContextMenuContent: View>: View {
+    // MARK: Internal
+
+    let rules: [AllowListRule]
+    @Binding var selectedRuleID: UUID?
+
+    let onToggle: (UUID) -> Void
+    let onEdit: (UUID) -> Void
+    @ViewBuilder let contextMenuItems: (UUID) -> ContextMenuContent
+
+    var body: some View {
+        VStack(spacing: 0) {
+            columnHeader
+            ZStack {
+                zebraRows
+
+                if rules.isEmpty {
+                    Text(String(localized: "Click \"+\" or ⌘N to add new entry"))
+                        .font(.system(size: 12))
+                        .foregroundStyle(.secondary)
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                } else {
+                    ScrollView {
+                        LazyVStack(spacing: 0) {
+                            ForEach(Array(rules.enumerated()), id: \.element.id) { index, rule in
+                                AllowListTableRow(
+                                    rule: rule,
+                                    isSelected: selectedRuleID == rule.id,
+                                    rowIndex: index,
+                                    onSelect: { selectedRuleID = rule.id },
+                                    onToggle: { onToggle(rule.id) }
+                                )
+                                .contextMenu {
+                                    contextMenuItems(rule.id)
+                                }
+                                .onTapGesture(count: 2) {
+                                    onEdit(rule.id)
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        .frame(height: 399)
+        .overlay {
+            Rectangle()
+                .stroke(.secondary.opacity(0.45), lineWidth: 1)
+        }
+        .padding(.horizontal, 20)
+    }
+
+    // MARK: Private
+
+    private var columnHeader: some View {
+        HStack(spacing: 0) {
+            Text(String(localized: "Enabled"))
+                .frame(width: 66, alignment: .leading)
+            tableDivider
+            Text(String(localized: "Name"))
+                .frame(width: 303, alignment: .leading)
+            tableDivider
+            Text(String(localized: "Method"))
+                .frame(width: 80, alignment: .leading)
+            tableDivider
+            Text(String(localized: "Matching Rule"))
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .font(.system(size: 11, weight: .medium))
+        .padding(.horizontal, 12)
+        .frame(height: 24)
+        .background(Color(nsColor: .textBackgroundColor))
+        .padding(.horizontal, 20)
+        .overlay(alignment: .bottom) {
+            Divider().padding(.horizontal, 20)
+        }
+    }
+
+    private var tableDivider: some View {
+        Rectangle()
+            .fill(.secondary.opacity(0.22))
+            .frame(width: 1, height: 16)
+            .padding(.trailing, 10)
+    }
+
+    private var zebraRows: some View {
+        VStack(spacing: 0) {
+            ForEach(0 ..< 17, id: \.self) { index in
+                Rectangle()
+                    .fill(index.isMultiple(of: 2) ? Color(nsColor: .textBackgroundColor) : Color.secondary
+                        .opacity(0.08))
+                    .frame(height: 22)
+            }
+            Spacer(minLength: 0)
+        }
+    }
+}
+
+// MARK: - AllowListTableRow
+
+private struct AllowListTableRow: View {
+    // MARK: Internal
+
     let rule: AllowListRule
+    let isSelected: Bool
+    let rowIndex: Int
+    let onSelect: () -> Void
     let onToggle: () -> Void
 
     var body: some View {
-        HStack(spacing: 10) {
+        HStack(spacing: 0) {
             Toggle("", isOn: Binding(
                 get: { rule.isEnabled },
                 set: { _ in onToggle() }
             ))
-            .toggleStyle(.switch)
+            .toggleStyle(.checkbox)
             .labelsHidden()
-            .controlSize(.small)
+            .frame(width: 66)
 
             Text(rule.name)
-                .font(.system(size: 12, weight: .medium))
                 .lineLimit(1)
-                .truncationMode(.tail)
-                .frame(width: 220, alignment: .leading)
+                .truncationMode(.middle)
+                .frame(width: 314, alignment: .leading)
 
             Text(rule.method ?? "ANY")
-                .font(.caption)
-                .foregroundStyle(.secondary)
-                .frame(width: 70, alignment: .leading)
+                .frame(width: 80, alignment: .leading)
 
             Text(rule.rawPattern)
-                .font(.system(.caption, design: .monospaced))
-                .foregroundStyle(.secondary)
+                .font(.system(size: 10.5, design: .monospaced))
                 .lineLimit(1)
                 .truncationMode(.middle)
                 .frame(maxWidth: .infinity, alignment: .leading)
         }
-        .padding(.vertical, 2)
+        .font(.system(size: 10.5))
+        .foregroundStyle(rule.isEnabled ? .primary : .secondary)
+        .frame(height: 22)
+        .background(rowBackground)
+        .contentShape(Rectangle())
+        .onTapGesture {
+            onSelect()
+        }
         .opacity(rule.isEnabled ? 1.0 : 0.5)
+    }
+
+    // MARK: Private
+
+    private var rowBackground: some ShapeStyle {
+        if isSelected {
+            return AnyShapeStyle(Color.accentColor.opacity(0.22))
+        }
+        return AnyShapeStyle(rowIndex.isMultiple(of: 2) ? Color(nsColor: .textBackgroundColor) : Color.secondary
+            .opacity(0.08))
     }
 }
 

--- a/Rockxy/Views/Rules/BlockListWindowView.swift
+++ b/Rockxy/Views/Rules/BlockListWindowView.swift
@@ -382,25 +382,7 @@ struct BlockListWindowView: View {
 
     private var footer: some View {
         HStack(spacing: 0) {
-            Button {
-                viewModel.presentNewRuleEditor()
-            } label: {
-                Image(systemName: "plus")
-                    .frame(width: 18, height: 18)
-            }
-            .buttonStyle(.borderless)
-            .keyboardShortcut("n", modifiers: .command)
-            .help(String(localized: "New Rule"))
-
-            Button {
-                viewModel.removeSelected()
-            } label: {
-                Image(systemName: "minus")
-                    .frame(width: 18, height: 18)
-            }
-            .buttonStyle(.borderless)
-            .disabled(viewModel.selectedRuleID == nil)
-            .help(String(localized: "Delete Rule"))
+            addRemoveControl
 
             Button {
                 // Help content is intentionally deferred; this mirrors the reference affordance.
@@ -421,6 +403,46 @@ struct BlockListWindowView: View {
         .padding(.horizontal, 20)
         .padding(.top, 10)
         .padding(.bottom, 18)
+    }
+
+    private var addRemoveControl: some View {
+        HStack(spacing: 0) {
+            Button {
+                viewModel.presentNewRuleEditor()
+            } label: {
+                Image(systemName: "plus")
+                    .font(.system(size: 13, weight: .regular))
+                    .foregroundStyle(.primary)
+                    .frame(width: 21, height: 21)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .keyboardShortcut("n", modifiers: .command)
+            .help(String(localized: "New Rule"))
+
+            Rectangle()
+                .fill(Color(nsColor: .separatorColor).opacity(0.7))
+                .frame(width: 1, height: 21)
+
+            Button {
+                viewModel.removeSelected()
+            } label: {
+                Image(systemName: "minus")
+                    .font(.system(size: 13, weight: .regular))
+                    .foregroundStyle(viewModel.selectedRuleID == nil ? .tertiary : .primary)
+                    .frame(width: 21, height: 21)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .disabled(viewModel.selectedRuleID == nil)
+            .help(String(localized: "Delete Rule"))
+        }
+        .frame(height: 23)
+        .background(Color(nsColor: .windowBackgroundColor))
+        .overlay(
+            Rectangle()
+                .stroke(Color(nsColor: .separatorColor), lineWidth: 1)
+        )
     }
 
     private var moreMenu: some View {
@@ -479,15 +501,13 @@ struct BlockListWindowView: View {
             .keyboardShortcut(.delete, modifiers: .command)
             .disabled(viewModel.selectedRuleID == nil)
         } label: {
-            HStack(spacing: 8) {
+            HStack(spacing: 6) {
                 Text(String(localized: "More"))
                 Image(systemName: "chevron.down")
-                    .font(.caption2)
+                    .font(.system(size: 8, weight: .semibold))
             }
-            .padding(.horizontal, 12)
-            .padding(.vertical, 3)
         }
-        .menuStyle(.borderlessButton)
+        .menuIndicator(.hidden)
     }
 
     @ViewBuilder

--- a/Rockxy/Views/Rules/BlockListWindowView.swift
+++ b/Rockxy/Views/Rules/BlockListWindowView.swift
@@ -1,24 +1,43 @@
 import os
 import SwiftUI
+import UniformTypeIdentifiers
 
 // Presents the block list window for rule editing and management.
+
+// MARK: - BlockListEditorSession
+
+struct BlockListEditorSession: Identifiable {
+    enum Mode {
+        case create(context: BlockRuleEditorContext?)
+        case edit(rule: ProxyRule)
+    }
+
+    let id = UUID()
+    let mode: Mode
+}
+
+// MARK: - BlockListImportSource
+
+private enum BlockListImportSource {
+    case proxyman
+    case charlesProxy
+}
 
 // MARK: - BlockListViewModel
 
 @MainActor @Observable
 final class BlockListViewModel {
     var selectedRuleID: UUID?
-    var showAddSheet = false
-    var pendingContext: BlockRuleEditorContext?
+    var editorSession: BlockListEditorSession?
+    var isBlockListActive: Bool
     private(set) var allRules: [ProxyRule] = []
 
+    init() {
+        isBlockListActive = UserDefaults.standard.object(forKey: "blockListToolEnabled") as? Bool ?? true
+    }
+
     var blockRules: [ProxyRule] {
-        allRules.filter { rule in
-            if case .block = rule.action {
-                return true
-            }
-            return false
-        }
+        allRules.filter(\.isBlockRule)
     }
 
     var ruleCount: Int {
@@ -27,12 +46,35 @@ final class BlockListViewModel {
 
     func refreshFromEngine() async {
         allRules = await RuleEngine.shared.allRules
+        reconcileSelectionAfterRulesChange()
     }
 
     func handleRulesDidChange(_ notification: Notification) {
         if let rules = notification.object as? [ProxyRule] {
             allRules = rules
+            reconcileSelectionAfterRulesChange()
         }
+    }
+
+    func setBlockListActive(_ active: Bool) {
+        isBlockListActive = active
+        Task { await RulePolicyGate.shared.setBlockListToolEnabled(active) }
+    }
+
+    func presentNewRuleEditor() {
+        editorSession = BlockListEditorSession(mode: .create(context: nil))
+    }
+
+    func presentEditorForContext(_ context: BlockRuleEditorContext) {
+        editorSession = BlockListEditorSession(mode: .create(context: context))
+    }
+
+    func presentEditorForEditing(_ rule: ProxyRule) {
+        editorSession = BlockListEditorSession(mode: .edit(rule: rule))
+    }
+
+    func dismissEditor() {
+        editorSession = nil
     }
 
     func addBlockRule(
@@ -43,37 +85,91 @@ final class BlockListViewModel {
         blockAction: BlockActionType,
         includeSubpaths: Bool
     ) {
-        let escapedPattern = RulePatternBuilder.regexSource(
-            rawPattern: urlPattern,
+        let rule = makeRule(
+            ruleName: ruleName,
+            urlPattern: urlPattern,
+            httpMethod: httpMethod,
             matchType: matchType,
+            blockAction: blockAction,
             includeSubpaths: includeSubpaths
         )
-        let displayName = ruleName.isEmpty ? urlPattern : ruleName
-
-        let rule = ProxyRule(
-            name: displayName,
-            matchCondition: RuleMatchCondition(
-                urlPattern: escapedPattern,
-                method: httpMethod.methodValue
-            ),
-            action: .block(statusCode: blockAction.statusCode)
-        )
         allRules.append(rule)
+        selectedRuleID = rule.id
         Task {
             let accepted = await RulePolicyGate.shared.addRule(rule)
             if !accepted {
                 allRules = await RuleEngine.shared.allRules
+                reconcileSelectionAfterRulesChange()
             }
         }
+    }
+
+    func updateBlockRule(
+        id: UUID,
+        ruleName: String,
+        urlPattern: String,
+        httpMethod: HTTPMethodFilter,
+        matchType: BlockMatchType,
+        blockAction: BlockActionType,
+        includeSubpaths: Bool
+    ) {
+        guard let index = allRules.firstIndex(where: { $0.id == id }) else {
+            return
+        }
+        var updated = makeRule(
+            id: id,
+            ruleName: ruleName,
+            urlPattern: urlPattern,
+            httpMethod: httpMethod,
+            matchType: matchType,
+            blockAction: blockAction,
+            includeSubpaths: includeSubpaths
+        )
+        updated.isEnabled = allRules[index].isEnabled
+        updated.priority = allRules[index].priority
+        allRules[index] = updated
+        selectedRuleID = updated.id
+        Task { await RulePolicyGate.shared.updateRule(updated) }
     }
 
     func removeSelected() {
         guard let id = selectedRuleID else {
             return
         }
+        removeRule(id: id)
+    }
+
+    func removeRule(id: UUID) {
         allRules.removeAll { $0.id == id }
-        selectedRuleID = nil
+        if selectedRuleID == id {
+            selectedRuleID = nil
+        }
         Task { await RulePolicyGate.shared.removeRule(id: id) }
+    }
+
+    func duplicateSelected() {
+        guard let id = selectedRuleID,
+              let original = blockRules.first(where: { $0.id == id }) else
+        {
+            return
+        }
+        var copy = original
+        copy = ProxyRule(
+            name: String(localized: "Copy of \(original.name)"),
+            isEnabled: original.isEnabled,
+            matchCondition: original.matchCondition,
+            action: original.action,
+            priority: original.priority
+        )
+        allRules.append(copy)
+        selectedRuleID = copy.id
+        Task {
+            let accepted = await RulePolicyGate.shared.addRule(copy)
+            if !accepted {
+                allRules = await RuleEngine.shared.allRules
+                reconcileSelectionAfterRulesChange()
+            }
+        }
     }
 
     func toggleRule(id: UUID) {
@@ -85,7 +181,65 @@ final class BlockListViewModel {
             let accepted = await RulePolicyGate.shared.toggleRule(id: id)
             if !accepted {
                 allRules = await RuleEngine.shared.allRules
+                reconcileSelectionAfterRulesChange()
             }
+        }
+    }
+
+    func exportBlockRules() throws -> Data {
+        try BlockListSettingsCodec.exportRules(blockRules)
+    }
+
+    func importBlockRules(_ importedRules: [ProxyRule]) {
+        let nonBlockRules = allRules.filter { !$0.isBlockRule }
+        allRules = nonBlockRules + importedRules
+        selectedRuleID = importedRules.first?.id
+        Task {
+            await RulePolicyGate.shared.replaceAllRules(allRules)
+            allRules = await RuleEngine.shared.allRules
+            reconcileSelectionAfterRulesChange()
+        }
+    }
+
+    // MARK: Private
+
+    private func makeRule(
+        id: UUID = UUID(),
+        ruleName: String,
+        urlPattern: String,
+        httpMethod: HTTPMethodFilter,
+        matchType: BlockMatchType,
+        blockAction: BlockActionType,
+        includeSubpaths: Bool
+    )
+        -> ProxyRule
+    {
+        let escapedPattern = RulePatternBuilder.regexSource(
+            rawPattern: urlPattern,
+            matchType: matchType,
+            includeSubpaths: includeSubpaths
+        )
+        let displayName = ruleName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            ? urlPattern
+            : ruleName
+
+        return ProxyRule(
+            id: id,
+            name: displayName,
+            matchCondition: RuleMatchCondition(
+                urlPattern: escapedPattern,
+                method: httpMethod.methodValue
+            ),
+            action: .block(statusCode: blockAction.statusCode)
+        )
+    }
+
+    private func reconcileSelectionAfterRulesChange() {
+        guard let id = selectedRuleID else {
+            return
+        }
+        if !blockRules.contains(where: { $0.id == id }) {
+            selectedRuleID = nil
         }
     }
 }
@@ -93,19 +247,21 @@ final class BlockListViewModel {
 // MARK: - BlockListWindowView
 
 struct BlockListWindowView: View {
-    // MARK: Internal
-
     var body: some View {
-        VStack(spacing: 0) {
-            toolbar
-            Divider()
-            infoBanner
-            Divider()
-            content
-            Divider()
-            bottomBar
+        VStack(alignment: .leading, spacing: 0) {
+            header
+            BlockListTableView(
+                rules: viewModel.blockRules,
+                selectedRuleID: $viewModel.selectedRuleID,
+                onToggle: { viewModel.toggleRule(id: $0) },
+                onEdit: openEditorForRule,
+                onDelete: { viewModel.removeRule(id: $0) },
+                contextMenuItems: contextMenuItems
+            )
+            shortcutHelp
+            footer
         }
-        .frame(width: 860, height: 620)
+        .frame(width: 1_200, height: 642)
         .task { await viewModel.refreshFromEngine() }
         .onAppear { consumePendingContext() }
         .onReceive(NotificationCenter.default.publisher(for: .openBlockListWindow)) { _ in
@@ -114,267 +270,522 @@ struct BlockListWindowView: View {
         .onReceive(NotificationCenter.default.publisher(for: .rulesDidChange)) { notification in
             viewModel.handleRulesDidChange(notification)
         }
-        .sheet(isPresented: $viewModel.showAddSheet) {
-            viewModel.pendingContext = nil
-        } content: {
-            AddBlockRuleSheet(editorContext: viewModel
-                .pendingContext)
-            { ruleName, pattern, method, matchType, action, includeSubpaths in
-                viewModel.addBlockRule(
-                    ruleName: ruleName,
-                    urlPattern: pattern,
-                    httpMethod: method,
-                    matchType: matchType,
-                    blockAction: action,
-                    includeSubpaths: includeSubpaths
-                )
-                viewModel.pendingContext = nil
+        .sheet(item: $viewModel.editorSession) { session in
+            AddBlockRuleSheet(session: session) { ruleName, pattern, method, matchType, action, includeSubpaths in
+                switch session.mode {
+                case .create:
+                    viewModel.addBlockRule(
+                        ruleName: ruleName,
+                        urlPattern: pattern,
+                        httpMethod: method,
+                        matchType: matchType,
+                        blockAction: action,
+                        includeSubpaths: includeSubpaths
+                    )
+                case let .edit(rule):
+                    viewModel.updateBlockRule(
+                        id: rule.id,
+                        ruleName: ruleName,
+                        urlPattern: pattern,
+                        httpMethod: method,
+                        matchType: matchType,
+                        blockAction: action,
+                        includeSubpaths: includeSubpaths
+                    )
+                }
+                viewModel.dismissEditor()
             }
+        }
+        .fileExporter(
+            isPresented: $showExporter,
+            document: exportDocument,
+            contentType: .json,
+            defaultFilename: "block-list-settings.json"
+        ) { _ in
+            exportDocument = nil
+        }
+        .fileImporter(
+            isPresented: $showImporter,
+            allowedContentTypes: [.json, .xml, .propertyList],
+            allowsMultipleSelection: false
+        ) { result in
+            handleImport(result)
+        }
+        .alert(
+            String(localized: "Import Failed"),
+            isPresented: Binding(
+                get: { importError != nil },
+                set: { if !$0 { importError = nil } }
+            )
+        ) {
+            Button(String(localized: "OK")) { importError = nil }
+        } message: {
+            if let importError {
+                Text(importError)
+            }
+        }
+        .onDeleteCommand {
+            viewModel.removeSelected()
         }
     }
 
     // MARK: Private
 
     private static let logger = Logger(subsystem: RockxyIdentity.current.logSubsystem, category: "BlockListWindowView")
+    private static let maxImportFileBytes = 1_024 * 1_024
 
     @State private var viewModel = BlockListViewModel()
+    @State private var showExporter = false
+    @State private var showImporter = false
+    @State private var exportDocument: BlockListSettingsDocument?
+    @State private var importError: String?
+    @State private var importSource: BlockListImportSource = .proxyman
 
-    private var toolbar: some View {
-        HStack {
-            Text(String(localized: "Block List"))
-                .font(.headline)
-            Spacer()
-        }
-        .padding(.horizontal, 16)
-        .padding(.vertical, 10)
-    }
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Toggle(
+                String(localized: "Enable Block List Tool"),
+                isOn: Binding(
+                    get: { viewModel.isBlockListActive },
+                    set: { viewModel.setBlockListActive($0) }
+                )
+            )
+            .toggleStyle(.checkbox)
+            .controlSize(.large)
+            .font(.system(size: 13, weight: .medium))
 
-    private var infoBanner: some View {
-        HStack(spacing: 6) {
-            Image(systemName: "info.circle")
-                .foregroundStyle(.secondary)
+            Text(String(localized: "Block or Hide any Requests. Useful to block/hide unnecessary requests."))
+                .font(.system(size: 13))
+                .foregroundStyle(.primary)
+
             Text(
                 String(
                     localized:
-                    "Blocked requests return 403 Forbidden or are silently dropped. Use wildcards (*) or regex for pattern matching."
+                    "Each request is checked against the rules from top to bottom, stopping when a match is found."
                 )
             )
-            .font(.caption)
+            .font(.system(size: 12.5))
             .foregroundStyle(.secondary)
-            Spacer()
         }
-        .padding(.horizontal, 16)
-        .padding(.vertical, 8)
-        .background(.quaternary.opacity(0.5))
+        .padding(.horizontal, 20)
+        .padding(.top, 20)
+        .padding(.bottom, 14)
     }
 
-    @ViewBuilder private var content: some View {
-        if viewModel.blockRules.isEmpty {
-            VStack(alignment: .center, spacing: 8) {
-                Image(systemName: "nosign")
-                    .font(.system(size: 20))
-                    .foregroundStyle(.tertiary)
-                Text(String(localized: "No Block Rules"))
-                    .font(.system(size: 13, weight: .medium))
-                    .foregroundStyle(.secondary)
-                Text(String(localized: "Add URL patterns to block matching requests."))
-                    .font(.caption)
-                    .foregroundStyle(.tertiary)
-                    .multilineTextAlignment(.center)
-
-                HStack(alignment: .top, spacing: 0) {
-                    RoundedRectangle(cornerRadius: 1)
-                        .fill(Color.red.opacity(0.4))
-                        .frame(width: 2, height: 28)
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text(String(localized: "Example"))
-                            .font(.caption2)
-                            .fontWeight(.semibold)
-                            .foregroundStyle(.tertiary)
-                        HStack(spacing: 5) {
-                            Text("*.example.com/ads/*")
-                                .font(.system(size: 10, design: .monospaced))
-                                .foregroundStyle(.secondary)
-                            Image(systemName: "arrow.right")
-                                .font(.system(size: 8))
-                                .foregroundStyle(.tertiary)
-                            Text("403 Forbidden")
-                                .font(.system(size: 10, design: .monospaced))
-                                .foregroundStyle(.red)
-                        }
-                    }
-                    .padding(.leading, 6)
-                }
-            }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .padding(.horizontal, 24)
+    private var shortcutHelp: some View {
+        Text(String(localized: "New: ⌘N    Edit: ⌘↩    Delete: ⌘⌫    Duplicate: ⌘D    Toggle: ␣"))
+            .font(.system(size: 10.5))
+            .foregroundStyle(.secondary)
+            .padding(.horizontal, 20)
             .padding(.top, 12)
-        } else {
-            List(selection: $viewModel.selectedRuleID) {
-                ForEach(viewModel.blockRules) { rule in
-                    BlockRuleRow(rule: rule) {
-                        viewModel.toggleRule(id: rule.id)
-                    }
-                    .tag(rule.id)
-                }
-            }
-            .listStyle(.inset(alternatesRowBackgrounds: true))
-        }
     }
 
-    private var bottomBar: some View {
-        HStack(spacing: 8) {
+    private var footer: some View {
+        HStack(spacing: 0) {
             Button {
-                viewModel.showAddSheet = true
+                viewModel.presentNewRuleEditor()
             } label: {
                 Image(systemName: "plus")
+                    .frame(width: 18, height: 18)
             }
             .buttonStyle(.borderless)
+            .keyboardShortcut("n", modifiers: .command)
+            .help(String(localized: "New Rule"))
 
             Button {
                 viewModel.removeSelected()
             } label: {
                 Image(systemName: "minus")
+                    .frame(width: 18, height: 18)
             }
             .buttonStyle(.borderless)
             .disabled(viewModel.selectedRuleID == nil)
+            .help(String(localized: "Delete Rule"))
 
-            Divider()
-                .frame(height: 16)
-
-            Text(
-                "\(viewModel.ruleCount) \(viewModel.ruleCount == 1 ? String(localized: "rule") : String(localized: "rules"))"
-            )
-            .font(.caption)
-            .foregroundStyle(.secondary)
+            Button {
+                // Help content is intentionally deferred; this mirrors the reference affordance.
+            } label: {
+                Image(systemName: "questionmark.circle.fill")
+                    .font(.system(size: 22))
+                    .foregroundStyle(.secondary.opacity(0.35), .clear)
+                    .overlay(Text("?").font(.system(size: 15, weight: .medium)).foregroundStyle(.primary))
+                    .frame(width: 34, height: 22)
+            }
+            .buttonStyle(.borderless)
+            .padding(.leading, 10)
 
             Spacer()
+
+            moreMenu
         }
-        .padding(.horizontal, 12)
-        .padding(.vertical, 8)
+        .padding(.horizontal, 20)
+        .padding(.top, 10)
+        .padding(.bottom, 18)
+    }
+
+    private var moreMenu: some View {
+        Menu {
+            Button(String(localized: "New…")) {
+                viewModel.presentNewRuleEditor()
+            }
+            .keyboardShortcut("n", modifiers: .command)
+
+            Divider()
+
+            Button(String(localized: "Edit…")) {
+                openEditorForSelection()
+            }
+            .keyboardShortcut(.return, modifiers: .command)
+            .disabled(viewModel.selectedRuleID == nil)
+
+            Button(String(localized: "Duplicate")) {
+                viewModel.duplicateSelected()
+            }
+            .keyboardShortcut("d", modifiers: .command)
+            .disabled(viewModel.selectedRuleID == nil)
+
+            Button(enableDisableLabel) {
+                if let id = viewModel.selectedRuleID {
+                    viewModel.toggleRule(id: id)
+                }
+            }
+            .keyboardShortcut(.space, modifiers: [])
+            .disabled(viewModel.selectedRuleID == nil)
+
+            Divider()
+
+            Button(String(localized: "Export Settings…")) {
+                prepareExport()
+            }
+            .disabled(viewModel.blockRules.isEmpty)
+
+            Menu(String(localized: "Import Settings")) {
+                Button(String(localized: "From Proxyman…")) {
+                    importSource = .proxyman
+                    showImporter = true
+                }
+
+                Button(String(localized: "From Charles Proxy…")) {
+                    importSource = .charlesProxy
+                    showImporter = true
+                }
+            }
+
+            Divider()
+
+            Button(String(localized: "Delete"), role: .destructive) {
+                viewModel.removeSelected()
+            }
+            .keyboardShortcut(.delete, modifiers: .command)
+            .disabled(viewModel.selectedRuleID == nil)
+        } label: {
+            HStack(spacing: 8) {
+                Text(String(localized: "More"))
+                Image(systemName: "chevron.down")
+                    .font(.caption2)
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 3)
+        }
+        .menuStyle(.borderlessButton)
+    }
+
+    @ViewBuilder
+    private func contextMenuItems(for id: UUID) -> some View {
+        Button(String(localized: "Edit…")) {
+            openEditorForRule(id)
+        }
+        .keyboardShortcut(.return, modifiers: .command)
+
+        Button(String(localized: "Duplicate")) {
+            viewModel.selectedRuleID = id
+            viewModel.duplicateSelected()
+        }
+        .keyboardShortcut("d", modifiers: .command)
+
+        Button(enableDisableLabel(for: id)) {
+            viewModel.toggleRule(id: id)
+        }
+        .keyboardShortcut(.space, modifiers: [])
+
+        Divider()
+
+        Button(String(localized: "Delete"), role: .destructive) {
+            viewModel.removeRule(id: id)
+        }
+        .keyboardShortcut(.delete, modifiers: .command)
+    }
+
+    private var enableDisableLabel: String {
+        guard let id = viewModel.selectedRuleID else {
+            return String(localized: "Enable Rule")
+        }
+        return enableDisableLabel(for: id)
+    }
+
+    private func enableDisableLabel(for id: UUID) -> String {
+        guard let rule = viewModel.blockRules.first(where: { $0.id == id }) else {
+            return String(localized: "Enable Rule")
+        }
+        return rule.isEnabled ? String(localized: "Disable Rule") : String(localized: "Enable Rule")
+    }
+
+    private func openEditorForSelection() {
+        guard let id = viewModel.selectedRuleID else {
+            return
+        }
+        openEditorForRule(id)
+    }
+
+    private func openEditorForRule(_ id: UUID) {
+        guard let rule = viewModel.blockRules.first(where: { $0.id == id }) else {
+            return
+        }
+        viewModel.selectedRuleID = id
+        viewModel.presentEditorForEditing(rule)
     }
 
     private func consumePendingContext() {
         guard let context = BlockRuleEditorContextStore.shared.consumePending() else {
             return
         }
-        viewModel.pendingContext = context
-        viewModel.showAddSheet = true
+        viewModel.presentEditorForContext(context)
+    }
+
+    private func prepareExport() {
+        do {
+            exportDocument = BlockListSettingsDocument(data: try viewModel.exportBlockRules())
+            showExporter = true
+        } catch {
+            importError = error.localizedDescription
+            Self.logger.error("Block list export failed: \(error.localizedDescription)")
+        }
+    }
+
+    private func handleImport(_ result: Result<[URL], Error>) {
+        switch result {
+        case let .success(urls):
+            guard let url = urls.first else {
+                return
+            }
+            let didStart = url.startAccessingSecurityScopedResource()
+            defer {
+                if didStart {
+                    url.stopAccessingSecurityScopedResource()
+                }
+            }
+            do {
+                let resourceValues = try url.resourceValues(forKeys: [.fileSizeKey])
+                if let fileSize = resourceValues.fileSize, fileSize > Self.maxImportFileBytes {
+                    importError = String(localized: "File is too large to import (max 1 MB).")
+                    return
+                }
+                let data = try Data(contentsOf: url)
+                let rules: [ProxyRule]
+                switch importSource {
+                case .proxyman:
+                    rules = try BlockListSettingsCodec.importFromProxyman(data)
+                case .charlesProxy:
+                    rules = try BlockListSettingsCodec.importFromCharlesProxy(data)
+                }
+                viewModel.importBlockRules(rules)
+            } catch {
+                importError = error.localizedDescription
+                Self.logger.error("Block list import failed: \(error.localizedDescription)")
+            }
+        case let .failure(error):
+            importError = error.localizedDescription
+        }
     }
 }
 
-// MARK: - BlockRuleRow
+// MARK: - BlockListTableView
 
-private struct BlockRuleRow: View {
-    // MARK: Internal
+private struct BlockListTableView<ContextMenuContent: View>: View {
+    let rules: [ProxyRule]
+    @Binding var selectedRuleID: UUID?
+    let onToggle: (UUID) -> Void
+    let onEdit: (UUID) -> Void
+    let onDelete: (UUID) -> Void
+    @ViewBuilder let contextMenuItems: (UUID) -> ContextMenuContent
 
+    var body: some View {
+        VStack(spacing: 0) {
+            columnHeader
+            ZStack {
+                zebraRows
+
+                if rules.isEmpty {
+                    Text(String(localized: "Click \"+\" or ⌘N to add new entry"))
+                        .font(.system(size: 12))
+                        .foregroundStyle(.secondary)
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                } else {
+                    ScrollView {
+                        LazyVStack(spacing: 0) {
+                            ForEach(Array(rules.enumerated()), id: \.element.id) { index, rule in
+                                BlockRuleTableRow(
+                                    rule: rule,
+                                    isSelected: selectedRuleID == rule.id,
+                                    rowIndex: index,
+                                    onSelect: { selectedRuleID = rule.id },
+                                    onToggle: { onToggle(rule.id) }
+                                )
+                                .contextMenu {
+                                    contextMenuItems(rule.id)
+                                }
+                                .onTapGesture(count: 2) {
+                                    onEdit(rule.id)
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        .frame(height: 399)
+        .overlay {
+            Rectangle()
+                .stroke(.secondary.opacity(0.45), lineWidth: 1)
+        }
+        .padding(.horizontal, 20)
+    }
+
+    private var columnHeader: some View {
+        HStack(spacing: 0) {
+            Text(String(localized: "Enabled"))
+                .frame(width: 66, alignment: .leading)
+            tableDivider
+            Text(String(localized: "Name"))
+                .frame(width: 303, alignment: .leading)
+            tableDivider
+            Text(String(localized: "Block Action"))
+                .frame(width: 110, alignment: .leading)
+            tableDivider
+            Text(String(localized: "Method"))
+                .frame(width: 80, alignment: .leading)
+            tableDivider
+            Text(String(localized: "Matching Rule"))
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .font(.system(size: 11, weight: .medium))
+        .padding(.horizontal, 12)
+        .frame(height: 24)
+        .background(Color(nsColor: .textBackgroundColor))
+        .padding(.horizontal, 20)
+        .overlay(alignment: .bottom) {
+            Divider().padding(.horizontal, 20)
+        }
+    }
+
+    private var tableDivider: some View {
+        Rectangle()
+            .fill(.secondary.opacity(0.22))
+            .frame(width: 1, height: 16)
+            .padding(.trailing, 10)
+    }
+
+    private var zebraRows: some View {
+        VStack(spacing: 0) {
+            ForEach(0 ..< 17, id: \.self) { index in
+                Rectangle()
+                    .fill(index.isMultiple(of: 2) ? Color(nsColor: .textBackgroundColor) : Color.secondary.opacity(0.08))
+                    .frame(height: 22)
+            }
+            Spacer(minLength: 0)
+        }
+    }
+}
+
+// MARK: - BlockRuleTableRow
+
+private struct BlockRuleTableRow: View {
     let rule: ProxyRule
+    let isSelected: Bool
+    let rowIndex: Int
+    let onSelect: () -> Void
     let onToggle: () -> Void
 
     var body: some View {
-        HStack(spacing: 10) {
+        HStack(spacing: 0) {
             Toggle("", isOn: Binding(
                 get: { rule.isEnabled },
                 set: { _ in onToggle() }
             ))
-            .toggleStyle(.switch)
+            .toggleStyle(.checkbox)
             .labelsHidden()
-            .controlSize(.small)
+            .frame(width: 66)
 
             Text(rule.name)
-                .font(.system(.body, design: .monospaced))
                 .lineLimit(1)
                 .truncationMode(.middle)
-
-            matchTypeBadge
-
-            Spacer()
+                .frame(width: 314, alignment: .leading)
 
             actionLabel
+                .frame(width: 110, alignment: .leading)
+
+            Text(rule.matchCondition.method ?? "ANY")
+                .frame(width: 80, alignment: .leading)
+
+            Text(rule.matchCondition.urlPattern ?? "")
+                .font(.system(size: 10.5, design: .monospaced))
+                .lineLimit(1)
+                .truncationMode(.middle)
+                .frame(maxWidth: .infinity, alignment: .leading)
         }
-        .padding(.vertical, 2)
+        .font(.system(size: 10.5))
+        .foregroundStyle(rule.isEnabled ? .primary : .secondary)
+        .frame(height: 22)
+        .background(rowBackground)
+        .contentShape(Rectangle())
+        .onTapGesture {
+            onSelect()
+        }
         .opacity(rule.isEnabled ? 1.0 : 0.5)
-    }
-
-    // MARK: Private
-
-    @ViewBuilder private var matchTypeBadge: some View {
-        let detected = detectMatchType(rule.matchCondition.urlPattern ?? "")
-        HStack(spacing: 4) {
-            Text(detected.symbol)
-                .font(.caption2.bold())
-                .frame(width: 18, height: 18)
-                .background(detected.color.opacity(0.15))
-                .foregroundStyle(detected.color)
-                .clipShape(RoundedRectangle(cornerRadius: 4))
-
-            if detected.isAutoDetected {
-                Text(String(localized: "auto"))
-                    .font(.system(size: 9, weight: .semibold))
-                    .padding(.horizontal, 4)
-                    .padding(.vertical, 1)
-                    .background(Color.yellow.opacity(0.2))
-                    .foregroundStyle(.yellow)
-                    .clipShape(Capsule())
-            }
-        }
     }
 
     @ViewBuilder private var actionLabel: some View {
         if case let .block(statusCode) = rule.action {
-            let text = statusCode == 0
-                ? String(localized: "Drop Connection")
-                : String(localized: "403 Forbidden")
-            Text(text)
-                .font(.caption)
-                .foregroundStyle(.secondary)
+            Text(statusCode == 0 ? String(localized: "Drop Connection") : String(localized: "Return 403 Forbidden"))
         }
     }
 
-    private func detectMatchType(_ pattern: String) -> (symbol: String, color: Color, isAutoDetected: Bool) {
-        let isAnchored = pattern.hasPrefix("^") && pattern.hasSuffix("$")
-        let regexSpecial = CharacterSet(charactersIn: "[](){}+?|^$\\")
-        let hasRegexChars = pattern.unicodeScalars.contains { regexSpecial.contains($0) }
-
-        if isAnchored, !hasRegexInner(pattern) {
-            return ("=", .green, true)
-        } else if hasRegexChars {
-            return ("R", .purple, true)
-        } else {
-            return ("*", .blue, true)
+    private var rowBackground: some ShapeStyle {
+        if isSelected {
+            return AnyShapeStyle(Color.accentColor.opacity(0.22))
         }
-    }
-
-    private func hasRegexInner(_ pattern: String) -> Bool {
-        let inner = String(pattern.dropFirst().dropLast())
-        let unescaped = inner.replacingOccurrences(of: "\\.", with: "")
-        let regexSpecial = CharacterSet(charactersIn: "[](){}+?|^$\\.*")
-        return unescaped.unicodeScalars.contains { regexSpecial.contains($0) }
+        return AnyShapeStyle(rowIndex.isMultiple(of: 2) ? Color(nsColor: .textBackgroundColor) : Color.secondary.opacity(0.08))
     }
 }
 
 // MARK: - AddBlockRuleSheet
 
 private struct AddBlockRuleSheet: View {
-    // MARK: Lifecycle
-
     init(
-        editorContext: BlockRuleEditorContext? = nil,
+        session: BlockListEditorSession,
         onSave: @escaping (String, String, HTTPMethodFilter, BlockMatchType, BlockActionType, Bool) -> Void
     ) {
-        self.editorContext = editorContext
+        self.session = session
         self.onSave = onSave
-        _ruleName = State(initialValue: editorContext?.suggestedName ?? "")
-        _urlPattern = State(initialValue: editorContext?.defaultPattern ?? "")
-        _httpMethod = State(initialValue: editorContext?.httpMethod ?? .any)
-        _matchType = State(initialValue: editorContext?.defaultMatchType ?? .wildcard)
-        _blockAction = State(initialValue: editorContext?.defaultAction ?? .returnForbidden)
-        _includeSubpaths = State(initialValue: editorContext?.includeSubpaths ?? true)
+        switch session.mode {
+        case let .create(context):
+            _ruleName = State(initialValue: context?.suggestedName ?? "")
+            _urlPattern = State(initialValue: context?.defaultPattern ?? "")
+            _httpMethod = State(initialValue: context?.httpMethod ?? .any)
+            _matchType = State(initialValue: context?.defaultMatchType ?? .wildcard)
+            _blockAction = State(initialValue: context?.defaultAction ?? .returnForbidden)
+            _includeSubpaths = State(initialValue: context?.includeSubpaths ?? true)
+        case let .edit(rule):
+            _ruleName = State(initialValue: rule.name)
+            _urlPattern = State(initialValue: rule.matchCondition.urlPattern ?? "")
+            _httpMethod = State(initialValue: HTTPMethodFilter(rawValue: rule.matchCondition.method ?? "ANY") ?? .any)
+            _matchType = State(initialValue: .regex)
+            _blockAction = State(initialValue: rule.blockActionType)
+            _includeSubpaths = State(initialValue: false)
+        }
     }
 
-    // MARK: Internal
-
-    let editorContext: BlockRuleEditorContext?
+    let session: BlockListEditorSession
     let onSave: (String, String, HTTPMethodFilter, BlockMatchType, BlockActionType, Bool) -> Void
 
     var body: some View {
@@ -422,7 +833,7 @@ private struct AddBlockRuleSheet: View {
                 }
                 .keyboardShortcut(.cancelAction)
 
-                Button(String(localized: "Done")) {
+                Button(primaryButtonTitle) {
                     onSave(
                         ruleName,
                         urlPattern,
@@ -434,7 +845,7 @@ private struct AddBlockRuleSheet: View {
                     dismiss()
                 }
                 .keyboardShortcut(.defaultAction)
-                .disabled(urlPattern.isEmpty)
+                .disabled(urlPattern.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
             }
             .padding(.horizontal, 24)
             .padding(.vertical, 8)
@@ -442,8 +853,6 @@ private struct AddBlockRuleSheet: View {
         .frame(width: 600)
         .fixedSize(horizontal: false, vertical: true)
     }
-
-    // MARK: Private
 
     private static let labelWidth: CGFloat = 110
 
@@ -455,8 +864,15 @@ private struct AddBlockRuleSheet: View {
     @State private var blockAction: BlockActionType
     @State private var includeSubpaths: Bool
 
+    private var primaryButtonTitle: String {
+        if case .edit = session.mode {
+            return String(localized: "Save")
+        }
+        return String(localized: "Done")
+    }
+
     @ViewBuilder private var provenanceBanner: some View {
-        if let context = editorContext {
+        if case let .create(context?) = session.mode {
             HStack(spacing: 6) {
                 Image(systemName: "info.circle")
                     .font(.caption)
@@ -465,17 +881,9 @@ private struct AddBlockRuleSheet: View {
                     switch context.origin {
                     case .selectedTransaction:
                         if let method = context.sourceMethod {
-                            Text(
-                                String(
-                                    localized: "Created from: \(method) \(context.sourceHost)\(context.sourcePath ?? "")"
-                                )
-                            )
+                            Text(String(localized: "Created from: \(method) \(context.sourceHost)\(context.sourcePath ?? "")"))
                         } else {
-                            Text(
-                                String(
-                                    localized: "Created from: \(context.sourceHost)\(context.sourcePath ?? "")"
-                                )
-                            )
+                            Text(String(localized: "Created from: \(context.sourceHost)\(context.sourcePath ?? "")"))
                         }
                     case .domainQuickCreate:
                         Text(String(localized: "Created from domain: \(context.sourceHost)"))
@@ -551,5 +959,43 @@ private struct AddBlockRuleSheet: View {
                 content()
             }
         }
+    }
+}
+
+// MARK: - BlockListSettingsDocument
+
+struct BlockListSettingsDocument: FileDocument {
+    init(data: Data) {
+        self.data = data
+    }
+
+    init(configuration: ReadConfiguration) throws {
+        data = configuration.file.regularFileContents ?? Data()
+    }
+
+    static var readableContentTypes: [UTType] {
+        [.json]
+    }
+
+    let data: Data
+
+    func fileWrapper(configuration _: WriteConfiguration) throws -> FileWrapper {
+        FileWrapper(regularFileWithContents: data)
+    }
+}
+
+private extension ProxyRule {
+    var isBlockRule: Bool {
+        if case .block = action {
+            return true
+        }
+        return false
+    }
+
+    var blockActionType: BlockActionType {
+        guard case let .block(statusCode) = action else {
+            return .returnForbidden
+        }
+        return statusCode == 0 ? .dropConnection : .returnForbidden
     }
 }

--- a/Rockxy/Views/Rules/MapLocalEditorMenuContent.swift
+++ b/Rockxy/Views/Rules/MapLocalEditorMenuContent.swift
@@ -1,0 +1,20 @@
+// MARK: - MapLocalEditorMenuContent
+
+enum MapLocalEditorMenuContent {
+    static let methodSections: [[MapLocalHTTPMethod]] = [
+        [.any],
+        [.get, .post, .put, .delete, .patch],
+        [.head, .options, .trace],
+    ]
+
+    static let matchTypeSections: [[MapLocalMatchType]] = [
+        [.wildcard, .regex],
+    ]
+
+    static let delaySections: [[MapLocalDelayPreset]] = [
+        [.none],
+        [.oneSecond, .twoSeconds, .threeSeconds, .fiveSeconds, .tenSeconds, .thirtySeconds, .sixtySeconds],
+        [.random],
+        [.custom],
+    ]
+}

--- a/Rockxy/Views/Rules/MapLocalHTTPMessageEditor.swift
+++ b/Rockxy/Views/Rules/MapLocalHTTPMessageEditor.swift
@@ -1,0 +1,258 @@
+import AppKit
+import SwiftUI
+
+// MARK: - MapLocalHTTPMessageEditor
+
+struct MapLocalHTTPMessageEditor: NSViewRepresentable {
+    final class Coordinator: NSObject, NSTextViewDelegate {
+        // MARK: Lifecycle
+
+        init(text: Binding<String>) {
+            self.text = text
+        }
+
+        deinit {
+            highlightTask?.cancel()
+        }
+
+        // MARK: Internal
+
+        var isProgrammaticChange = false
+        var highlightTask: Task<Void, Never>?
+
+        func textDidChange(_ notification: Notification) {
+            guard !isProgrammaticChange,
+                  let textView = notification.object as? NSTextView,
+                  let scrollView = textView.enclosingScrollView else
+            {
+                return
+            }
+            text.wrappedValue = textView.string
+            (scrollView.verticalRulerView as? ScriptCodeEditorRulerView)?.invalidateLineNumbers()
+            scheduleHighlight(text: textView.string, in: scrollView)
+        }
+
+        @MainActor
+        func scheduleHighlight(text: String, in scrollView: NSScrollView) {
+            highlightTask?.cancel()
+            highlightTask = Task { [weak self, weak scrollView] in
+                let spans = await Task.detached(priority: .utility) {
+                    Self.highlightSpans(for: text)
+                }.value
+
+                guard !Task.isCancelled,
+                      let self,
+                      let scrollView,
+                      let textView = scrollView.documentView as? NSTextView,
+                      textView.string == text else
+                {
+                    return
+                }
+
+                let selectedRange = textView.selectedRange()
+                let attributed = Self.baseAttributedString(text)
+                for span in spans where NSMaxRange(span.range) <= attributed.length {
+                    attributed.addAttribute(.foregroundColor, value: span.role.color, range: span.range)
+                }
+                isProgrammaticChange = true
+                textView.textStorage?.setAttributedString(attributed)
+                textView.setSelectedRange(Self.clamped(range: selectedRange, length: attributed.length))
+                textView.typingAttributes = Self.typingAttributes
+                isProgrammaticChange = false
+                (scrollView.verticalRulerView as? ScriptCodeEditorRulerView)?.invalidateLineNumbers()
+            }
+        }
+
+        static func clamped(range: NSRange, length: Int) -> NSRange {
+            guard range.location != NSNotFound else {
+                return NSRange(location: 0, length: 0)
+            }
+            let location = min(range.location, length)
+            let upperBound = min(range.location + range.length, length)
+            return NSRange(location: location, length: max(0, upperBound - location))
+        }
+
+        // MARK: Private
+
+        private var text: Binding<String>
+
+        private static let editorFont = NSFont.monospacedSystemFont(ofSize: 12, weight: .regular)
+
+        private static var typingAttributes: [NSAttributedString.Key: Any] {
+            [
+                .font: editorFont,
+                .foregroundColor: NSColor.textColor,
+                .backgroundColor: NSColor.textBackgroundColor,
+            ]
+        }
+
+        private static func baseAttributedString(_ text: String) -> NSMutableAttributedString {
+            NSMutableAttributedString(string: text, attributes: typingAttributes)
+        }
+
+        nonisolated private static func highlightSpans(for text: String) -> [HighlightSpan] {
+            let fullRange = NSRange(location: 0, length: (text as NSString).length)
+            var spans: [HighlightSpan] = []
+            appendSpans(
+                #"(?m)^HTTP/\d(?:\.\d)?\s+\d{3}(?:\s+[A-Za-z ]+)?"#,
+                role: .status,
+                text: text,
+                range: fullRange,
+                spans: &spans
+            )
+            appendSpans(
+                #"(?m)^[A-Za-z0-9!#$%&'*+.^_`|~-]+:"#,
+                role: .header,
+                text: text,
+                range: fullRange,
+                spans: &spans
+            )
+            appendSpans(#""(?:\\.|[^"\\])*"(?=\s*:)"#, role: .key, text: text, range: fullRange, spans: &spans)
+            appendSpans(#""(?:\\.|[^"\\])*""#, role: .string, text: text, range: fullRange, spans: &spans)
+            appendSpans(
+                #"(?<![\w.])-?\b\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\b"#,
+                role: .number,
+                text: text,
+                range: fullRange,
+                spans: &spans
+            )
+            appendSpans(#"\b(?:true|false)\b"#, role: .bool, text: text, range: fullRange, spans: &spans)
+            appendSpans(#"\bnull\b"#, role: .null, text: text, range: fullRange, spans: &spans)
+            appendSpans(#"[\{\}\[\],:]"#, role: .bracket, text: text, range: fullRange, spans: &spans)
+            return spans
+        }
+
+        nonisolated private static func appendSpans(
+            _ pattern: String,
+            role: HighlightRole,
+            text: String,
+            range: NSRange,
+            spans: inout [HighlightSpan]
+        ) {
+            guard let regex = try? NSRegularExpression(pattern: pattern) else {
+                return
+            }
+            regex.enumerateMatches(in: text, range: range) { match, _, _ in
+                guard let match else {
+                    return
+                }
+                spans.append(HighlightSpan(range: match.range, role: role))
+            }
+        }
+
+        private struct HighlightSpan: Sendable {
+            let range: NSRange
+            let role: HighlightRole
+        }
+
+        private enum HighlightRole: Sendable {
+            case status
+            case header
+            case key
+            case string
+            case number
+            case bool
+            case null
+            case bracket
+
+            @MainActor var color: NSColor {
+                switch self {
+                case .status: Theme.JSON.statusNS
+                case .header: Theme.JSON.headerNS
+                case .key: Theme.JSON.keyNS
+                case .string: Theme.JSON.stringNS
+                case .number: Theme.JSON.numberNS
+                case .bool: Theme.JSON.boolNS
+                case .null: Theme.JSON.nullNS
+                case .bracket: Theme.JSON.bracketNS
+                }
+            }
+        }
+    }
+
+    @Binding var text: String
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(text: $text)
+    }
+
+    func makeNSView(context: Context) -> NSScrollView {
+        let scrollView = NSTextView.scrollableTextView()
+        configure(scrollView, coordinator: context.coordinator)
+        apply(text, to: scrollView, coordinator: context.coordinator)
+        return scrollView
+    }
+
+    func updateNSView(_ nsView: NSScrollView, context: Context) {
+        guard let textView = nsView.documentView as? NSTextView else {
+            return
+        }
+        if textView.string != text {
+            let selectedRange = textView.selectedRange()
+            apply(text, to: nsView, coordinator: context.coordinator)
+            textView.setSelectedRange(Coordinator.clamped(range: selectedRange, length: (text as NSString).length))
+        }
+    }
+
+    private func configure(_ scrollView: NSScrollView, coordinator: Coordinator) {
+        scrollView.wantsLayer = true
+        scrollView.layer?.masksToBounds = true
+        scrollView.drawsBackground = true
+        scrollView.backgroundColor = .textBackgroundColor
+        scrollView.borderType = .noBorder
+        scrollView.hasVerticalScroller = true
+        scrollView.hasHorizontalScroller = true
+        scrollView.autohidesScrollers = true
+        scrollView.contentView.wantsLayer = true
+        scrollView.contentView.layer?.masksToBounds = true
+
+        guard let textView = scrollView.documentView as? NSTextView else {
+            return
+        }
+        textView.isEditable = true
+        textView.isSelectable = true
+        textView.allowsUndo = true
+        textView.usesFindBar = true
+        textView.isRichText = true
+        textView.importsGraphics = false
+        textView.isAutomaticQuoteSubstitutionEnabled = false
+        textView.isAutomaticDashSubstitutionEnabled = false
+        textView.isAutomaticTextReplacementEnabled = false
+        textView.isAutomaticSpellingCorrectionEnabled = false
+        textView.font = .monospacedSystemFont(ofSize: 12, weight: .regular)
+        textView.textColor = .textColor
+        textView.backgroundColor = .textBackgroundColor
+        textView.textContainerInset = NSSize(width: 8, height: 7)
+        textView.isHorizontallyResizable = true
+        textView.isVerticallyResizable = true
+        textView.minSize = NSSize(width: 0, height: 0)
+        textView.maxSize = NSSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude)
+        textView.autoresizingMask = [.width]
+        textView.textContainer?.containerSize = NSSize(
+            width: CGFloat.greatestFiniteMagnitude,
+            height: CGFloat.greatestFiniteMagnitude
+        )
+        textView.textContainer?.widthTracksTextView = false
+        textView.delegate = coordinator
+
+        let ruler = ScriptCodeEditorRulerView(textView: textView)
+        ruler.ruleThickness = 46
+        scrollView.verticalRulerView = ruler
+        scrollView.hasVerticalRuler = true
+        scrollView.rulersVisible = true
+    }
+
+    private func apply(_ text: String, to scrollView: NSScrollView, coordinator: Coordinator) {
+        guard let textView = scrollView.documentView as? NSTextView else {
+            return
+        }
+        coordinator.isProgrammaticChange = true
+        textView.string = text
+        textView.font = .monospacedSystemFont(ofSize: 12, weight: .regular)
+        textView.textColor = .textColor
+        textView.backgroundColor = .textBackgroundColor
+        coordinator.isProgrammaticChange = false
+        coordinator.scheduleHighlight(text: text, in: scrollView)
+        (scrollView.verticalRulerView as? ScriptCodeEditorRulerView)?.invalidateLineNumbers()
+    }
+}

--- a/Rockxy/Views/Rules/MapLocalHTTPMessageEditor.swift
+++ b/Rockxy/Views/Rules/MapLocalHTTPMessageEditor.swift
@@ -101,6 +101,13 @@ struct MapLocalHTTPMessageEditor: NSViewRepresentable {
                 spans: &spans
             )
             appendSpans(
+                #"(?m)^(?:GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS|TRACE)\s+\S+\s+HTTP/\d(?:\.\d)?"#,
+                role: .status,
+                text: text,
+                range: fullRange,
+                spans: &spans
+            )
+            appendSpans(
                 #"(?m)^[A-Za-z0-9!#$%&'*+.^_`|~-]+:"#,
                 role: .header,
                 text: text,

--- a/Rockxy/Views/Rules/MapLocalPatternFormatter.swift
+++ b/Rockxy/Views/Rules/MapLocalPatternFormatter.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+// MARK: - MapLocalPatternFormatter
+
+enum MapLocalPatternFormatter {
+    static func wildcardToRegex(_ pattern: String) -> String {
+        var result = ""
+        for char in pattern {
+            switch char {
+            case "*":
+                result += ".*"
+            case "?":
+                result += "."
+            default:
+                result += NSRegularExpression.escapedPattern(for: String(char))
+            }
+        }
+        return result
+    }
+
+    static func readablePattern(_ pattern: String) -> String {
+        pattern
+            .trimmingCharacters(in: CharacterSet(charactersIn: "^$"))
+            .replacingOccurrences(of: #"\/"#, with: "/")
+            .replacingOccurrences(of: #"\."#, with: ".")
+            .replacingOccurrences(of: ".*", with: "*")
+            .trimmingCharacters(in: CharacterSet(charactersIn: "^$"))
+    }
+
+    static func prefersWildcardPresentation(_ pattern: String) -> Bool {
+        pattern.contains(".*") || pattern.contains("\\.") || pattern.contains("\\/")
+    }
+}

--- a/Rockxy/Views/Rules/MapLocalWindowView.swift
+++ b/Rockxy/Views/Rules/MapLocalWindowView.swift
@@ -543,22 +543,36 @@ struct MapLocalWindowView: View {
                     openNewEditor()
                 } label: {
                     Image(systemName: "plus")
-                        .frame(width: 22, height: 20)
+                        .font(.system(size: 12, weight: .regular))
+                        .frame(width: 18, height: 18)
+                        .contentShape(Rectangle())
                 }
+                .buttonStyle(.plain)
                 .keyboardShortcut("n", modifiers: .command)
 
-                Divider().frame(height: 14)
+                Rectangle()
+                    .fill(Color(nsColor: .separatorColor))
+                    .frame(width: 1, height: 18)
 
                 Button {
                     viewModel.removeSelectedRules()
                 } label: {
                     Image(systemName: "minus")
-                        .frame(width: 22, height: 20)
+                        .font(.system(size: 12, weight: .regular))
+                        .frame(width: 18, height: 18)
+                        .contentShape(Rectangle())
                 }
+                .buttonStyle(.plain)
                 .keyboardShortcut(.delete, modifiers: .command)
                 .disabled(viewModel.selectedRuleIDs.isEmpty)
             }
-            .buttonStyle(.bordered)
+            .foregroundStyle(.primary)
+            .background(Color(nsColor: .controlBackgroundColor))
+            .overlay(
+                Rectangle()
+                    .stroke(Color(nsColor: .separatorColor), lineWidth: 1)
+            )
+            .frame(width: 37, height: 19)
 
             Button(String(localized: "New Folder")) {
                 viewModel.createNewFolderPlaceholder()
@@ -583,7 +597,7 @@ struct MapLocalWindowView: View {
             }
             .keyboardShortcut("f", modifiers: .command)
 
-            Menu(String(localized: "More")) {
+            Menu {
                 Button(String(localized: "New")) { openNewEditor() }
                     .keyboardShortcut("n", modifiers: .command)
                 Button(String(localized: "Edit")) {
@@ -609,8 +623,15 @@ struct MapLocalWindowView: View {
                 }
                 .keyboardShortcut(.delete, modifiers: .command)
                 .disabled(viewModel.selectedRuleIDs.isEmpty)
+            } label: {
+                HStack(spacing: 6) {
+                    Text(String(localized: "More"))
+                    Image(systemName: "chevron.down")
+                        .font(.system(size: 9, weight: .semibold))
+                }
             }
-            .menuStyle(.borderlessButton)
+            .menuIndicator(.hidden)
+            .buttonStyle(.bordered)
             .fixedSize()
         }
         .padding(.horizontal, 18)

--- a/Rockxy/Views/Rules/MapLocalWindowView.swift
+++ b/Rockxy/Views/Rules/MapLocalWindowView.swift
@@ -4,6 +4,38 @@ import SwiftUI
 
 // Presents the Proxyman-style Map Local management and editor windows.
 
+// MARK: - MapLocalPatternFormatter
+
+enum MapLocalPatternFormatter {
+    static func wildcardToRegex(_ pattern: String) -> String {
+        var result = ""
+        for char in pattern {
+            switch char {
+            case "*":
+                result += ".*"
+            case "?":
+                result += "."
+            default:
+                result += NSRegularExpression.escapedPattern(for: String(char))
+            }
+        }
+        return result
+    }
+
+    static func readablePattern(_ pattern: String) -> String {
+        pattern
+            .trimmingCharacters(in: CharacterSet(charactersIn: "^$"))
+            .replacingOccurrences(of: #"\/"#, with: "/")
+            .replacingOccurrences(of: #"\."#, with: ".")
+            .replacingOccurrences(of: ".*", with: "*")
+            .trimmingCharacters(in: CharacterSet(charactersIn: "^$"))
+    }
+
+    static func prefersWildcardPresentation(_ pattern: String) -> Bool {
+        pattern.contains(".*") || pattern.contains("\\.") || pattern.contains("\\/")
+    }
+}
+
 // MARK: - MapLocalHTTPMethod
 
 enum MapLocalHTTPMethod: String, CaseIterable, Identifiable {
@@ -331,8 +363,8 @@ final class MapLocalViewModel {
         guard let pattern = rule.matchCondition.urlPattern, !pattern.isEmpty else {
             return "<Missing URL>"
         }
-        if pattern.contains(".*") || pattern.contains("\\.") {
-            return "Wildcard: \(readablePattern(pattern))"
+        if MapLocalPatternFormatter.prefersWildcardPresentation(pattern) {
+            return "Wildcard: \(MapLocalPatternFormatter.readablePattern(pattern))"
         }
         return pattern
     }
@@ -363,14 +395,6 @@ final class MapLocalViewModel {
     private static let logger = Logger(subsystem: RockxyIdentity.current.logSubsystem, category: "MapLocalViewModel")
     private static var defaultToolEnabled: Bool {
         UserDefaults.standard.object(forKey: toolEnabledKey) as? Bool ?? true
-    }
-
-    private func readablePattern(_ pattern: String) -> String {
-        pattern
-            .replacingOccurrences(of: #"^https?://"#, with: "https://", options: .regularExpression)
-            .replacingOccurrences(of: #"\\."#, with: ".")
-            .replacingOccurrences(of: #"\.\*"#, with: "*", options: .regularExpression)
-            .trimmingCharacters(in: CharacterSet(charactersIn: "^$"))
     }
 
     private func abbreviatedPath(_ path: String) -> String {
@@ -831,7 +855,7 @@ final class MapLocalEditorViewModel {
             return trimmed
         }
         let pattern = includeSubpaths && !trimmed.hasSuffix("*") ? "\(trimmed)*" : trimmed
-        return Self.wildcardToRegex(pattern)
+        return MapLocalPatternFormatter.wildcardToRegex(pattern)
     }
 
     // MARK: Private
@@ -881,9 +905,15 @@ final class MapLocalEditorViewModel {
 
     private func load(existingRule rule: ProxyRule) {
         name = rule.name.isEmpty ? "Untitled" : rule.name
-        urlText = rule.matchCondition.urlPattern ?? ""
+        let storedPattern = rule.matchCondition.urlPattern ?? ""
+        if MapLocalPatternFormatter.prefersWildcardPresentation(storedPattern) {
+            urlText = MapLocalPatternFormatter.readablePattern(storedPattern)
+            matchType = .wildcard
+        } else {
+            urlText = storedPattern
+            matchType = .regex
+        }
         method = MapLocalHTTPMethod(ruleMethod: rule.matchCondition.method)
-        matchType = .regex
         includeSubpaths = false
         if case let .mapLocal(path, statusCode, isDirectory, delayMs) = rule.action {
             targetMode = isDirectory ? .localDirectory : .localFile
@@ -921,21 +951,6 @@ final class MapLocalEditorViewModel {
             .appendingPathComponent("default_message_\(UUID().uuidString.prefix(8)).json")
             .path
     }
-
-    private static func wildcardToRegex(_ pattern: String) -> String {
-        var result = ""
-        for char in pattern {
-            switch char {
-            case "*":
-                result += ".*"
-            case "?":
-                result += "."
-            default:
-                result += NSRegularExpression.escapedPattern(for: String(char))
-            }
-        }
-        return result
-    }
 }
 
 private extension Result where Success == NSRegularExpression, Failure == RegexValidator.ValidationError {
@@ -955,14 +970,14 @@ struct MapLocalEditorWindowView: View {
     @State var viewModel = MapLocalEditorViewModel()
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 18) {
+        VStack(alignment: .leading, spacing: 12) {
             matchingRuleSection
             mapToSection
         }
         .padding(.horizontal, 18)
-        .padding(.top, 20)
-        .padding(.bottom, 18)
-        .frame(width: 960, height: 640)
+        .padding(.top, 28)
+        .padding(.bottom, 14)
+        .frame(width: 1_024, height: 720)
         .navigationTitle(viewModel.windowTitle)
         .onAppear { viewModel.load(context: editorStore.context) }
         .onChange(of: editorStore.draftVersion) { _, _ in
@@ -984,11 +999,11 @@ struct MapLocalEditorWindowView: View {
     }
 
     private var matchingRuleSection: some View {
-        VStack(alignment: .leading, spacing: 10) {
+        VStack(alignment: .leading, spacing: 7) {
             Text(String(localized: "Matching Rule"))
                 .font(.system(size: 15))
 
-            VStack(alignment: .leading, spacing: 12) {
+            VStack(alignment: .leading, spacing: 8) {
                 HStack {
                     Text(String(localized: "Name:"))
                         .frame(width: 70, alignment: .trailing)
@@ -1041,42 +1056,53 @@ struct MapLocalEditorWindowView: View {
                     }
                 }
             }
-            .padding(18)
+            .padding(.horizontal, 16)
+            .padding(.vertical, 12)
             .background(Color(nsColor: .controlBackgroundColor))
-            .clipShape(RoundedRectangle(cornerRadius: 12))
+            .clipShape(RoundedRectangle(cornerRadius: 8))
         }
     }
 
     private var mapToSection: some View {
-        VStack(alignment: .leading, spacing: 10) {
+        VStack(alignment: .leading, spacing: 7) {
             Text(String(localized: "Map To"))
                 .font(.system(size: 15))
 
-            VStack(spacing: 0) {
+            ZStack(alignment: .top) {
+                VStack(spacing: 0) {
+                    if viewModel.targetMode == .localFile {
+                        localFileSection
+                    } else {
+                        localDirectorySection
+                    }
+                }
+                .padding(.horizontal, 18)
+                .padding(.top, 30)
+                .padding(.bottom, 14)
+                .frame(maxWidth: .infinity, alignment: .topLeading)
+                .background(Color(nsColor: .controlBackgroundColor))
+                .clipShape(RoundedRectangle(cornerRadius: 7))
+                .overlay(RoundedRectangle(cornerRadius: 7).stroke(Color(nsColor: .separatorColor).opacity(0.35)))
+                .padding(.top, 10)
+
                 Picker("", selection: $viewModel.targetMode) {
                     Text(MapLocalTargetMode.localFile.displayName).tag(MapLocalTargetMode.localFile)
                     Text(MapLocalTargetMode.localDirectory.displayName).tag(MapLocalTargetMode.localDirectory)
                 }
                 .pickerStyle(.segmented)
-                .frame(width: 230)
-                .offset(y: -22)
-
-                if viewModel.targetMode == .localFile {
-                    localFileSection
-                } else {
-                    localDirectorySection
-                }
+                .frame(width: 240)
+                .background(
+                    Color(nsColor: .controlBackgroundColor)
+                        .padding(.horizontal, -8)
+                        .padding(.vertical, -3)
+                )
+                .zIndex(1)
             }
-            .padding(.horizontal, 22)
-            .padding(.bottom, 18)
-            .background(Color(nsColor: .controlBackgroundColor))
-            .clipShape(RoundedRectangle(cornerRadius: 7))
-            .overlay(RoundedRectangle(cornerRadius: 7).stroke(Color(nsColor: .separatorColor).opacity(0.35)))
         }
     }
 
     private var localFileSection: some View {
-        VStack(alignment: .leading, spacing: 9) {
+        VStack(alignment: .leading, spacing: 7) {
             Toggle(String(localized: "Enable Local File"), isOn: $viewModel.localFileEnabled)
                 .toggleStyle(.checkbox)
             Text("File: \(viewModel.filePath)")
@@ -1087,18 +1113,21 @@ struct MapLocalEditorWindowView: View {
                 Circle()
                     .fill(.green)
                     .frame(width: 10, height: 10)
-                Text(String(localized: "Map Response with HTTP Message format (Saved)"))
+                Text(String(localized: "Map Response Body with a local file (Saved)"))
                     .foregroundStyle(.secondary)
             }
 
-            ScriptCodeEditor(text: $viewModel.httpMessageText)
-                .frame(minHeight: 210)
-                .overlay(Rectangle().stroke(Color(nsColor: .separatorColor).opacity(0.3)))
+            MapLocalHTTPMessageEditor(text: $viewModel.httpMessageText)
+                .frame(minHeight: 238)
+                .clipped()
+                .overlay(Rectangle().stroke(Color(nsColor: .separatorColor).opacity(0.35)))
 
             HStack(spacing: 10) {
                 Button(String(localized: "Select Local File")) { viewModel.choosePath() }
                 Text(String(localized: "Accept HTTP Message Format or Local File"))
                     .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.9)
                 Button {
                     viewModel.errorMessage = String(localized: """
                     Paste an HTTP response message or plain body. Rockxy saves the body to the local file and uses the status line for the response code.
@@ -1114,7 +1143,6 @@ struct MapLocalEditorWindowView: View {
                     .disabled(!viewModel.isSaveEnabled)
             }
         }
-        .offset(y: -12)
     }
 
     private var localDirectorySection: some View {
@@ -1165,7 +1193,6 @@ struct MapLocalEditorWindowView: View {
             }
             Spacer(minLength: 80)
         }
-        .offset(y: -6)
     }
 
     private var methodMenu: some View {
@@ -1178,7 +1205,8 @@ struct MapLocalEditorWindowView: View {
         } label: {
             menuLabel(viewModel.method.rawValue)
         }
-        .menuStyle(.borderlessButton)
+        .menuIndicator(.hidden)
+        .buttonStyle(.bordered)
         .fixedSize()
     }
 
@@ -1196,7 +1224,8 @@ struct MapLocalEditorWindowView: View {
         } label: {
             menuLabel(viewModel.matchType.displayName)
         }
-        .menuStyle(.borderlessButton)
+        .menuIndicator(.hidden)
+        .buttonStyle(.bordered)
         .fixedSize()
     }
 
@@ -1210,7 +1239,8 @@ struct MapLocalEditorWindowView: View {
         } label: {
             menuLabel(viewModel.delayPreset.displayName, minWidth: 132)
         }
-        .menuStyle(.borderlessButton)
+        .menuIndicator(.hidden)
+        .buttonStyle(.bordered)
         .fixedSize()
     }
 
@@ -1224,11 +1254,15 @@ struct MapLocalEditorWindowView: View {
                 Button(editor.displayName) { viewModel.openSelectedPath(with: editor) }
             }
         } label: {
-            Label(String(localized: "Settings"), systemImage: "gearshape.fill")
-                .labelStyle(.iconOnly)
-                .frame(width: 54)
+            HStack(spacing: 8) {
+                Image(systemName: "gearshape.fill")
+                Image(systemName: "chevron.down")
+                    .font(.system(size: 9, weight: .semibold))
+            }
+            .frame(minWidth: 50)
         }
-        .menuStyle(.borderlessButton)
+        .menuIndicator(.hidden)
+        .buttonStyle(.bordered)
         .fixedSize()
     }
 
@@ -1239,10 +1273,6 @@ struct MapLocalEditorWindowView: View {
                 .font(.system(size: 10, weight: .semibold))
         }
         .frame(minWidth: minWidth)
-        .padding(.horizontal, 8)
-        .padding(.vertical, 5)
-        .background(Color(nsColor: .controlColor))
-        .clipShape(RoundedRectangle(cornerRadius: 6))
     }
 
     private func saveAndClose() {

--- a/Rockxy/Views/Rules/MapLocalWindowView.swift
+++ b/Rockxy/Views/Rules/MapLocalWindowView.swift
@@ -2,7 +2,162 @@ import AppKit
 import os
 import SwiftUI
 
-// Presents the map local window for rule editing and management.
+// Presents the Proxyman-style Map Local management and editor windows.
+
+// MARK: - MapLocalHTTPMethod
+
+enum MapLocalHTTPMethod: String, CaseIterable, Identifiable {
+    case any = "ANY"
+    case get = "GET"
+    case post = "POST"
+    case put = "PUT"
+    case delete = "DELETE"
+    case patch = "PATCH"
+    case head = "HEAD"
+    case options = "OPTIONS"
+    case trace = "TRACE"
+
+    var id: String { rawValue }
+
+    init(ruleMethod: String?) {
+        guard let ruleMethod,
+              let method = Self(rawValue: ruleMethod.uppercased()) else
+        {
+            self = .any
+            return
+        }
+        self = method
+    }
+
+    var ruleValue: String? {
+        self == .any ? nil : rawValue
+    }
+}
+
+// MARK: - MapLocalMatchType
+
+enum MapLocalMatchType: String, CaseIterable, Identifiable {
+    case wildcard
+    case regex
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .wildcard: "Use Wildcard"
+        case .regex: "Use Regex"
+        }
+    }
+}
+
+// MARK: - MapLocalTargetMode
+
+enum MapLocalTargetMode: String, CaseIterable, Identifiable {
+    case localFile
+    case localDirectory
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .localFile: "Local File"
+        case .localDirectory: "Local Directory"
+        }
+    }
+}
+
+// MARK: - MapLocalDelayPreset
+
+enum MapLocalDelayPreset: String, CaseIterable, Identifiable {
+    case none
+    case oneSecond
+    case twoSeconds
+    case threeSeconds
+    case fiveSeconds
+    case tenSeconds
+    case thirtySeconds
+    case sixtySeconds
+    case random
+    case custom
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .none: "No Delay"
+        case .oneSecond: "1 second"
+        case .twoSeconds: "2 seconds"
+        case .threeSeconds: "3 seconds"
+        case .fiveSeconds: "5 seconds"
+        case .tenSeconds: "10 seconds"
+        case .thirtySeconds: "30 seconds"
+        case .sixtySeconds: "60 seconds"
+        case .random: "Random (1-15s)"
+        case .custom: "Custom"
+        }
+    }
+
+    var delayMs: Int {
+        switch self {
+        case .none: 0
+        case .oneSecond: 1_000
+        case .twoSeconds: 2_000
+        case .threeSeconds: 3_000
+        case .fiveSeconds: 5_000
+        case .tenSeconds: 10_000
+        case .thirtySeconds: 30_000
+        case .sixtySeconds: 60_000
+        case .random: -1
+        case .custom: 0
+        }
+    }
+
+    static func from(delayMs: Int) -> Self {
+        switch delayMs {
+        case 0: .none
+        case 1_000: .oneSecond
+        case 2_000: .twoSeconds
+        case 3_000: .threeSeconds
+        case 5_000: .fiveSeconds
+        case 10_000: .tenSeconds
+        case 30_000: .thirtySeconds
+        case 60_000: .sixtySeconds
+        case -1: .random
+        default: .custom
+        }
+    }
+}
+
+// MARK: - MapLocalEditorContext
+
+struct MapLocalEditorContext {
+    var existingRule: ProxyRule?
+    var draft: MapLocalDraft?
+
+    static let blank = MapLocalEditorContext()
+}
+
+// MARK: - MapLocalEditorStore
+
+@MainActor @Observable
+final class MapLocalEditorStore {
+    private init() {}
+
+    static let shared = MapLocalEditorStore()
+
+    private(set) var context = MapLocalEditorContext.blank
+    var draftVersion: UInt64 = 0
+
+    func openNew(draft: MapLocalDraft? = nil) {
+        context = MapLocalEditorContext(existingRule: nil, draft: draft)
+        draftVersion &+= 1
+    }
+
+    func openExisting(_ rule: ProxyRule) {
+        context = MapLocalEditorContext(existingRule: rule, draft: nil)
+        draftVersion &+= 1
+    }
+}
 
 // MARK: - MapLocalViewModel
 
@@ -13,10 +168,13 @@ final class MapLocalViewModel {
     var allRules: [ProxyRule] = []
     var searchText = ""
     var selectedRuleIDs: Set<UUID> = []
-    var showEditSheet = false
-    var editingRule: ProxyRule?
-    var pendingDraft: MapLocalDraft?
+    var isFilterVisible = false
+    var isToolEnabled: Bool
     var errorMessage: String?
+
+    init(isToolEnabled: Bool? = nil) {
+        self.isToolEnabled = isToolEnabled ?? Self.defaultToolEnabled
+    }
 
     var mapLocalRules: [ProxyRule] {
         allRules.filter {
@@ -35,8 +193,16 @@ final class MapLocalViewModel {
         return mapLocalRules.filter { rule in
             rule.name.lowercased().contains(query)
                 || (rule.matchCondition.urlPattern?.lowercased().contains(query) ?? false)
+                || methodLabel(for: rule).lowercased().contains(query)
                 || filePath(for: rule).lowercased().contains(query)
         }
+    }
+
+    var selectedRule: ProxyRule? {
+        guard let id = selectedRuleIDs.first else {
+            return nil
+        }
+        return allRules.first { $0.id == id }
     }
 
     var areAllEnabled: Bool {
@@ -51,6 +217,7 @@ final class MapLocalViewModel {
                     updated[index].isEnabled = newValue
                 }
             }
+            allRules = updated
             Task {
                 await RulePolicyGate.shared.replaceAllRules(updated)
                 allRules = await RuleEngine.shared.allRules
@@ -65,7 +232,15 @@ final class MapLocalViewModel {
     func handleRulesDidChange(_ notification: Notification) {
         if let rules = notification.object as? [ProxyRule] {
             allRules = rules
+            selectedRuleIDs = selectedRuleIDs.filter { id in
+                rules.contains { $0.id == id }
+            }
         }
+    }
+
+    func setToolEnabled(_ enabled: Bool) {
+        isToolEnabled = enabled
+        Task { await RulePolicyGate.shared.setMapLocalToolEnabled(enabled) }
     }
 
     func toggleRule(id: UUID) {
@@ -83,6 +258,7 @@ final class MapLocalViewModel {
 
     func addRule(_ rule: ProxyRule) {
         allRules.append(rule)
+        selectedRuleIDs = [rule.id]
         Task {
             let accepted = await RulePolicyGate.shared.addRule(rule)
             if !accepted {
@@ -101,6 +277,9 @@ final class MapLocalViewModel {
 
     func removeSelectedRules() {
         let idsToRemove = selectedRuleIDs
+        guard !idsToRemove.isEmpty else {
+            return
+        }
         allRules.removeAll { idsToRemove.contains($0.id) }
         selectedRuleIDs.removeAll()
         let updated = allRules
@@ -113,773 +292,1008 @@ final class MapLocalViewModel {
         Task { await RulePolicyGate.shared.removeRule(id: id) }
     }
 
-    func beginEditing(_ rule: ProxyRule) {
-        editingRule = rule
-        showEditSheet = true
-    }
-
-    func beginAdding() {
-        editingRule = nil
-        showEditSheet = true
-    }
-
-    func updateFilePath(for ruleID: UUID, newPath: String) {
-        guard let index = allRules.firstIndex(where: { $0.id == ruleID }),
-              case let .mapLocal(_, statusCode, isDirectory) = allRules[index].action else
-        {
+    func duplicateSelectedRule() {
+        guard var rule = selectedRule else {
             return
         }
-        allRules[index].action = .mapLocal(filePath: newPath, statusCode: statusCode, isDirectory: isDirectory)
-        let updatedRule = allRules[index]
-        Task { await RulePolicyGate.shared.updateRule(updatedRule) }
+        rule = ProxyRule(
+            name: "\(rule.name) Copy",
+            isEnabled: rule.isEnabled,
+            matchCondition: rule.matchCondition,
+            action: rule.action,
+            priority: rule.priority
+        )
+        addRule(rule)
+    }
+
+    func createNewFolderPlaceholder() {
+        let rule = ProxyRule(
+            name: "New Folder",
+            isEnabled: false,
+            matchCondition: RuleMatchCondition(urlPattern: nil),
+            action: .mapLocal(filePath: "", isDirectory: true)
+        )
+        addRule(rule)
     }
 
     func filePath(for rule: ProxyRule) -> String {
-        if case let .mapLocal(path, _, _) = rule.action {
+        if case let .mapLocal(path, _, _, _) = rule.action {
             return path
         }
         return ""
     }
 
-    func statusCode(for rule: ProxyRule) -> String {
-        if case let .mapLocal(_, statusCode, _) = rule.action {
-            return "\(statusCode)"
+    func methodLabel(for rule: ProxyRule) -> String {
+        rule.matchCondition.method?.uppercased() ?? "ANY"
+    }
+
+    func matchingRuleLabel(for rule: ProxyRule) -> String {
+        guard let pattern = rule.matchCondition.urlPattern, !pattern.isEmpty else {
+            return "<Missing URL>"
         }
-        return "200"
+        if pattern.contains(".*") || pattern.contains("\\.") {
+            return "Wildcard: \(readablePattern(pattern))"
+        }
+        return pattern
+    }
+
+    func mapFromLabel(for rule: ProxyRule) -> String {
+        let prefix = isDirectory(for: rule) ? "Directory: " : "File: "
+        let path = filePath(for: rule)
+        return prefix + (path.isEmpty ? "<Missing Path>" : abbreviatedPath(path))
     }
 
     func isDirectory(for rule: ProxyRule) -> Bool {
-        if case let .mapLocal(_, _, isDirectory) = rule.action {
+        if case let .mapLocal(_, _, isDirectory, _) = rule.action {
             return isDirectory
         }
         return false
     }
 
+    func delayLabel(for rule: ProxyRule) -> String {
+        if case let .mapLocal(_, _, _, delayMs) = rule.action, delayMs != 0 {
+            return MapLocalDelayPreset.from(delayMs: delayMs).displayName
+        }
+        return ""
+    }
+
     // MARK: Private
 
+    private static let toolEnabledKey = "mapLocalToolEnabled"
     private static let logger = Logger(subsystem: RockxyIdentity.current.logSubsystem, category: "MapLocalViewModel")
+    private static var defaultToolEnabled: Bool {
+        UserDefaults.standard.object(forKey: toolEnabledKey) as? Bool ?? true
+    }
+
+    private func readablePattern(_ pattern: String) -> String {
+        pattern
+            .replacingOccurrences(of: #"^https?://"#, with: "https://", options: .regularExpression)
+            .replacingOccurrences(of: #"\\."#, with: ".")
+            .replacingOccurrences(of: #"\.\*"#, with: "*", options: .regularExpression)
+            .trimmingCharacters(in: CharacterSet(charactersIn: "^$"))
+    }
+
+    private func abbreviatedPath(_ path: String) -> String {
+        guard !path.isEmpty else {
+            return "<Missing Path>"
+        }
+        let maxLength = 78
+        guard path.count > maxLength else {
+            return path
+        }
+        let suffix = path.suffix(maxLength - 3)
+        return "...\(suffix)"
+    }
 }
 
 // MARK: - MapLocalWindowView
 
 struct MapLocalWindowView: View {
-    // MARK: Internal
-
+    @Environment(\.openWindow) private var openWindow
     @State var viewModel = MapLocalViewModel()
 
     var body: some View {
-        VStack(spacing: 0) {
-            toolbar
-            Divider()
-            infoBar
-            Divider()
+        VStack(alignment: .leading, spacing: 0) {
+            header
             tableContent
-            Divider()
+            shortcutStrip
             bottomBar
         }
-        .frame(width: 800, height: 480)
-        .sheet(isPresented: $viewModel.showEditSheet) {
-            MapLocalEditSheet(
-                existingRule: viewModel.editingRule,
-                draft: viewModel.pendingDraft,
-                onSave: { rule in
-                    if viewModel.editingRule != nil {
-                        viewModel.updateRule(rule)
-                    } else {
-                        viewModel.addRule(rule)
-                    }
-                    viewModel.pendingDraft = nil
-                }
-            )
-        }
+        .frame(width: 1_024, height: 570)
         .task { await viewModel.refreshFromEngine() }
-        .onAppear { consumePendingDraft() }
+        .onAppear { consumePendingDraftIfNeeded() }
         .onReceive(NotificationCenter.default.publisher(for: .openMapLocalWindow)) { _ in
-            consumePendingDraft()
+            consumePendingDraftIfNeeded()
         }
         .onReceive(NotificationCenter.default.publisher(for: .rulesDidChange)) { notification in
             viewModel.handleRulesDidChange(notification)
         }
         .alert(
-            String(localized: "Error"),
+            String(localized: "Map Local"),
             isPresented: Binding(
                 get: { viewModel.errorMessage != nil },
-                set: { if !$0 {
-                    viewModel.errorMessage = nil
-                }
-                }
+                set: { if !$0 { viewModel.errorMessage = nil } }
             )
         ) {
-            Button(String(localized: "OK")) {
-                viewModel.errorMessage = nil
-            }
+            Button(String(localized: "OK")) { viewModel.errorMessage = nil }
         } message: {
-            if let msg = viewModel.errorMessage {
-                Text(msg)
+            if let error = viewModel.errorMessage {
+                Text(error)
             }
         }
     }
 
-    // MARK: Private
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Toggle(isOn: Binding(
+                get: { viewModel.isToolEnabled },
+                set: { viewModel.setToolEnabled($0) }
+            )) {
+                Text(String(localized: "Enable Map Local Tool"))
+                    .font(.system(size: 13))
+            }
+            .toggleStyle(.checkbox)
+            .padding(.top, 16)
 
-    private var ruleCountLabel: String {
-        let count = viewModel.mapLocalRules.count
-        if count == 1 {
-            return String(localized: "1 rule")
-        }
-        return String(localized: "\(count) rules")
-    }
-
-    private var infoBar: some View {
-        HStack(spacing: 6) {
-            Image(systemName: "info.circle")
+            Text(String(localized: "Map a Response with a Local File or Directory. Support Status Code, Headers and Body."))
+                .font(.system(size: 13))
+            Text(String(localized: "Each request is checked against the rules from top to bottom, stopping when a match is found."))
+                .font(.system(size: 13))
                 .foregroundStyle(.secondary)
-            Text(String(localized: "Intercept matching requests and serve responses from local files or directories."))
-                .font(.caption)
-                .foregroundStyle(.secondary)
-        }
-        .padding(.horizontal, 12)
-        .padding(.vertical, 6)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .background(.quaternary.opacity(0.5))
-    }
 
-    private var toolbar: some View {
-        HStack(spacing: 12) {
-            Toggle(isOn: $viewModel.areAllEnabled) {
-                Text(String(localized: "Enable All"))
-                    .font(.callout)
-            }
-            .toggleStyle(.switch)
-            .controlSize(.small)
-
-            Spacer()
-
-            TextField(String(localized: "Search"), text: $viewModel.searchText)
-                .textFieldStyle(.roundedBorder)
-                .frame(width: 200)
-
-            Button {
-                viewModel.beginAdding()
-            } label: {
-                Label(String(localized: "Add Rule"), systemImage: "plus")
-            }
-        }
-        .padding(.horizontal, 12)
-        .padding(.vertical, 8)
-    }
-
-    @ViewBuilder private var tableContent: some View {
-        if viewModel.filteredRules.isEmpty {
-            VStack(alignment: .center, spacing: 8) {
-                Image(systemName: "doc.on.doc")
-                    .font(.system(size: 20))
-                    .foregroundStyle(.tertiary)
-                Text(String(localized: "No Map Local Rules"))
-                    .font(.system(size: 13, weight: .medium))
-                    .foregroundStyle(.secondary)
-                Text(String(localized: "Right-click a captured request and choose \"Map Local...\", or click + below."))
-                    .font(.caption)
-                    .foregroundStyle(.tertiary)
-                    .multilineTextAlignment(.center)
-
-                HStack(spacing: 0) {
-                    Rectangle()
-                        .fill(Color.green.opacity(0.4))
-                        .frame(width: 2)
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text(String(localized: "Example"))
-                            .font(.caption2)
-                            .fontWeight(.semibold)
-                            .foregroundStyle(.tertiary)
-                        HStack(spacing: 5) {
-                            Text("api.example.com/v2/users")
-                                .font(.system(size: 10, design: .monospaced))
-                                .foregroundStyle(.secondary)
-                            Image(systemName: "arrow.right")
-                                .font(.system(size: 8))
-                                .foregroundStyle(.tertiary)
-                            Text("~/mock/users.json")
-                                .font(.system(size: 10, design: .monospaced))
-                                .foregroundStyle(.green)
-                        }
+            if viewModel.isFilterVisible {
+                HStack(spacing: 8) {
+                    Image(systemName: "magnifyingglass")
+                        .foregroundStyle(.secondary)
+                    TextField(String(localized: "Filter Map Local rules"), text: $viewModel.searchText)
+                        .textFieldStyle(.roundedBorder)
+                    Button {
+                        viewModel.searchText = ""
+                        viewModel.isFilterVisible = false
+                    } label: {
+                        Image(systemName: "xmark.circle.fill")
                     }
-                    .padding(.leading, 6)
-                    .padding(.vertical, 4)
+                    .buttonStyle(.plain)
+                    .foregroundStyle(.secondary)
                 }
             }
-            .frame(maxWidth: .infinity)
-            .padding(.horizontal, 24)
-            .padding(.top, 12)
-        } else {
-            Table(viewModel.filteredRules, selection: $viewModel.selectedRuleIDs) {
-                TableColumn(String(localized: "Enable")) { (rule: ProxyRule) in
+        }
+        .padding(.horizontal, 18)
+        .padding(.bottom, 10)
+    }
+
+    private var tableContent: some View {
+        Table(viewModel.filteredRules, selection: $viewModel.selectedRuleIDs) {
+            TableColumn(String(localized: "Name")) { rule in
+                HStack(spacing: 7) {
                     Toggle("", isOn: Binding(
                         get: { rule.isEnabled },
                         set: { _ in viewModel.toggleRule(id: rule.id) }
                     ))
-                    .labelsHidden()
                     .toggleStyle(.checkbox)
-                }
-                .width(50)
-
-                TableColumn(String(localized: "URL Pattern")) { rule in
-                    Text(rule.matchCondition.urlPattern ?? "*")
-                        .font(.system(.body, design: .monospaced))
+                    .labelsHidden()
+                    Text(rule.name.isEmpty ? String(localized: "Untitled") : rule.name)
                         .lineLimit(1)
-                        .help(rule.matchCondition.urlPattern ?? "*")
                 }
-                .width(min: 150, ideal: 220)
-
-                TableColumn(String(localized: "Local Path")) { rule in
-                    let path = viewModel.filePath(for: rule)
-                    let isDir = viewModel.isDirectory(for: rule)
-                    HStack(spacing: 4) {
-                        Image(systemName: isDir ? "folder.fill" : "doc.fill")
-                            .foregroundStyle(isDir ? .blue : .secondary)
-                            .font(.caption2)
-                        Text(abbreviatedPath(path))
-                            .lineLimit(1)
-                            .help(path)
-                        Spacer()
-                        Button {
-                            browseFile(for: rule.id)
-                        } label: {
-                            Text("…")
-                                .font(.caption.bold())
-                        }
-                        .buttonStyle(.borderless)
-                        .help(isDir
-                            ? String(localized: "Choose local directory")
-                            : String(localized: "Choose local file"))
-                    }
-                }
-                .width(min: 150, ideal: 200)
-
-                TableColumn(String(localized: "Status Code")) { rule in
-                    let code = viewModel.statusCode(for: rule)
-                    Text(code)
-                        .monospacedDigit()
-                        .foregroundColor(code == "200" ? .primary : .orange)
-                }
-                .width(70)
-
-                TableColumn(String(localized: "Comment")) { (rule: ProxyRule) in
-                    Text(rule.name)
-                        .lineLimit(1)
-                        .foregroundStyle(.secondary)
-                }
-                .width(min: 80, ideal: 120)
             }
-            .contextMenu(forSelectionType: UUID.self) { ids in
-                if let id = ids.first {
-                    Button(String(localized: "Edit Rule")) {
-                        if let rule = viewModel.allRules.first(where: { $0.id == id }) {
-                            viewModel.beginEditing(rule)
-                        }
-                    }
-                    Divider()
-                    Button(String(localized: "Delete Rule"), role: .destructive) {
-                        viewModel.removeRule(id: id)
+            .width(min: 190, ideal: 220)
+
+            TableColumn(String(localized: "Method")) { rule in
+                Text(viewModel.methodLabel(for: rule))
+                    .lineLimit(1)
+            }
+            .width(86)
+
+            TableColumn(String(localized: "Matching Rule")) { rule in
+                Text(viewModel.matchingRuleLabel(for: rule))
+                    .lineLimit(1)
+                    .help(rule.matchCondition.urlPattern ?? "<Missing URL>")
+            }
+            .width(min: 260, ideal: 320)
+
+            TableColumn(String(localized: "Map from")) { rule in
+                HStack(spacing: 6) {
+                    Text(viewModel.mapFromLabel(for: rule))
+                        .lineLimit(1)
+                        .help(viewModel.filePath(for: rule))
+                    if !viewModel.delayLabel(for: rule).isEmpty {
+                        Text(viewModel.delayLabel(for: rule))
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
                     }
                 }
-            } primaryAction: { ids in
-                if let id = ids.first,
-                   let rule = viewModel.allRules.first(where: { $0.id == id })
-                {
-                    viewModel.beginEditing(rule)
-                }
+            }
+            .width(min: 360, ideal: 500)
+        }
+        .contextMenu(forSelectionType: UUID.self) { ids in
+            tableContextMenu(ids: ids)
+        } primaryAction: { ids in
+            guard let id = ids.first,
+                  let rule = viewModel.allRules.first(where: { $0.id == id }) else
+            {
+                return
+            }
+            openEditor(for: rule)
+        }
+        .overlay {
+            if viewModel.filteredRules.isEmpty {
+                ContentUnavailableView(
+                    String(localized: "No Map Local Rules"),
+                    systemImage: "folder.badge.gearshape",
+                    description: Text(String(localized: "Click + or create a rule from a captured request."))
+                )
             }
         }
+        .padding(.horizontal, 18)
+    }
+
+    private var shortcutStrip: some View {
+        Text("New: ⌘N    Edit: ⌘↩    Delete: ⌘⌫    Duplicate: ⌘D    Toggle: ↵")
+            .font(.system(size: 11))
+            .foregroundStyle(.secondary)
+            .padding(.horizontal, 18)
+            .padding(.top, 8)
+            .padding(.bottom, 4)
     }
 
     private var bottomBar: some View {
-        HStack(spacing: 4) {
-            Button {
-                viewModel.beginAdding()
-            } label: {
-                Image(systemName: "plus")
+        HStack(spacing: 8) {
+            HStack(spacing: 0) {
+                Button {
+                    openNewEditor()
+                } label: {
+                    Image(systemName: "plus")
+                        .frame(width: 22, height: 20)
+                }
+                .keyboardShortcut("n", modifiers: .command)
+
+                Divider().frame(height: 14)
+
+                Button {
+                    viewModel.removeSelectedRules()
+                } label: {
+                    Image(systemName: "minus")
+                        .frame(width: 22, height: 20)
+                }
+                .keyboardShortcut(.delete, modifiers: .command)
+                .disabled(viewModel.selectedRuleIDs.isEmpty)
             }
-            .buttonStyle(.borderless)
+            .buttonStyle(.bordered)
+
+            Button(String(localized: "New Folder")) {
+                viewModel.createNewFolderPlaceholder()
+            }
+            .keyboardShortcut("n", modifiers: [.command, .option])
 
             Button {
-                viewModel.removeSelectedRules()
+                viewModel.errorMessage = String(localized: "Map Local checks rules from top to bottom and returns the first matching local response.")
             } label: {
-                Image(systemName: "minus")
+                Image(systemName: "questionmark.circle")
             }
-            .buttonStyle(.borderless)
-            .disabled(viewModel.selectedRuleIDs.isEmpty)
+            .buttonStyle(.bordered)
 
             Spacer()
 
-            Text(ruleCountLabel)
-                .font(.caption)
-                .foregroundStyle(.secondary)
+            Button {
+                withAnimation {
+                    viewModel.isFilterVisible.toggle()
+                }
+            } label: {
+                Label(String(localized: "Filter"), systemImage: "magnifyingglass")
+            }
+            .keyboardShortcut("f", modifiers: .command)
+
+            Menu(String(localized: "More")) {
+                Button(String(localized: "New")) { openNewEditor() }
+                    .keyboardShortcut("n", modifiers: .command)
+                Button(String(localized: "Edit")) {
+                    if let rule = viewModel.selectedRule {
+                        openEditor(for: rule)
+                    }
+                }
+                .keyboardShortcut(.return, modifiers: .command)
+                .disabled(viewModel.selectedRule == nil)
+                Button(String(localized: "Duplicate")) { viewModel.duplicateSelectedRule() }
+                    .keyboardShortcut("d", modifiers: .command)
+                    .disabled(viewModel.selectedRule == nil)
+                Button(String(localized: "Toggle")) {
+                    if let id = viewModel.selectedRuleIDs.first {
+                        viewModel.toggleRule(id: id)
+                    }
+                }
+                .keyboardShortcut(.return, modifiers: [])
+                .disabled(viewModel.selectedRule == nil)
+                Divider()
+                Button(String(localized: "Delete"), role: .destructive) {
+                    viewModel.removeSelectedRules()
+                }
+                .keyboardShortcut(.delete, modifiers: .command)
+                .disabled(viewModel.selectedRuleIDs.isEmpty)
+            }
+            .menuStyle(.borderlessButton)
+            .fixedSize()
         }
-        .padding(.horizontal, 12)
-        .padding(.vertical, 6)
+        .padding(.horizontal, 18)
+        .padding(.bottom, 14)
     }
 
-    private func consumePendingDraft() {
+    @ViewBuilder
+    private func tableContextMenu(ids: Set<UUID>) -> some View {
+        if let id = ids.first {
+            Button(String(localized: "Edit Rule")) {
+                if let rule = viewModel.allRules.first(where: { $0.id == id }) {
+                    openEditor(for: rule)
+                }
+            }
+            Button(String(localized: "Duplicate")) {
+                viewModel.selectedRuleIDs = [id]
+                viewModel.duplicateSelectedRule()
+            }
+            Divider()
+            Button(String(localized: "Delete Rule"), role: .destructive) {
+                viewModel.removeRule(id: id)
+            }
+        }
+    }
+
+    private func openNewEditor(draft: MapLocalDraft? = nil) {
+        MapLocalEditorStore.shared.openNew(draft: draft)
+        openWindow(id: "mapLocalEditor")
+    }
+
+    private func openEditor(for rule: ProxyRule) {
+        MapLocalEditorStore.shared.openExisting(rule)
+        openWindow(id: "mapLocalEditor")
+    }
+
+    private func consumePendingDraftIfNeeded() {
         guard let draft = MapLocalDraftStore.shared.consumePending() else {
             return
         }
-        viewModel.pendingDraft = draft
-        viewModel.editingRule = nil
-        viewModel.showEditSheet = true
+        openNewEditor(draft: draft)
+    }
+}
+
+// MARK: - MapLocalEditorViewModel
+
+@MainActor @Observable
+final class MapLocalEditorViewModel {
+    // MARK: Internal
+
+    var name = "Untitled"
+    var urlText = ""
+    var method: MapLocalHTTPMethod = .any
+    var matchType: MapLocalMatchType = .wildcard
+    var includeSubpaths = false
+    var delayPreset: MapLocalDelayPreset = .none
+    var customDelaySeconds = 15
+    var targetMode: MapLocalTargetMode = .localFile
+    var localFileEnabled = true
+    var localDirectoryEnabled = false
+    var filePath = ""
+    var directoryPath = ""
+    var httpMessageText = MapLocalHTTPMessage.defaultMessage(statusCode: 200)
+    var autoSave = true
+    var errorMessage: String?
+
+    private(set) var existingID: UUID?
+    private(set) var originalRule: ProxyRule?
+    private(set) var draft: MapLocalDraft?
+    private(set) var isLoaded = false
+
+    var windowTitle: String {
+        "Map Local Editor: \(name.isEmpty ? "Untitled" : name)"
     }
 
-    private func browseFile(for ruleID: UUID) {
-        let rule = viewModel.allRules.first { $0.id == ruleID }
-        let isDir = rule.map { viewModel.isDirectory(for: $0) } ?? false
+    var selectedPath: String {
+        targetMode == .localDirectory ? directoryPath : filePath
+    }
 
+    var isDirectoryValid: Bool {
+        guard !directoryPath.isEmpty else {
+            return false
+        }
+        var isDirectory: ObjCBool = false
+        return FileManager.default.fileExists(atPath: directoryPath, isDirectory: &isDirectory) && isDirectory.boolValue
+    }
+
+    var isSaveEnabled: Bool {
+        !name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            && !urlText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            && isTargetValid
+            && RegexValidator.compile(urlPatternForSaving()).isSuccess
+    }
+
+    var delayMs: Int {
+        if delayPreset == .custom {
+            return max(0, customDelaySeconds) * 1_000
+        }
+        return delayPreset.delayMs
+    }
+
+    func load(context: MapLocalEditorContext) {
+        existingID = context.existingRule?.id
+        originalRule = context.existingRule
+        draft = context.draft
+
+        if let rule = context.existingRule {
+            load(existingRule: rule)
+        } else if let draft = context.draft {
+            load(draft: draft)
+        } else {
+            loadBlank()
+        }
+        isLoaded = true
+    }
+
+    func choosePath() {
         let panel = NSOpenPanel()
-        panel.canChooseFiles = !isDir
-        panel.canChooseDirectories = isDir
+        panel.canChooseFiles = targetMode == .localFile
+        panel.canChooseDirectories = targetMode == .localDirectory
         panel.allowsMultipleSelection = false
-        panel.message = isDir
+        panel.message = targetMode == .localDirectory
             ? String(localized: "Select a local directory to serve files from")
             : String(localized: "Select a local file to serve for matched requests")
 
         if panel.runModal() == .OK, let url = panel.url {
-            viewModel.updateFilePath(for: ruleID, newPath: url.path(percentEncoded: false))
+            if targetMode == .localDirectory {
+                directoryPath = url.path(percentEncoded: false)
+                localDirectoryEnabled = true
+            } else {
+                filePath = url.path(percentEncoded: false)
+                localFileEnabled = true
+                httpMessageText = MapLocalHTTPMessage.message(statusCode: statusCodeFromText(), filePath: filePath)
+            }
         }
     }
 
-    private func abbreviatedPath(_ path: String) -> String {
+    func showSelectedPathInFinder() {
+        let path = selectedPath
         guard !path.isEmpty else {
-            return "—"
+            return
+        }
+        NSWorkspace.shared.activateFileViewerSelecting([URL(fileURLWithPath: path)])
+    }
+
+    func openSelectedPath(with app: MapLocalExternalEditor) {
+        let path = selectedPath
+        guard !path.isEmpty else {
+            return
         }
         let url = URL(fileURLWithPath: path)
-        let name = url.lastPathComponent
-        let parent = url.deletingLastPathComponent().lastPathComponent
-        return "…/\(parent)/\(name)"
-    }
-}
-
-// MARK: - MapLocalMatchMode
-
-private enum MapLocalMatchMode: String, CaseIterable {
-    case exactPath
-    case includeSubpaths
-    case regexAdvanced
-
-    // MARK: Internal
-
-    var displayName: String {
-        switch self {
-        case .exactPath: "Exact Path"
-        case .includeSubpaths: "Subpaths"
-        case .regexAdvanced: "Regex"
-        }
-    }
-}
-
-// MARK: - MapLocalMapToMode
-
-private enum MapLocalMapToMode: String, CaseIterable {
-    case localFile
-    case localDirectory
-    case snapshot
-
-    // MARK: Internal
-
-    var displayName: String {
-        switch self {
-        case .localFile: "Local File"
-        case .localDirectory: "Directory"
-        case .snapshot: "Snapshot"
-        }
-    }
-}
-
-// MARK: - MapLocalEditSheet
-
-private struct MapLocalEditSheet: View {
-    // MARK: Lifecycle
-
-    init(
-        existingRule: ProxyRule?,
-        draft: MapLocalDraft? = nil,
-        onSave: @escaping (ProxyRule) -> Void
-    ) {
-        self.onSave = onSave
-        self.draft = draft
-        self.existingID = existingRule?.id
-
-        if let existingRule {
-            _comment = State(initialValue: existingRule.name)
-            _urlPattern = State(initialValue: existingRule.matchCondition.urlPattern ?? "")
-            _priority = State(initialValue: existingRule.priority)
-            _isEnabled = State(initialValue: existingRule.isEnabled)
-            _matchMode = State(initialValue: .regexAdvanced)
-            if case let .mapLocal(path, code, isDir) = existingRule.action {
-                _filePath = State(initialValue: path)
-                _statusCode = State(initialValue: code)
-                _mapToMode = State(initialValue: isDir ? .localDirectory : .localFile)
-            }
-        } else if let draft {
-            _comment = State(initialValue: draft.suggestedName)
-            let defaultMode: MapLocalMatchMode = draft.origin == .domainQuickCreate
-                ? .includeSubpaths : .exactPath
-            _matchMode = State(initialValue: defaultMode)
-            if let url = draft.sourceURL {
-                _urlPattern = State(initialValue: Self.generatePattern(
-                    from: url, mode: defaultMode
-                ))
-            } else {
-                _urlPattern = State(initialValue: Self.generateDomainPattern(
-                    from: draft.sourceHost, mode: defaultMode
-                ))
-            }
+        if let bundleID = app.bundleIdentifier,
+           let appURL = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleID)
+        {
+            NSWorkspace.shared.open([url], withApplicationAt: appURL, configuration: .init()) { _, _ in }
+        } else {
+            NSWorkspace.shared.open(url)
         }
     }
 
-    // MARK: Internal
-
-    let onSave: (ProxyRule) -> Void
-
-    var body: some View {
-        VStack(spacing: 0) {
-            Form {
-                matchingRuleSection
-                mapToSection
-            }
-            .formStyle(.grouped)
-
-            HStack {
-                Spacer()
-                Button(String(localized: "Cancel")) { dismiss() }
-                    .keyboardShortcut(.cancelAction)
-                Button(isEditing ? String(localized: "Save") : String(localized: "Add Rule")) {
-                    saveRule()
-                }
-                .keyboardShortcut(.defaultAction)
-                .disabled(!isValid)
-            }
-            .padding()
+    func makeRule() -> ProxyRule? {
+        guard isSaveEnabled else {
+            errorMessage = String(localized: "Complete the matching rule and local target before saving.")
+            return nil
         }
-        .frame(width: 540, height: 520)
+
+        do {
+            if targetMode == .localFile {
+                try saveLocalFileIfNeeded()
+            }
+        } catch {
+            errorMessage = error.localizedDescription
+            return nil
+        }
+
+        var condition = originalRule?.matchCondition ?? RuleMatchCondition()
+        condition.urlPattern = urlPatternForSaving()
+        condition.method = method.ruleValue
+
+        return ProxyRule(
+            id: existingID ?? UUID(),
+            name: name,
+            isEnabled: originalRule?.isEnabled ?? true,
+            matchCondition: condition,
+            action: .mapLocal(
+                filePath: targetMode == .localDirectory ? directoryPath : filePath,
+                statusCode: statusCodeFromText(),
+                isDirectory: targetMode == .localDirectory,
+                delayMs: delayMs
+            ),
+            priority: originalRule?.priority ?? 0
+        )
+    }
+
+    func urlPatternForSaving() -> String {
+        let trimmed = urlText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard matchType == .wildcard else {
+            return trimmed
+        }
+        let pattern = includeSubpaths && !trimmed.hasSuffix("*") ? "\(trimmed)*" : trimmed
+        return Self.wildcardToRegex(pattern)
     }
 
     // MARK: Private
 
+    private var isTargetValid: Bool {
+        switch targetMode {
+        case .localFile:
+            return localFileEnabled && !filePath.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        case .localDirectory:
+            return localDirectoryEnabled && isDirectoryValid
+        }
+    }
+
+    private func loadBlank() {
+        name = "Untitled"
+        urlText = ""
+        method = .any
+        matchType = .wildcard
+        includeSubpaths = false
+        delayPreset = .none
+        customDelaySeconds = 15
+        targetMode = .localFile
+        localFileEnabled = true
+        localDirectoryEnabled = false
+        filePath = Self.defaultMapLocalFilePath()
+        directoryPath = ""
+        httpMessageText = MapLocalHTTPMessage.defaultMessage(statusCode: 200)
+    }
+
+    private func load(draft: MapLocalDraft) {
+        loadBlank()
+        name = draft.suggestedName.isEmpty ? "Untitled" : draft.suggestedName
+        method = MapLocalHTTPMethod(ruleMethod: draft.sourceMethod)
+        includeSubpaths = draft.origin == .domainQuickCreate
+        if let sourceURL = draft.sourceURL {
+            urlText = sourceURL.absoluteString
+        } else {
+            urlText = "https://\(draft.sourceHost)/*"
+        }
+        if let body = draft.responseBody, !body.isEmpty {
+            let status = 200
+            let contentType = draft.responseContentType ?? "application/json; charset=utf-8"
+            let bodyText = String(data: body, encoding: .utf8) ?? ""
+            httpMessageText = MapLocalHTTPMessage.message(statusCode: status, contentType: contentType, body: bodyText)
+        }
+    }
+
+    private func load(existingRule rule: ProxyRule) {
+        name = rule.name.isEmpty ? "Untitled" : rule.name
+        urlText = rule.matchCondition.urlPattern ?? ""
+        method = MapLocalHTTPMethod(ruleMethod: rule.matchCondition.method)
+        matchType = .regex
+        includeSubpaths = false
+        if case let .mapLocal(path, statusCode, isDirectory, delayMs) = rule.action {
+            targetMode = isDirectory ? .localDirectory : .localFile
+            filePath = isDirectory ? "" : path
+            directoryPath = isDirectory ? path : ""
+            localFileEnabled = !isDirectory
+            localDirectoryEnabled = isDirectory
+            delayPreset = MapLocalDelayPreset.from(delayMs: delayMs)
+            if delayPreset == .custom {
+                customDelaySeconds = max(0, delayMs / 1_000)
+            }
+            httpMessageText = MapLocalHTTPMessage.message(statusCode: statusCode, filePath: path)
+        }
+    }
+
+    private func statusCodeFromText() -> Int {
+        MapLocalHTTPMessage.parse(httpMessageText).statusCode
+    }
+
+    private func saveLocalFileIfNeeded() throws {
+        let parsed = MapLocalHTTPMessage.parse(httpMessageText)
+        let url = URL(fileURLWithPath: filePath)
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try Data(parsed.body.utf8).write(to: url, options: .atomic)
+    }
+
+    private static func defaultMapLocalFilePath() -> String {
+        let directory = RockxyIdentity.current
+            .appSupportDirectory()
+            .appendingPathComponent("map-local", isDirectory: true)
+        return directory
+            .appendingPathComponent("default_message_\(UUID().uuidString.prefix(8)).json")
+            .path
+    }
+
+    private static func wildcardToRegex(_ pattern: String) -> String {
+        var result = ""
+        for char in pattern {
+            switch char {
+            case "*":
+                result += ".*"
+            case "?":
+                result += "."
+            default:
+                result += NSRegularExpression.escapedPattern(for: String(char))
+            }
+        }
+        return result
+    }
+}
+
+private extension Result where Success == NSRegularExpression, Failure == RegexValidator.ValidationError {
+    var isSuccess: Bool {
+        if case .success = self {
+            return true
+        }
+        return false
+    }
+}
+
+// MARK: - MapLocalEditorWindowView
+
+struct MapLocalEditorWindowView: View {
     @Environment(\.dismiss) private var dismiss
-    @State private var comment = ""
-    @State private var urlPattern = ""
-    @State private var matchMode: MapLocalMatchMode = .exactPath
-    @State private var mapToMode: MapLocalMapToMode = .localFile
-    @State private var filePath = ""
-    @State private var statusCode = 200
-    @State private var priority = 0
-    @State private var isEnabled = true
-    @State private var regexError: String?
+    @State private var editorStore = MapLocalEditorStore.shared
+    @State var viewModel = MapLocalEditorViewModel()
 
-    private let draft: MapLocalDraft?
-    private let existingID: UUID?
-    private let statusCodeOptions = [200, 201, 204, 301, 302, 400, 403, 404, 500, 502, 503]
-
-    private var isEditing: Bool {
-        existingID != nil
+    var body: some View {
+        VStack(alignment: .leading, spacing: 18) {
+            matchingRuleSection
+            mapToSection
+        }
+        .padding(.horizontal, 18)
+        .padding(.top, 20)
+        .padding(.bottom, 18)
+        .frame(width: 960, height: 640)
+        .navigationTitle(viewModel.windowTitle)
+        .onAppear { viewModel.load(context: editorStore.context) }
+        .onChange(of: editorStore.draftVersion) { _, _ in
+            viewModel.load(context: editorStore.context)
+        }
+        .alert(
+            String(localized: "Map Local"),
+            isPresented: Binding(
+                get: { viewModel.errorMessage != nil },
+                set: { if !$0 { viewModel.errorMessage = nil } }
+            )
+        ) {
+            Button(String(localized: "OK")) { viewModel.errorMessage = nil }
+        } message: {
+            if let error = viewModel.errorMessage {
+                Text(error)
+            }
+        }
     }
-
-    private var isValid: Bool {
-        guard !comment.isEmpty else {
-            return false
-        }
-        if mapToMode == .snapshot {
-            return draft?.hasResponseBody == true
-        }
-        guard !filePath.isEmpty else {
-            return false
-        }
-        if matchMode == .regexAdvanced {
-            return validateRegex(urlPattern)
-        }
-        return true
-    }
-
-    // MARK: - Matching Rule Section
 
     private var matchingRuleSection: some View {
-        Section(String(localized: "Matching Rule")) {
-            TextField(String(localized: "Name"), text: $comment)
+        VStack(alignment: .leading, spacing: 10) {
+            Text(String(localized: "Matching Rule"))
+                .font(.system(size: 15))
 
-            if let draft, let url = draft.sourceURL {
-                LabeledContent(String(localized: "Source")) {
-                    Text("\(draft.sourceMethod ?? "GET") \(url.absoluteString)")
-                        .font(.system(size: 10, design: .monospaced))
+            VStack(alignment: .leading, spacing: 12) {
+                HStack {
+                    Text(String(localized: "Name:"))
+                        .frame(width: 70, alignment: .trailing)
+                    TextField(String(localized: "Untitled"), text: $viewModel.name)
+                        .textFieldStyle(.roundedBorder)
+                }
+
+                HStack {
+                    Text(String(localized: "URL:"))
+                        .frame(width: 70, alignment: .trailing)
+                    TextField("api.proxyman.com/v1/*", text: $viewModel.urlText)
+                        .textFieldStyle(.roundedBorder)
+                }
+
+                HStack(spacing: 10) {
+                    Spacer().frame(width: 70)
+                    methodMenu
+                    matchTypeMenu
+                    Text(String(localized: "Support wildcard * and ?."))
                         .foregroundStyle(.secondary)
-                        .lineLimit(1)
-                        .truncationMode(.middle)
-                        .textSelection(.enabled)
+                    Button(String(localized: "Test your Rule")) {}
+                        .buttonStyle(.link)
+                }
+
+                HStack {
+                    Spacer().frame(width: 70)
+                    Toggle(String(localized: "Include all subpaths of this URL"), isOn: $viewModel.includeSubpaths)
+                        .toggleStyle(.checkbox)
+                }
+
+                Divider()
+                    .padding(.leading, 70)
+
+                HStack(spacing: 12) {
+                    Spacer().frame(width: 70)
+                    Text(String(localized: "Advanced Settings:"))
+                        .font(.system(size: 13, weight: .semibold))
+                }
+                HStack(spacing: 10) {
+                    Text(String(localized: "Delay Response:"))
+                        .frame(width: 140, alignment: .trailing)
+                    delayMenu
+                    if viewModel.delayPreset == .custom {
+                        Stepper(
+                            String(localized: "\(viewModel.customDelaySeconds) seconds"),
+                            value: $viewModel.customDelaySeconds,
+                            in: 0 ... 300
+                        )
+                        .frame(width: 160)
+                    }
                 }
             }
-
-            Picker(String(localized: "Match"), selection: $matchMode) {
-                ForEach(MapLocalMatchMode.allCases, id: \.self) { mode in
-                    Text(mode.displayName).tag(mode)
-                }
-            }
-            .pickerStyle(.segmented)
-            .onChange(of: matchMode) { _, newMode in
-                if let draft, let url = draft.sourceURL {
-                    urlPattern = Self.generatePattern(from: url, mode: newMode)
-                } else if let draft {
-                    urlPattern = Self.generateDomainPattern(from: draft.sourceHost, mode: newMode)
-                }
-                regexError = nil
-            }
-
-            TextField(String(localized: "URL Pattern"), text: $urlPattern)
-                .font(.system(.body, design: .monospaced))
-
-            if matchMode == .regexAdvanced, let error = regexError {
-                Text(error)
-                    .font(.caption)
-                    .foregroundStyle(.red)
-            }
-
-            if let draft, draft.sourceURL != nil {
-                matchPreview
-            }
+            .padding(18)
+            .background(Color(nsColor: .controlBackgroundColor))
+            .clipShape(RoundedRectangle(cornerRadius: 12))
         }
     }
-
-    @ViewBuilder private var matchPreview: some View {
-        let sourceURL = draft?.sourceURL?.absoluteString ?? ""
-        let subpathURL = (draft?.sourceURL?.absoluteString ?? "") + "/123"
-        let siblingURL = {
-            guard let url = draft?.sourceURL else {
-                return ""
-            }
-            return url.deletingLastPathComponent().appendingPathComponent("other").absoluteString
-        }()
-
-        VStack(alignment: .leading, spacing: 2) {
-            previewLine(url: sourceURL, matches: testMatch(sourceURL))
-            previewLine(url: subpathURL, matches: testMatch(subpathURL))
-            previewLine(url: siblingURL, matches: testMatch(siblingURL))
-        }
-        .padding(7)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .background(.quaternary.opacity(0.5))
-        .clipShape(RoundedRectangle(cornerRadius: 5))
-    }
-
-    // MARK: - Map To Section
 
     private var mapToSection: some View {
-        Section(String(localized: "Map To")) {
-            Picker(String(localized: "Mode"), selection: $mapToMode) {
-                Text(MapLocalMapToMode.localFile.displayName).tag(MapLocalMapToMode.localFile)
-                Text(MapLocalMapToMode.localDirectory.displayName).tag(MapLocalMapToMode.localDirectory)
-                Text(MapLocalMapToMode.snapshot.displayName).tag(MapLocalMapToMode.snapshot)
-                    .disabled(draft?.hasResponseBody != true)
-            }
-            .pickerStyle(.segmented)
+        VStack(alignment: .leading, spacing: 10) {
+            Text(String(localized: "Map To"))
+                .font(.system(size: 15))
 
-            if mapToMode == .snapshot, draft?.hasResponseBody != true {
-                Text(String(localized: "No captured response body available for this draft."))
-                    .font(.caption)
-                    .foregroundStyle(.tertiary)
-            }
-
-            if mapToMode == .snapshot, draft?.hasResponseBody == true {
-                let expectedPath = MapLocalSnapshotService.expectedSnapshotPath(
-                    contentType: draft?.responseContentType,
-                    requestURL: draft?.sourceURL
-                )
-                LabeledContent(String(localized: "Path")) {
-                    Text(expectedPath)
-                        .font(.system(size: 10, design: .monospaced))
-                        .foregroundStyle(.secondary)
-                        .lineLimit(1)
-                        .truncationMode(.middle)
+            VStack(spacing: 0) {
+                Picker("", selection: $viewModel.targetMode) {
+                    Text(MapLocalTargetMode.localFile.displayName).tag(MapLocalTargetMode.localFile)
+                    Text(MapLocalTargetMode.localDirectory.displayName).tag(MapLocalTargetMode.localDirectory)
                 }
-                Text(String(localized: "Snapshot will be saved when you click Add Rule."))
-                    .font(.caption)
-                    .foregroundStyle(.orange)
-            } else if mapToMode != .snapshot {
-                HStack {
-                    TextField(
-                        mapToMode == .localDirectory
-                            ? String(localized: "Directory Path")
-                            : String(localized: "File Path"),
-                        text: $filePath
-                    )
-                    .font(.system(.body, design: .monospaced))
-                    .lineLimit(1)
+                .pickerStyle(.segmented)
+                .frame(width: 230)
+                .offset(y: -22)
 
-                    Button(String(localized: "Browse…")) { choosePath() }
-                }
-
-                if filePath.isEmpty {
-                    Text(String(localized: "Select a local file or directory"))
-                        .font(.caption)
-                        .foregroundStyle(.red)
+                if viewModel.targetMode == .localFile {
+                    localFileSection
+                } else {
+                    localDirectorySection
                 }
             }
-
-            if !filePath.isEmpty, mapToMode != .snapshot {
-                LabeledContent(String(localized: "Content-Type")) {
-                    Text(MimeTypeResolver.mimeType(for: filePath))
-                        .font(.system(size: 11, design: .monospaced))
-                        .foregroundStyle(.secondary)
-                }
-            }
-
-            Picker(String(localized: "Status Code"), selection: $statusCode) {
-                ForEach(statusCodeOptions, id: \.self) { code in
-                    Text("\(code)").tag(code)
-                }
-            }
-            .pickerStyle(.menu)
-
-            if mapToMode == .localDirectory {
-                directoryResolutionHint
-            }
+            .padding(.horizontal, 22)
+            .padding(.bottom, 18)
+            .background(Color(nsColor: .controlBackgroundColor))
+            .clipShape(RoundedRectangle(cornerRadius: 7))
+            .overlay(RoundedRectangle(cornerRadius: 7).stroke(Color(nsColor: .separatorColor).opacity(0.35)))
         }
     }
 
-    @ViewBuilder private var directoryResolutionHint: some View {
-        let sourcePath = draft?.sourcePath ?? "/example/path"
-        let dirDisplay = filePath.isEmpty ? "~/Projects/dist/" : filePath
-
-        VStack(alignment: .leading, spacing: 4) {
-            Text(String(localized: "Path Resolution"))
-                .font(.caption.bold())
-                .foregroundStyle(.secondary)
-            VStack(alignment: .leading, spacing: 2) {
-                Text("Request: \(sourcePath)")
-                    .font(.system(.caption2, design: .monospaced))
-                    .foregroundStyle(.secondary)
-                HStack(spacing: 4) {
-                    Image(systemName: "arrow.down")
-                        .font(.caption2)
-                        .foregroundStyle(.green)
-                    Text("Local: \(dirDisplay)\(sourcePath)")
-                        .font(.system(.caption2, design: .monospaced))
-                        .foregroundStyle(.green)
-                }
-                Text(String(localized: "Root path (/) falls back to index.html"))
-                    .font(.caption2)
-                    .foregroundStyle(.tertiary)
-            }
-        }
-        .padding(8)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .background(.quaternary.opacity(0.5))
-        .clipShape(RoundedRectangle(cornerRadius: 6))
-    }
-
-    private func previewLine(url: String, matches: Bool) -> some View {
-        HStack(spacing: 4) {
-            Image(systemName: matches ? "checkmark.circle" : "xmark.circle")
-                .font(.system(size: 9))
-                .foregroundStyle(matches ? .green : .red)
-            Text(url)
-                .font(.system(size: 9, design: .monospaced))
+    private var localFileSection: some View {
+        VStack(alignment: .leading, spacing: 9) {
+            Toggle(String(localized: "Enable Local File"), isOn: $viewModel.localFileEnabled)
+                .toggleStyle(.checkbox)
+            Text("File: \(viewModel.filePath)")
                 .foregroundStyle(.secondary)
                 .lineLimit(1)
                 .truncationMode(.middle)
-        }
-    }
-
-    private static func escapeRegex(_ string: String) -> String {
-        NSRegularExpression.escapedPattern(for: string)
-    }
-
-    private static func generatePattern(from url: URL, mode: MapLocalMatchMode) -> String {
-        let scheme = url.scheme ?? "https"
-        let host = escapeRegex(url.host ?? "")
-        let path = escapeRegex(url.path)
-
-        switch mode {
-        case .exactPath:
-            return "^\(scheme)://\(host)\(path)$"
-        case .includeSubpaths:
-            return "^\(scheme)://\(host)\(path).*"
-        case .regexAdvanced:
-            return "\(scheme)://\(host)\(path)"
-        }
-    }
-
-    private static func generateDomainPattern(from host: String, mode: MapLocalMatchMode) -> String {
-        let escapedHost = escapeRegex(host)
-        switch mode {
-        case .exactPath:
-            return "^https://\(escapedHost)/?$"
-        case .includeSubpaths:
-            return "^https://\(escapedHost)/.*"
-        case .regexAdvanced:
-            return ".*\(escapedHost).*"
-        }
-    }
-
-    private func testMatch(_ url: String) -> Bool {
-        guard !urlPattern.isEmpty else {
-            return false
-        }
-        return url.range(of: urlPattern, options: .regularExpression) != nil
-    }
-
-    private func choosePath() {
-        let isDir = mapToMode == .localDirectory
-        let panel = NSOpenPanel()
-        panel.canChooseFiles = !isDir
-        panel.canChooseDirectories = isDir
-        panel.allowsMultipleSelection = false
-        panel.message = isDir
-            ? String(localized: "Select a local directory to serve files from")
-            : String(localized: "Select a local file to serve for matched requests")
-
-        if panel.runModal() == .OK, let url = panel.url {
-            filePath = url.path(percentEncoded: false)
-        }
-    }
-
-    private func saveRule() {
-        var resolvedPath = filePath
-        let isDir = mapToMode == .localDirectory
-
-        if mapToMode == .snapshot, let draft {
-            guard let result = MapLocalSnapshotService.saveSnapshot(
-                responseBody: draft.responseBody,
-                contentType: draft.responseContentType,
-                requestURL: draft.sourceURL
-            ) else {
-                return
+            HStack(spacing: 7) {
+                Circle()
+                    .fill(.green)
+                    .frame(width: 10, height: 10)
+                Text(String(localized: "Map Response with HTTP Message format (Saved)"))
+                    .foregroundStyle(.secondary)
             }
-            resolvedPath = result.path
-        }
 
-        let condition = RuleMatchCondition(
-            urlPattern: urlPattern.isEmpty ? nil : urlPattern
-        )
-        let rule = ProxyRule(
-            id: existingID ?? UUID(),
-            name: comment,
-            isEnabled: isEnabled,
-            matchCondition: condition,
-            action: .mapLocal(filePath: resolvedPath, statusCode: statusCode, isDirectory: isDir),
-            priority: priority
-        )
-        onSave(rule)
+            ScriptCodeEditor(text: $viewModel.httpMessageText)
+                .frame(minHeight: 210)
+                .overlay(Rectangle().stroke(Color(nsColor: .separatorColor).opacity(0.3)))
+
+            HStack(spacing: 10) {
+                Button(String(localized: "Select Local File")) { viewModel.choosePath() }
+                Text(String(localized: "Accept HTTP Message Format or Local File"))
+                    .foregroundStyle(.secondary)
+                Button {
+                    viewModel.errorMessage = String(localized: """
+                    Paste an HTTP response message or plain body. Rockxy saves the body to the local file and uses the status line for the response code.
+                    """)
+                } label: {
+                    Image(systemName: "questionmark.circle")
+                }
+                .buttonStyle(.borderless)
+                Spacer()
+                gearMenu
+                Button(String(localized: "Save ⌘S")) { saveAndClose() }
+                    .keyboardShortcut("s", modifiers: .command)
+                    .disabled(!viewModel.isSaveEnabled)
+            }
+        }
+        .offset(y: -12)
+    }
+
+    private var localDirectorySection: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Toggle(String(localized: "Enable Local Directory"), isOn: $viewModel.localDirectoryEnabled)
+                .toggleStyle(.checkbox)
+
+            HStack {
+                Text(String(localized: "Directory Path:"))
+                TextField("", text: $viewModel.directoryPath)
+                    .textFieldStyle(.roundedBorder)
+            }
+
+            HStack(spacing: 8) {
+                Circle()
+                    .fill(viewModel.isDirectoryValid ? .green : .red)
+                    .frame(width: 10, height: 10)
+                Text(viewModel.isDirectoryValid
+                    ? String(localized: "Directory Found")
+                    : String(localized: "Directory Not Found!"))
+                .foregroundStyle(.secondary)
+            }
+            .padding(.leading, 205)
+
+            HStack(spacing: 12) {
+                Spacer().frame(width: 200)
+                Button(String(localized: "Select Directory")) { viewModel.choosePath() }
+                Button(String(localized: "Show in Finder")) { viewModel.showSelectedPathInFinder() }
+                    .disabled(!viewModel.isDirectoryValid)
+            }
+
+            HStack(spacing: 12) {
+                Spacer().frame(width: 200)
+                Text(String(localized: "Support map from Root or Sub-Directories"))
+                    .foregroundStyle(.secondary)
+                Button {
+                    viewModel.errorMessage = String(localized: """
+                    Directory mode maps request subpaths into the selected local directory. Root requests fall back to index.html when present.
+                    """)
+                } label: {
+                    Image(systemName: "questionmark.circle")
+                }
+                .buttonStyle(.borderless)
+                Spacer()
+                Button(String(localized: "Save ⌘S")) { saveAndClose() }
+                    .keyboardShortcut("s", modifiers: .command)
+                    .disabled(!viewModel.isSaveEnabled)
+            }
+            Spacer(minLength: 80)
+        }
+        .offset(y: -6)
+    }
+
+    private var methodMenu: some View {
+        Menu {
+            Picker("", selection: $viewModel.method) {
+                ForEach(MapLocalHTTPMethod.allCases) { method in
+                    Text(method.rawValue).tag(method)
+                }
+            }
+        } label: {
+            menuLabel(viewModel.method.rawValue)
+        }
+        .menuStyle(.borderlessButton)
+        .fixedSize()
+    }
+
+    private var matchTypeMenu: some View {
+        Menu {
+            Picker("", selection: $viewModel.matchType) {
+                Text(MapLocalMatchType.wildcard.displayName).tag(MapLocalMatchType.wildcard)
+                Text(MapLocalMatchType.regex.displayName).tag(MapLocalMatchType.regex)
+                Divider()
+                Menu(String(localized: "Advanced")) {
+                    Button(String(localized: "Use Regex")) { viewModel.matchType = .regex }
+                    Button(String(localized: "Use Wildcard")) { viewModel.matchType = .wildcard }
+                }
+            }
+        } label: {
+            menuLabel(viewModel.matchType.displayName)
+        }
+        .menuStyle(.borderlessButton)
+        .fixedSize()
+    }
+
+    private var delayMenu: some View {
+        Menu {
+            Picker("", selection: $viewModel.delayPreset) {
+                ForEach(MapLocalDelayPreset.allCases) { preset in
+                    Text(preset.displayName).tag(preset)
+                }
+            }
+        } label: {
+            menuLabel(viewModel.delayPreset.displayName, minWidth: 132)
+        }
+        .menuStyle(.borderlessButton)
+        .fixedSize()
+    }
+
+    private var gearMenu: some View {
+        Menu {
+            Toggle(String(localized: "Auto-Save"), isOn: $viewModel.autoSave)
+            Divider()
+            Button(String(localized: "Show in Finder...")) { viewModel.showSelectedPathInFinder() }
+            Divider()
+            ForEach(MapLocalExternalEditor.allCases) { editor in
+                Button(editor.displayName) { viewModel.openSelectedPath(with: editor) }
+            }
+        } label: {
+            Label(String(localized: "Settings"), systemImage: "gearshape.fill")
+                .labelStyle(.iconOnly)
+                .frame(width: 54)
+        }
+        .menuStyle(.borderlessButton)
+        .fixedSize()
+    }
+
+    private func menuLabel(_ title: String, minWidth: CGFloat = 90) -> some View {
+        HStack(spacing: 6) {
+            Text(title)
+            Image(systemName: "chevron.up.chevron.down")
+                .font(.system(size: 10, weight: .semibold))
+        }
+        .frame(minWidth: minWidth)
+        .padding(.horizontal, 8)
+        .padding(.vertical, 5)
+        .background(Color(nsColor: .controlColor))
+        .clipShape(RoundedRectangle(cornerRadius: 6))
+    }
+
+    private func saveAndClose() {
+        guard let rule = viewModel.makeRule() else {
+            return
+        }
+        if viewModel.existingID == nil {
+            Task { await RulePolicyGate.shared.addRule(rule) }
+        } else {
+            Task { await RulePolicyGate.shared.updateRule(rule) }
+        }
         dismiss()
     }
+}
 
-    private func validateRegex(_ pattern: String) -> Bool {
-        guard !pattern.isEmpty else {
-            return false
+// MARK: - MapLocalExternalEditor
+
+enum MapLocalExternalEditor: String, CaseIterable, Identifiable {
+    case code
+    case cursor
+    case textEdit
+    case xcode
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .code: "Code"
+        case .cursor: "Cursor"
+        case .textEdit: "TextEdit"
+        case .xcode: "Xcode"
         }
-        do {
-            _ = try NSRegularExpression(pattern: pattern)
-            regexError = nil
-            return true
-        } catch {
-            regexError = String(localized: "Invalid regex: \(error.localizedDescription)")
-            return false
+    }
+
+    var bundleIdentifier: String? {
+        switch self {
+        case .code: "com.microsoft.VSCode"
+        case .cursor: "com.todesktop.230313mzl4w4u92"
+        case .textEdit: "com.apple.TextEdit"
+        case .xcode: "com.apple.dt.Xcode"
         }
+    }
+}
+
+// MARK: - MapLocalHTTPMessage
+
+enum MapLocalHTTPMessage {
+    static func defaultMessage(statusCode: Int) -> String {
+        message(statusCode: statusCode, contentType: "application/json; charset=utf-8", body: "{\n  \"status\": \"ok\"\n}")
+    }
+
+    static func message(statusCode: Int, filePath: String) -> String {
+        let body = (try? String(contentsOfFile: filePath, encoding: .utf8)) ?? "{\n  \"status\": \"ok\"\n}"
+        return message(statusCode: statusCode, contentType: MimeTypeResolver.mimeType(for: filePath), body: body)
+    }
+
+    static func message(statusCode: Int, contentType: String, body: String) -> String {
+        let status = HTTPURLResponse.localizedString(forStatusCode: statusCode).uppercased()
+        return "HTTP/1.1 \(statusCode) \(status)\nContent-Type: \(contentType)\n\n\(body)"
+    }
+
+    static func parse(_ text: String) -> (statusCode: Int, body: String) {
+        let normalized = text.replacingOccurrences(of: "\r\n", with: "\n")
+        let lines = normalized.components(separatedBy: "\n")
+        let statusCode = lines.first
+            .flatMap { line in
+                line.split(separator: " ").dropFirst().first.flatMap { Int($0) }
+            } ?? 200
+
+        if let range = normalized.range(of: "\n\n") {
+            return (statusCode, String(normalized[range.upperBound...]))
+        }
+        return (statusCode, normalized)
     }
 }

--- a/Rockxy/Views/Rules/MapLocalWindowView.swift
+++ b/Rockxy/Views/Rules/MapLocalWindowView.swift
@@ -4,38 +4,6 @@ import SwiftUI
 
 // Presents the Proxyman-style Map Local management and editor windows.
 
-// MARK: - MapLocalPatternFormatter
-
-enum MapLocalPatternFormatter {
-    static func wildcardToRegex(_ pattern: String) -> String {
-        var result = ""
-        for char in pattern {
-            switch char {
-            case "*":
-                result += ".*"
-            case "?":
-                result += "."
-            default:
-                result += NSRegularExpression.escapedPattern(for: String(char))
-            }
-        }
-        return result
-    }
-
-    static func readablePattern(_ pattern: String) -> String {
-        pattern
-            .trimmingCharacters(in: CharacterSet(charactersIn: "^$"))
-            .replacingOccurrences(of: #"\/"#, with: "/")
-            .replacingOccurrences(of: #"\."#, with: ".")
-            .replacingOccurrences(of: ".*", with: "*")
-            .trimmingCharacters(in: CharacterSet(charactersIn: "^$"))
-    }
-
-    static func prefersWildcardPresentation(_ pattern: String) -> Bool {
-        pattern.contains(".*") || pattern.contains("\\.") || pattern.contains("\\/")
-    }
-}
-
 // MARK: - MapLocalHTTPMethod
 
 enum MapLocalHTTPMethod: String, CaseIterable, Identifiable {
@@ -1197,9 +1165,14 @@ struct MapLocalEditorWindowView: View {
 
     private var methodMenu: some View {
         Menu {
-            Picker("", selection: $viewModel.method) {
-                ForEach(MapLocalHTTPMethod.allCases) { method in
-                    Text(method.rawValue).tag(method)
+            ForEach(Array(MapLocalEditorMenuContent.methodSections.enumerated()), id: \.offset) { index, section in
+                ForEach(section) { method in
+                    Button { viewModel.method = method } label: {
+                        menuCheckmarkLabel(method.rawValue, isSelected: viewModel.method == method)
+                    }
+                }
+                if index < MapLocalEditorMenuContent.methodSections.count - 1 {
+                    Divider()
                 }
             }
         } label: {
@@ -1212,14 +1185,20 @@ struct MapLocalEditorWindowView: View {
 
     private var matchTypeMenu: some View {
         Menu {
-            Picker("", selection: $viewModel.matchType) {
-                Text(MapLocalMatchType.wildcard.displayName).tag(MapLocalMatchType.wildcard)
-                Text(MapLocalMatchType.regex.displayName).tag(MapLocalMatchType.regex)
-                Divider()
-                Menu(String(localized: "Advanced")) {
-                    Button(String(localized: "Use Regex")) { viewModel.matchType = .regex }
-                    Button(String(localized: "Use Wildcard")) { viewModel.matchType = .wildcard }
+            ForEach(Array(MapLocalEditorMenuContent.matchTypeSections.enumerated()), id: \.offset) { index, section in
+                ForEach(section) { matchType in
+                    Button { viewModel.matchType = matchType } label: {
+                        menuCheckmarkLabel(matchType.displayName, isSelected: viewModel.matchType == matchType)
+                    }
                 }
+                if index < MapLocalEditorMenuContent.matchTypeSections.count - 1 {
+                    Divider()
+                }
+            }
+            Divider()
+            Menu(String(localized: "Advanced")) {
+                Button(String(localized: "Use Regex")) { viewModel.matchType = .regex }
+                Button(String(localized: "Use Wildcard")) { viewModel.matchType = .wildcard }
             }
         } label: {
             menuLabel(viewModel.matchType.displayName)
@@ -1231,9 +1210,14 @@ struct MapLocalEditorWindowView: View {
 
     private var delayMenu: some View {
         Menu {
-            Picker("", selection: $viewModel.delayPreset) {
-                ForEach(MapLocalDelayPreset.allCases) { preset in
-                    Text(preset.displayName).tag(preset)
+            ForEach(Array(MapLocalEditorMenuContent.delaySections.enumerated()), id: \.offset) { index, section in
+                ForEach(section) { preset in
+                    Button { viewModel.delayPreset = preset } label: {
+                        menuCheckmarkLabel(preset.displayName, isSelected: viewModel.delayPreset == preset)
+                    }
+                }
+                if index < MapLocalEditorMenuContent.delaySections.count - 1 {
+                    Divider()
                 }
             }
         } label: {
@@ -1264,6 +1248,15 @@ struct MapLocalEditorWindowView: View {
         .menuIndicator(.hidden)
         .buttonStyle(.bordered)
         .fixedSize()
+    }
+
+    private func menuCheckmarkLabel(_ title: String, isSelected: Bool) -> some View {
+        HStack(spacing: 7) {
+            if isSelected {
+                Image(systemName: "checkmark")
+            }
+            Text(title)
+        }
     }
 
     private func menuLabel(_ title: String, minWidth: CGFloat = 90) -> some View {

--- a/Rockxy/Views/Rules/MapRemoteWindowView.swift
+++ b/Rockxy/Views/Rules/MapRemoteWindowView.swift
@@ -52,6 +52,7 @@ final class MapRemoteWindowViewModel {
     var isFilterVisible = false
     var isToolEnabled: Bool
     var errorMessage: String?
+    private var pendingRuleSyncTask: Task<Void, Never>?
 
     var mapRemoteRules: [ProxyRule] {
         allRules.filter { rule in
@@ -97,7 +98,9 @@ final class MapRemoteWindowViewModel {
 
     func setToolEnabled(_ enabled: Bool) {
         isToolEnabled = enabled
-        Task { await RulePolicyGate.shared.setMapRemoteToolEnabled(enabled) }
+        pendingRuleSyncTask = Task {
+            await RulePolicyGate.shared.setMapRemoteToolEnabled(enabled)
+        }
     }
 
     func toggleRule(id: UUID) {
@@ -105,7 +108,7 @@ final class MapRemoteWindowViewModel {
             return
         }
         allRules[index].isEnabled.toggle()
-        Task {
+        pendingRuleSyncTask = Task {
             let accepted = await RulePolicyGate.shared.toggleRule(id: id)
             if !accepted {
                 allRules = await RuleEngine.shared.allRules
@@ -120,7 +123,8 @@ final class MapRemoteWindowViewModel {
                 updated[index].isEnabled = true
             }
         }
-        Task {
+        allRules = updated
+        pendingRuleSyncTask = Task {
             await RulePolicyGate.shared.replaceAllRules(updated)
             allRules = await RuleEngine.shared.allRules
         }
@@ -134,13 +138,13 @@ final class MapRemoteWindowViewModel {
         allRules.removeAll { idsToRemove.contains($0.id) }
         selectedRuleIDs.removeAll()
         let updated = allRules
-        Task { await RulePolicyGate.shared.replaceAllRules(updated) }
+        pendingRuleSyncTask = Task { await RulePolicyGate.shared.replaceAllRules(updated) }
     }
 
     func removeRule(id: UUID) {
         allRules.removeAll { $0.id == id }
         selectedRuleIDs.remove(id)
-        Task { await RulePolicyGate.shared.removeRule(id: id) }
+        pendingRuleSyncTask = Task { await RulePolicyGate.shared.removeRule(id: id) }
     }
 
     func duplicateSelectedRule() {
@@ -156,12 +160,16 @@ final class MapRemoteWindowViewModel {
         )
         allRules.append(rule)
         selectedRuleIDs = [rule.id]
-        Task {
+        pendingRuleSyncTask = Task {
             let accepted = await RulePolicyGate.shared.addRule(rule)
             if !accepted {
                 allRules = await RuleEngine.shared.allRules
             }
         }
+    }
+
+    func waitForPendingRuleSync() async {
+        await pendingRuleSyncTask?.value
     }
 
     func methodLabel(for rule: ProxyRule) -> String {

--- a/Rockxy/Views/Rules/MapRemoteWindowView.swift
+++ b/Rockxy/Views/Rules/MapRemoteWindowView.swift
@@ -749,16 +749,15 @@ struct MapRemoteEditorWindowView: View {
     @State var viewModel = MapRemoteEditorViewModel()
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 18) {
+        VStack(alignment: .leading, spacing: 14) {
             matchingRuleSection
             mapToSection
-            Spacer(minLength: 0)
             actionBar
         }
         .padding(.horizontal, 18)
-        .padding(.top, 20)
-        .padding(.bottom, 16)
-        .frame(width: 834, height: 634)
+        .padding(.top, 16)
+        .padding(.bottom, 14)
+        .frame(width: 834)
         .navigationTitle(viewModel.windowTitle)
         .onAppear { viewModel.load(context: editorStore.context) }
         .onChange(of: editorStore.draftVersion) { _, _ in
@@ -784,7 +783,7 @@ struct MapRemoteEditorWindowView: View {
             Text(String(localized: "Matching Rule"))
                 .font(.system(size: 15))
 
-            VStack(alignment: .leading, spacing: 8) {
+            VStack(alignment: .leading, spacing: 6) {
                 labeledTextField(String(localized: "Name:"), placeholder: String(localized: "Untitled"), text: $viewModel.name)
 
                 labeledTextField(String(localized: "Rule:"), placeholder: "/v1/*", text: $viewModel.urlText)
@@ -807,7 +806,7 @@ struct MapRemoteEditorWindowView: View {
                 }
             }
             .padding(.horizontal, 16)
-            .padding(.vertical, 12)
+            .padding(.vertical, 10)
             .background(Color(nsColor: .controlBackgroundColor))
             .clipShape(RoundedRectangle(cornerRadius: 10))
         }
@@ -818,7 +817,7 @@ struct MapRemoteEditorWindowView: View {
             Text(String(localized: "Map To"))
                 .font(.system(size: 15))
 
-            VStack(alignment: .leading, spacing: 8) {
+            VStack(alignment: .leading, spacing: 6) {
                 HStack {
                     Text(String(localized: "Protocol:"))
                         .frame(width: 64, alignment: .trailing)
@@ -850,7 +849,7 @@ struct MapRemoteEditorWindowView: View {
 
                 Divider()
                     .padding(.leading, 78)
-                    .padding(.vertical, 6)
+                    .padding(.vertical, 4)
 
                 Text(String(localized: "Advanced Settings:"))
                     .font(.system(size: 13, weight: .semibold))
@@ -866,14 +865,14 @@ struct MapRemoteEditorWindowView: View {
                 Toggle(String(localized: "Preserve Host Header"), isOn: $viewModel.preserveHost)
                     .toggleStyle(.checkbox)
                     .padding(.leading, 78)
-                    .padding(.top, 4)
+                    .padding(.top, 2)
                 Text(String(localized: "The `Host` header of Requests are not changed."))
                     .foregroundStyle(.secondary)
                     .padding(.leading, 78)
             }
             .font(.system(size: 13))
             .padding(.horizontal, 16)
-            .padding(.vertical, 12)
+            .padding(.vertical, 10)
             .background(Color(nsColor: .controlBackgroundColor))
             .clipShape(RoundedRectangle(cornerRadius: 10))
         }
@@ -892,6 +891,7 @@ struct MapRemoteEditorWindowView: View {
             .frame(width: 100)
             .disabled(!viewModel.isSaveEnabled)
         }
+        .padding(.top, 2)
     }
 
     private var methodMenu: some View {

--- a/Rockxy/Views/Rules/MapRemoteWindowView.swift
+++ b/Rockxy/Views/Rules/MapRemoteWindowView.swift
@@ -1,36 +1,85 @@
 import os
 import SwiftUI
 
-// Presents the map remote window for rule editing and management.
+// Presents the Proxyman-style Map Remote management and editor windows.
+
+// MARK: - MapRemoteEditorContext
+
+struct MapRemoteEditorContext {
+    var existingRule: ProxyRule?
+    var draft: MapRemoteDraft?
+
+    static let blank = MapRemoteEditorContext()
+}
+
+// MARK: - MapRemoteEditorStore
+
+@MainActor @Observable
+final class MapRemoteEditorStore {
+    private init() {}
+
+    static let shared = MapRemoteEditorStore()
+
+    private(set) var context = MapRemoteEditorContext.blank
+    var draftVersion: UInt64 = 0
+
+    func openNew(draft: MapRemoteDraft? = nil) {
+        context = MapRemoteEditorContext(existingRule: nil, draft: draft)
+        draftVersion &+= 1
+    }
+
+    func openExisting(_ rule: ProxyRule) {
+        context = MapRemoteEditorContext(existingRule: rule, draft: nil)
+        draftVersion &+= 1
+    }
+}
 
 // MARK: - MapRemoteWindowViewModel
 
 @MainActor @Observable
 final class MapRemoteWindowViewModel {
+    // MARK: Lifecycle
+
+    init(isToolEnabled: Bool? = nil) {
+        self.isToolEnabled = isToolEnabled ?? Self.defaultToolEnabled
+    }
+
     // MARK: Internal
 
-    private(set) var allRules: [ProxyRule] = []
+    var allRules: [ProxyRule] = []
     var searchText = ""
+    var selectedRuleIDs: Set<UUID> = []
+    var isFilterVisible = false
+    var isToolEnabled: Bool
+    var errorMessage: String?
 
     var mapRemoteRules: [ProxyRule] {
-        let remote = allRules.filter { rule in
+        allRules.filter { rule in
             if case .mapRemote = rule.action {
                 return true
             }
             return false
         }
+    }
+
+    var filteredRules: [ProxyRule] {
         guard !searchText.isEmpty else {
-            return remote
+            return mapRemoteRules
         }
-        return remote.filter { rule in
-            rule.name.localizedCaseInsensitiveContains(searchText)
-                || (rule.matchCondition.urlPattern ?? "").localizedCaseInsensitiveContains(searchText)
-                || destinationSummary(for: rule).localizedCaseInsensitiveContains(searchText)
+        let query = searchText.lowercased()
+        return mapRemoteRules.filter { rule in
+            rule.name.lowercased().contains(query)
+                || methodLabel(for: rule).lowercased().contains(query)
+                || matchingRuleLabel(for: rule).lowercased().contains(query)
+                || destinationLabel(for: rule).lowercased().contains(query)
         }
     }
 
-    var ruleCount: Int {
-        mapRemoteRules.count
+    var selectedRule: ProxyRule? {
+        guard let id = selectedRuleIDs.first else {
+            return nil
+        }
+        return allRules.first { $0.id == id }
     }
 
     func refreshFromEngine() async {
@@ -40,7 +89,15 @@ final class MapRemoteWindowViewModel {
     func handleRulesDidChange(_ notification: Notification) {
         if let rules = notification.object as? [ProxyRule] {
             allRules = rules
+            selectedRuleIDs = selectedRuleIDs.filter { id in
+                rules.contains { $0.id == id }
+            }
         }
+    }
+
+    func setToolEnabled(_ enabled: Bool) {
+        isToolEnabled = enabled
+        Task { await RulePolicyGate.shared.setMapRemoteToolEnabled(enabled) }
     }
 
     func toggleRule(id: UUID) {
@@ -69,8 +126,36 @@ final class MapRemoteWindowViewModel {
         }
     }
 
-    func addRule(_ rule: ProxyRule) {
+    func removeSelectedRules() {
+        let idsToRemove = selectedRuleIDs
+        guard !idsToRemove.isEmpty else {
+            return
+        }
+        allRules.removeAll { idsToRemove.contains($0.id) }
+        selectedRuleIDs.removeAll()
+        let updated = allRules
+        Task { await RulePolicyGate.shared.replaceAllRules(updated) }
+    }
+
+    func removeRule(id: UUID) {
+        allRules.removeAll { $0.id == id }
+        selectedRuleIDs.remove(id)
+        Task { await RulePolicyGate.shared.removeRule(id: id) }
+    }
+
+    func duplicateSelectedRule() {
+        guard let selectedRule else {
+            return
+        }
+        let rule = ProxyRule(
+            name: "\(selectedRule.name) Copy",
+            isEnabled: selectedRule.isEnabled,
+            matchCondition: selectedRule.matchCondition,
+            action: selectedRule.action,
+            priority: selectedRule.priority
+        )
         allRules.append(rule)
+        selectedRuleIDs = [rule.id]
         Task {
             let accepted = await RulePolicyGate.shared.addRule(rule)
             if !accepted {
@@ -79,24 +164,45 @@ final class MapRemoteWindowViewModel {
         }
     }
 
-    func updateRule(_ rule: ProxyRule) {
-        guard let index = allRules.firstIndex(where: { $0.id == rule.id }) else {
-            return
-        }
-        allRules[index] = rule
-        Task { await RulePolicyGate.shared.updateRule(rule) }
+    func methodLabel(for rule: ProxyRule) -> String {
+        rule.matchCondition.method?.uppercased() ?? "ANY"
     }
 
-    func removeRule(id: UUID) {
-        allRules.removeAll { $0.id == id }
-        Task { await RulePolicyGate.shared.removeRule(id: id) }
+    func matchingRuleLabel(for rule: ProxyRule) -> String {
+        guard let pattern = rule.matchCondition.urlPattern, !pattern.isEmpty else {
+            return "<Missing URL>"
+        }
+        if MapLocalPatternFormatter.prefersWildcardPresentation(pattern) {
+            return "Wildcard: \(MapLocalPatternFormatter.readablePattern(pattern))"
+        }
+        return "Regex: \(pattern)"
     }
 
-    func destinationSummary(for rule: ProxyRule) -> String {
-        if case let .mapRemote(config) = rule.action {
-            return config.destinationSummary
+    func destinationLabel(for rule: ProxyRule) -> String {
+        guard case let .mapRemote(config) = rule.action else {
+            return ""
         }
-        return ""
+        var result = ""
+        if let scheme = config.scheme {
+            result += "\(scheme)://"
+        }
+        if let host = config.host {
+            result += host
+        }
+        if let port = config.port {
+            result += ":\(port)"
+        }
+        if let path = config.path {
+            if result.isEmpty {
+                result += path
+            } else {
+                result += path.hasPrefix("/") ? path : "/\(path)"
+            }
+        }
+        if let query = config.query {
+            result += "?\(query)"
+        }
+        return result.isEmpty ? "—" : result
     }
 
     func preservesHost(for rule: ProxyRule) -> Bool {
@@ -108,661 +214,397 @@ final class MapRemoteWindowViewModel {
 
     // MARK: Private
 
+    private static let toolEnabledKey = "mapRemoteToolEnabled"
     private static let logger = Logger(
         subsystem: RockxyIdentity.current.logSubsystem,
         category: "MapRemoteWindowViewModel"
     )
+    private static var defaultToolEnabled: Bool {
+        UserDefaults.standard.object(forKey: toolEnabledKey) as? Bool ?? true
+    }
 }
 
 // MARK: - MapRemoteWindowView
 
 struct MapRemoteWindowView: View {
-    // MARK: Internal
-
+    @Environment(\.openWindow) private var openWindow
     @State var viewModel = MapRemoteWindowViewModel()
 
     var body: some View {
-        VStack(spacing: 0) {
-            toolbar
-            Divider()
-            infoBar
-            Divider()
+        VStack(alignment: .leading, spacing: 0) {
+            header
             tableContent
-            Divider()
+            localhostHint
+            shortcutStrip
             bottomBar
         }
-        .frame(width: 880, height: 480)
+        .frame(width: 1_202, height: 640)
         .task { await viewModel.refreshFromEngine() }
-        .onAppear { consumePendingDraft() }
+        .onAppear { consumePendingDraftIfNeeded() }
         .onReceive(NotificationCenter.default.publisher(for: .openMapRemoteWindow)) { _ in
-            consumePendingDraft()
+            consumePendingDraftIfNeeded()
         }
         .onReceive(NotificationCenter.default.publisher(for: .rulesDidChange)) { notification in
             viewModel.handleRulesDidChange(notification)
         }
-        .sheet(isPresented: $showEditSheet) {
-            MapRemoteEditSheet(
-                existingRule: editingRule,
-                draft: pendingDraft,
-                onSave: { rule in
-                    if editingRule != nil {
-                        viewModel.updateRule(rule)
-                    } else {
-                        viewModel.addRule(rule)
-                    }
-                    pendingDraft = nil
-                }
+        .alert(
+            String(localized: "Map Remote"),
+            isPresented: Binding(
+                get: { viewModel.errorMessage != nil },
+                set: { if !$0 { viewModel.errorMessage = nil } }
             )
+        ) {
+            Button(String(localized: "OK")) { viewModel.errorMessage = nil }
+        } message: {
+            if let error = viewModel.errorMessage {
+                Text(error)
+            }
         }
     }
 
-    // MARK: Private
-
-    @State private var selectedRuleID: UUID?
-    @State private var showEditSheet = false
-    @State private var editingRule: ProxyRule?
-    @State private var pendingDraft: MapRemoteDraft?
-
-    private var toolbar: some View {
-        HStack(spacing: 12) {
-            Button {
-                viewModel.enableAll()
-            } label: {
-                Text(String(localized: "Enable All"))
-                    .font(.callout)
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Toggle(isOn: Binding(
+                get: { viewModel.isToolEnabled },
+                set: { viewModel.setToolEnabled($0) }
+            )) {
+                Text(String(localized: "Enable Map Remote Tool"))
+                    .font(.system(size: 13))
             }
+            .toggleStyle(.checkbox)
+            .padding(.top, 16)
 
-            Spacer()
+            Text(String(localized: "Map Requests to different Host, Path, Post. Useful to map from Localhost ↔ Production."))
+                .font(.system(size: 13))
+            Text(String(localized: "Each request is checked against the rules from top to bottom, stopping when a match is found."))
+                .font(.system(size: 13))
+                .foregroundStyle(.secondary)
 
-            TextField(String(localized: "Search"), text: $viewModel.searchText)
-                .textFieldStyle(.roundedBorder)
-                .frame(width: 160)
-
-            Button {
-                pendingDraft = nil
-                editingRule = nil
-                showEditSheet = true
-            } label: {
-                Label(String(localized: "Add Rule"), systemImage: "plus")
-            }
-        }
-        .padding(.horizontal, 12)
-        .padding(.vertical, 8)
-    }
-
-    @ViewBuilder private var tableContent: some View {
-        if viewModel.mapRemoteRules.isEmpty {
-            VStack(alignment: .center, spacing: 8) {
-                Image(systemName: "arrow.triangle.swap")
-                    .font(.system(size: 20))
-                    .foregroundStyle(.tertiary)
-                Text(String(localized: "No Map Remote Rules"))
-                    .font(.system(size: 13, weight: .medium))
-                    .foregroundStyle(.secondary)
-                Text(
-                    String(localized: "Right-click a captured request and choose \"Map Remote...\", or click + below.")
-                )
-                .font(.caption)
-                .foregroundStyle(.tertiary)
-                .multilineTextAlignment(.center)
-
-                HStack(alignment: .top, spacing: 0) {
-                    RoundedRectangle(cornerRadius: 1)
-                        .fill(Color.green.opacity(0.4))
-                        .frame(width: 2, height: 28)
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text(String(localized: "Example"))
-                            .font(.caption2)
-                            .fontWeight(.semibold)
-                            .foregroundStyle(.tertiary)
-                        HStack(spacing: 5) {
-                            Text("api.prod.example.com")
-                                .font(.system(size: 10, design: .monospaced))
-                                .foregroundStyle(.secondary)
-                            Image(systemName: "arrow.right")
-                                .font(.system(size: 8))
-                                .foregroundStyle(.tertiary)
-                            Text("api.staging.example.com")
-                                .font(.system(size: 10, design: .monospaced))
-                                .foregroundStyle(.green)
-                        }
-                    }
-                    .padding(.leading, 6)
-                }
-            }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .padding(.horizontal, 24)
-            .padding(.top, 12)
-        } else {
-            Table(viewModel.mapRemoteRules, selection: $selectedRuleID) {
-                TableColumn("") { rule in
-                    Toggle("", isOn: Binding(
-                        get: { rule.isEnabled },
-                        set: { _ in viewModel.toggleRule(id: rule.id) }
-                    ))
-                    .toggleStyle(.switch)
-                    .labelsHidden()
-                    .controlSize(.small)
-                }
-                .width(40)
-
-                TableColumn(String(localized: "Name")) { rule in
-                    Text(rule.name)
-                        .fontWeight(.medium)
-                        .lineLimit(1)
-                        .opacity(rule.isEnabled ? 1.0 : 0.5)
-                }
-                .width(min: 100, ideal: 140)
-
-                TableColumn(String(localized: "Source Pattern")) { rule in
-                    Text(rule.matchCondition.urlPattern ?? "*")
-                        .font(.system(.body, design: .monospaced))
-                        .lineLimit(1)
-                        .help(rule.matchCondition.urlPattern ?? "*")
-                        .opacity(rule.isEnabled ? 1.0 : 0.5)
-                }
-                .width(min: 160, ideal: 200)
-
-                TableColumn("") { (_: ProxyRule) in
-                    Image(systemName: "arrow.right")
+            if viewModel.isFilterVisible {
+                HStack(spacing: 8) {
+                    Image(systemName: "magnifyingglass")
                         .foregroundStyle(.secondary)
-                        .font(.caption)
+                    TextField(String(localized: "Filter Map Remote rules"), text: $viewModel.searchText)
+                        .textFieldStyle(.roundedBorder)
+                    Button {
+                        viewModel.searchText = ""
+                        viewModel.isFilterVisible = false
+                    } label: {
+                        Image(systemName: "xmark.circle.fill")
+                    }
+                    .buttonStyle(.plain)
+                    .foregroundStyle(.secondary)
                 }
-                .width(20)
+            }
+        }
+        .padding(.horizontal, 22)
+        .padding(.bottom, 10)
+    }
 
-                TableColumn(String(localized: "Destination")) { rule in
-                    Text(viewModel.destinationSummary(for: rule))
-                        .font(.system(.body, design: .monospaced))
-                        .foregroundStyle(.purple)
+    private var tableContent: some View {
+        Table(viewModel.filteredRules, selection: $viewModel.selectedRuleIDs) {
+            TableColumn(String(localized: "Enabled")) { rule in
+                Toggle("", isOn: Binding(
+                    get: { rule.isEnabled },
+                    set: { _ in viewModel.toggleRule(id: rule.id) }
+                ))
+                .toggleStyle(.checkbox)
+                .labelsHidden()
+            }
+            .width(58)
+
+            TableColumn(String(localized: "Name")) { rule in
+                Text(rule.name.isEmpty ? String(localized: "Untitled") : rule.name)
+                    .lineLimit(1)
+                    .opacity(rule.isEnabled ? 1.0 : 0.5)
+            }
+            .width(min: 210, ideal: 260)
+
+            TableColumn(String(localized: "Method")) { rule in
+                Text(viewModel.methodLabel(for: rule))
+                    .lineLimit(1)
+                    .opacity(rule.isEnabled ? 1.0 : 0.5)
+            }
+            .width(86)
+
+            TableColumn(String(localized: "Matching Rule")) { rule in
+                Text(viewModel.matchingRuleLabel(for: rule))
+                    .lineLimit(1)
+                    .help(rule.matchCondition.urlPattern ?? "<Missing URL>")
+                    .opacity(rule.isEnabled ? 1.0 : 0.5)
+            }
+            .width(min: 300, ideal: 320)
+
+            TableColumn(String(localized: "To")) { rule in
+                HStack(spacing: 6) {
+                    Text(viewModel.destinationLabel(for: rule))
                         .lineLimit(1)
-                        .help(viewModel.destinationSummary(for: rule))
-                        .opacity(rule.isEnabled ? 1.0 : 0.5)
-                }
-
-                TableColumn("") { rule in
+                        .help(viewModel.destinationLabel(for: rule))
                     if viewModel.preservesHost(for: rule) {
                         Text("H")
                             .font(.caption2)
                             .fontWeight(.semibold)
-                            .padding(.horizontal, 4)
-                            .padding(.vertical, 1)
-                            .background(Color.accentColor.opacity(0.12))
-                            .foregroundStyle(Color.accentColor)
-                            .clipShape(RoundedRectangle(cornerRadius: 2))
+                            .foregroundStyle(.secondary)
                     }
                 }
-                .width(30)
+                .opacity(rule.isEnabled ? 1.0 : 0.5)
             }
-            .contextMenu(forSelectionType: UUID.self) { ids in
-                if let id = ids.first {
-                    Button(String(localized: "Edit")) {
-                        editingRule = viewModel.allRules.first { $0.id == id }
-                        pendingDraft = nil
-                        showEditSheet = true
-                    }
-                    Divider()
-                    Button(String(localized: "Delete"), role: .destructive) {
-                        viewModel.removeRule(id: id)
-                        selectedRuleID = nil
-                    }
-                }
+            .width(min: 360, ideal: 440)
+        }
+        .contextMenu(forSelectionType: UUID.self) { ids in
+            tableContextMenu(ids: ids)
+        } primaryAction: { ids in
+            guard let id = ids.first,
+                  let rule = viewModel.allRules.first(where: { $0.id == id }) else
+            {
+                return
+            }
+            openEditor(for: rule)
+        }
+        .overlay {
+            if viewModel.filteredRules.isEmpty {
+                Text(String(localized: "Click \"+\" or ⌘N to add new entry"))
+                    .font(.system(size: 13))
+                    .foregroundStyle(.secondary)
             }
         }
+        .padding(.horizontal, 22)
     }
 
-    private var infoBar: some View {
-        HStack(spacing: 6) {
-            Image(systemName: "info.circle")
-                .foregroundStyle(.secondary)
-            Text(
-                String(
-                    localized: "Redirect matching requests to different servers. Blank destination fields keep the original value."
-                )
-            )
-            .font(.caption)
+    private var localhostHint: some View {
+        Text(String(localized: "If your `localhost` requests don't show on Proxyman, please set domain aliases on /etc/hosts file"))
+            .font(.system(size: 11))
             .foregroundStyle(.secondary)
-            Spacer()
-        }
-        .padding(.horizontal, 12)
-        .padding(.vertical, 6)
-        .background(.quaternary.opacity(0.5))
+            .padding(.horizontal, 22)
+            .padding(.top, 8)
+    }
+
+    private var shortcutStrip: some View {
+        Text("New: ⌘N    Edit: ⌘↩    Delete: ⌘⌫    Duplicate: ⌘D    Toggle: ↵")
+            .font(.system(size: 11))
+            .foregroundStyle(.secondary)
+            .padding(.horizontal, 22)
+            .padding(.top, 8)
+            .padding(.bottom, 4)
     }
 
     private var bottomBar: some View {
-        HStack(spacing: 0) {
-            Button {
-                pendingDraft = nil
-                editingRule = nil
-                showEditSheet = true
-            } label: {
-                Image(systemName: "plus")
-                    .frame(width: 28, height: 22)
+        HStack(spacing: 8) {
+            HStack(spacing: 0) {
+                Button {
+                    openNewEditor()
+                } label: {
+                    Image(systemName: "plus")
+                        .font(.system(size: 12, weight: .regular))
+                        .frame(width: 18, height: 18)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .keyboardShortcut("n", modifiers: .command)
+
+                Rectangle()
+                    .fill(Color(nsColor: .separatorColor))
+                    .frame(width: 1, height: 18)
+
+                Button {
+                    viewModel.removeSelectedRules()
+                } label: {
+                    Image(systemName: "minus")
+                        .font(.system(size: 12, weight: .regular))
+                        .frame(width: 18, height: 18)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .keyboardShortcut(.delete, modifiers: .command)
+                .disabled(viewModel.selectedRuleIDs.isEmpty)
             }
-            .buttonStyle(.borderless)
+            .foregroundStyle(.primary)
+            .background(Color(nsColor: .controlBackgroundColor))
+            .overlay(Rectangle().stroke(Color(nsColor: .separatorColor), lineWidth: 1))
+            .frame(width: 43, height: 25)
 
             Button {
-                guard let id = selectedRuleID else {
-                    return
-                }
-                viewModel.removeRule(id: id)
-                selectedRuleID = nil
+                viewModel.errorMessage = String(localized: "Map Remote checks rules from top to bottom and rewrites the first matching request to the configured destination.")
             } label: {
-                Image(systemName: "minus")
-                    .frame(width: 28, height: 22)
+                Image(systemName: "questionmark.circle")
             }
-            .buttonStyle(.borderless)
-            .disabled(selectedRuleID == nil)
+            .buttonStyle(.bordered)
 
             Spacer()
 
-            Text(
-                "\(viewModel.ruleCount) \(viewModel.ruleCount == 1 ? String(localized: "rule") : String(localized: "rules"))"
-            )
-            .font(.caption)
-            .foregroundStyle(.secondary)
+            Button {
+                withAnimation {
+                    viewModel.isFilterVisible.toggle()
+                }
+            } label: {
+                Label(String(localized: "Filter"), systemImage: "magnifyingglass")
+            }
+            .keyboardShortcut("f", modifiers: .command)
+
+            Menu {
+                Button(String(localized: "New")) { openNewEditor() }
+                    .keyboardShortcut("n", modifiers: .command)
+                Button(String(localized: "Edit")) {
+                    if let rule = viewModel.selectedRule {
+                        openEditor(for: rule)
+                    }
+                }
+                .keyboardShortcut(.return, modifiers: .command)
+                .disabled(viewModel.selectedRule == nil)
+                Button(String(localized: "Duplicate")) { viewModel.duplicateSelectedRule() }
+                    .keyboardShortcut("d", modifiers: .command)
+                    .disabled(viewModel.selectedRule == nil)
+                Button(String(localized: "Toggle")) {
+                    if let id = viewModel.selectedRuleIDs.first {
+                        viewModel.toggleRule(id: id)
+                    }
+                }
+                .keyboardShortcut(.return, modifiers: [])
+                .disabled(viewModel.selectedRule == nil)
+                Divider()
+                Button(String(localized: "Enable All")) { viewModel.enableAll() }
+                Divider()
+                Button(String(localized: "Delete"), role: .destructive) {
+                    viewModel.removeSelectedRules()
+                }
+                .keyboardShortcut(.delete, modifiers: .command)
+                .disabled(viewModel.selectedRuleIDs.isEmpty)
+            } label: {
+                HStack(spacing: 6) {
+                    Text(String(localized: "More"))
+                    Image(systemName: "chevron.down")
+                        .font(.system(size: 9, weight: .semibold))
+                }
+            }
+            .menuIndicator(.hidden)
+            .buttonStyle(.bordered)
+            .fixedSize()
         }
-        .padding(.horizontal, 8)
-        .padding(.vertical, 4)
+        .padding(.horizontal, 22)
+        .padding(.bottom, 14)
     }
 
-    private func consumePendingDraft() {
+    @ViewBuilder
+    private func tableContextMenu(ids: Set<UUID>) -> some View {
+        if let id = ids.first {
+            Button(String(localized: "Edit Rule")) {
+                if let rule = viewModel.allRules.first(where: { $0.id == id }) {
+                    openEditor(for: rule)
+                }
+            }
+            Button(String(localized: "Duplicate")) {
+                viewModel.selectedRuleIDs = [id]
+                viewModel.duplicateSelectedRule()
+            }
+            Divider()
+            Button(String(localized: "Delete Rule"), role: .destructive) {
+                viewModel.removeRule(id: id)
+            }
+        }
+    }
+
+    private func openNewEditor(draft: MapRemoteDraft? = nil) {
+        MapRemoteEditorStore.shared.openNew(draft: draft)
+        openWindow(id: "mapRemoteEditor")
+    }
+
+    private func openEditor(for rule: ProxyRule) {
+        MapRemoteEditorStore.shared.openExisting(rule)
+        openWindow(id: "mapRemoteEditor")
+    }
+
+    private func consumePendingDraftIfNeeded() {
         guard let draft = MapRemoteDraftStore.shared.consumePending() else {
             return
         }
-        pendingDraft = draft
-        editingRule = nil
-        showEditSheet = true
+        openNewEditor(draft: draft)
     }
 }
 
-// MARK: - MapRemoteMatchMode
+// MARK: - MapRemoteEditorViewModel
 
-private enum MapRemoteMatchMode: String, CaseIterable {
-    case exactPath
-    case includeSubpaths
-    case regexAdvanced
-
+@MainActor @Observable
+final class MapRemoteEditorViewModel {
     // MARK: Internal
 
-    var displayName: String {
-        switch self {
-        case .exactPath: "Exact Path"
-        case .includeSubpaths: "Subpaths"
-        case .regexAdvanced: "Regex"
-        }
-    }
-}
+    var name = "Untitled"
+    var urlText = ""
+    var method: MapLocalHTTPMethod = .any
+    var matchType: MapLocalMatchType = .wildcard
+    var includeSubpaths = true
+    var destScheme = ""
+    var destHost = ""
+    var destPort = ""
+    var destPath = ""
+    var destQuery = ""
+    var preserveOriginalURL = false
+    var preserveHost = false
+    var errorMessage: String?
 
-// MARK: - MapRemoteEditSheet
+    private(set) var existingID: UUID?
+    private(set) var originalRule: ProxyRule?
+    private(set) var draft: MapRemoteDraft?
+    private(set) var isLoaded = false
 
-private struct MapRemoteEditSheet: View {
-    // MARK: Lifecycle
-
-    init(
-        existingRule: ProxyRule?,
-        draft: MapRemoteDraft? = nil,
-        onSave: @escaping (ProxyRule) -> Void
-    ) {
-        self.onSave = onSave
-        self.draft = draft
-        self.existingID = existingRule?.id
-
-        if let existingRule {
-            _comment = State(initialValue: existingRule.name)
-            _urlPattern = State(initialValue: existingRule.matchCondition.urlPattern ?? "")
-            _matchMode = State(initialValue: .regexAdvanced)
-            if case let .mapRemote(config) = existingRule.action {
-                _destScheme = State(initialValue: config.scheme ?? "")
-                _destHost = State(initialValue: config.host ?? "")
-                _destPort = State(initialValue: config.port.map(String.init) ?? "")
-                _destPath = State(initialValue: config.path ?? "")
-                _destQuery = State(initialValue: config.query ?? "")
-                _preserveHost = State(initialValue: config.preserveHostHeader)
-            }
-            _isEnabled = State(initialValue: existingRule.isEnabled)
-            _priority = State(initialValue: existingRule.priority)
-        } else if let draft {
-            _comment = State(initialValue: draft.suggestedName)
-            let defaultMode: MapRemoteMatchMode = draft.origin == .domainQuickCreate
-                ? .includeSubpaths : .exactPath
-            _matchMode = State(initialValue: defaultMode)
-            if let url = draft.sourceURL {
-                _urlPattern = State(initialValue: Self.generatePattern(from: url, mode: defaultMode))
-            } else {
-                _urlPattern = State(initialValue: Self.generateDomainPattern(
-                    from: draft.sourceHost, mode: defaultMode
-                ))
-            }
-        }
+    var windowTitle: String {
+        "Map Remote Editor: \(name.isEmpty ? "Untitled" : name)"
     }
 
-    // MARK: Internal
-
-    let onSave: (ProxyRule) -> Void
-
-    var body: some View {
-        VStack(spacing: 0) {
-            Form {
-                matchingRuleSection
-                mapRemoteSection
-                advancedSection
-            }
-            .formStyle(.grouped)
-
-            HStack {
-                Spacer()
-                Button(String(localized: "Cancel")) { dismiss() }
-                    .keyboardShortcut(.cancelAction)
-                Button(isEditing ? String(localized: "Save") : String(localized: "Add Rule")) {
-                    saveRule()
-                }
-                .keyboardShortcut(.defaultAction)
-                .disabled(!isValid)
-            }
-            .padding()
-        }
-        .frame(width: 600, height: 540)
+    var isSaveEnabled: Bool {
+        !name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            && !urlText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            && hasAnyDestination
+            && isPortValid
+            && RegexValidator.compile(urlPatternForSaving()).isSuccess
     }
 
-    // MARK: Private
-
-    @Environment(\.dismiss) private var dismiss
-    @State private var comment = ""
-    @State private var urlPattern = ""
-    @State private var matchMode: MapRemoteMatchMode = .exactPath
-    @State private var destScheme = ""
-    @State private var destHost = ""
-    @State private var destPort = ""
-    @State private var destPath = ""
-    @State private var destQuery = ""
-    @State private var preserveHost = false
-    @State private var isEnabled = true
-    @State private var priority = 0
-    @State private var urlParseConfirm = false
-
-    private let draft: MapRemoteDraft?
-    private let existingID: UUID?
-
-    private var isEditing: Bool {
-        existingID != nil
+    var hasAnyDestination: Bool {
+        !destScheme.isEmpty
+            || !destHost.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            || !destPort.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            || !destPath.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            || !destQuery.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 
-    private var hasAnyDestination: Bool {
-        !destScheme.isEmpty || !destHost.isEmpty || !destPort.isEmpty
-            || !destPath.isEmpty || !destQuery.isEmpty
-    }
-
-    private var isValid: Bool {
-        guard !comment.isEmpty else {
-            return false
-        }
-        guard hasAnyDestination else {
-            return false
-        }
-        if matchMode == .regexAdvanced {
-            guard !urlPattern.isEmpty else {
-                return false
-            }
-            guard (try? NSRegularExpression(pattern: urlPattern)) != nil else {
-                return false
-            }
-        }
-        return true
-    }
-
-    private var destinationPreviewString: String {
-        let sourceURL = draft?.sourceURL ?? URL(string: "https://example.com/path")
-        let scheme = destScheme.isEmpty ? (sourceURL?.scheme ?? "https") : destScheme
-        let host = destHost.isEmpty ? (sourceURL?.host ?? "example.com") : destHost
-        let port = Int(destPort)
-        let path = destPath.isEmpty ? (sourceURL?.path ?? "/") : destPath
-        let query = destQuery.isEmpty ? sourceURL?.query : destQuery
+    var destinationPreviewString: String {
+        let scheme = destScheme.isEmpty ? "https" : destScheme
+        let host = destHost.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            ? "example.com"
+            : destHost.trimmingCharacters(in: .whitespacesAndNewlines)
+        let path = normalizedPath().isEmpty ? "/" : normalizedPath()
 
         var result = "\(scheme)://\(host)"
-        if let port {
+        if let port = parsedPort {
             result += ":\(port)"
         }
         result += path
-        if let query {
+        let query = destQuery.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !query.isEmpty {
             result += "?\(query)"
         }
         return result
     }
 
-    // MARK: - Matching Rule Section
+    func load(context: MapRemoteEditorContext) {
+        existingID = context.existingRule?.id
+        originalRule = context.existingRule
+        draft = context.draft
 
-    private var matchingRuleSection: some View {
-        Section(String(localized: "Matching Rule")) {
-            TextField(String(localized: "Name"), text: $comment)
-
-            if let draft, let url = draft.sourceURL {
-                LabeledContent(String(localized: "Source")) {
-                    Text("\(draft.sourceMethod ?? "GET") \(url.absoluteString)")
-                        .font(.system(size: 10, design: .monospaced))
-                        .foregroundStyle(.secondary)
-                        .lineLimit(1)
-                        .truncationMode(.middle)
-                        .textSelection(.enabled)
-                }
-            }
-
-            Picker(String(localized: "Match"), selection: $matchMode) {
-                ForEach(MapRemoteMatchMode.allCases, id: \.self) { mode in
-                    Text(mode.displayName).tag(mode)
-                }
-            }
-            .pickerStyle(.segmented)
-            .onChange(of: matchMode) { _, newMode in
-                if let draft, let url = draft.sourceURL {
-                    urlPattern = Self.generatePattern(from: url, mode: newMode)
-                } else if let draft {
-                    urlPattern = Self.generateDomainPattern(from: draft.sourceHost, mode: newMode)
-                }
-            }
-
-            TextField(String(localized: "URL Pattern"), text: $urlPattern)
-                .font(.system(.body, design: .monospaced))
-
-            if let draft, draft.sourceURL != nil {
-                matchPreview
-            }
+        if let rule = context.existingRule {
+            load(existingRule: rule)
+        } else if let draft = context.draft {
+            load(draft: draft)
+        } else {
+            loadBlank()
         }
+        isLoaded = true
     }
 
-    @ViewBuilder private var matchPreview: some View {
-        let sourceURL = draft?.sourceURL?.absoluteString ?? ""
-        let subpathURL = sourceURL + "/123"
-        let siblingURL = {
-            guard let url = draft?.sourceURL else {
-                return ""
-            }
-            return url.deletingLastPathComponent().appendingPathComponent("other").absoluteString
-        }()
-
-        VStack(alignment: .leading, spacing: 2) {
-            previewLine(url: sourceURL, matches: testMatch(sourceURL))
-            previewLine(url: subpathURL, matches: testMatch(subpathURL))
-            previewLine(url: siblingURL, matches: testMatch(siblingURL))
-        }
-        .padding(6)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .background(.quaternary.opacity(0.5))
-        .clipShape(RoundedRectangle(cornerRadius: 5))
-    }
-
-    // MARK: - Map Remote Section
-
-    private var mapRemoteSection: some View {
-        Section(String(localized: "Map Remote")) {
-            Text(String(localized: "Leave fields blank to keep the original request value."))
-                .font(.caption)
-                .foregroundStyle(.tertiary)
-
-            HStack {
-                Text(String(localized: "Protocol"))
-                    .frame(width: 65, alignment: .leading)
-                Picker("", selection: $destScheme) {
-                    Text(String(localized: "Keep Original")).tag("")
-                    Text("http").tag("http")
-                    Text("https").tag("https")
-                }
-                .labelsHidden()
-                .frame(width: 140)
-            }
-
-            HStack {
-                Text(String(localized: "Host"))
-                    .frame(width: 65, alignment: .leading)
-                TextField(String(localized: "Destination host"), text: $destHost)
-                    .font(.system(.body, design: .monospaced))
-                    .onChange(of: destHost) { _, newValue in
-                        tryParseURL(newValue)
-                    }
-            }
-
-            HStack {
-                Text(String(localized: "Port"))
-                    .frame(width: 65, alignment: .leading)
-                TextField(String(localized: "Default"), text: $destPort)
-                    .font(.system(.body, design: .monospaced))
-                    .frame(width: 130)
-            }
-
-            HStack {
-                Text(String(localized: "Path"))
-                    .frame(width: 65, alignment: .leading)
-                TextField(String(localized: "Keep original path"), text: $destPath)
-                    .font(.system(.body, design: .monospaced))
-            }
-
-            HStack {
-                Text(String(localized: "Query"))
-                    .frame(width: 65, alignment: .leading)
-                TextField(String(localized: "Keep original query"), text: $destQuery)
-                    .font(.system(.body, design: .monospaced))
-            }
-
-            if urlParseConfirm {
-                Text(String(localized: "URL parsed into components"))
-                    .font(.caption)
-                    .foregroundStyle(.green)
-            }
-
-            if !hasAnyDestination {
-                Text(String(localized: "At least one destination field is required"))
-                    .font(.caption)
-                    .foregroundStyle(.red)
-            }
-
-            if hasAnyDestination {
-                destinationPreview
-            }
-        }
-    }
-
-    private var destinationPreview: some View {
-        VStack(alignment: .leading, spacing: 2) {
-            Text(String(localized: "Destination Preview"))
-                .font(.system(size: 9))
-                .foregroundStyle(.tertiary)
-            Text(destinationPreviewString)
-                .font(.system(size: 10, design: .monospaced))
-                .foregroundStyle(.purple)
-                .lineLimit(1)
-                .truncationMode(.middle)
-        }
-        .padding(6)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .background(.quaternary.opacity(0.5))
-        .clipShape(RoundedRectangle(cornerRadius: 5))
-    }
-
-    // MARK: - Advanced Section
-
-    private var advancedSection: some View {
-        Section(String(localized: "Advanced")) {
-            Toggle(String(localized: "Preserve Host Header"), isOn: $preserveHost)
-            Text(
-                String(
-                    localized: "Send the original Host header to the destination server. Useful when the backend validates the Host header."
-                )
-            )
-            .font(.caption)
-            .foregroundStyle(.tertiary)
-
-            if preserveHost, !destHost.isEmpty {
-                VStack(alignment: .leading, spacing: 2) {
-                    let originalHost = draft?.sourceHost ?? "original-host"
-                    Text(String(localized: "Request will connect to \(destHost) but send Host: \(originalHost)"))
-                        .font(.system(size: 9, design: .monospaced))
-                        .foregroundStyle(.tertiary)
-                }
-                .padding(6)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .background(.quaternary.opacity(0.5))
-                .clipShape(RoundedRectangle(cornerRadius: 5))
-            }
-        }
-    }
-
-    private func previewLine(url: String, matches: Bool) -> some View {
-        HStack(spacing: 4) {
-            Image(systemName: matches ? "checkmark.circle" : "xmark.circle")
-                .font(.system(size: 9))
-                .foregroundStyle(matches ? .green : .red)
-            Text(url)
-                .font(.system(size: 9, design: .monospaced))
-                .foregroundStyle(.secondary)
-                .lineLimit(1)
-                .truncationMode(.middle)
-        }
-    }
-
-    // MARK: - Pattern Helpers
-
-    private static func escapeRegex(_ string: String) -> String {
-        NSRegularExpression.escapedPattern(for: string)
-    }
-
-    private static func generatePattern(from url: URL, mode: MapRemoteMatchMode) -> String {
-        let scheme = url.scheme ?? "https"
-        let host = escapeRegex(url.host ?? "")
-        let path = escapeRegex(url.path)
-        switch mode {
-        case .exactPath:
-            return "^\(scheme)://\(host)\(path)$"
-        case .includeSubpaths:
-            return "^\(scheme)://\(host)\(path).*"
-        case .regexAdvanced:
-            return "\(scheme)://\(host)\(path)"
-        }
-    }
-
-    private static func generateDomainPattern(from host: String, mode: MapRemoteMatchMode) -> String {
-        let escapedHost = escapeRegex(host)
-        switch mode {
-        case .exactPath:
-            return "^https://\(escapedHost)/?$"
-        case .includeSubpaths:
-            return "^https://\(escapedHost)/.*"
-        case .regexAdvanced:
-            return ".*\(escapedHost).*"
-        }
-    }
-
-    private func testMatch(_ url: String) -> Bool {
-        guard !urlPattern.isEmpty else {
-            return false
-        }
-        return url.range(of: urlPattern, options: .regularExpression) != nil
-    }
-
-    private func tryParseURL(_ input: String) {
+    func tryParseDestinationURL(_ input: String) {
         guard input.contains("://"),
               let components = URLComponents(string: input),
               let host = components.host, !host.isEmpty else
         {
-            urlParseConfirm = false
             return
         }
 
@@ -772,39 +614,386 @@ private struct MapRemoteEditSheet: View {
             destPort = String(port)
         }
         if !components.path.isEmpty, components.path != "/" {
-            destPath = components.path
+            destPath = String(components.path.drop(while: { $0 == "/" }))
         }
         if let query = components.query {
             destQuery = query
         }
-        urlParseConfirm = true
+    }
 
-        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
-            urlParseConfirm = false
+    func makeRule() -> ProxyRule? {
+        guard isSaveEnabled else {
+            errorMessage = String(localized: "Complete the matching rule and destination before saving.")
+            return nil
+        }
+
+        var condition = originalRule?.matchCondition ?? RuleMatchCondition()
+        condition.urlPattern = urlPatternForSaving()
+        condition.method = method.ruleValue
+
+        let config = MapRemoteConfiguration(
+            scheme: destScheme.isEmpty ? nil : destScheme,
+            host: nilIfBlank(destHost),
+            port: parsedPort,
+            path: nilIfBlank(normalizedPath()),
+            query: nilIfBlank(destQuery),
+            preserveOriginalURL: preserveOriginalURL,
+            preserveHostHeader: preserveHost
+        )
+
+        return ProxyRule(
+            id: existingID ?? UUID(),
+            name: name,
+            isEnabled: originalRule?.isEnabled ?? true,
+            matchCondition: condition,
+            action: .mapRemote(configuration: config),
+            priority: originalRule?.priority ?? 0
+        )
+    }
+
+    func urlPatternForSaving() -> String {
+        let trimmed = urlText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard matchType == .wildcard else {
+            return trimmed
+        }
+        let pattern = includeSubpaths && !trimmed.hasSuffix("*") ? "\(trimmed)*" : trimmed
+        return MapLocalPatternFormatter.wildcardToRegex(pattern)
+    }
+
+    // MARK: Private
+
+    private var parsedPort: Int? {
+        Int(destPort.trimmingCharacters(in: .whitespacesAndNewlines))
+    }
+
+    private var isPortValid: Bool {
+        let trimmed = destPort.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            return true
+        }
+        guard let port = Int(trimmed) else {
+            return false
+        }
+        return (1 ... 65_535).contains(port)
+    }
+
+    private func loadBlank() {
+        name = "Untitled"
+        urlText = ""
+        method = .any
+        matchType = .wildcard
+        includeSubpaths = true
+        destScheme = ""
+        destHost = ""
+        destPort = ""
+        destPath = ""
+        destQuery = ""
+        preserveOriginalURL = false
+        preserveHost = false
+    }
+
+    private func load(draft: MapRemoteDraft) {
+        loadBlank()
+        name = draft.suggestedName.isEmpty ? "Untitled" : draft.suggestedName
+        method = MapLocalHTTPMethod(ruleMethod: draft.sourceMethod)
+        includeSubpaths = draft.origin == .domainQuickCreate
+        if let sourceURL = draft.sourceURL {
+            urlText = sourceURL.absoluteString
+        } else {
+            urlText = "https://\(draft.sourceHost)/*"
         }
     }
 
-    private func saveRule() {
-        let condition = RuleMatchCondition(
-            urlPattern: urlPattern.isEmpty ? nil : urlPattern
-        )
-        let config = MapRemoteConfiguration(
-            scheme: destScheme.isEmpty ? nil : destScheme,
-            host: destHost.isEmpty ? nil : destHost,
-            port: Int(destPort),
-            path: destPath.isEmpty ? nil : destPath,
-            query: destQuery.isEmpty ? nil : destQuery,
-            preserveHostHeader: preserveHost
-        )
-        let rule = ProxyRule(
-            id: existingID ?? UUID(),
-            name: comment,
-            isEnabled: isEnabled,
-            matchCondition: condition,
-            action: .mapRemote(configuration: config),
-            priority: priority
-        )
-        onSave(rule)
+    private func load(existingRule rule: ProxyRule) {
+        name = rule.name.isEmpty ? "Untitled" : rule.name
+        let storedPattern = rule.matchCondition.urlPattern ?? ""
+        if MapLocalPatternFormatter.prefersWildcardPresentation(storedPattern) {
+            urlText = MapLocalPatternFormatter.readablePattern(storedPattern)
+            matchType = .wildcard
+        } else {
+            urlText = storedPattern
+            matchType = .regex
+        }
+        method = MapLocalHTTPMethod(ruleMethod: rule.matchCondition.method)
+        includeSubpaths = false
+        if case let .mapRemote(config) = rule.action {
+            destScheme = config.scheme ?? ""
+            destHost = config.host ?? ""
+            destPort = config.port.map(String.init) ?? ""
+            destPath = config.path.map { String($0.drop(while: { $0 == "/" })) } ?? ""
+            destQuery = config.query ?? ""
+            preserveOriginalURL = config.preserveOriginalURL
+            preserveHost = config.preserveHostHeader
+        }
+    }
+
+    private func normalizedPath() -> String {
+        let trimmed = destPath.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            return ""
+        }
+        return trimmed.hasPrefix("/") ? trimmed : "/\(trimmed)"
+    }
+
+    private func nilIfBlank(_ value: String) -> String? {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+}
+
+// MARK: - MapRemoteEditorWindowView
+
+struct MapRemoteEditorWindowView: View {
+    @Environment(\.dismiss) private var dismiss
+    @State private var editorStore = MapRemoteEditorStore.shared
+    @State var viewModel = MapRemoteEditorViewModel()
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 18) {
+            matchingRuleSection
+            mapToSection
+            Spacer(minLength: 0)
+            actionBar
+        }
+        .padding(.horizontal, 18)
+        .padding(.top, 20)
+        .padding(.bottom, 16)
+        .frame(width: 834, height: 634)
+        .navigationTitle(viewModel.windowTitle)
+        .onAppear { viewModel.load(context: editorStore.context) }
+        .onChange(of: editorStore.draftVersion) { _, _ in
+            viewModel.load(context: editorStore.context)
+        }
+        .alert(
+            String(localized: "Map Remote"),
+            isPresented: Binding(
+                get: { viewModel.errorMessage != nil },
+                set: { if !$0 { viewModel.errorMessage = nil } }
+            )
+        ) {
+            Button(String(localized: "OK")) { viewModel.errorMessage = nil }
+        } message: {
+            if let error = viewModel.errorMessage {
+                Text(error)
+            }
+        }
+    }
+
+    private var matchingRuleSection: some View {
+        VStack(alignment: .leading, spacing: 7) {
+            Text(String(localized: "Matching Rule"))
+                .font(.system(size: 15))
+
+            VStack(alignment: .leading, spacing: 8) {
+                labeledTextField(String(localized: "Name:"), placeholder: String(localized: "Untitled"), text: $viewModel.name)
+
+                labeledTextField(String(localized: "Rule:"), placeholder: "/v1/*", text: $viewModel.urlText)
+
+                HStack(spacing: 8) {
+                    Spacer().frame(width: 70)
+                    methodMenu
+                    matchTypeMenu
+                    Text(String(localized: "Support wildcard * and ?."))
+                        .font(.system(size: 12))
+                        .foregroundStyle(.secondary)
+                    Button(String(localized: "Test your Rule")) {}
+                        .buttonStyle(.link)
+                }
+
+                HStack {
+                    Spacer().frame(width: 70)
+                    Toggle(String(localized: "Include all subpaths of this URL"), isOn: $viewModel.includeSubpaths)
+                        .toggleStyle(.checkbox)
+                }
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 12)
+            .background(Color(nsColor: .controlBackgroundColor))
+            .clipShape(RoundedRectangle(cornerRadius: 10))
+        }
+    }
+
+    private var mapToSection: some View {
+        VStack(alignment: .leading, spacing: 7) {
+            Text(String(localized: "Map To"))
+                .font(.system(size: 15))
+
+            VStack(alignment: .leading, spacing: 8) {
+                HStack {
+                    Text(String(localized: "Protocol:"))
+                        .frame(width: 64, alignment: .trailing)
+                    schemeMenu
+                }
+
+                labeledTextField(String(localized: "Host:"), placeholder: "", text: $viewModel.destHost)
+                    .onChange(of: viewModel.destHost) { _, newValue in
+                        viewModel.tryParseDestinationURL(newValue)
+                    }
+
+                HStack {
+                    Text(String(localized: "Port:"))
+                        .frame(width: 64, alignment: .trailing)
+                    TextField("443", text: $viewModel.destPort)
+                        .textFieldStyle(.roundedBorder)
+                        .frame(width: 60)
+                }
+
+                labeledTextField(String(localized: "Path:"), placeholder: "v2/api", text: $viewModel.destPath)
+                labeledTextField(String(localized: "Query:"), placeholder: "id=123", text: $viewModel.destQuery)
+
+                Text(String(localized: "Leave textfields blank to keep it unchanged from matched requests. Wildcard/Regex is not allowed."))
+                    .foregroundStyle(.secondary)
+                    .padding(.leading, 78)
+                Text(String(localized: "Hint: Paste your URL to the Host textfield to auto-parse each components (Host, Port, Path, Query)."))
+                    .foregroundStyle(.secondary)
+                    .padding(.leading, 78)
+
+                Divider()
+                    .padding(.leading, 78)
+                    .padding(.vertical, 6)
+
+                Text(String(localized: "Advanced Settings:"))
+                    .font(.system(size: 13, weight: .semibold))
+                    .padding(.leading, 78)
+
+                Toggle(String(localized: "Preserve the Original URL after matching with Map Remote"), isOn: $viewModel.preserveOriginalURL)
+                    .toggleStyle(.checkbox)
+                    .padding(.leading, 78)
+                Text(String(localized: "The Request URL will be replaced with a new Map Remote URL."))
+                    .foregroundStyle(.secondary)
+                    .padding(.leading, 78)
+
+                Toggle(String(localized: "Preserve Host Header"), isOn: $viewModel.preserveHost)
+                    .toggleStyle(.checkbox)
+                    .padding(.leading, 78)
+                    .padding(.top, 4)
+                Text(String(localized: "The `Host` header of Requests are not changed."))
+                    .foregroundStyle(.secondary)
+                    .padding(.leading, 78)
+            }
+            .font(.system(size: 13))
+            .padding(.horizontal, 16)
+            .padding(.vertical, 12)
+            .background(Color(nsColor: .controlBackgroundColor))
+            .clipShape(RoundedRectangle(cornerRadius: 10))
+        }
+    }
+
+    private var actionBar: some View {
+        HStack {
+            Spacer()
+            Button(String(localized: "Cancel")) { dismiss() }
+                .keyboardShortcut(.cancelAction)
+                .frame(width: 100)
+            Button(viewModel.existingID == nil ? String(localized: "Add (⌘↩)") : String(localized: "Save (⌘↩)")) {
+                saveAndClose()
+            }
+            .keyboardShortcut(.defaultAction)
+            .frame(width: 100)
+            .disabled(!viewModel.isSaveEnabled)
+        }
+    }
+
+    private var methodMenu: some View {
+        Menu {
+            ForEach(Array(MapLocalEditorMenuContent.methodSections.enumerated()), id: \.offset) { index, section in
+                ForEach(section) { method in
+                    Button { viewModel.method = method } label: {
+                        menuCheckmarkLabel(method.rawValue, isSelected: viewModel.method == method)
+                    }
+                }
+                if index < MapLocalEditorMenuContent.methodSections.count - 1 {
+                    Divider()
+                }
+            }
+        } label: {
+            menuLabel(viewModel.method.rawValue, minWidth: 86)
+        }
+        .menuIndicator(.hidden)
+        .buttonStyle(.bordered)
+        .fixedSize()
+    }
+
+    private var matchTypeMenu: some View {
+        Menu {
+            ForEach(MapLocalMatchType.allCases) { matchType in
+                Button { viewModel.matchType = matchType } label: {
+                    menuCheckmarkLabel(matchType.displayName, isSelected: viewModel.matchType == matchType)
+                }
+            }
+        } label: {
+            menuLabel(viewModel.matchType.displayName, minWidth: 128)
+        }
+        .menuIndicator(.hidden)
+        .buttonStyle(.bordered)
+        .fixedSize()
+    }
+
+    private var schemeMenu: some View {
+        Menu {
+            Button { viewModel.destScheme = "" } label: {
+                menuCheckmarkLabel(String(localized: "Keep Original"), isSelected: viewModel.destScheme.isEmpty)
+            }
+            Divider()
+            Button { viewModel.destScheme = "http" } label: {
+                menuCheckmarkLabel("http", isSelected: viewModel.destScheme == "http")
+            }
+            Button { viewModel.destScheme = "https" } label: {
+                menuCheckmarkLabel("https", isSelected: viewModel.destScheme == "https")
+            }
+        } label: {
+            menuLabel(viewModel.destScheme.isEmpty ? "http/https" : viewModel.destScheme, minWidth: 80)
+        }
+        .menuIndicator(.hidden)
+        .buttonStyle(.bordered)
+        .fixedSize()
+    }
+
+    private func labeledTextField(_ label: String, placeholder: String, text: Binding<String>) -> some View {
+        HStack {
+            Text(label)
+                .frame(width: 70, alignment: .trailing)
+            TextField(placeholder, text: text)
+                .textFieldStyle(.roundedBorder)
+        }
+    }
+
+    private func menuCheckmarkLabel(_ title: String, isSelected: Bool) -> some View {
+        HStack(spacing: 7) {
+            if isSelected {
+                Image(systemName: "checkmark")
+            }
+            Text(title)
+        }
+    }
+
+    private func menuLabel(_ title: String, minWidth: CGFloat) -> some View {
+        HStack(spacing: 6) {
+            Text(title)
+            Image(systemName: "chevron.up.chevron.down")
+                .font(.system(size: 10, weight: .semibold))
+        }
+        .frame(minWidth: minWidth)
+    }
+
+    private func saveAndClose() {
+        guard let rule = viewModel.makeRule() else {
+            return
+        }
+        if viewModel.existingID == nil {
+            Task { await RulePolicyGate.shared.addRule(rule) }
+        } else {
+            Task { await RulePolicyGate.shared.updateRule(rule) }
+        }
         dismiss()
+    }
+}
+
+private extension Result where Success == NSRegularExpression, Failure == RegexValidator.ValidationError {
+    var isSuccess: Bool {
+        if case .success = self {
+            return true
+        }
+        return false
     }
 }

--- a/Rockxy/Views/Rules/NetworkConditionsWindowView.swift
+++ b/Rockxy/Views/Rules/NetworkConditionsWindowView.swift
@@ -4,24 +4,6 @@ import SwiftUI
 
 // Presents the network conditions window for rule editing and management.
 
-// MARK: - NetworkConditionsMatchMode
-
-private enum NetworkConditionsMatchMode: String, CaseIterable {
-    case exactPath
-    case includeSubpaths
-    case regexAdvanced
-
-    // MARK: Internal
-
-    var displayName: String {
-        switch self {
-        case .exactPath: "Exact Path"
-        case .includeSubpaths: "Subpaths"
-        case .regexAdvanced: "Regex"
-        }
-    }
-}
-
 // MARK: - NetworkConditionProfileMetadata
 
 struct NetworkConditionProfileMetadata: Equatable {
@@ -288,6 +270,11 @@ final class NetworkConditionsWindowViewModel {
     }
 
     private static func readableHost(from pattern: String) -> String {
+        let formattedHost = NetworkConditionsPatternFormatter.hostText(from: pattern)
+        if !formattedHost.isEmpty, formattedHost != pattern {
+            return formattedHost
+        }
+
         var value = pattern.trimmingCharacters(in: .whitespacesAndNewlines)
         value = value.replacingOccurrences(of: "^", with: "")
         value = value.replacingOccurrences(of: "$", with: "")
@@ -326,7 +313,7 @@ enum NetworkConditionsPatternFormatter {
         guard var value = pattern, !value.isEmpty else {
             return ""
         }
-        value = value.replacingOccurrences(of: "^https?://", with: "", options: .regularExpression)
+        value = value.replacingOccurrences(of: "^https?://", with: "")
         value = value.replacingOccurrences(of: "^", with: "")
         value = value.replacingOccurrences(of: "$", with: "")
         value = value.replacingOccurrences(of: "(?:/.*)?", with: "")
@@ -362,6 +349,60 @@ enum NetworkConditionsPatternFormatter {
             return false
         }
         return host[host.index(after: colonIndex)...].allSatisfy(\.isNumber)
+    }
+}
+
+// MARK: - NetworkConditionsRuleForm
+
+enum NetworkConditionsRuleForm {
+    static let defaultName = "Untitled"
+    static let defaultPreset = NetworkConditionPreset.threeG
+    static let defaultCustomLatencyMs = 500
+
+    static func effectiveLatencyMs(preset: NetworkConditionPreset, customLatencyMs: Int) -> Int {
+        preset == .custom ? customLatencyMs : preset.defaultLatencyMs
+    }
+
+    static func isValid(
+        name: String,
+        hostText: String,
+        applySystemWide: Bool,
+        preset: NetworkConditionPreset,
+        customLatencyMs: Int
+    )
+        -> Bool
+    {
+        !name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            && effectiveLatencyMs(preset: preset, customLatencyMs: customLatencyMs) > 0
+            && (applySystemWide || !hostText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+    }
+
+    static func makeRule(
+        existingID: UUID?,
+        name: String,
+        isEnabled: Bool,
+        hostText: String,
+        applySystemWide: Bool,
+        preset: NetworkConditionPreset,
+        customLatencyMs: Int
+    )
+        -> ProxyRule
+    {
+        let trimmedHost = hostText.trimmingCharacters(in: .whitespacesAndNewlines)
+        let condition = RuleMatchCondition(
+            urlPattern: applySystemWide || trimmedHost.isEmpty ? nil : NetworkConditionsPatternFormatter
+                .hostScopedPattern(from: trimmedHost)
+        )
+        return ProxyRule(
+            id: existingID ?? UUID(),
+            name: name,
+            isEnabled: isEnabled,
+            matchCondition: condition,
+            action: .networkCondition(
+                preset: preset,
+                delayMs: effectiveLatencyMs(preset: preset, customLatencyMs: customLatencyMs)
+            )
+        )
     }
 }
 
@@ -848,11 +889,11 @@ private struct NetworkConditionsEditSheet: View {
     // MARK: Private
 
     @Environment(\.dismiss) private var dismiss
-    @State private var name = "Untitled"
+    @State private var name = NetworkConditionsRuleForm.defaultName
     @State private var hostText = ""
     @State private var applySystemWide = false
-    @State private var selectedPreset: NetworkConditionPreset = .threeG
-    @State private var customLatencyMs = 500
+    @State private var selectedPreset = NetworkConditionsRuleForm.defaultPreset
+    @State private var customLatencyMs = NetworkConditionsRuleForm.defaultCustomLatencyMs
     @State private var isEnabled = true
 
     private let draft: NetworkConditionsDraft?
@@ -866,13 +907,17 @@ private struct NetworkConditionsEditSheet: View {
     }
 
     private var effectiveLatencyMs: Int {
-        selectedPreset == .custom ? customLatencyMs : selectedPreset.defaultLatencyMs
+        NetworkConditionsRuleForm.effectiveLatencyMs(preset: selectedPreset, customLatencyMs: customLatencyMs)
     }
 
     private var isValid: Bool {
-        !name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-            && effectiveLatencyMs > 0
-            && (applySystemWide || !hostText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+        NetworkConditionsRuleForm.isValid(
+            name: name,
+            hostText: hostText,
+            applySystemWide: applySystemWide,
+            preset: selectedPreset,
+            customLatencyMs: customLatencyMs
+        )
     }
 
     private var profileStats: some View {
@@ -943,17 +988,14 @@ private struct NetworkConditionsEditSheet: View {
     }
 
     private func saveRule() {
-        let trimmedHost = hostText.trimmingCharacters(in: .whitespacesAndNewlines)
-        let condition = RuleMatchCondition(
-            urlPattern: applySystemWide || trimmedHost.isEmpty ? nil : NetworkConditionsPatternFormatter
-                .hostScopedPattern(from: trimmedHost)
-        )
-        let rule = ProxyRule(
-            id: existingID ?? UUID(),
+        let rule = NetworkConditionsRuleForm.makeRule(
+            existingID: existingID,
             name: name,
             isEnabled: isEnabled,
-            matchCondition: condition,
-            action: .networkCondition(preset: selectedPreset, delayMs: effectiveLatencyMs)
+            hostText: hostText,
+            applySystemWide: applySystemWide,
+            preset: selectedPreset,
+            customLatencyMs: customLatencyMs
         )
         onSave(rule)
         dismiss()

--- a/Rockxy/Views/Rules/NetworkConditionsWindowView.swift
+++ b/Rockxy/Views/Rules/NetworkConditionsWindowView.swift
@@ -1,3 +1,4 @@
+import AppKit
 import os
 import SwiftUI
 
@@ -21,14 +22,47 @@ private enum NetworkConditionsMatchMode: String, CaseIterable {
     }
 }
 
+// MARK: - NetworkConditionProfileMetadata
+
+struct NetworkConditionProfileMetadata: Equatable {
+    let name: String
+    let latencyMs: Int
+    let downloadBandwidth: String
+    let uploadBandwidth: String
+    let packetLoss: String
+    let systemImage: String
+
+    static func from(preset: NetworkConditionPreset, latencyMs: Int) -> Self {
+        let effectiveLatency = latencyMs > 0 ? latencyMs : preset.defaultLatencyMs
+        return Self(
+            name: preset.displayName,
+            latencyMs: effectiveLatency,
+            downloadBandwidth: preset.downloadBandwidthLabel,
+            uploadBandwidth: preset.uploadBandwidthLabel,
+            packetLoss: preset.packetLossLabel,
+            systemImage: preset.systemImage
+        )
+    }
+}
+
 // MARK: - NetworkConditionsWindowViewModel
 
 @MainActor @Observable
 final class NetworkConditionsWindowViewModel {
+    // MARK: Lifecycle
+
+    init(commitChanges: Bool = true, isToolEnabled: Bool? = nil) {
+        self.commitChanges = commitChanges
+        self.isToolEnabled = isToolEnabled ?? Self.defaultToolEnabled
+    }
+
     // MARK: Internal
 
     private(set) var allRules: [ProxyRule] = []
     var searchText = ""
+    var selectedRuleID: UUID?
+    var isFilterVisible = false
+    var isToolEnabled: Bool
 
     var networkConditionRules: [ProxyRule] {
         allRules.filter { rule in
@@ -47,7 +81,8 @@ final class NetworkConditionsWindowViewModel {
         return conditions.filter { rule in
             rule.name.localizedCaseInsensitiveContains(searchText)
                 || (rule.matchCondition.urlPattern ?? "").localizedCaseInsensitiveContains(searchText)
-                || presetInfo(for: rule).name.localizedCaseInsensitiveContains(searchText)
+                || hostLabel(for: rule).localizedCaseInsensitiveContains(searchText)
+                || networkProfile(for: rule).name.localizedCaseInsensitiveContains(searchText)
         }
     }
 
@@ -63,13 +98,29 @@ final class NetworkConditionsWindowViewModel {
         networkConditionRules.count
     }
 
+    var selectedRule: ProxyRule? {
+        guard let selectedRuleID else {
+            return nil
+        }
+        return allRules.first { $0.id == selectedRuleID }
+    }
+
     func loadRules() async {
         allRules = await RuleEngine.shared.allRules
+        reconcileSelectionAfterRulesChange()
     }
 
     func handleRulesDidChange(_ notification: Notification) {
         if let rules = notification.object as? [ProxyRule] {
             allRules = rules
+            reconcileSelectionAfterRulesChange()
+        }
+    }
+
+    func setToolEnabled(_ enabled: Bool) {
+        isToolEnabled = enabled
+        if commitChanges {
+            Task { await RulePolicyGate.shared.setNetworkConditionsToolEnabled(enabled) }
         }
     }
 
@@ -81,7 +132,9 @@ final class NetworkConditionsWindowViewModel {
             if let index = allRules.firstIndex(where: { $0.id == id }) {
                 allRules[index].isEnabled = false
             }
-            Task { await RulePolicyGate.shared.setRuleEnabled(id: id, enabled: false) }
+            if commitChanges {
+                Task { await RulePolicyGate.shared.setRuleEnabled(id: id, enabled: false) }
+            }
         } else {
             for index in allRules.indices {
                 if case .networkCondition = allRules[index].action, allRules[index].isEnabled {
@@ -91,10 +144,13 @@ final class NetworkConditionsWindowViewModel {
             if let index = allRules.firstIndex(where: { $0.id == id }) {
                 allRules[index].isEnabled = true
             }
-            Task {
-                let accepted = await RulePolicyGate.shared.enableExclusiveNetworkCondition(id: id)
-                if !accepted {
-                    allRules = await RuleEngine.shared.allRules
+            if commitChanges {
+                Task {
+                    let accepted = await RulePolicyGate.shared.enableExclusiveNetworkCondition(id: id)
+                    if !accepted {
+                        allRules = await RuleEngine.shared.allRules
+                        reconcileSelectionAfterRulesChange()
+                    }
                 }
             }
         }
@@ -107,16 +163,21 @@ final class NetworkConditionsWindowViewModel {
             }
         }
         allRules.append(rule)
-        Task {
-            if rule.isEnabled {
-                let accepted = await RulePolicyGate.shared.addNetworkConditionExclusive(rule)
-                if !accepted {
-                    allRules = await RuleEngine.shared.allRules
-                }
-            } else {
-                let accepted = await RulePolicyGate.shared.addRule(rule)
-                if !accepted {
-                    allRules = await RuleEngine.shared.allRules
+        selectedRuleID = rule.id
+        if commitChanges {
+            Task {
+                if rule.isEnabled {
+                    let accepted = await RulePolicyGate.shared.addNetworkConditionExclusive(rule)
+                    if !accepted {
+                        allRules = await RuleEngine.shared.allRules
+                        reconcileSelectionAfterRulesChange()
+                    }
+                } else {
+                    let accepted = await RulePolicyGate.shared.addRule(rule)
+                    if !accepted {
+                        allRules = await RuleEngine.shared.allRules
+                        reconcileSelectionAfterRulesChange()
+                    }
                 }
             }
         }
@@ -127,12 +188,41 @@ final class NetworkConditionsWindowViewModel {
             return
         }
         allRules[index] = rule
-        Task { await RulePolicyGate.shared.updateRule(rule) }
+        selectedRuleID = rule.id
+        if commitChanges {
+            Task { await RulePolicyGate.shared.updateRule(rule) }
+        }
+    }
+
+    func removeSelectedRule() {
+        guard let selectedRuleID else {
+            return
+        }
+        removeRule(id: selectedRuleID)
     }
 
     func removeRule(id: UUID) {
         allRules.removeAll { $0.id == id }
-        Task { await RulePolicyGate.shared.removeRule(id: id) }
+        if selectedRuleID == id {
+            selectedRuleID = nil
+        }
+        if commitChanges {
+            Task { await RulePolicyGate.shared.removeRule(id: id) }
+        }
+    }
+
+    func duplicateSelectedRule() {
+        guard let selectedRule else {
+            return
+        }
+        let copy = ProxyRule(
+            name: String(localized: "Copy of \(selectedRule.name)"),
+            isEnabled: false,
+            matchCondition: selectedRule.matchCondition,
+            action: selectedRule.action,
+            priority: selectedRule.priority
+        )
+        addRule(copy)
     }
 
     func disableAll() {
@@ -143,7 +233,9 @@ final class NetworkConditionsWindowViewModel {
             }
         }
         allRules = updated
-        Task { await RulePolicyGate.shared.disableAllNetworkConditions() }
+        if commitChanges {
+            Task { await RulePolicyGate.shared.disableAllNetworkConditions() }
+        }
     }
 
     func presetInfo(for rule: ProxyRule) -> (name: String, latencyMs: Int) {
@@ -153,7 +245,26 @@ final class NetworkConditionsWindowViewModel {
         return ("", 0)
     }
 
+    func networkProfile(for rule: ProxyRule) -> NetworkConditionProfileMetadata {
+        if case let .networkCondition(preset, delayMs) = rule.action {
+            return .from(preset: preset, latencyMs: delayMs)
+        }
+        return .from(preset: .custom, latencyMs: 0)
+    }
+
+    func hostLabel(for rule: ProxyRule) -> String {
+        guard let pattern = rule.matchCondition.urlPattern,
+              !pattern.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else
+        {
+            return String(localized: "System-wide")
+        }
+        return Self.readableHost(from: pattern)
+    }
+
     func statusLabel(for rule: ProxyRule) -> (String, Color) {
+        guard isToolEnabled else {
+            return (String(localized: "Paused"), .secondary)
+        }
         guard rule.isEnabled else {
             return (String(localized: "Inactive"), .secondary)
         }
@@ -165,13 +276,94 @@ final class NetworkConditionsWindowViewModel {
 
     // MARK: Private
 
+    private let commitChanges: Bool
+
+    private static let toolEnabledKey = "networkConditionsToolEnabled"
     private static let logger = Logger(
         subsystem: RockxyIdentity.current.logSubsystem,
         category: "NetworkConditionsWindowViewModel"
     )
+    private static var defaultToolEnabled: Bool {
+        UserDefaults.standard.object(forKey: toolEnabledKey) as? Bool ?? true
+    }
+
+    private static func readableHost(from pattern: String) -> String {
+        var value = pattern.trimmingCharacters(in: .whitespacesAndNewlines)
+        value = value.replacingOccurrences(of: "^", with: "")
+        value = value.replacingOccurrences(of: "$", with: "")
+        value = value.replacingOccurrences(of: ".*", with: "")
+        value = value.replacingOccurrences(of: "\\.", with: ".")
+        value = value.replacingOccurrences(of: "\\:", with: ":")
+        value = value.replacingOccurrences(of: "https://", with: "")
+        value = value.replacingOccurrences(of: "http://", with: "")
+        if let slashIndex = value.firstIndex(of: "/") {
+            value = String(value[..<slashIndex])
+        }
+        return value.isEmpty ? pattern : value
+    }
+
+    private func reconcileSelectionAfterRulesChange() {
+        guard let selectedRuleID,
+              networkConditionRules.contains(where: { $0.id == selectedRuleID }) else
+        {
+            self.selectedRuleID = nil
+            return
+        }
+    }
 }
 
 // MARK: - NetworkConditionsWindowView
+
+enum NetworkConditionsPatternFormatter {
+    static func hostScopedPattern(from hostText: String) -> String {
+        let host = normalizedHostAndPort(from: hostText)
+        let escapedHost = NSRegularExpression.escapedPattern(for: host)
+        let portPattern = hostContainsPort(host) ? "" : "(?::\\d+)?"
+        return "^https?://\(escapedHost)\(portPattern)(?:/.*)?$"
+    }
+
+    static func hostText(from pattern: String?) -> String {
+        guard var value = pattern, !value.isEmpty else {
+            return ""
+        }
+        value = value.replacingOccurrences(of: "^https?://", with: "", options: .regularExpression)
+        value = value.replacingOccurrences(of: "^", with: "")
+        value = value.replacingOccurrences(of: "$", with: "")
+        value = value.replacingOccurrences(of: "(?:/.*)?", with: "")
+        value = value.replacingOccurrences(of: "(?::\\d+)?", with: "")
+        value = value.replacingOccurrences(of: "\\.", with: ".")
+        value = value.replacingOccurrences(of: "\\:", with: ":")
+        value = value.replacingOccurrences(of: "https://", with: "")
+        value = value.replacingOccurrences(of: "http://", with: "")
+        if let slashIndex = value.firstIndex(of: "/") {
+            value = String(value[..<slashIndex])
+        }
+        return value.isEmpty ? pattern ?? "" : value
+    }
+
+    private static func normalizedHostAndPort(from hostText: String) -> String {
+        var value = hostText.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let components = URLComponents(string: value), let host = components.host {
+            value = host
+            if let port = components.port {
+                value += ":\(port)"
+            }
+        }
+        value = value.replacingOccurrences(of: "https://", with: "")
+        value = value.replacingOccurrences(of: "http://", with: "")
+        if let slashIndex = value.firstIndex(of: "/") {
+            value = String(value[..<slashIndex])
+        }
+        return value
+    }
+
+    private static func hostContainsPort(_ host: String) -> Bool {
+        guard let colonIndex = host.lastIndex(of: ":") else {
+            return false
+        }
+        return host[host.index(after: colonIndex)...].allSatisfy(\.isNumber)
+    }
+}
 
 struct NetworkConditionsWindowView: View {
     // MARK: Internal
@@ -179,20 +371,16 @@ struct NetworkConditionsWindowView: View {
     @State var viewModel = NetworkConditionsWindowViewModel()
 
     var body: some View {
-        VStack(spacing: 0) {
-            toolbar
-            Divider()
-            infoBar
-            Divider()
-            if viewModel.hasMultipleActive {
-                warningBanner
-                Divider()
+        VStack(alignment: .leading, spacing: 0) {
+            header
+            if viewModel.isFilterVisible {
+                filterBar
             }
             tableContent
-            Divider()
+            shortcutStrip
             bottomBar
         }
-        .frame(width: 880, height: 480)
+        .frame(width: 1_198, height: 641)
         .task { await viewModel.loadRules() }
         .onAppear { consumePendingDraft() }
         .onReceive(NotificationCenter.default.publisher(for: .openNetworkConditionsWindow)) { _ in
@@ -219,217 +407,322 @@ struct NetworkConditionsWindowView: View {
 
     // MARK: Private
 
-    @State private var selectedRuleID: UUID?
     @State private var showEditSheet = false
     @State private var editingRule: ProxyRule?
     @State private var pendingDraft: NetworkConditionsDraft?
 
-    @ViewBuilder private var tableContent: some View {
-        if viewModel.networkConditionRules.isEmpty {
-            VStack(alignment: .center, spacing: 8) {
-                Image(systemName: "wifi.exclamationmark")
-                    .font(.system(size: 20))
-                    .foregroundStyle(.tertiary)
-                Text(String(localized: "No Network Conditions"))
-                    .font(.system(size: 13, weight: .medium))
-                    .foregroundStyle(.secondary)
-                Text(String(localized: "Simulate slow networks. Click + below to create a condition."))
-                    .font(.caption)
-                    .foregroundStyle(.tertiary)
-                    .multilineTextAlignment(.center)
-
-                HStack(alignment: .top, spacing: 0) {
-                    RoundedRectangle(cornerRadius: 1)
-                        .fill(Color.orange.opacity(0.4))
-                        .frame(width: 2, height: 28)
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text(String(localized: "Example"))
-                            .font(.caption2)
-                            .fontWeight(.semibold)
-                            .foregroundStyle(.tertiary)
-                        HStack(spacing: 5) {
-                            Text("api.example.com")
-                                .font(.system(size: 10, design: .monospaced))
-                                .foregroundStyle(.secondary)
-                            Image(systemName: "tortoise")
-                                .font(.system(size: 8))
-                                .foregroundStyle(.tertiary)
-                            Text("3G — 400 ms")
-                                .font(.system(size: 10, design: .monospaced))
-                                .foregroundStyle(.orange)
-                        }
-                    }
-                    .padding(.leading, 6)
-                }
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Toggle(isOn: Binding(
+                get: { viewModel.isToolEnabled },
+                set: { viewModel.setToolEnabled($0) }
+            )) {
+                Text(String(localized: "Enable Network Conditions"))
+                    .font(.system(size: 13))
             }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .padding(.horizontal, 24)
-            .padding(.top, 12)
-        } else {
-            Table(viewModel.filteredRules, selection: $selectedRuleID) {
-                TableColumn("") { rule in
+            .toggleStyle(.checkbox)
+            .padding(.top, 16)
+
+            Text(String(localized: "Simulate Network Conditions with various Preset Profiles. Useful to test with slow networks."))
+                .font(.system(size: 13))
+                .foregroundStyle(.primary)
+
+            Text(String(localized: "Only 1 Rule can be activated at once."))
+                .font(.system(size: 13))
+                .foregroundStyle(.orange)
+        }
+        .padding(.horizontal, 18)
+        .padding(.bottom, 10)
+    }
+
+    private var filterBar: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "magnifyingglass")
+                .foregroundStyle(.secondary)
+            TextField(String(localized: "Filter Network Conditions"), text: $viewModel.searchText)
+                .textFieldStyle(.roundedBorder)
+            Button {
+                viewModel.searchText = ""
+                viewModel.isFilterVisible = false
+            } label: {
+                Image(systemName: "xmark.circle.fill")
+            }
+            .buttonStyle(.plain)
+            .foregroundStyle(.secondary)
+        }
+        .padding(.horizontal, 18)
+        .padding(.bottom, 8)
+    }
+
+    private var tableContent: some View {
+        Table(viewModel.filteredRules, selection: $viewModel.selectedRuleID) {
+            TableColumn(String(localized: "Enabled")) { rule in
+                HStack {
+                    Spacer()
                     Toggle("", isOn: Binding(
                         get: { rule.isEnabled },
                         set: { _ in viewModel.toggleRule(id: rule.id) }
                     ))
-                    .toggleStyle(.switch)
+                    .toggleStyle(.checkbox)
                     .labelsHidden()
                     .controlSize(.small)
+                    Spacer()
                 }
-                .width(40)
-
-                TableColumn(String(localized: "Name")) { rule in
-                    Text(rule.name)
-                        .fontWeight(.medium)
-                        .lineLimit(1)
-                        .opacity(rule.isEnabled ? 1.0 : 0.5)
-                }
-                .width(min: 100, ideal: 140)
-
-                TableColumn(String(localized: "Scope")) { rule in
-                    Text(rule.matchCondition.urlPattern ?? "*")
-                        .font(.system(.body, design: .monospaced))
-                        .lineLimit(1)
-                        .help(rule.matchCondition.urlPattern ?? "*")
-                        .opacity(rule.isEnabled ? 1.0 : 0.5)
-                }
-                .width(min: 160, ideal: 200)
-
-                TableColumn(String(localized: "Profile")) { rule in
-                    Text(viewModel.presetInfo(for: rule).name)
-                        .lineLimit(1)
-                        .opacity(rule.isEnabled ? 1.0 : 0.5)
-                }
-                .width(80)
-
-                TableColumn(String(localized: "Latency")) { rule in
-                    Text("\(viewModel.presetInfo(for: rule).latencyMs) ms")
-                        .font(.system(.body, design: .monospaced))
-                        .lineLimit(1)
-                        .opacity(rule.isEnabled ? 1.0 : 0.5)
-                }
-                .width(80)
-
-                TableColumn(String(localized: "Status")) { rule in
-                    let (label, color) = viewModel.statusLabel(for: rule)
-                    Text(label)
-                        .font(.caption)
-                        .fontWeight(.medium)
-                        .padding(.horizontal, 6)
-                        .padding(.vertical, 2)
-                        .background(color.opacity(0.12))
-                        .foregroundStyle(color)
-                        .clipShape(RoundedRectangle(cornerRadius: 4))
-                }
-                .width(80)
             }
-            .contextMenu(forSelectionType: UUID.self) { ids in
-                if let id = ids.first {
-                    Button(String(localized: "Edit")) {
-                        editingRule = viewModel.allRules.first { $0.id == id }
-                        pendingDraft = nil
-                        showEditSheet = true
-                    }
-                    Divider()
-                    Button(String(localized: "Delete"), role: .destructive) {
-                        viewModel.removeRule(id: id)
-                        selectedRuleID = nil
-                    }
-                }
+            .width(62)
+
+            TableColumn(String(localized: "Name")) { rule in
+                Text(rule.name.isEmpty ? String(localized: "Untitled") : rule.name)
+                    .font(.system(size: 12))
+                    .lineLimit(1)
+                    .opacity(rule.isEnabled ? 1.0 : 0.62)
+            }
+            .width(min: 250, ideal: 300)
+
+            TableColumn(String(localized: "Status")) { rule in
+                let (label, color) = viewModel.statusLabel(for: rule)
+                Text(label)
+                    .font(.system(size: 12))
+                    .lineLimit(1)
+                    .foregroundStyle(color)
+            }
+            .width(110)
+
+            TableColumn(String(localized: "Host")) { rule in
+                Text(viewModel.hostLabel(for: rule))
+                    .font(.system(size: 12))
+                    .lineLimit(1)
+                    .help(rule.matchCondition.urlPattern ?? String(localized: "System-wide"))
+                    .opacity(rule.isEnabled ? 1.0 : 0.75)
+            }
+            .width(min: 230, ideal: 250)
+
+            TableColumn(String(localized: "Network Profile")) { rule in
+                let profile = viewModel.networkProfile(for: rule)
+                Text(profile.name)
+                    .font(.system(size: 12))
+                    .lineLimit(1)
+                    .help("\(profile.name), \(profile.latencyMs) ms")
+                    .opacity(rule.isEnabled ? 1.0 : 0.75)
+            }
+            .width(min: 230, ideal: 260)
+        }
+        .contextMenu(forSelectionType: UUID.self) { ids in
+            tableContextMenu(ids: ids)
+        } primaryAction: { ids in
+            guard let id = ids.first,
+                  let rule = viewModel.allRules.first(where: { $0.id == id }) else
+            {
+                return
+            }
+            openEditor(for: rule)
+        }
+        .overlay {
+            if viewModel.filteredRules.isEmpty {
+                Text(emptyTableMessage)
+                    .font(.system(size: 13))
+                    .foregroundStyle(.secondary)
             }
         }
+        .padding(.horizontal, 18)
     }
 
-    private var toolbar: some View {
-        HStack(spacing: 12) {
-            Button {
-                viewModel.disableAll()
-            } label: {
-                Text(String(localized: "Disable All"))
-                    .font(.callout)
-            }
-
-            Spacer()
-
-            TextField(String(localized: "Search"), text: $viewModel.searchText)
-                .textFieldStyle(.roundedBorder)
-                .frame(width: 160)
-
-            Button {
-                pendingDraft = nil
-                editingRule = nil
-                showEditSheet = true
-            } label: {
-                Label(String(localized: "Add Rule"), systemImage: "plus")
-            }
-        }
-        .padding(.horizontal, 12)
-        .padding(.vertical, 8)
-    }
-
-    private var infoBar: some View {
-        HStack(spacing: 6) {
-            Image(systemName: "info.circle")
-                .foregroundStyle(.secondary)
-            Text(String(localized: "Simulate slow network behavior for proxied requests using latency presets."))
-                .font(.caption)
-                .foregroundStyle(.secondary)
-            Spacer()
-        }
-        .padding(.horizontal, 12)
-        .padding(.vertical, 6)
-        .background(.quaternary.opacity(0.5))
-    }
-
-    private var warningBanner: some View {
-        HStack(spacing: 6) {
-            Image(systemName: "exclamationmark.triangle.fill")
-                .foregroundStyle(.orange)
-            Text(String(localized: "Only one Network Conditions rule can be active at a time."))
-                .font(.caption)
-                .foregroundStyle(.orange)
-            Spacer()
-        }
-        .padding(.horizontal, 12)
-        .padding(.vertical, 6)
-        .background(.orange.opacity(0.08))
+    private var shortcutStrip: some View {
+        Text("New: ⌘N    Edit: ⌘↩    Delete: ⌘⌫    Duplicate: ⌘D    Toggle: ↵")
+            .font(.system(size: 11))
+            .foregroundStyle(.secondary)
+            .padding(.horizontal, 18)
+            .padding(.top, 8)
+            .padding(.bottom, 4)
     }
 
     private var bottomBar: some View {
-        HStack(spacing: 0) {
-            Button {
-                pendingDraft = nil
-                editingRule = nil
-                showEditSheet = true
-            } label: {
-                Image(systemName: "plus")
-                    .frame(width: 28, height: 22)
-            }
-            .buttonStyle(.borderless)
+        HStack(spacing: 8) {
+            addRemoveControl
 
             Button {
-                guard let id = selectedRuleID else {
-                    return
-                }
-                viewModel.removeRule(id: id)
-                selectedRuleID = nil
+                // Help content is intentionally deferred; this mirrors the reference affordance.
             } label: {
-                Image(systemName: "minus")
-                    .frame(width: 28, height: 22)
+                Image(systemName: "questionmark.circle.fill")
+                    .font(.system(size: 22))
+                    .foregroundStyle(.secondary.opacity(0.35), .clear)
+                    .overlay(Text("?").font(.system(size: 15, weight: .medium)).foregroundStyle(.primary))
+                    .frame(width: 34, height: 22)
             }
             .buttonStyle(.borderless)
-            .disabled(selectedRuleID == nil)
+            .padding(.leading, 2)
 
             Spacer()
 
-            Text(
-                "\(viewModel.ruleCount) \(viewModel.ruleCount == 1 ? String(localized: "rule") : String(localized: "rules"))"
-            )
-            .font(.caption)
-            .foregroundStyle(.secondary)
+            moreMenu
         }
-        .padding(.horizontal, 8)
-        .padding(.vertical, 4)
+        .padding(.horizontal, 18)
+        .padding(.bottom, 14)
+    }
+
+    private var addRemoveControl: some View {
+        HStack(spacing: 0) {
+            Button {
+                openNewEditor()
+            } label: {
+                Image(systemName: "plus")
+                    .font(.system(size: 13, weight: .regular))
+                    .foregroundStyle(.primary)
+                    .frame(width: 21, height: 21)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .keyboardShortcut("n", modifiers: .command)
+            .help(String(localized: "New Rule"))
+
+            Rectangle()
+                .fill(Color(nsColor: .separatorColor).opacity(0.7))
+                .frame(width: 1, height: 21)
+
+            Button {
+                viewModel.removeSelectedRule()
+            } label: {
+                Image(systemName: "minus")
+                    .font(.system(size: 13, weight: .regular))
+                    .foregroundStyle(viewModel.selectedRuleID == nil ? .tertiary : .primary)
+                    .frame(width: 21, height: 21)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .keyboardShortcut("-", modifiers: [])
+            .disabled(viewModel.selectedRuleID == nil)
+            .help(String(localized: "Delete Rule"))
+        }
+        .frame(height: 23)
+        .background(Color(nsColor: .windowBackgroundColor))
+        .overlay(
+            Rectangle()
+                .stroke(Color(nsColor: .separatorColor), lineWidth: 1)
+        )
+    }
+
+    private var moreMenu: some View {
+        Menu {
+            Button(String(localized: "New…")) {
+                openNewEditor()
+            }
+            .keyboardShortcut("n", modifiers: .command)
+
+            Divider()
+
+            Button(String(localized: "Edit…")) {
+                openEditorForSelection()
+            }
+            .keyboardShortcut(.return, modifiers: .command)
+            .disabled(viewModel.selectedRule == nil)
+
+            Button(String(localized: "Duplicate")) {
+                viewModel.duplicateSelectedRule()
+            }
+            .keyboardShortcut("d", modifiers: .command)
+            .disabled(viewModel.selectedRule == nil)
+
+            Button(enableDisableLabel) {
+                if let id = viewModel.selectedRuleID {
+                    viewModel.toggleRule(id: id)
+                }
+            }
+            .keyboardShortcut(.return, modifiers: [])
+            .disabled(viewModel.selectedRule == nil)
+
+            Divider()
+
+            Button(viewModel.isFilterVisible ? String(localized: "Hide Filter") : String(localized: "Show Filter")) {
+                withAnimation {
+                    viewModel.isFilterVisible.toggle()
+                }
+            }
+            .keyboardShortcut("f", modifiers: .command)
+
+            Button(String(localized: "Disable All")) {
+                viewModel.disableAll()
+            }
+            .disabled(viewModel.activeCount == 0)
+
+            Divider()
+
+            Button(String(localized: "Delete"), role: .destructive) {
+                viewModel.removeSelectedRule()
+            }
+            .keyboardShortcut(.delete, modifiers: .command)
+            .disabled(viewModel.selectedRuleID == nil)
+        } label: {
+            HStack(spacing: 6) {
+                Text(String(localized: "More"))
+                Image(systemName: "chevron.down")
+                    .font(.system(size: 9, weight: .semibold))
+            }
+        }
+        .menuIndicator(.hidden)
+        .buttonStyle(.bordered)
+        .fixedSize()
+    }
+
+    private var emptyTableMessage: String {
+        if viewModel.networkConditionRules.isEmpty {
+            return String(localized: "Click \"+\" or ⌘N to add new entry")
+        }
+        return String(localized: "No Network Conditions match the current filter")
+    }
+
+    private var enableDisableLabel: String {
+        guard let selectedRule = viewModel.selectedRule else {
+            return String(localized: "Toggle")
+        }
+        return selectedRule.isEnabled ? String(localized: "Disable") : String(localized: "Enable")
+    }
+
+    @ViewBuilder
+    private func tableContextMenu(ids: Set<UUID>) -> some View {
+        if let id = ids.first {
+            Button(String(localized: "Edit…")) {
+                if let rule = viewModel.allRules.first(where: { $0.id == id }) {
+                    openEditor(for: rule)
+                }
+            }
+            Button(String(localized: "Duplicate")) {
+                viewModel.selectedRuleID = id
+                viewModel.duplicateSelectedRule()
+            }
+            Button(enableDisableContextLabel(for: id)) {
+                viewModel.toggleRule(id: id)
+            }
+            Divider()
+            Button(String(localized: "Delete"), role: .destructive) {
+                viewModel.removeRule(id: id)
+            }
+        }
+    }
+
+    private func enableDisableContextLabel(for id: UUID) -> String {
+        guard let rule = viewModel.allRules.first(where: { $0.id == id }) else {
+            return String(localized: "Toggle")
+        }
+        return rule.isEnabled ? String(localized: "Disable") : String(localized: "Enable")
+    }
+
+    private func openNewEditor() {
+        pendingDraft = nil
+        editingRule = nil
+        showEditSheet = true
+    }
+
+    private func openEditorForSelection() {
+        guard let rule = viewModel.selectedRule else {
+            return
+        }
+        openEditor(for: rule)
+    }
+
+    private func openEditor(for rule: ProxyRule) {
+        editingRule = rule
+        pendingDraft = nil
+        showEditSheet = true
     }
 
     private func consumePendingDraft() {
@@ -458,29 +751,16 @@ private struct NetworkConditionsEditSheet: View {
 
         if let existingRule {
             _name = State(initialValue: existingRule.name)
-            _urlPattern = State(initialValue: existingRule.matchCondition.urlPattern ?? "")
-            _matchMode = State(initialValue: .regexAdvanced)
+            _hostText = State(initialValue: Self.hostText(from: existingRule.matchCondition.urlPattern))
+            _applySystemWide = State(initialValue: existingRule.matchCondition.urlPattern == nil)
             _isEnabled = State(initialValue: existingRule.isEnabled)
             if case let .networkCondition(preset, delayMs) = existingRule.action {
                 _selectedPreset = State(initialValue: preset)
-                if preset == .custom {
-                    _customLatencyMs = State(initialValue: delayMs)
-                } else {
-                    _customLatencyMs = State(initialValue: delayMs)
-                }
+                _customLatencyMs = State(initialValue: delayMs)
             }
         } else if let draft {
             _name = State(initialValue: draft.suggestedName)
-            let defaultMode: NetworkConditionsMatchMode = draft.origin == .domainQuickCreate
-                ? .includeSubpaths : .exactPath
-            _matchMode = State(initialValue: defaultMode)
-            if let url = draft.sourceURL {
-                _urlPattern = State(initialValue: Self.generatePattern(from: url, mode: defaultMode))
-            } else {
-                _urlPattern = State(initialValue: Self.generateDomainPattern(
-                    from: draft.sourceHost, mode: defaultMode
-                ))
-            }
+            _hostText = State(initialValue: draft.sourceURL?.host ?? draft.sourceHost)
         }
     }
 
@@ -489,44 +769,97 @@ private struct NetworkConditionsEditSheet: View {
     let onSave: (ProxyRule) -> Void
 
     var body: some View {
-        VStack(spacing: 0) {
-            Form {
-                ruleInfoSection
-                scopeSection
-                profileSection
-                if selectedPreset == .custom {
-                    advancedSection
+        VStack(alignment: .leading, spacing: 0) {
+            VStack(alignment: .leading, spacing: 9) {
+                labeledTextField(
+                    String(localized: "Name:"),
+                    text: $name,
+                    prompt: String(localized: "Untitled")
+                )
+
+                labeledTextField(
+                    String(localized: "Host:"),
+                    text: $hostText,
+                    prompt: "api.proxyman.com"
+                )
+                .disabled(applySystemWide)
+
+                Text(String(localized: "Only support Host and Port. No Wildcard or Regex"))
+                    .font(.system(size: 13))
+                    .foregroundStyle(.secondary)
+                    .padding(.leading, Self.fieldLeading)
+
+                Toggle(isOn: $applySystemWide) {
+                    Text(String(localized: "Apply System-wide"))
+                        .font(.system(size: 13))
                 }
+                .toggleStyle(.checkbox)
+                .padding(.leading, Self.fieldLeading)
+
+                Text(String(localized: "All traffic being proxied through Rockxy will be affected by Network Throttling"))
+                    .font(.system(size: 13))
+                    .foregroundStyle(.secondary)
+                    .padding(.leading, Self.fieldLeading)
+                    .padding(.bottom, 6)
+
+                HStack(spacing: 8) {
+                    Text(String(localized: "Preset Profiles:"))
+                        .font(.system(size: 13))
+                        .frame(width: Self.labelWidth, alignment: .trailing)
+                    Picker("", selection: $selectedPreset) {
+                        ForEach(NetworkConditionPreset.allCases, id: \.self) { preset in
+                            Text(preset.displayName).tag(preset)
+                        }
+                    }
+                    .labelsHidden()
+                    .frame(width: 160)
+                }
+
+                profileStats
             }
-            .formStyle(.grouped)
+            .padding(.top, 14)
+            .padding(.horizontal, 18)
+
+            Text(String(localized: "To simulate network condition in real-life, the bandwidth is generated randomly in a given range"))
+                .font(.system(size: 13))
+                .foregroundStyle(.secondary)
+                .padding(.leading, Self.fieldLeading + 18)
+                .padding(.top, 12)
 
             HStack {
                 Spacer()
                 Button(String(localized: "Cancel")) { dismiss() }
                     .keyboardShortcut(.cancelAction)
-                Button(isEditing ? String(localized: "Save") : String(localized: "Add Rule")) {
+                    .frame(width: 100)
+                Button(isEditing ? String(localized: "Save (⌘↩)") : String(localized: "Add (⌘↩)")) {
                     saveRule()
                 }
                 .keyboardShortcut(.defaultAction)
                 .disabled(!isValid)
+                .frame(width: 100)
             }
-            .padding()
+            .padding(.top, 16)
+            .padding(.horizontal, 18)
+            .padding(.bottom, 18)
         }
-        .frame(width: 520, height: 420)
+        .frame(width: 838, height: 390)
     }
 
     // MARK: Private
 
     @Environment(\.dismiss) private var dismiss
-    @State private var name = ""
-    @State private var urlPattern = ""
-    @State private var matchMode: NetworkConditionsMatchMode = .exactPath
-    @State private var selectedPreset: NetworkConditionPreset = .lte
+    @State private var name = "Untitled"
+    @State private var hostText = ""
+    @State private var applySystemWide = false
+    @State private var selectedPreset: NetworkConditionPreset = .threeG
     @State private var customLatencyMs = 500
     @State private var isEnabled = true
 
     private let draft: NetworkConditionsDraft?
     private let existingID: UUID?
+    private static let labelWidth: CGFloat = 96
+    private static let fieldWidth: CGFloat = 700
+    private static let fieldLeading = labelWidth + 8
 
     private var isEditing: Bool {
         existingID != nil
@@ -537,118 +870,83 @@ private struct NetworkConditionsEditSheet: View {
     }
 
     private var isValid: Bool {
-        !name.isEmpty && effectiveLatencyMs > 0
+        !name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            && effectiveLatencyMs > 0
+            && (applySystemWide || !hostText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
     }
 
-    // MARK: - Rule Info Section
+    private var profileStats: some View {
+        let metadata = NetworkConditionProfileMetadata.from(preset: selectedPreset, latencyMs: effectiveLatencyMs)
+        return VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 20) {
+                Text(String(localized: "Download"))
+                    .font(.system(size: 13))
+                    .frame(width: 260, alignment: .leading)
+                Text(String(localized: "Upload"))
+                    .font(.system(size: 13))
+                    .frame(width: 260, alignment: .leading)
+            }
+            HStack(spacing: 20) {
+                statsCard(
+                    bandwidth: metadata.downloadBandwidth,
+                    packetLoss: metadata.packetLoss,
+                    latencyMs: metadata.latencyMs
+                )
+                statsCard(
+                    bandwidth: metadata.uploadBandwidth,
+                    packetLoss: metadata.packetLoss,
+                    latencyMs: metadata.latencyMs
+                )
+            }
+        }
+        .padding(.leading, Self.fieldLeading)
+        .padding(.top, 4)
+    }
 
-    private var ruleInfoSection: some View {
-        Section(String(localized: "Rule Info")) {
-            TextField(String(localized: "Name"), text: $name)
+    private func labeledTextField(_ label: String, text: Binding<String>, prompt: String) -> some View {
+        HStack(spacing: 8) {
+            Text(label)
+                .font(.system(size: 13))
+                .frame(width: Self.labelWidth, alignment: .trailing)
+            TextField(prompt, text: text)
+                .textFieldStyle(.roundedBorder)
+                .font(.system(size: 13))
+                .frame(width: Self.fieldWidth)
         }
     }
 
-    // MARK: - Scope Section
-
-    private var scopeSection: some View {
-        Section(String(localized: "Scope")) {
-            Picker(String(localized: "Match"), selection: $matchMode) {
-                ForEach(NetworkConditionsMatchMode.allCases, id: \.self) { mode in
-                    Text(mode.displayName).tag(mode)
-                }
-            }
-            .pickerStyle(.segmented)
-            .onChange(of: matchMode) { _, newMode in
-                if let draft, let url = draft.sourceURL {
-                    urlPattern = Self.generatePattern(from: url, mode: newMode)
-                } else if let draft {
-                    urlPattern = Self.generateDomainPattern(from: draft.sourceHost, mode: newMode)
-                }
-            }
-
-            TextField(String(localized: "URL Pattern"), text: $urlPattern)
-                .font(.system(.body, design: .monospaced))
-        }
-    }
-
-    // MARK: - Profile Section
-
-    private var profileSection: some View {
-        Section(String(localized: "Profile")) {
-            Picker(String(localized: "Preset"), selection: $selectedPreset) {
-                ForEach(NetworkConditionPreset.allCases, id: \.self) { preset in
-                    HStack {
-                        Text(preset.displayName)
-                        Spacer()
-                        if preset != .custom {
-                            Text("\(preset.defaultLatencyMs) ms")
-                                .foregroundStyle(.secondary)
-                        }
-                    }
-                    .tag(preset)
-                }
-            }
-
+    private func statsCard(bandwidth: String, packetLoss: String, latencyMs: Int) -> some View {
+        VStack(alignment: .trailing, spacing: 8) {
+            Text("Bandwidth:  \(bandwidth)")
+            Text("Packets Dropped:  \(packetLoss)")
             HStack(spacing: 6) {
-                Image(systemName: selectedPreset.systemImage)
-                    .foregroundStyle(.secondary)
-                Text("\(selectedPreset.displayName) — \(effectiveLatencyMs) ms")
-                    .font(.system(.body, design: .monospaced))
-                    .foregroundStyle(.secondary)
+                Text("Delay:")
+                if selectedPreset == .custom {
+                    TextField("", value: $customLatencyMs, format: .number)
+                        .textFieldStyle(.roundedBorder)
+                        .frame(width: 70)
+                    Text("ms")
+                } else {
+                    Text("\(latencyMs).0 ms")
+                }
             }
         }
+        .font(.system(size: 13))
+        .padding(.horizontal, 20)
+        .frame(width: 260, height: 88, alignment: .center)
+        .background(Color(nsColor: .controlBackgroundColor))
+        .clipShape(RoundedRectangle(cornerRadius: 8))
     }
 
-    // MARK: - Advanced Section
-
-    private var advancedSection: some View {
-        Section(String(localized: "Advanced")) {
-            HStack {
-                Text(String(localized: "Latency (ms)"))
-                TextField("", value: $customLatencyMs, format: .number)
-                    .font(.system(.body, design: .monospaced))
-                    .frame(width: 100)
-                Stepper("", value: $customLatencyMs, in: 1 ... 30_000, step: 50)
-                    .labelsHidden()
-            }
-        }
-    }
-
-    // MARK: - Pattern Helpers
-
-    private static func escapeRegex(_ string: String) -> String {
-        NSRegularExpression.escapedPattern(for: string)
-    }
-
-    private static func generatePattern(from url: URL, mode: NetworkConditionsMatchMode) -> String {
-        let scheme = url.scheme ?? "https"
-        let host = escapeRegex(url.host ?? "")
-        let path = escapeRegex(url.path)
-        switch mode {
-        case .exactPath:
-            return "^\(scheme)://\(host)\(path)$"
-        case .includeSubpaths:
-            return "^\(scheme)://\(host)\(path).*"
-        case .regexAdvanced:
-            return "\(scheme)://\(host)\(path)"
-        }
-    }
-
-    private static func generateDomainPattern(from host: String, mode: NetworkConditionsMatchMode) -> String {
-        let escapedHost = escapeRegex(host)
-        switch mode {
-        case .exactPath:
-            return "^https://\(escapedHost)/?$"
-        case .includeSubpaths:
-            return "^https://\(escapedHost)/.*"
-        case .regexAdvanced:
-            return ".*\(escapedHost).*"
-        }
+    private static func hostText(from pattern: String?) -> String {
+        NetworkConditionsPatternFormatter.hostText(from: pattern)
     }
 
     private func saveRule() {
+        let trimmedHost = hostText.trimmingCharacters(in: .whitespacesAndNewlines)
         let condition = RuleMatchCondition(
-            urlPattern: urlPattern.isEmpty ? nil : urlPattern
+            urlPattern: applySystemWide || trimmedHost.isEmpty ? nil : NetworkConditionsPatternFormatter
+                .hostScopedPattern(from: trimmedHost)
         )
         let rule = ProxyRule(
             id: existingID ?? UUID(),

--- a/Rockxy/Views/Scripting/ScriptCodeEditor.swift
+++ b/Rockxy/Views/Scripting/ScriptCodeEditor.swift
@@ -106,7 +106,6 @@ struct ScriptCodeEditor: NSViewRepresentable {
         textView.delegate = context.coordinator
         scrollView.drawsBackground = true
         scrollView.backgroundColor = .textBackgroundColor
-        scrollView.borderType = .noBorder
         scrollView.hasHorizontalScroller = true
         scrollView.autohidesScrollers = true
 

--- a/Rockxy/Views/Scripting/ScriptCodeEditor.swift
+++ b/Rockxy/Views/Scripting/ScriptCodeEditor.swift
@@ -106,6 +106,7 @@ struct ScriptCodeEditor: NSViewRepresentable {
         textView.delegate = context.coordinator
         scrollView.drawsBackground = true
         scrollView.backgroundColor = .textBackgroundColor
+        scrollView.borderType = .noBorder
         scrollView.hasHorizontalScroller = true
         scrollView.autohidesScrollers = true
 

--- a/Rockxy/Views/Scripting/ScriptCodeEditor.swift
+++ b/Rockxy/Views/Scripting/ScriptCodeEditor.swift
@@ -16,11 +16,51 @@ struct ScriptCodeEditor: NSViewRepresentable {
 
         // MARK: Internal
 
+        var highlightTask: Task<Void, Never>?
+
+        deinit {
+            highlightTask?.cancel()
+        }
+
         func textDidChange(_ notification: Notification) {
             guard let textView = notification.object as? NSTextView else {
                 return
             }
             text.wrappedValue = textView.string
+            if let scrollView = textView.enclosingScrollView {
+                scheduleHighlight(text: textView.string, in: scrollView)
+            }
+        }
+
+        @MainActor
+        func scheduleHighlight(text: String, in scrollView: NSScrollView) {
+            highlightTask?.cancel()
+
+            highlightTask = Task { [weak scrollView] in
+                let spans = await Task.detached(priority: .utility) {
+                    ScriptCodeHighlighting.spans(for: text)
+                }.value
+
+                guard !Task.isCancelled,
+                      let scrollView,
+                      let textView = scrollView.documentView as? NSTextView,
+                      textView.string == text else
+                {
+                    return
+                }
+
+                let selectedRange = textView.selectedRange()
+                let highlighted = ScriptCodeHighlighting.highlightedString(text, spans: spans)
+                textView.undoManager?.disableUndoRegistration()
+                textView.textStorage?.setAttributedString(highlighted)
+                textView.undoManager?.enableUndoRegistration()
+                textView.typingAttributes = ScriptCodeHighlighting.baseAttributes
+                textView.setSelectedRange(ScriptCodeEditorRulerLayout.clamped(
+                    range: selectedRange,
+                    length: highlighted.length
+                ))
+                (scrollView.verticalRulerView as? ScriptCodeEditorRulerView)?.invalidateLineNumbers()
+            }
         }
 
         // MARK: Private
@@ -43,11 +83,31 @@ struct ScriptCodeEditor: NSViewRepresentable {
         textView.isAutomaticDashSubstitutionEnabled = false
         textView.isAutomaticTextReplacementEnabled = false
         textView.isAutomaticSpellingCorrectionEnabled = false
-        textView.font = NSFont.monospacedSystemFont(ofSize: 13, weight: .regular)
-        textView.textColor = NSColor.textColor
-        textView.backgroundColor = NSColor.textBackgroundColor
-        textView.isRichText = false
+        textView.font = ScriptCodeHighlighting.font
+        textView.textColor = .textColor
+        textView.backgroundColor = .textBackgroundColor
+        textView.textContainerInset = NSSize(width: 8, height: 6)
+        textView.isRichText = true
+        textView.importsGraphics = false
+        textView.isHorizontallyResizable = true
+        textView.isVerticallyResizable = true
+        textView.minSize = NSSize(width: 0, height: 0)
+        textView.maxSize = NSSize(
+            width: CGFloat.greatestFiniteMagnitude,
+            height: CGFloat.greatestFiniteMagnitude
+        )
+        textView.autoresizingMask = [.width]
+        textView.textContainer?.containerSize = NSSize(
+            width: CGFloat.greatestFiniteMagnitude,
+            height: CGFloat.greatestFiniteMagnitude
+        )
+        textView.textContainer?.widthTracksTextView = false
+        textView.typingAttributes = ScriptCodeHighlighting.baseAttributes
         textView.delegate = context.coordinator
+        scrollView.drawsBackground = true
+        scrollView.backgroundColor = .textBackgroundColor
+        scrollView.hasHorizontalScroller = true
+        scrollView.autohidesScrollers = true
 
         let ruler = ScriptCodeEditorRulerView(textView: textView)
         scrollView.verticalRulerView = ruler
@@ -55,21 +115,124 @@ struct ScriptCodeEditor: NSViewRepresentable {
         scrollView.rulersVisible = true
 
         textView.string = text
+        context.coordinator.scheduleHighlight(text: text, in: scrollView)
         return scrollView
     }
 
-    func updateNSView(_ nsView: NSScrollView, context _: Context) {
+    func updateNSView(_ nsView: NSScrollView, context: Context) {
         guard let textView = nsView.documentView as? NSTextView else {
             return
         }
         if textView.string != text {
             textView.string = text
+            context.coordinator.scheduleHighlight(text: text, in: nsView)
             (nsView.verticalRulerView as? ScriptCodeEditorRulerView)?.invalidateLineNumbers()
         }
     }
 
     func makeCoordinator() -> Coordinator {
         Coordinator(text: $text)
+    }
+}
+
+// MARK: - ScriptCodeHighlighting
+
+enum ScriptCodeHighlighting {
+    struct Span: Sendable, Equatable {
+        let range: NSRange
+        let role: Role
+    }
+
+    enum Role: Sendable, Equatable {
+        case comment
+        case string
+        case keyword
+        case function
+        case number
+        case bool
+        case null
+        case punctuation
+
+        @MainActor var color: NSColor {
+            switch self {
+            case .comment:
+                .secondaryLabelColor
+            case .string:
+                Theme.JSON.stringNS
+            case .keyword:
+                Theme.JSON.boolNS
+            case .function:
+                Theme.JSON.keyNS
+            case .number:
+                Theme.JSON.numberNS
+            case .bool:
+                Theme.JSON.boolNS
+            case .null:
+                Theme.JSON.nullNS
+            case .punctuation:
+                Theme.JSON.bracketNS
+            }
+        }
+    }
+
+    @MainActor
+    static let font = NSFont.monospacedSystemFont(ofSize: 13, weight: .regular)
+
+    @MainActor
+    static var baseAttributes: [NSAttributedString.Key: Any] {
+        [
+            .font: font,
+            .foregroundColor: NSColor.textColor,
+            .backgroundColor: NSColor.textBackgroundColor,
+        ]
+    }
+
+    @MainActor
+    static func highlightedString(_ text: String, spans: [Span]) -> NSMutableAttributedString {
+        let attributed = NSMutableAttributedString(string: text, attributes: baseAttributes)
+        for span in spans where NSMaxRange(span.range) <= attributed.length {
+            attributed.addAttribute(.foregroundColor, value: span.role.color, range: span.range)
+        }
+        return attributed
+    }
+
+    nonisolated static func spans(for text: String) -> [Span] {
+        let fullRange = NSRange(location: 0, length: (text as NSString).length)
+        var spans: [Span] = []
+        appendSpans(#""(?:\\.|[^"\\])*""#, role: .string, text: text, range: fullRange, spans: &spans)
+        appendSpans(
+            #"\b(?:async|await|break|case|catch|class|const|continue|default|else|export|for|function|if|import|let|return|switch|throw|try|var|while)\b"#,
+            role: .keyword,
+            text: text,
+            range: fullRange,
+            spans: &spans
+        )
+        appendSpans(#"\b[A-Za-z_$][A-Za-z0-9_$]*(?=\s*\()"#, role: .function, text: text, range: fullRange, spans: &spans)
+        appendSpans(#"(?<![\w.])-?\b\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\b"#, role: .number, text: text, range: fullRange, spans: &spans)
+        appendSpans(#"\b(?:true|false)\b"#, role: .bool, text: text, range: fullRange, spans: &spans)
+        appendSpans(#"\b(?:null|undefined)\b"#, role: .null, text: text, range: fullRange, spans: &spans)
+        appendSpans(#"[\{\}\[\]\(\),.;:]"#, role: .punctuation, text: text, range: fullRange, spans: &spans)
+        appendSpans(#"(?m)//.*$"#, role: .comment, text: text, range: fullRange, spans: &spans)
+        appendSpans(#"/\*[\s\S]*?\*/"#, role: .comment, text: text, range: fullRange, spans: &spans)
+        return spans
+    }
+
+    nonisolated private static func appendSpans(
+        _ pattern: String,
+        role: Role,
+        text: String,
+        range: NSRange,
+        spans: inout [Span]
+    ) {
+        guard let regex = try? NSRegularExpression(pattern: pattern) else {
+            return
+        }
+        regex.enumerateMatches(in: text, range: range) { match, _, _ in
+            guard let match else {
+                return
+            }
+            spans.append(Span(range: match.range, role: role))
+        }
     }
 }
 
@@ -211,6 +374,15 @@ final class ScriptCodeEditorRulerView: NSRulerView {
 
 enum ScriptCodeEditorRulerLayout {
     static let labelTrailingPadding: CGFloat = 4
+
+    static func clamped(range: NSRange, length: Int) -> NSRange {
+        guard range.location != NSNotFound else {
+            return NSRange(location: 0, length: 0)
+        }
+        let location = min(range.location, length)
+        let upperBound = min(range.location + range.length, length)
+        return NSRange(location: location, length: max(0, upperBound - location))
+    }
 
     static func visibleTextContainerRect(contentBounds: NSRect, textContainerOrigin: NSPoint) -> NSRect {
         NSRect(

--- a/Rockxy/Views/Scripting/ScriptCodeEditor.swift
+++ b/Rockxy/Views/Scripting/ScriptCodeEditor.swift
@@ -64,6 +64,7 @@ struct ScriptCodeEditor: NSViewRepresentable {
         }
         if textView.string != text {
             textView.string = text
+            (nsView.verticalRulerView as? ScriptCodeEditorRulerView)?.invalidateLineNumbers()
         }
     }
 
@@ -75,7 +76,7 @@ struct ScriptCodeEditor: NSViewRepresentable {
 // MARK: - ScriptCodeEditorRulerView
 
 /// Draws monospaced line numbers alongside the code editor. Re-renders on
-/// text changes via `NSText.didChangeNotification`.
+/// text changes, scroll bounds changes, and text view layout changes.
 final class ScriptCodeEditorRulerView: NSRulerView {
     // MARK: Lifecycle
 
@@ -84,11 +85,27 @@ final class ScriptCodeEditorRulerView: NSRulerView {
         super.init(scrollView: textView.enclosingScrollView, orientation: .verticalRuler)
         self.ruleThickness = 40
         self.clientView = textView
+        scrollView?.contentView.postsBoundsChangedNotifications = true
+        textView.postsFrameChangedNotifications = true
 
         NotificationCenter.default.addObserver(
             self,
-            selector: #selector(textDidChange),
+            selector: #selector(invalidateLineNumbers),
             name: NSText.didChangeNotification,
+            object: textView
+        )
+        if let contentView = scrollView?.contentView {
+            NotificationCenter.default.addObserver(
+                self,
+                selector: #selector(invalidateLineNumbers),
+                name: NSView.boundsDidChangeNotification,
+                object: contentView
+            )
+        }
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(invalidateLineNumbers),
+            name: NSView.frameDidChangeNotification,
             object: textView
         )
     }
@@ -98,30 +115,38 @@ final class ScriptCodeEditorRulerView: NSRulerView {
         fatalError("init(coder:) has not been implemented")
     }
 
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+
     // MARK: Internal
 
     override func drawHashMarksAndLabels(in rect: NSRect) {
+        let dirtyRect = bounds.intersection(rect)
+        NSColor.textBackgroundColor.setFill()
+        dirtyRect.fill()
+        NSGraphicsContext.current?.saveGraphicsState()
+        dirtyRect.clip()
+        defer {
+            NSGraphicsContext.current?.restoreGraphicsState()
+        }
+
         guard let textView,
               let layoutManager = textView.layoutManager,
-              let textContainer = textView.textContainer else
+              let textContainer = textView.textContainer,
+              let contentView = scrollView?.contentView else
         {
             return
         }
 
-        let visibleRect = scrollView?.contentView.bounds ?? rect
-        let visibleGlyphRange = layoutManager.glyphRange(forBoundingRect: visibleRect, in: textContainer)
-        let visibleCharRange = layoutManager.characterRange(forGlyphRange: visibleGlyphRange, actualGlyphRange: nil)
+        layoutManager.ensureLayout(for: textContainer)
 
         let content = textView.string as NSString
-        var lineNumber = 1
-        var index = 0
-
-        while index < visibleCharRange.location {
-            if content.character(at: index) == 0x0A {
-                lineNumber += 1
-            }
-            index += 1
-        }
+        let visibleRect = ScriptCodeEditorRulerLayout.visibleTextContainerRect(
+            contentBounds: contentView.bounds,
+            textContainerOrigin: textView.textContainerOrigin
+        )
+        let visibleGlyphRange = layoutManager.glyphRange(forBoundingRect: visibleRect, in: textContainer)
 
         let attrs: [NSAttributedString.Key: Any] = [
             .font: NSFont.monospacedDigitSystemFont(ofSize: 11, weight: .regular),
@@ -129,39 +154,95 @@ final class ScriptCodeEditorRulerView: NSRulerView {
         ]
 
         var glyphIndex = visibleGlyphRange.location
+        var lastLineRange = NSRange(location: NSNotFound, length: 0)
         while glyphIndex < NSMaxRange(visibleGlyphRange) {
             let charIndex = layoutManager.characterIndexForGlyph(at: glyphIndex)
             let lineRange = content.lineRange(for: NSRange(location: charIndex, length: 0))
-            var lineRect = layoutManager.boundingRect(
-                forGlyphRange: layoutManager.glyphRange(
-                    forCharacterRange: NSRange(location: lineRange.location, length: 0),
-                    actualCharacterRange: nil
-                ),
-                in: textContainer
+            let lineGlyphRange = layoutManager.glyphRange(forCharacterRange: lineRange, actualCharacterRange: nil)
+            if lineRange.location == lastLineRange.location, lineRange.length == lastLineRange.length {
+                glyphIndex = max(NSMaxRange(lineGlyphRange), glyphIndex + 1)
+                continue
+            }
+            lastLineRange = lineRange
+
+            var effectiveGlyphRange = NSRange(location: 0, length: 0)
+            let lineRect = layoutManager.lineFragmentRect(
+                forGlyphAt: glyphIndex,
+                effectiveRange: &effectiveGlyphRange,
+                withoutAdditionalLayout: true
             )
-            lineRect.origin.y += textView.textContainerInset.height - (scrollView?.contentView.bounds.origin.y ?? 0)
+            let lineNumber = ScriptCodeEditorRulerLayout.lineNumber(
+                in: content,
+                forCharacterAt: lineRange.location
+            )
 
             let str = "\(lineNumber)" as NSString
             let size = str.size(withAttributes: attrs)
+            let y = ScriptCodeEditorRulerLayout.rulerY(
+                lineFragmentY: lineRect.origin.y,
+                textContainerOriginY: textView.textContainerOrigin.y,
+                contentOffsetY: contentView.bounds.origin.y
+            )
             str.draw(
-                at: NSPoint(x: ruleThickness - size.width - 4, y: lineRect.origin.y),
+                at: NSPoint(
+                    x: ScriptCodeEditorRulerLayout.labelX(ruleThickness: ruleThickness, labelWidth: size.width),
+                    y: y
+                ),
                 withAttributes: attrs
             )
 
-            lineNumber += 1
-            glyphIndex = NSMaxRange(layoutManager.glyphRange(
-                forCharacterRange: lineRange,
-                actualCharacterRange: nil
-            ))
+            let nextGlyphIndex = max(NSMaxRange(lineGlyphRange), NSMaxRange(effectiveGlyphRange), glyphIndex + 1)
+            glyphIndex = nextGlyphIndex
         }
+    }
+
+    @objc
+    func invalidateLineNumbers() {
+        needsDisplay = true
+        setNeedsDisplay(bounds)
     }
 
     // MARK: Private
 
     private weak var textView: NSTextView?
+}
 
-    @objc
-    private func textDidChange(_: Notification) {
-        needsDisplay = true
+// MARK: - ScriptCodeEditorRulerLayout
+
+enum ScriptCodeEditorRulerLayout {
+    static let labelTrailingPadding: CGFloat = 4
+
+    static func visibleTextContainerRect(contentBounds: NSRect, textContainerOrigin: NSPoint) -> NSRect {
+        NSRect(
+            x: contentBounds.origin.x - textContainerOrigin.x,
+            y: contentBounds.origin.y - textContainerOrigin.y,
+            width: contentBounds.width,
+            height: contentBounds.height
+        )
+    }
+
+    static func lineNumber(in content: NSString, forCharacterAt characterIndex: Int) -> Int {
+        let end = min(max(characterIndex, 0), content.length)
+        guard end > 0 else {
+            return 1
+        }
+
+        var lineNumber = 1
+        var index = 0
+        while index < end {
+            if content.character(at: index) == 0x0A {
+                lineNumber += 1
+            }
+            index += 1
+        }
+        return lineNumber
+    }
+
+    static func rulerY(lineFragmentY: CGFloat, textContainerOriginY: CGFloat, contentOffsetY: CGFloat) -> CGFloat {
+        lineFragmentY + textContainerOriginY - contentOffsetY
+    }
+
+    static func labelX(ruleThickness: CGFloat, labelWidth: CGFloat) -> CGFloat {
+        max(0, ruleThickness - labelWidth - labelTrailingPadding)
     }
 }

--- a/Rockxy/Views/Scripting/ScriptConsolePanel.swift
+++ b/Rockxy/Views/Scripting/ScriptConsolePanel.swift
@@ -11,45 +11,24 @@ struct ScriptConsolePanel: View {
     @Bindable var viewModel: ScriptEditorViewModel
 
     var body: some View {
-        VStack(spacing: 0) {
-            header
-            Divider()
-            content
-        }
+        content
         .frame(maxHeight: .infinity)
     }
 
     // MARK: Private
 
-    private var header: some View {
-        HStack {
-            Text(viewModel.consoleEntries.isEmpty ? "Empty Console" : "Console")
-                .font(.subheadline.weight(.semibold))
-            Spacer()
-            Button {
-                viewModel.clearConsole()
-            } label: {
-                Image(systemName: "trash")
-                    .foregroundStyle(.secondary)
-            }
-            .buttonStyle(.plain)
-            .disabled(viewModel.consoleEntries.isEmpty)
-        }
-        .padding(.horizontal, 12)
-        .padding(.vertical, 8)
-        .background(.quaternary.opacity(0.3))
-    }
-
     @ViewBuilder private var content: some View {
         let visible = viewModel.consoleEntries.filter { viewModel.consoleFilter.contains($0.level) }
         if visible.isEmpty {
-            VStack(alignment: .leading, spacing: 4) {
+            VStack(spacing: 6) {
+                Text("Empty Console")
+                    .font(.system(size: 16))
+                    .foregroundStyle(.primary)
                 Text("Use console.log() to log events")
                     .font(.caption)
                     .foregroundStyle(.secondary)
-                Spacer()
             }
-            .padding(12)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
         } else {
             ScrollViewReader { proxy in
                 ScrollView {

--- a/Rockxy/Views/Scripting/ScriptEditorMenuContent.swift
+++ b/Rockxy/Views/Scripting/ScriptEditorMenuContent.swift
@@ -1,0 +1,14 @@
+// MARK: - ScriptEditorMenuContent
+
+enum ScriptEditorMenuContent {
+    static let methodSections: [[ScriptMatchMethod]] = [
+        [.any],
+        [.get, .post, .put, .delete, .patch],
+        [.head, .options, .trace],
+    ]
+
+    static let patternModeSections: [[ScriptMatchPatternMode]] = [
+        [.wildcard, .regex],
+        [.advanced],
+    ]
+}

--- a/Rockxy/Views/Scripting/ScriptEditorWindowView.swift
+++ b/Rockxy/Views/Scripting/ScriptEditorWindowView.swift
@@ -185,7 +185,6 @@ struct ScriptEditorWindowView: View {
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             if viewModel.consolePanelVisible {
-                Divider()
                 ScriptConsolePanel(viewModel: viewModel)
                     .frame(width: 230)
             }

--- a/Rockxy/Views/Scripting/ScriptEditorWindowView.swift
+++ b/Rockxy/Views/Scripting/ScriptEditorWindowView.swift
@@ -185,6 +185,7 @@ struct ScriptEditorWindowView: View {
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             if viewModel.consolePanelVisible {
+                Divider()
                 ScriptConsolePanel(viewModel: viewModel)
                     .frame(width: 230)
             }

--- a/Rockxy/Views/Scripting/ScriptEditorWindowView.swift
+++ b/Rockxy/Views/Scripting/ScriptEditorWindowView.swift
@@ -35,57 +35,73 @@ struct ScriptEditorWindowView: View {
             Text("Matching Rule")
                 .font(.headline)
 
-            HStack(spacing: 8) {
-                Text("Name:")
-                TextField("", text: $viewModel.name)
-                    .textFieldStyle(.roundedBorder)
-                    .frame(width: 260)
-                Spacer()
-            }
+            VStack(alignment: .leading, spacing: 9) {
+                HStack(spacing: 8) {
+                    Text("Name:")
+                        .frame(width: 58, alignment: .trailing)
+                    TextField("", text: $viewModel.name)
+                        .textFieldStyle(.roundedBorder)
+                }
 
-            HStack(spacing: 8) {
-                Text("URL:")
-                TextField("", text: $viewModel.urlPattern)
-                    .textFieldStyle(.roundedBorder)
-                    .font(.system(size: 12, design: .monospaced))
-                    .frame(width: 420)
+                HStack(spacing: 8) {
+                    Text("URL:")
+                        .frame(width: 58, alignment: .trailing)
+                    TextField("", text: $viewModel.urlPattern)
+                        .textFieldStyle(.roundedBorder)
+                        .font(.system(size: 12, design: .monospaced))
+                }
 
-                methodMenu
-                patternModeMenu
+                HStack(spacing: 8) {
+                    Spacer()
+                        .frame(width: 66)
 
-                if viewModel.patternMode == .wildcard {
-                    Text("Support wildcard * and ?.")
+                    methodMenu
+                    patternModeMenu
+
+                    if viewModel.patternMode == .wildcard {
+                        Text("Support wildcard * and ?.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+
+                    Button {
+                        let sample = viewModel.sampleURL.trimmingCharacters(in: .whitespacesAndNewlines)
+                        let effectiveSample = sample.isEmpty ? "https://api.example.com/path" : sample
+                        viewModel.testRulePreview = viewModel.testRule(against: effectiveSample)
+                            ? "Matches: \(effectiveSample)"
+                            : "No match for: \(effectiveSample)"
+                    } label: {
+                        Text("Test your Rule")
+                            .font(.caption.weight(.medium))
+                    }
+                    .buttonStyle(.plain)
+                    .foregroundStyle(Color.accentColor)
+
+                    Spacer(minLength: 0)
+                }
+
+                Toggle(isOn: $viewModel.includeSubpaths) {
+                    Text("Include all subpaths of this URL")
+                }
+                .toggleStyle(.checkbox)
+                .padding(.leading, 66)
+
+                if !viewModel.testRulePreview.isEmpty {
+                    Text(viewModel.testRulePreview)
                         .font(.caption)
                         .foregroundStyle(.secondary)
+                        .padding(.leading, 66)
                 }
-
-                Button {
-                    let sample = viewModel.sampleURL.trimmingCharacters(in: .whitespacesAndNewlines)
-                    let effectiveSample = sample.isEmpty ? "https://api.example.com/path" : sample
-                    viewModel.testRulePreview = viewModel.testRule(against: effectiveSample)
-                        ? "Matches: \(effectiveSample)"
-                        : "No match for: \(effectiveSample)"
-                } label: {
-                    Text("Test your Rule")
-                        .font(.caption.weight(.medium))
-                }
-                .buttonStyle(.plain)
-                .foregroundStyle(Color.accentColor)
             }
-
-            if !viewModel.testRulePreview.isEmpty {
-                Text(viewModel.testRulePreview)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            }
-
-            Toggle(isOn: $viewModel.includeSubpaths) {
-                Text("Include all subpaths of this URL")
-            }
-            .toggleStyle(.checkbox)
+            .padding(.horizontal, 14)
+            .padding(.vertical, 9)
+            .background(
+                RoundedRectangle(cornerRadius: 10, style: .continuous)
+                    .fill(Color(nsColor: .controlBackgroundColor).opacity(0.65))
+            )
         }
-        .padding(.horizontal, 20)
-        .padding(.vertical, 14)
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
     }
 
     private var methodMenu: some View {
@@ -142,7 +158,6 @@ struct ScriptEditorWindowView: View {
                 .toggleStyle(.checkbox)
             Toggle(isOn: $viewModel.runOnResponse) { Text("Response") }
                 .toggleStyle(.checkbox)
-            Divider().frame(height: 14)
             Toggle(isOn: $viewModel.runAsMock) { Text("Run as Mock API") }
                 .toggleStyle(.checkbox)
             Spacer()

--- a/Rockxy/Views/Scripting/ScriptEditorWindowView.swift
+++ b/Rockxy/Views/Scripting/ScriptEditorWindowView.swift
@@ -179,9 +179,14 @@ struct ScriptEditorWindowView: View {
         HStack(spacing: 0) {
             VStack(spacing: 0) {
                 matchingRuleHeader
+                    .zIndex(1)
                 runOnRow
+                    .zIndex(1)
                 Divider()
+                    .zIndex(1)
                 ScriptCodeEditor(text: $viewModel.code)
+                    .clipped()
+                    .zIndex(0)
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             if viewModel.consolePanelVisible {

--- a/Rockxy/Views/Scripting/ScriptEditorWindowView.swift
+++ b/Rockxy/Views/Scripting/ScriptEditorWindowView.swift
@@ -7,10 +7,6 @@ struct ScriptEditorWindowView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            matchingRuleHeader
-            Divider()
-            runOnRow
-            Divider()
             bodySplit
             Divider()
             footer
@@ -54,47 +50,14 @@ struct ScriptEditorWindowView: View {
                     .font(.system(size: 12, design: .monospaced))
                     .frame(width: 420)
 
-                Picker("", selection: $viewModel.method) {
-                    ForEach([
-                        ScriptMatchMethod.any,
-                    ]) { Text($0.label).tag($0) }
-                    Divider()
-                    ForEach([
-                        ScriptMatchMethod.get,
-                        ScriptMatchMethod.post,
-                        ScriptMatchMethod.put,
-                        ScriptMatchMethod.delete,
-                        ScriptMatchMethod.patch,
-                    ]) { Text($0.label).tag($0) }
-                    Divider()
-                    ForEach([
-                        ScriptMatchMethod.head,
-                        ScriptMatchMethod.options,
-                        ScriptMatchMethod.trace,
-                    ]) { Text($0.label).tag($0) }
-                }
-                .labelsHidden()
-                .frame(width: 90)
-
-                Picker("", selection: $viewModel.patternMode) {
-                    Text("Use Wildcard").tag(ScriptMatchPatternMode.wildcard)
-                    Text("Use Regex").tag(ScriptMatchPatternMode.regex)
-                    Divider()
-                    Text("Advanced").tag(ScriptMatchPatternMode.advanced)
-                }
-                .labelsHidden()
-                .frame(width: 140)
+                methodMenu
+                patternModeMenu
 
                 if viewModel.patternMode == .wildcard {
                     Text("Support wildcard * and ?.")
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }
-
-                TextField(String(localized: "Sample URL"), text: $viewModel.sampleURL)
-                    .textFieldStyle(.roundedBorder)
-                    .font(.system(size: 12, design: .monospaced))
-                    .frame(width: 240)
 
                 Button {
                     let sample = viewModel.sampleURL.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -123,6 +86,50 @@ struct ScriptEditorWindowView: View {
         }
         .padding(.horizontal, 20)
         .padding(.vertical, 14)
+    }
+
+    private var methodMenu: some View {
+        Menu {
+            ForEach(Array(ScriptEditorMenuContent.methodSections.enumerated()), id: \.offset) { index, section in
+                ForEach(section) { method in
+                    Button {
+                        viewModel.method = method
+                    } label: {
+                        menuCheckmarkLabel(method.label, isSelected: viewModel.method == method)
+                    }
+                }
+                if index < ScriptEditorMenuContent.methodSections.count - 1 {
+                    Divider()
+                }
+            }
+        } label: {
+            menuLabel(viewModel.method.label, minWidth: 88)
+        }
+        .menuIndicator(.hidden)
+        .buttonStyle(.bordered)
+        .fixedSize()
+    }
+
+    private var patternModeMenu: some View {
+        Menu {
+            ForEach(Array(ScriptEditorMenuContent.patternModeSections.enumerated()), id: \.offset) { index, section in
+                ForEach(section) { mode in
+                    Button {
+                        viewModel.patternMode = mode
+                    } label: {
+                        menuCheckmarkLabel(mode.title, isSelected: viewModel.patternMode == mode)
+                    }
+                }
+                if index < ScriptEditorMenuContent.patternModeSections.count - 1 {
+                    Divider()
+                }
+            }
+        } label: {
+            menuLabel(viewModel.patternMode.title, minWidth: 128)
+        }
+        .menuIndicator(.hidden)
+        .buttonStyle(.bordered)
+        .fixedSize()
     }
 
     // MARK: - Run On row
@@ -155,12 +162,17 @@ struct ScriptEditorWindowView: View {
 
     private var bodySplit: some View {
         HStack(spacing: 0) {
-            ScriptCodeEditor(text: $viewModel.code)
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            VStack(spacing: 0) {
+                matchingRuleHeader
+                runOnRow
+                Divider()
+                ScriptCodeEditor(text: $viewModel.code)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
             if viewModel.consolePanelVisible {
                 Divider()
                 ScriptConsolePanel(viewModel: viewModel)
-                    .frame(width: 320)
+                    .frame(width: 230)
             }
         }
     }
@@ -169,20 +181,22 @@ struct ScriptEditorWindowView: View {
 
     private var footer: some View {
         HStack(spacing: 8) {
-            Menu("More") {
+            Menu {
                 moreMenuItems
             }
-            .menuStyle(.borderlessButton)
+            label: {
+                menuLabel(String(localized: "More"))
+            }
+            .menuIndicator(.hidden)
+            .buttonStyle(.bordered)
             .fixedSize()
 
             Button {
                 viewModel.beautify()
             } label: {
-                HStack(spacing: 4) {
-                    Text("Beautify")
-                    Text("⌘B").foregroundStyle(.secondary)
-                }
+                Text("Beautify (⌘B)")
             }
+            .buttonStyle(.bordered)
             .keyboardShortcut("b", modifiers: .command)
 
             Button {
@@ -191,20 +205,16 @@ struct ScriptEditorWindowView: View {
             } label: {
                 Text("Snippet Code")
             }
+            .buttonStyle(.bordered)
 
             Spacer()
 
             Button {
                 Task { await viewModel.saveAndActivate() }
             } label: {
-                HStack(spacing: 6) {
-                    Text("Save & Activate")
-                        .fontWeight(.semibold)
-                    Text("⌘S")
-                        .foregroundStyle(.white.opacity(0.85))
-                }
+                Text("Save & Activate ⌘S")
             }
-            .buttonStyle(.borderedProminent)
+            .buttonStyle(.bordered)
             .keyboardShortcut("s", modifiers: .command)
 
             Menu {
@@ -221,13 +231,40 @@ struct ScriptEditorWindowView: View {
                     )) { Text(level.title) }
                 }
             } label: {
-                Image(systemName: "eye")
+                HStack(spacing: 3) {
+                    Image(systemName: "eye")
+                    Image(systemName: "chevron.down")
+                        .font(.system(size: 8, weight: .semibold))
+                }
             }
-            .menuStyle(.borderlessButton)
+            .menuIndicator(.hidden)
+            .buttonStyle(.plain)
             .fixedSize()
+
+            Button {
+                viewModel.clearConsole()
+            } label: {
+                Image(systemName: "trash")
+                    .frame(width: 24, height: 18)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .foregroundStyle(.secondary)
+            .disabled(viewModel.consoleEntries.isEmpty)
+
+            Button {
+                viewModel.toggleConsolePanel()
+            } label: {
+                Image(systemName: "sidebar.right")
+                    .frame(width: 24, height: 18)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .foregroundStyle(.secondary)
         }
         .padding(.horizontal, 12)
-        .padding(.vertical, 7)
+        .padding(.vertical, 4)
+        .background(Color(nsColor: .controlBackgroundColor))
     }
 
     @ViewBuilder private var moreMenuItems: some View {
@@ -256,6 +293,24 @@ struct ScriptEditorWindowView: View {
             Button("Scripting Guide") {} // deferred
             Button("Matching Rules") {}
             Button("Mock Responses") {}
+        }
+    }
+
+    private func menuCheckmarkLabel(_ title: String, isSelected: Bool) -> some View {
+        HStack(spacing: 7) {
+            if isSelected {
+                Image(systemName: "checkmark")
+            }
+            Text(title)
+        }
+    }
+
+    private func menuLabel(_ title: String, minWidth: CGFloat? = nil) -> some View {
+        HStack(spacing: 6) {
+            Text(title)
+                .frame(minWidth: minWidth, alignment: .leading)
+            Image(systemName: "chevron.down")
+                .font(.system(size: 9, weight: .semibold))
         }
     }
 }

--- a/Rockxy/Views/Scripting/ScriptingListWindowView.swift
+++ b/Rockxy/Views/Scripting/ScriptingListWindowView.swift
@@ -7,22 +7,13 @@ struct ScriptingListWindowView: View {
     // MARK: Internal
 
     var body: some View {
-        VStack(spacing: 0) {
-            toolbar
-            Divider()
-            infoBanner
-            Divider()
-            columnHeader
-            Divider()
-            listContent
-            if viewModel.isFilterVisible {
-                Divider()
-                filterBar
-            }
-            Divider()
+        VStack(alignment: .leading, spacing: 0) {
+            header
+            tableContent
+            shortcutStrip
             bottomBar
         }
-        .frame(minWidth: 860, minHeight: 600)
+        .frame(width: 1_200, height: 672)
         .task { await viewModel.load() }
         .onReceive(NotificationCenter.default.publisher(for: .rulesDidChange)) { _ in
             Task { await viewModel.refresh() }
@@ -50,91 +41,176 @@ struct ScriptingListWindowView: View {
         return false
     }
 
-    // MARK: - Toolbar
+    private var selectedRows: Binding<Set<ScriptListRowID>> {
+        Binding(
+            get: {
+                if let selected = viewModel.selectedRowID {
+                    return [selected]
+                }
+                return []
+            },
+            set: { newValue in
+                viewModel.selectedRowID = newValue.first
+            }
+        )
+    }
 
-    private var toolbar: some View {
-        HStack(spacing: 12) {
+    // MARK: - Header
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 10) {
             Toggle(isOn: Binding(
                 get: { viewModel.toolEnabled },
                 set: { viewModel.setToolEnabled($0) }
             )) {
                 Text("Enable Scripting Tool")
-                    .font(.headline)
+                    .font(.system(size: 13))
             }
             .toggleStyle(.checkbox)
-            Spacer()
-        }
-        .padding(.horizontal, 20)
-        .padding(.vertical, 10)
-    }
+            .padding(.top, 16)
 
-    // MARK: - Info banner
-
-    private var infoBanner: some View {
-        VStack(alignment: .leading, spacing: 4) {
             Text(
                 "Modify the Request or Response automatically with JavaScript. Support URL, Status Code, Header, Method, and Body."
             )
-            .font(.system(size: 12))
+            .font(.system(size: 13))
             Text("Each request is checked against the rules from top to bottom, stopping when a match is found.")
-                .font(.system(size: 11))
+                .font(.system(size: 13))
                 .foregroundStyle(.secondary)
+
+            if viewModel.isFilterVisible {
+                filterBar
+            }
         }
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(.horizontal, 20)
-        .padding(.vertical, 8)
-        .background(.quaternary.opacity(0.4))
+        .padding(.horizontal, 18)
+        .padding(.bottom, 10)
     }
 
-    // MARK: - Column header
+    // MARK: - Table
 
-    private var columnHeader: some View {
-        HStack(spacing: 0) {
-            Text("Name")
-                .frame(width: 380 + 34, alignment: .leading)
-            Text("Method")
-                .frame(width: 110, alignment: .leading)
-            Text("Matching Rule")
-                .frame(maxWidth: .infinity, alignment: .leading)
-        }
-        .font(.caption.weight(.semibold))
-        .foregroundStyle(.secondary)
-        .padding(.horizontal, 20)
-        .padding(.vertical, 6)
-        .background(.background.tertiary)
-    }
+    private var tableContent: some View {
+        Table(viewModel.filteredDisplayRows, selection: selectedRows) {
+            TableColumn(String(localized: "Name")) { row in
+                nameCell(for: row)
+            }
+            .width(min: 300, ideal: 340)
 
-    // MARK: - List
-
-    @ViewBuilder private var listContent: some View {
-        if viewModel.filteredDisplayRows.isEmpty {
-            emptyState
-        } else {
-            List(selection: $viewModel.selectedRowID) {
-                ForEach(viewModel.filteredDisplayRows) { row in
-                    ScriptListRow(viewModel: viewModel, row: row)
-                        .tag(row.id)
-                        .contextMenu { rowContextMenu }
+            TableColumn(String(localized: "Method")) { row in
+                switch row.kind {
+                case .folder:
+                    Text("")
+                case let .script(script):
+                    Text(script.method ?? "ANY")
+                        .lineLimit(1)
                 }
             }
-            .listStyle(.inset(alternatesRowBackgrounds: true))
-            .onDeleteCommand { Task { await viewModel.deleteSelection() } }
+            .width(96)
+
+            TableColumn(String(localized: "Matching Rule")) { row in
+                switch row.kind {
+                case .folder:
+                    Text("")
+                case let .script(script):
+                    Text(script.urlPattern?.isEmpty == false ? script.urlPattern ?? "" : "<Missing URL>")
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                        .help(script.urlPattern ?? "<Missing URL>")
+                }
+            }
+            .width(min: 420, ideal: 660)
+        }
+        .contextMenu(forSelectionType: ScriptListRowID.self) { rows in
+            tableContextMenu(rows: rows)
+        } primaryAction: { rows in
+            guard let row = rows.first else {
+                return
+            }
+            primaryAction(for: row)
+        }
+        .overlay {
+            if viewModel.filteredDisplayRows.isEmpty {
+                ContentUnavailableView(
+                    String(localized: "No Scripts"),
+                    systemImage: "curlybraces",
+                    description: Text(String(localized: "Click + to create a new script."))
+                )
+            }
+        }
+        .padding(.horizontal, 18)
+        .onDeleteCommand {
+            Task { await viewModel.deleteSelection() }
         }
     }
 
-    private var emptyState: some View {
-        VStack(spacing: 8) {
-            Image(systemName: "curlybraces")
-                .font(.system(size: 36))
-                .foregroundStyle(.tertiary)
-            Text("No scripts yet")
-                .font(.headline)
-                .foregroundStyle(.secondary)
-            Text("Click + to create a new script.")
-                .font(.caption)
-                .foregroundStyle(.tertiary)
+    private func nameCell(for row: ScriptListDisplayRow) -> some View {
+        HStack(spacing: 6) {
+            Spacer().frame(width: CGFloat(row.indent) * 16)
+            switch row.kind {
+            case let .folder(folder):
+                Button {
+                    viewModel.toggleFolder(id: folder.id)
+                } label: {
+                    Image(systemName: folder.expanded ? "chevron.down" : "chevron.right")
+                        .font(.system(size: 10, weight: .semibold))
+                        .foregroundStyle(.secondary)
+                        .frame(width: 12)
+                }
+                .buttonStyle(.plain)
+
+                Toggle("", isOn: allChildrenBinding(for: folder))
+                    .labelsHidden()
+                    .toggleStyle(.checkbox)
+                    .controlSize(.small)
+
+                Image(systemName: "folder.fill")
+                    .foregroundStyle(.secondary)
+
+                if viewModel.renamingFolderID == folder.id {
+                    TextField(
+                        "",
+                        text: $viewModel.renamingFolderText,
+                        onEditingChanged: { isEditing in
+                            if !isEditing, viewModel.renamingFolderID == folder.id {
+                                viewModel.cancelFolderRename()
+                            }
+                        },
+                        onCommit: {
+                            viewModel.commitFolderRename()
+                        }
+                    )
+                    .textFieldStyle(.roundedBorder)
+                    .frame(width: 200)
+                } else {
+                    Text(folder.name)
+                        .fontWeight(.semibold)
+                        .lineLimit(1)
+                }
+
+            case let .script(script):
+                Spacer().frame(width: row.indent == 0 ? 14 : 0)
+                Toggle("", isOn: Binding(
+                    get: { script.isEnabled },
+                    set: { _ in Task { await viewModel.toggleScript(id: script.id) } }
+                ))
+                .labelsHidden()
+                .toggleStyle(.checkbox)
+                .controlSize(.small)
+                Text(script.name.isEmpty ? String(localized: "Untitled") : script.name)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+                    .foregroundStyle(script.isEnabled ? Color.primary : Color.secondary)
+            }
+            Spacer()
         }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .opacity(row.isEnabled ? 1.0 : 0.6)
+    }
+
+    private var shortcutStrip: some View {
+        Text("New: ⌘N    Edit: ⌘↩    Delete: ⌘⌫    Duplicate: ⌘D    Toggle: ↵")
+            .font(.system(size: 11))
+            .foregroundStyle(.secondary)
+            .padding(.horizontal, 18)
+            .padding(.top, 8)
+            .padding(.bottom, 4)
     }
 
     // MARK: - Bottom bar
@@ -147,6 +223,7 @@ struct ScriptingListWindowView: View {
             } label: {
                 Text("New Folder")
             }
+            .buttonStyle(.bordered)
             .keyboardShortcut("n", modifiers: [.command, .option])
 
             Button {
@@ -161,14 +238,12 @@ struct ScriptingListWindowView: View {
             Button {
                 withAnimation { viewModel.isFilterVisible.toggle() }
             } label: {
-                HStack(spacing: 4) {
-                    Image(systemName: "magnifyingglass")
-                    Text("Filter")
-                }
+                Label(String(localized: "Filter"), systemImage: "magnifyingglass")
             }
+            .buttonStyle(.bordered)
             .keyboardShortcut("f", modifiers: .command)
 
-            Menu("Advance") {
+            Menu {
                 Toggle(isOn: Binding(
                     get: { viewModel.advanceAllowSystemEnvVars },
                     set: { viewModel.setAdvanceAllowSystemEnvVars($0) }
@@ -177,18 +252,24 @@ struct ScriptingListWindowView: View {
                     get: { viewModel.advanceAllowChaining },
                     set: { viewModel.setAdvanceAllowChaining($0) }
                 )) { Text("Allow Running Multiple Scripts for one Request") }
+            } label: {
+                menuLabel(String(localized: "Advance"))
             }
-            .menuStyle(.borderlessButton)
+            .menuIndicator(.hidden)
+            .buttonStyle(.bordered)
             .fixedSize()
 
-            Menu("More") {
+            Menu {
                 moreMenuItems
+            } label: {
+                menuLabel(String(localized: "More"))
             }
-            .menuStyle(.borderlessButton)
+            .menuIndicator(.hidden)
+            .buttonStyle(.bordered)
             .fixedSize()
         }
-        .padding(.horizontal, 12)
-        .padding(.vertical, 6)
+        .padding(.horizontal, 18)
+        .padding(.bottom, 14)
     }
 
     private var addRemoveButtons: some View {
@@ -203,21 +284,36 @@ struct ScriptingListWindowView: View {
                 }
             } label: {
                 Image(systemName: "plus")
-                    .frame(width: 22, height: 22)
+                    .font(.system(size: 12, weight: .regular))
+                    .frame(width: 18, height: 18)
+                    .contentShape(Rectangle())
             }
+            .buttonStyle(.plain)
             .keyboardShortcut("n", modifiers: .command)
 
-            Divider().frame(height: 14)
+            Rectangle()
+                .fill(Color(nsColor: .separatorColor))
+                .frame(width: 1, height: 18)
 
             Button {
                 Task { await viewModel.deleteSelection() }
             } label: {
                 Image(systemName: "minus")
-                    .frame(width: 22, height: 22)
+                    .font(.system(size: 12, weight: .regular))
+                    .frame(width: 18, height: 18)
+                    .contentShape(Rectangle())
             }
+            .buttonStyle(.plain)
+            .keyboardShortcut(.delete, modifiers: .command)
             .disabled(viewModel.selectedRowID == nil)
         }
-        .buttonStyle(.bordered)
+        .foregroundStyle(.primary)
+        .background(Color(nsColor: .controlBackgroundColor))
+        .overlay(
+            Rectangle()
+                .stroke(Color(nsColor: .separatorColor), lineWidth: 1)
+        )
+        .frame(width: 37, height: 19)
     }
 
     @ViewBuilder private var moreMenuItems: some View {
@@ -272,14 +368,12 @@ struct ScriptingListWindowView: View {
             .disabled(viewModel.selectedRowID == nil)
     }
 
-    private var rowContextMenu: some View {
-        moreMenuItems
-    }
-
     // MARK: - Filter bar
 
     private var filterBar: some View {
         HStack(spacing: 8) {
+            Image(systemName: "magnifyingglass")
+                .foregroundStyle(.secondary)
             Picker("", selection: $viewModel.filterColumn) {
                 ForEach(ScriptListFilterColumn.allCases) { column in
                     Text(column.title).tag(column)
@@ -298,9 +392,116 @@ struct ScriptingListWindowView: View {
             }
             .buttonStyle(.plain)
         }
-        .padding(.horizontal, 12)
-        .padding(.vertical, 6)
-        .background(.quaternary.opacity(0.3))
         .transition(.move(edge: .bottom).combined(with: .opacity))
+    }
+
+    private func allChildrenBinding(for folder: ScriptFolder) -> Binding<Bool> {
+        Binding<Bool>(
+            get: {
+                let ids = Set(folder.scriptIDs)
+                let matching = viewModel.plugins.filter { ids.contains($0.id) }
+                return !matching.isEmpty && matching.allSatisfy(\.isEnabled)
+            },
+            set: { newValue in
+                Task {
+                    await viewModel.setScriptsEnabled(ids: folder.scriptIDs, enabled: newValue)
+                }
+            }
+        )
+    }
+
+    private func primaryAction(for row: ScriptListRowID) {
+        switch row {
+        case let .folder(id):
+            viewModel.toggleFolder(id: id)
+        case let .script(id):
+            viewModel.openEditor(for: id)
+            openWindow(id: "scriptEditor")
+        }
+    }
+
+    @ViewBuilder
+    private func tableContextMenu(rows: Set<ScriptListRowID>) -> some View {
+        if let row = rows.first {
+            moreMenuItems(for: row)
+        }
+    }
+
+    @ViewBuilder
+    private func moreMenuItems(for row: ScriptListRowID) -> some View {
+        let previousSelection = viewModel.selectedRowID
+        Button("Edit") {
+            viewModel.selectedRowID = row
+            viewModel.openEditorForSelection()
+            openWindow(id: "scriptEditor")
+            if case .folder = row {
+                viewModel.selectedRowID = previousSelection
+            }
+        }
+        .keyboardShortcut(.return, modifiers: .command)
+        .disabled({
+            if case .script = row {
+                return false
+            }
+            return true
+        }())
+        Button("Duplicate") {
+            viewModel.selectedRowID = row
+            Task { await viewModel.duplicateSelection() }
+        }
+        .keyboardShortcut("d", modifiers: .command)
+        .disabled({
+            if case .script = row {
+                return false
+            }
+            return true
+        }())
+        Button("Toggle") {
+            if case let .script(id) = row {
+                Task { await viewModel.toggleScript(id: id) }
+            }
+        }
+        .keyboardShortcut(.return, modifiers: [])
+        .disabled({
+            if case .script = row {
+                return false
+            }
+            return true
+        }())
+        Button("Rename Folder") {
+            viewModel.selectedRowID = row
+            viewModel.beginRenameSelectedFolder()
+        }
+        .disabled({
+            if case .folder = row {
+                return false
+            }
+            return true
+        }())
+        Divider()
+        Button("Delete", role: .destructive) {
+            viewModel.selectedRowID = row
+            Task { await viewModel.deleteSelection() }
+        }
+        .keyboardShortcut(.delete, modifiers: .command)
+    }
+
+    private func menuLabel(_ title: String) -> some View {
+        HStack(spacing: 6) {
+            Text(title)
+            Image(systemName: "chevron.down")
+                .font(.system(size: 9, weight: .semibold))
+        }
+    }
+}
+
+private extension ScriptListDisplayRow {
+    var isEnabled: Bool {
+        switch kind {
+        case .folder:
+            true
+        case let .script(script):
+            script.isEnabled
+        }
     }
 }

--- a/RockxyTests/Core/Plugins/ScriptBridgeTests.swift
+++ b/RockxyTests/Core/Plugins/ScriptBridgeTests.swift
@@ -61,7 +61,7 @@ struct ScriptBridgeTests {
     func storageSetGetDelete() {
         let context = makeContext()
         let testKey = "unit_test_\(UUID().uuidString)"
-        let storagePrefix = "\(TestIdentity.defaultsPrefix).plugin.\(testPluginID).storage."
+        let storagePrefix = RockxyIdentity.current.pluginStoragePrefix(pluginID: testPluginID)
 
         context.evaluateScript("$rockxy.storage.set('\(testKey)', 'testValue')")
 

--- a/RockxyTests/Core/ProxyEngine/NetworkThrottlePlannerTests.swift
+++ b/RockxyTests/Core/ProxyEngine/NetworkThrottlePlannerTests.swift
@@ -1,4 +1,5 @@
 @testable import Rockxy
+import NIOCore
 import Testing
 
 struct NetworkThrottlePlannerTests {
@@ -32,5 +33,46 @@ struct NetworkThrottlePlannerTests {
 
         #expect(plan.totalDelayMs == 2_000)
         #expect(NetworkThrottlePlanner.millisecondsUntil(nowNanos: 1_000, readyAtNanos: plan.readyAtNanos) == 2_000)
+    }
+
+    @Test("planner splits large payload into bounded chunks")
+    func splitsLargePayloadIntoBoundedChunks() throws {
+        let plan = try #require(NetworkThrottlePlanner.makePlan(
+            byteCount: 200_000,
+            bytesPerSecond: 1_000_000,
+            nowNanos: 0
+        ))
+
+        #expect(plan.chunks.count == 4)
+        #expect(plan.chunks.map(\.offset) == [0, 65_536, 131_072, 196_608])
+        #expect(plan.chunks.map(\.length) == [65_536, 65_536, 65_536, 3_392])
+        #expect(plan.chunks.map(\.delayMs) == [66, 132, 197, 200])
+        #expect(plan.readyAtNanos == 200_000_000)
+    }
+
+    @Test("profile exposes upload and download caps for preset")
+    func profileExposesPresetCaps() {
+        let profile = NetworkConditionProfile(preset: .threeG, latencyMs: 400)
+        let expectedLatency = TimeAmount.milliseconds(400)
+
+        #expect(profile.preset == .threeG)
+        #expect(profile.latencyMs == 400)
+        #expect(profile.downloadBytesPerSecond == 97_500)
+        #expect(profile.uploadBytesPerSecond == 41_250)
+        #expect(profile.packetLossRate == 0.0)
+        #expect(profile.latencyDelay == expectedLatency)
+    }
+
+    @Test("custom profile leaves upload and download unlimited")
+    func customProfileLeavesUploadDownloadUnlimited() {
+        let profile = NetworkConditionProfile(preset: .custom, latencyMs: -10)
+        let expectedLatency = TimeAmount.milliseconds(0)
+
+        #expect(profile.preset == .custom)
+        #expect(profile.latencyMs == 0)
+        #expect(profile.downloadBytesPerSecond == nil)
+        #expect(profile.uploadBytesPerSecond == nil)
+        #expect(profile.packetLossRate == 0.0)
+        #expect(profile.latencyDelay == expectedLatency)
     }
 }

--- a/RockxyTests/Core/ProxyEngine/NetworkThrottlePlannerTests.swift
+++ b/RockxyTests/Core/ProxyEngine/NetworkThrottlePlannerTests.swift
@@ -1,0 +1,36 @@
+@testable import Rockxy
+import Testing
+
+struct NetworkThrottlePlannerTests {
+    @Test("planner returns nil when bandwidth is unlimited")
+    func unlimitedBandwidthReturnsNil() {
+        #expect(NetworkThrottlePlanner.makePlan(byteCount: 1_024, bytesPerSecond: nil) == nil)
+        #expect(NetworkThrottlePlanner.makePlan(byteCount: 1_024, bytesPerSecond: 0) == nil)
+    }
+
+    @Test("planner preserves total bandwidth duration")
+    func totalBandwidthDuration() throws {
+        let plan = try #require(NetworkThrottlePlanner.makePlan(
+            byteCount: 1_000,
+            bytesPerSecond: 500,
+            nowNanos: 1_000
+        ))
+
+        #expect(plan.chunks.count == 1)
+        #expect(plan.chunks[0].length == 1_000)
+        #expect(plan.totalDelayMs == 2_000)
+    }
+
+    @Test("planner chains behind existing response backlog")
+    func chainsBehindBacklog() throws {
+        let plan = try #require(NetworkThrottlePlanner.makePlan(
+            byteCount: 500,
+            bytesPerSecond: 500,
+            nowNanos: 1_000,
+            earliestReadyAtNanos: 1_000_001_000
+        ))
+
+        #expect(plan.totalDelayMs == 2_000)
+        #expect(NetworkThrottlePlanner.millisecondsUntil(nowNanos: 1_000, readyAtNanos: plan.readyAtNanos) == 2_000)
+    }
+}

--- a/RockxyTests/Core/ProxyEngine/SigningDiagnosticsTests.swift
+++ b/RockxyTests/Core/ProxyEngine/SigningDiagnosticsTests.swift
@@ -192,6 +192,7 @@ struct SigningDiagnosticsClassifyTests {
 struct SigningDiagnosticsLiveTests {
     @Test("LiveEnvironment validates test host app signature successfully")
     func liveAppSignatureValid() {
+        guard !TestIdentity.isRunningUnderRawXCTestTool else { return }
         let env = SigningDiagnostics.LiveEnvironment()
         guard env.validateAppSignature() == nil else {
             return
@@ -203,6 +204,7 @@ struct SigningDiagnosticsLiveTests {
 
     @Test("LiveEnvironment resolves the bundled helper executable from the app package")
     func liveBundledHelperExecutableDetected() {
+        guard !TestIdentity.isRunningUnderRawXCTestTool else { return }
         let bundledHelperURL = Bundle.main.bundleURL
             .appendingPathComponent("Contents/Library/HelperTools", isDirectory: true)
             .appendingPathComponent("RockxyHelperTool", isDirectory: false)
@@ -215,6 +217,7 @@ struct SigningDiagnosticsLiveTests {
 
     @Test("LiveEnvironment can extract app certificate chain from test host")
     func liveAppCertificateChainExtractable() {
+        guard !TestIdentity.isRunningUnderRawXCTestTool else { return }
         let env = SigningDiagnostics.LiveEnvironment()
         guard env.validateAppSignature() == nil else {
             return
@@ -227,6 +230,7 @@ struct SigningDiagnosticsLiveTests {
 
     @Test("LiveEnvironment handles helper certificate chain availability")
     func liveHelperCertificateChainAvailability() {
+        guard !TestIdentity.isRunningUnderRawXCTestTool else { return }
         let env = SigningDiagnostics.LiveEnvironment()
         guard env.validateAppSignature() == nil else {
             return
@@ -242,6 +246,7 @@ struct SigningDiagnosticsLiveTests {
 
     @Test("Live classify returns healthy or helperBinaryNotFound depending on helper install state")
     func liveClassifyContract() {
+        guard !TestIdentity.isRunningUnderRawXCTestTool else { return }
         let env = SigningDiagnostics.LiveEnvironment()
         guard env.validateAppSignature() == nil else {
             return

--- a/RockxyTests/Core/RuleEngine/BlockListSettingsCodecTests.swift
+++ b/RockxyTests/Core/RuleEngine/BlockListSettingsCodecTests.swift
@@ -1,0 +1,101 @@
+import Foundation
+@testable import Rockxy
+import Testing
+
+// MARK: - BlockListSettingsCodecTests
+
+struct BlockListSettingsCodecTests {
+    @Test("export includes only block rules")
+    func exportIncludesOnlyBlockRules() throws {
+        let block = TestFixtures.makeRule(name: "Block", action: .block(statusCode: 403))
+        let throttle = TestFixtures.makeRule(name: "Throttle", action: .throttle(delayMs: 100))
+
+        let data = try BlockListSettingsCodec.exportRules([block, throttle])
+        let object = try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let blockRules = try #require(object["blockRules"] as? [[String: Any]])
+
+        #expect(blockRules.count == 1)
+        #expect(blockRules.first?["name"] as? String == "Block")
+    }
+
+    @Test("imports Proxyman-style flat patterns")
+    func importProxymanFlatPatterns() throws {
+        let data = Data(#"["*.example.com/ads/*","api.example.com"]"#.utf8)
+        let rules = try BlockListSettingsCodec.importFromProxyman(data)
+
+        #expect(rules.count == 2)
+        #expect(rules.allSatisfy { rule in
+            if case let .block(statusCode) = rule.action {
+                return statusCode == 403
+            }
+            return false
+        })
+        #expect(rules.first?.matchCondition.urlPattern?.contains(".*") == true)
+    }
+
+    @Test("imports structured Proxyman entries with action and method")
+    func importStructuredProxymanEntries() throws {
+        let data = Data("""
+        {
+          "blockRules": [
+            {"name":"Drop tracker","pattern":"^https://tracker\\\\.example/.*$","matchType":"regex","method":"GET","action":"Drop Connection","enabled":false}
+          ]
+        }
+        """.utf8)
+
+        let rules = try BlockListSettingsCodec.importFromProxyman(data)
+        let rule = try #require(rules.first)
+
+        #expect(rule.name == "Drop tracker")
+        #expect(rule.isEnabled == false)
+        #expect(rule.matchCondition.method == "GET")
+        #expect(rule.matchCondition.urlPattern == #"^https://tracker\.example/.*$"#)
+        if case let .block(statusCode) = rule.action {
+            #expect(statusCode == 0)
+        } else {
+            Issue.record("Expected block action")
+        }
+    }
+
+    @Test("imports Charles Proxy plist locations")
+    func importCharlesProxyLocations() throws {
+        let plist = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0">
+        <dict>
+            <key>location</key>
+            <array>
+                <dict>
+                    <key>host</key>
+                    <string>api.example.com</string>
+                    <key>path</key>
+                    <string>/v1/ads</string>
+                </dict>
+            </array>
+        </dict>
+        </plist>
+        """
+
+        let rules = try BlockListSettingsCodec.importFromCharlesProxy(Data(plist.utf8))
+        let rule = try #require(rules.first)
+
+        #expect(rule.name == "*api.example.com/v1/ads")
+        #expect(rule.matchCondition.urlPattern?.contains("api\\.example\\.com") == true)
+        if case let .block(statusCode) = rule.action {
+            #expect(statusCode == 403)
+        } else {
+            Issue.record("Expected block action")
+        }
+    }
+
+    @Test("invalid import throws")
+    func invalidImportThrows() {
+        #expect(throws: BlockListSettingsCodec.ImportError.self) {
+            try BlockListSettingsCodec.importFromProxyman(Data("not json".utf8))
+        }
+        #expect(throws: BlockListSettingsCodec.ImportError.self) {
+            try BlockListSettingsCodec.importFromCharlesProxy(Data("not plist".utf8))
+        }
+    }
+}

--- a/RockxyTests/Core/RuleEngine/MapRemoteConfigurationCodableTests.swift
+++ b/RockxyTests/Core/RuleEngine/MapRemoteConfigurationCodableTests.swift
@@ -7,9 +7,9 @@ import Testing
 struct MapRemoteConfigurationCodableTests {
     @Test("Legacy URL string decodes into structured configuration")
     func legacyDecode() throws {
-        let json = """
+        let json = Data("""
         {"type":"mapRemote","url":"https://staging.example.com:8443/api/v2?debug=true"}
-        """.data(using: .utf8)!
+        """.utf8)
         let decoded = try JSONDecoder().decode(RuleAction.self, from: json)
 
         if case let .mapRemote(config) = decoded {
@@ -32,6 +32,7 @@ struct MapRemoteConfigurationCodableTests {
             port: 8_443,
             path: "/api/v2",
             query: "debug=true",
+            preserveOriginalURL: true,
             preserveHostHeader: true
         )
         let action = RuleAction.mapRemote(configuration: config)
@@ -44,6 +45,7 @@ struct MapRemoteConfigurationCodableTests {
             #expect(decodedConfig.port == 8_443)
             #expect(decodedConfig.path == "/api/v2")
             #expect(decodedConfig.query == "debug=true")
+            #expect(decodedConfig.preserveOriginalURL == true)
             #expect(decodedConfig.preserveHostHeader == true)
         } else {
             Issue.record("Expected .mapRemote")
@@ -71,9 +73,9 @@ struct MapRemoteConfigurationCodableTests {
 
     @Test("Empty configuration decodes without error")
     func emptyConfig() throws {
-        let json = """
+        let json = Data("""
         {"type":"mapRemote","configuration":{}}
-        """.data(using: .utf8)!
+        """.utf8)
         let decoded = try JSONDecoder().decode(RuleAction.self, from: json)
 
         if case let .mapRemote(config) = decoded {

--- a/RockxyTests/Core/RuleEngine/RuleActionTests.swift
+++ b/RockxyTests/Core/RuleEngine/RuleActionTests.swift
@@ -39,10 +39,11 @@ struct RuleActionTests {
         let url = try #require(URL(string: "https://api.test/data"))
         let result = await engine.evaluate(method: "GET", url: url, headers: [])
 
-        if case let .mapLocal(filePath, statusCode, isDirectory) = result {
+        if case let .mapLocal(filePath, statusCode, isDirectory, delayMs) = result {
             #expect(filePath == "/tmp/mock.json")
             #expect(statusCode == 200)
             #expect(isDirectory == false)
+            #expect(delayMs == 0)
         } else {
             Issue.record("Expected .mapLocal action")
         }
@@ -248,10 +249,11 @@ struct RuleActionTests {
             switch (action, decoded) {
             case let (.block(a), .block(b)):
                 #expect(a == b)
-            case let (.mapLocal(aPath, aStatus, aIsDir), .mapLocal(bPath, bStatus, bIsDir)):
+            case let (.mapLocal(aPath, aStatus, aIsDir, aDelay), .mapLocal(bPath, bStatus, bIsDir, bDelay)):
                 #expect(aPath == bPath)
                 #expect(aStatus == bStatus)
                 #expect(aIsDir == bIsDir)
+                #expect(aDelay == bDelay)
             case let (.mapRemote(a), .mapRemote(b)):
                 #expect(a == b)
             case let (.throttle(a), .throttle(b)):
@@ -278,10 +280,11 @@ struct RuleActionTests {
         {"type":"mapLocal","filePath":"/tmp/old.json"}
         """.data(using: .utf8)!
         let decoded = try JSONDecoder().decode(RuleAction.self, from: json)
-        if case let .mapLocal(path, code, isDir) = decoded {
+        if case let .mapLocal(path, code, isDir, delayMs) = decoded {
             #expect(path == "/tmp/old.json")
             #expect(code == 200)
             #expect(isDir == false)
+            #expect(delayMs == 0)
         } else {
             Issue.record("Expected .mapLocal")
         }
@@ -292,7 +295,7 @@ struct RuleActionTests {
         let action = RuleAction.mapLocal(filePath: "/tmp/test.json", statusCode: 404)
         let data = try JSONEncoder().encode(action)
         let decoded = try JSONDecoder().decode(RuleAction.self, from: data)
-        if case let .mapLocal(path, code, _) = decoded {
+        if case let .mapLocal(path, code, _, _) = decoded {
             #expect(path == "/tmp/test.json")
             #expect(code == 404)
         } else {
@@ -303,7 +306,7 @@ struct RuleActionTests {
     @Test("MapLocal default statusCode is 200")
     func mapLocalDefaultStatusCode() {
         let action = RuleAction.mapLocal(filePath: "/tmp/test.json")
-        if case let .mapLocal(_, code, _) = action {
+        if case let .mapLocal(_, code, _, _) = action {
             #expect(code == 200)
         } else {
             Issue.record("Expected .mapLocal")
@@ -313,7 +316,7 @@ struct RuleActionTests {
     @Test("MapLocal directory flag defaults to false")
     func mapLocalDefaultIsDirectory() {
         let action = RuleAction.mapLocal(filePath: "/tmp/dir")
-        if case let .mapLocal(_, _, isDir) = action {
+        if case let .mapLocal(_, _, isDir, _) = action {
             #expect(isDir == false)
         } else {
             Issue.record("Expected .mapLocal")
@@ -325,7 +328,7 @@ struct RuleActionTests {
         let action = RuleAction.mapLocal(filePath: "/tmp/webroot", statusCode: 200, isDirectory: true)
         let data = try JSONEncoder().encode(action)
         let decoded = try JSONDecoder().decode(RuleAction.self, from: data)
-        if case let .mapLocal(path, code, isDir) = decoded {
+        if case let .mapLocal(path, code, isDir, _) = decoded {
             #expect(path == "/tmp/webroot")
             #expect(code == 200)
             #expect(isDir == true)
@@ -340,8 +343,24 @@ struct RuleActionTests {
         {"type":"mapLocal","filePath":"/tmp/old.json","statusCode":200}
         """.data(using: .utf8)!
         let decoded = try JSONDecoder().decode(RuleAction.self, from: json)
-        if case let .mapLocal(_, _, isDir) = decoded {
+        if case let .mapLocal(_, _, isDir, delayMs) = decoded {
             #expect(isDir == false)
+            #expect(delayMs == 0)
+        } else {
+            Issue.record("Expected .mapLocal")
+        }
+    }
+
+    @Test("MapLocal delay round-trips through Codable")
+    func mapLocalDelayRoundtrip() throws {
+        let action = RuleAction.mapLocal(filePath: "/tmp/delayed.json", statusCode: 202, delayMs: 5_000)
+        let data = try JSONEncoder().encode(action)
+        let decoded = try JSONDecoder().decode(RuleAction.self, from: data)
+        if case let .mapLocal(path, code, isDir, delayMs) = decoded {
+            #expect(path == "/tmp/delayed.json")
+            #expect(code == 202)
+            #expect(isDir == false)
+            #expect(delayMs == 5_000)
         } else {
             Issue.record("Expected .mapLocal")
         }

--- a/RockxyTests/Core/RuleEngine/RuleEngineTests.swift
+++ b/RockxyTests/Core/RuleEngine/RuleEngineTests.swift
@@ -198,6 +198,42 @@ struct RuleEngineTests {
         }
     }
 
+    @Test("Network Conditions tool gate skips network condition rules only")
+    func networkConditionsToolGateSkipsOnlyNetworkConditionRules() async throws {
+        let engine = RuleEngine()
+        let networkRule = ProxyRule(
+            name: "3G API",
+            isEnabled: true,
+            matchCondition: RuleMatchCondition(urlPattern: ".*example\\.com.*"),
+            action: .networkCondition(preset: .threeG, delayMs: 400)
+        )
+        let throttleRule = ProxyRule(
+            name: "Throttle",
+            isEnabled: true,
+            matchCondition: RuleMatchCondition(urlPattern: ".*example\\.com.*"),
+            action: .throttle(delayMs: 250)
+        )
+        await engine.addRule(networkRule)
+        await engine.addRule(throttleRule)
+
+        let url = try #require(URL(string: "https://example.com/test"))
+        let enabledResult = await engine.evaluate(method: "GET", url: url, headers: [])
+        guard case let .networkCondition(preset, delayMs) = enabledResult else {
+            Issue.record("Expected network condition rule while Network Conditions tool is enabled")
+            return
+        }
+        #expect(preset == .threeG)
+        #expect(delayMs == 400)
+
+        await engine.setNetworkConditionsToolEnabled(false)
+        let disabledResult = await engine.evaluate(method: "GET", url: url, headers: [])
+        if case let .throttle(delayMs) = disabledResult {
+            #expect(delayMs == 250)
+        } else {
+            Issue.record("Expected non-network-condition rule to remain active")
+        }
+    }
+
     @Test("Add rule and evaluate successfully")
     func addRuleAndEvaluate() async throws {
         let engine = RuleEngine()

--- a/RockxyTests/Core/RuleEngine/RuleEngineTests.swift
+++ b/RockxyTests/Core/RuleEngine/RuleEngineTests.swift
@@ -150,10 +150,9 @@ struct RuleEngineTests {
 
         let url = try #require(URL(string: "https://example.com/test"))
         let enabledResult = await engine.evaluate(method: "GET", url: url, headers: [])
-        if case .block = enabledResult {
-            #expect(true)
-        } else {
+        guard case .block = enabledResult else {
             Issue.record("Expected block rule while Block List tool is enabled")
+            return
         }
 
         await engine.setBlockListToolEnabled(false)
@@ -162,6 +161,40 @@ struct RuleEngineTests {
             #expect(delayMs == 250)
         } else {
             Issue.record("Expected non-block rule to remain active")
+        }
+    }
+
+    @Test("Map Remote tool gate skips map remote rules only")
+    func mapRemoteToolGateSkipsOnlyMapRemoteRules() async throws {
+        let engine = RuleEngine()
+        let remoteRule = ProxyRule(
+            name: "Remote",
+            isEnabled: true,
+            matchCondition: RuleMatchCondition(urlPattern: ".*example\\.com.*"),
+            action: .mapRemote(configuration: MapRemoteConfiguration(host: "staging.example.com"))
+        )
+        let throttleRule = ProxyRule(
+            name: "Throttle",
+            isEnabled: true,
+            matchCondition: RuleMatchCondition(urlPattern: ".*example\\.com.*"),
+            action: .throttle(delayMs: 250)
+        )
+        await engine.addRule(remoteRule)
+        await engine.addRule(throttleRule)
+
+        let url = try #require(URL(string: "https://example.com/test"))
+        let enabledResult = await engine.evaluate(method: "GET", url: url, headers: [])
+        guard case .mapRemote = enabledResult else {
+            Issue.record("Expected map remote rule while Map Remote tool is enabled")
+            return
+        }
+
+        await engine.setMapRemoteToolEnabled(false)
+        let disabledResult = await engine.evaluate(method: "GET", url: url, headers: [])
+        if case let .throttle(delayMs) = disabledResult {
+            #expect(delayMs == 250)
+        } else {
+            Issue.record("Expected non-map-remote rule to remain active")
         }
     }
 

--- a/RockxyTests/Core/RuleEngine/RuleEngineTests.swift
+++ b/RockxyTests/Core/RuleEngine/RuleEngineTests.swift
@@ -130,6 +130,41 @@ struct RuleEngineTests {
         #expect(afterToggle == nil)
     }
 
+    @Test("Block List tool gate skips block rules only")
+    func blockListToolGateSkipsOnlyBlockRules() async throws {
+        let engine = RuleEngine()
+        let blockRule = ProxyRule(
+            name: "Blocked",
+            isEnabled: true,
+            matchCondition: RuleMatchCondition(urlPattern: ".*example\\.com.*"),
+            action: .block(statusCode: 403)
+        )
+        let throttleRule = ProxyRule(
+            name: "Throttle",
+            isEnabled: true,
+            matchCondition: RuleMatchCondition(urlPattern: ".*example\\.com.*"),
+            action: .throttle(delayMs: 250)
+        )
+        await engine.addRule(blockRule)
+        await engine.addRule(throttleRule)
+
+        let url = try #require(URL(string: "https://example.com/test"))
+        let enabledResult = await engine.evaluate(method: "GET", url: url, headers: [])
+        if case .block = enabledResult {
+            #expect(true)
+        } else {
+            Issue.record("Expected block rule while Block List tool is enabled")
+        }
+
+        await engine.setBlockListToolEnabled(false)
+        let disabledResult = await engine.evaluate(method: "GET", url: url, headers: [])
+        if case let .throttle(delayMs) = disabledResult {
+            #expect(delayMs == 250)
+        } else {
+            Issue.record("Expected non-block rule to remain active")
+        }
+    }
+
     @Test("Add rule and evaluate successfully")
     func addRuleAndEvaluate() async throws {
         let engine = RuleEngine()

--- a/RockxyTests/Core/RuleEngine/RuleSyncServiceTests.swift
+++ b/RockxyTests/Core/RuleEngine/RuleSyncServiceTests.swift
@@ -64,12 +64,94 @@ struct RuleSyncServiceTests {
         }
     }
 
+    @Test("setNetworkConditionsToolEnabled persists UserDefaults and updates evaluation gate")
+    func setNetworkConditionsToolEnabledPersistsAndUpdatesGate() async throws {
+        await withRuleTestLock { [self] in
+            let defaultsBackup = backupNetworkConditionsToolDefault()
+            let networkRule = ProxyRule(
+                name: "3G API",
+                isEnabled: true,
+                matchCondition: RuleMatchCondition(urlPattern: ".*example\\.com.*"),
+                action: .networkCondition(preset: .threeG, delayMs: 400)
+            )
+            let throttleRule = ProxyRule(
+                name: "Fallback",
+                isEnabled: true,
+                matchCondition: RuleMatchCondition(urlPattern: ".*example\\.com.*"),
+                action: .throttle(delayMs: 250)
+            )
+            await RuleSyncService.replaceAllRules([networkRule, throttleRule])
+
+            await RuleSyncService.setNetworkConditionsToolEnabled(false)
+
+            #expect(UserDefaults.standard.object(forKey: Self.networkConditionsToolEnabledKey) as? Bool == false)
+            guard let url = URL(string: "https://example.com/test") else {
+                Issue.record("Expected test URL to be valid")
+                restoreNetworkConditionsToolDefault(defaultsBackup)
+                return
+            }
+            let disabledResult = await RuleEngine.shared.evaluate(method: "GET", url: url, headers: [])
+            if case let .throttle(delayMs) = disabledResult {
+                #expect(delayMs == 250)
+            } else {
+                Issue.record("Expected fallback throttle rule while Network Conditions tool is disabled")
+            }
+
+            await RuleSyncService.setNetworkConditionsToolEnabled(true)
+            #expect(UserDefaults.standard.object(forKey: Self.networkConditionsToolEnabledKey) as? Bool == true)
+
+            restoreNetworkConditionsToolDefault(defaultsBackup)
+        }
+    }
+
+    @Test("loadFromDisk applies persisted Network Conditions tool gate")
+    func loadFromDiskAppliesNetworkConditionsToolEnabled() async {
+        await withRuleTestLock { [self] in
+            let defaultsBackup = backupNetworkConditionsToolDefault()
+            let networkRule = ProxyRule(
+                name: "3G API",
+                isEnabled: true,
+                matchCondition: RuleMatchCondition(urlPattern: ".*example\\.com.*"),
+                action: .networkCondition(preset: .threeG, delayMs: 400)
+            )
+            let throttleRule = ProxyRule(
+                name: "Fallback",
+                isEnabled: true,
+                matchCondition: RuleMatchCondition(urlPattern: ".*example\\.com.*"),
+                action: .throttle(delayMs: 250)
+            )
+            await RuleSyncService.replaceAllRules([networkRule, throttleRule])
+            UserDefaults.standard.set(false, forKey: Self.networkConditionsToolEnabledKey)
+
+            await RuleEngine.shared.setNetworkConditionsToolEnabled(true)
+            await RuleSyncService.loadFromDisk()
+            await RuleEngine.shared.replaceAll([networkRule, throttleRule])
+
+            guard let url = URL(string: "https://example.com/test") else {
+                Issue.record("Expected test URL to be valid")
+                restoreNetworkConditionsToolDefault(defaultsBackup)
+                return
+            }
+            let result = await RuleEngine.shared.evaluate(method: "GET", url: url, headers: [])
+            if case let .throttle(delayMs) = result {
+                #expect(delayMs == 250)
+            } else {
+                Issue.record("Expected persisted disabled gate to skip network condition after load")
+            }
+
+            restoreNetworkConditionsToolDefault(defaultsBackup)
+            await RuleEngine.shared.setNetworkConditionsToolEnabled(true)
+        }
+    }
+
     // MARK: Private
 
     private struct RulesBackup {
         let diskData: Data?
         let engineRules: [ProxyRule]
     }
+
+    private static let networkConditionsToolEnabledKey = "networkConditionsToolEnabled"
 
     private static let rulesPath: URL = {
         let appSupport = FileManager.default.urls(
@@ -94,6 +176,18 @@ struct RuleSyncServiceTests {
             try? FileManager.default.removeItem(at: Self.rulesPath)
         }
         await RuleEngine.shared.replaceAll(backup.engineRules)
+    }
+
+    private func backupNetworkConditionsToolDefault() -> Bool? {
+        UserDefaults.standard.object(forKey: Self.networkConditionsToolEnabledKey) as? Bool
+    }
+
+    private func restoreNetworkConditionsToolDefault(_ value: Bool?) {
+        if let value {
+            UserDefaults.standard.set(value, forKey: Self.networkConditionsToolEnabledKey)
+        } else {
+            UserDefaults.standard.removeObject(forKey: Self.networkConditionsToolEnabledKey)
+        }
     }
 
     /// Runs `body` between `RuleTestLock` acquire/release with shared rule state

--- a/RockxyTests/Core/TrafficCapture/AllowListManagerTests.swift
+++ b/RockxyTests/Core/TrafficCapture/AllowListManagerTests.swift
@@ -344,6 +344,30 @@ struct AllowListManagerTests {
     }
 
     @Test
+    func importLegacySchemaMigratesEntries() throws {
+        let (manager, url) = makeManager()
+        defer { cleanup(url) }
+
+        let legacy = LegacyStorage(
+            isActive: true,
+            entries: [
+                LegacyEntry(id: UUID(), domain: "api.example.com", isEnabled: true),
+                LegacyEntry(id: UUID(), domain: "*.example.org", isEnabled: false),
+            ]
+        )
+        let data = try JSONEncoder().encode(legacy)
+
+        try manager.importRulesJSON(data)
+
+        #expect(manager.isActive)
+        #expect(manager.rules.count == 2)
+        #expect(manager.rules[0].name == "api.example.com")
+        #expect(manager.rules[0].matchType == .regex)
+        #expect(manager.rules[1].name == "*.example.org")
+        #expect(!manager.rules[1].isEnabled)
+    }
+
+    @Test
     func importMalformedJSONThrows() {
         let (manager, url) = makeManager()
         defer { cleanup(url) }

--- a/RockxyTests/Core/TrafficCapture/AllowListSettingsCodecTests.swift
+++ b/RockxyTests/Core/TrafficCapture/AllowListSettingsCodecTests.swift
@@ -1,0 +1,131 @@
+import Foundation
+@testable import Rockxy
+import Testing
+
+// MARK: - AllowListSettingsCodecTests
+
+@MainActor
+struct AllowListSettingsCodecTests {
+    // MARK: - Proxyman / JSON
+
+    @Test("imports flat JSON array as wildcard allow rules")
+    func importProxymanFlatArray() throws {
+        let json = """
+        ["*.example.com", "api.stripe.com", "API.STRIPE.com", " "]
+        """
+
+        let rules = try AllowListSettingsCodec.importFromProxyman(Data(json.utf8))
+
+        #expect(rules.count == 2)
+        #expect(rules[0].rawPattern == "*.example.com")
+        #expect(rules[0].matchType == .wildcard)
+        #expect(rules[0].method == nil)
+        #expect(rules[1].rawPattern == "api.stripe.com")
+    }
+
+    @Test("imports structured JSON entries with method, enabled state, and names")
+    func importProxymanStructuredEntries() throws {
+        let json = """
+        {
+          "allowRules": [
+            {
+              "name": "Stripe charges",
+              "host": "api.stripe.com",
+              "path": "/v1/charges",
+              "method": "post",
+              "enabled": false
+            },
+            {
+              "name": "GitHub regex",
+              "pattern": "^https://api\\\\.github\\\\.com/.*$",
+              "matchType": "regex",
+              "method": "ANY"
+            }
+          ]
+        }
+        """
+
+        let rules = try AllowListSettingsCodec.importFromProxyman(Data(json.utf8))
+
+        #expect(rules.count == 2)
+        #expect(rules[0].name == "Stripe charges")
+        #expect(rules[0].rawPattern == "*api.stripe.com/v1/charges")
+        #expect(rules[0].method == "POST")
+        #expect(!rules[0].isEnabled)
+        #expect(rules[1].matchType == .regex)
+        #expect(rules[1].includeSubpaths == false)
+        #expect(rules[1].method == nil)
+    }
+
+    @Test("throws for invalid JSON")
+    func importProxymanInvalidJSON() {
+        #expect(throws: AllowListSettingsCodec.ImportError.self) {
+            try AllowListSettingsCodec.importFromProxyman(Data("bad".utf8))
+        }
+    }
+
+    @Test("throws when JSON contains no usable rules")
+    func importProxymanNoRules() {
+        let json = """
+        {"allowRules":[{"host":"   "}]}
+        """
+
+        #expect(throws: AllowListSettingsCodec.ImportError.self) {
+            try AllowListSettingsCodec.importFromProxyman(Data(json.utf8))
+        }
+    }
+
+    @Test("throws when imported regex is invalid")
+    func importProxymanInvalidRegex() {
+        let json = """
+        {"allowRules":[{"pattern":"^[unclosed","matchType":"regex"}]}
+        """
+
+        #expect(throws: AllowListSettingsCodec.ImportError.self) {
+            try AllowListSettingsCodec.importFromProxyman(Data(json.utf8))
+        }
+    }
+
+    // MARK: - Charles Proxy / Plist
+
+    @Test("imports Charles plist locations")
+    func importCharlesLocations() throws {
+        let plist = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0">
+        <dict>
+            <key>location</key>
+            <array>
+                <dict>
+                    <key>host</key>
+                    <string>api.github.com</string>
+                    <key>path</key>
+                    <string>/repos</string>
+                    <key>method</key>
+                    <string>GET</string>
+                </dict>
+                <dict>
+                    <key>host</key>
+                    <string>*.example.com</string>
+                </dict>
+            </array>
+        </dict>
+        </plist>
+        """
+
+        let rules = try AllowListSettingsCodec.importFromCharlesProxy(Data(plist.utf8))
+
+        #expect(rules.count == 2)
+        #expect(rules[0].rawPattern == "*api.github.com/repos")
+        #expect(rules[0].method == "GET")
+        #expect(rules[1].rawPattern == "**.example.com/")
+    }
+
+    @Test("throws for invalid Charles plist")
+    func importCharlesInvalidFormat() {
+        #expect(throws: AllowListSettingsCodec.ImportError.self) {
+            try AllowListSettingsCodec.importFromCharlesProxy(Data("not plist".utf8))
+        }
+    }
+}

--- a/RockxyTests/Core/Utilities/MapLocalFileValidatorTests.swift
+++ b/RockxyTests/Core/Utilities/MapLocalFileValidatorTests.swift
@@ -1,0 +1,62 @@
+import Foundation
+@testable import Rockxy
+import Testing
+
+struct MapLocalFileValidatorTests {
+    @Test("loads regular file data")
+    func loadsRegularFile() throws {
+        let directory = try makeDirectory()
+        let file = directory.appendingPathComponent("response.json")
+        try Data(#"{"status":"ok"}"#.utf8).write(to: file)
+
+        let data = try #require(MapLocalFileValidator.loadFileData(at: file.path))
+        #expect(String(data: data, encoding: .utf8) == #"{"status":"ok"}"#)
+    }
+
+    @Test("returns nil for nonexistent file")
+    func rejectsMissingFile() {
+        let path = FileManager.default.temporaryDirectory
+            .appendingPathComponent("RockxyTests-missing-\(UUID().uuidString).json")
+            .path
+
+        #expect(MapLocalFileValidator.loadFileData(at: path) == nil)
+    }
+
+    @Test("rejects directories")
+    func rejectsDirectory() throws {
+        let directory = try makeDirectory()
+        #expect(MapLocalFileValidator.loadFileData(at: directory.path) == nil)
+    }
+
+    @Test("rejects oversized files")
+    func rejectsOversizedFile() throws {
+        let directory = try makeDirectory()
+        let file = directory.appendingPathComponent("large.bin")
+        let data = Data(repeating: 0x41, count: (10 * 1_024 * 1_024) + 1)
+        try data.write(to: file)
+
+        #expect(MapLocalFileValidator.loadFileData(at: file.path) == nil)
+    }
+
+    @Test("expands tilde paths")
+    func expandsTildePath() throws {
+        let home = FileManager.default.homeDirectoryForCurrentUser
+        let directory = home.appendingPathComponent("RockxyTests-MapLocal-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let file = directory.appendingPathComponent("tilde.txt")
+        try Data("hello".utf8).write(to: file)
+        let tildePath = "~/" + file.path.replacingOccurrences(of: home.path + "/", with: "")
+
+        let data = try #require(MapLocalFileValidator.loadFileData(at: tildePath))
+        #expect(String(data: data, encoding: .utf8) == "hello")
+    }
+
+    private func makeDirectory() throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("RockxyTests-MapLocalFile-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        return directory
+    }
+}

--- a/RockxyTests/Helpers/RuleTestLock.swift
+++ b/RockxyTests/Helpers/RuleTestLock.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Darwin
 
 /// Serializes all tests that mutate `RuleEngine.shared` or `RulePolicyGate.shared`.
 ///
@@ -13,6 +14,7 @@ actor RuleTestLock {
 
     func acquire() async {
         if !isLocked {
+            acquireProcessLock()
             isLocked = true
             return
         }
@@ -26,6 +28,7 @@ actor RuleTestLock {
             waiters.removeFirst()
             next.resume()
         } else {
+            releaseProcessLock()
             isLocked = false
         }
     }
@@ -33,5 +36,30 @@ actor RuleTestLock {
     // MARK: Private
 
     private var isLocked = false
+    private var processLockFileDescriptor: Int32?
     private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    private func acquireProcessLock() {
+        let path = NSTemporaryDirectory() + "rockxy-rule-tests.lock"
+        let fd = open(path, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR)
+        precondition(fd >= 0, "Unable to open rule test lock file")
+
+        while flock(fd, LOCK_EX) != 0 {
+            if errno == EINTR {
+                continue
+            }
+            close(fd)
+            preconditionFailure("Unable to acquire rule test lock")
+        }
+        processLockFileDescriptor = fd
+    }
+
+    private func releaseProcessLock() {
+        guard let fd = processLockFileDescriptor else {
+            return
+        }
+        flock(fd, LOCK_UN)
+        close(fd)
+        processLockFileDescriptor = nil
+    }
 }

--- a/RockxyTests/Helpers/SettingsTestHelpers.swift
+++ b/RockxyTests/Helpers/SettingsTestHelpers.swift
@@ -3,7 +3,15 @@ import Foundation
 @testable import Rockxy
 
 /// All UserDefaults keys written by AppSettingsStorage.
-let appSettingsKeys = TestIdentity.appSettingsKeys
+let appSettingsKeys = Array(Set(TestIdentity.appSettingsKeys + [
+    "proxyPort",
+    "autoStart",
+    "recordOnLaunch",
+    "onlyListenOnLocalhost",
+    "listenIPv6",
+    "autoSelectPort",
+    "certificate.lastExportedRootCAPath",
+].map { RockxyIdentity.current.defaultsKey($0) }))
 
 /// Shared lock ensuring tests that mutate AppSettings UserDefaults keys do not race.
 let settingsTestLock = NSLock()

--- a/RockxyTests/Helpers/TestIdentity.swift
+++ b/RockxyTests/Helpers/TestIdentity.swift
@@ -1,4 +1,5 @@
 import Foundation
+@testable import Rockxy
 
 enum TestIdentity {
     static let familyNamespace = "com.amunx.rockxy"
@@ -49,4 +50,9 @@ enum TestIdentity {
         communityBundleIdentifier,
         familyNamespace,
     ]
+
+    static var isRunningUnderRawXCTestTool: Bool {
+        RockxyIdentity.current.appBundleIdentifier == "com.apple.dt.xctest.tool"
+            || RockxyIdentity.current.displayName == "xctest"
+    }
 }

--- a/RockxyTests/Models/Rules/BlockListModelTests.swift
+++ b/RockxyTests/Models/Rules/BlockListModelTests.swift
@@ -424,6 +424,155 @@ struct BlockListViewModelTests {
         #expect(vm.selectedRuleID == imported.id)
     }
 
+    @Test("importBlockRules with no imported blocks clears selection and preserves non-block rules")
+    @MainActor
+    func importBlockRulesEmptyClearsSelectionAndPreservesNonBlockRules() throws {
+        let vm = BlockListViewModel()
+        let existingBlock = TestFixtures.makeRule(name: "Existing Block", action: .block(statusCode: 403))
+        let throttle = TestFixtures.makeRule(name: "Throttle", action: .throttle(delayMs: 100))
+        vm.handleRulesDidChange(Notification(name: .rulesDidChange, object: [existingBlock, throttle]))
+        vm.selectedRuleID = existingBlock.id
+
+        vm.importBlockRules([])
+
+        #expect(vm.blockRules.isEmpty)
+        #expect(vm.allRules.count == 1)
+        #expect(vm.allRules.first?.id == throttle.id)
+        #expect(vm.selectedRuleID == nil)
+    }
+
+    @Test("exportBlockRules serializes only block rules from current mixed rule list")
+    @MainActor
+    func exportBlockRulesSerializesOnlyBlockRules() throws {
+        let vm = BlockListViewModel()
+        let block = TestFixtures.makeRule(name: "Exported Block", action: .block(statusCode: 403))
+        let throttle = TestFixtures.makeRule(name: "Throttle", action: .throttle(delayMs: 100))
+        vm.handleRulesDidChange(Notification(name: .rulesDidChange, object: [block, throttle]))
+
+        let data = try vm.exportBlockRules()
+        let object = try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let blockRules = try #require(object["blockRules"] as? [[String: Any]])
+
+        #expect(blockRules.count == 1)
+        #expect(blockRules.first?["name"] as? String == "Exported Block")
+    }
+
+    // MARK: - Editor Session Flow
+
+    @Test("presentNewRuleEditor opens blank create session")
+    @MainActor
+    func presentNewRuleEditorAssignsCreateSession() throws {
+        let vm = BlockListViewModel()
+
+        vm.presentNewRuleEditor()
+
+        let session = try #require(vm.editorSession)
+        guard case .create(nil) = session.mode else {
+            Issue.record("expected .create(nil) mode")
+            return
+        }
+    }
+
+    @Test("presentEditorForContext opens create session with quick-create context")
+    @MainActor
+    func presentEditorForContextAssignsCreateSessionWithContext() throws {
+        let vm = BlockListViewModel()
+        let context = BlockRuleEditorContextBuilder.fromDomain("api.example.com")
+
+        vm.presentEditorForContext(context)
+
+        let session = try #require(vm.editorSession)
+        guard case let .create(receivedContext?) = session.mode else {
+            Issue.record("expected .create(context) mode")
+            return
+        }
+        #expect(receivedContext.origin == .domainQuickCreate)
+        #expect(receivedContext.sourceHost == "api.example.com")
+        #expect(receivedContext.defaultPattern == "*api.example.com/")
+    }
+
+    @Test("second quick-create replaces open block editor session with fresh identity")
+    @MainActor
+    func secondQuickCreateReplacesOpenEditorSessionWithFreshIdentity() throws {
+        let vm = BlockListViewModel()
+        vm.presentEditorForContext(BlockRuleEditorContextBuilder.fromDomain("first.example.com"))
+        let firstID = try #require(vm.editorSession?.id)
+
+        vm.presentEditorForContext(BlockRuleEditorContextBuilder.fromDomain("second.example.com"))
+
+        let secondSession = try #require(vm.editorSession)
+        #expect(secondSession.id != firstID)
+        guard case let .create(context?) = secondSession.mode else {
+            Issue.record("expected second session to carry context")
+            return
+        }
+        #expect(context.sourceHost == "second.example.com")
+    }
+
+    @Test("presentEditorForEditing opens edit session for selected row")
+    @MainActor
+    func presentEditorForEditingAssignsEditSession() throws {
+        let vm = BlockListViewModel()
+        let rule = TestFixtures.makeRule(name: "Editable", action: .block(statusCode: 403))
+
+        vm.presentEditorForEditing(rule)
+
+        let session = try #require(vm.editorSession)
+        guard case let .edit(editingRule) = session.mode else {
+            Issue.record("expected .edit mode")
+            return
+        }
+        #expect(editingRule.id == rule.id)
+        #expect(editingRule.name == "Editable")
+    }
+
+    @Test("dismissEditor clears block editor session")
+    @MainActor
+    func dismissEditorClearsSession() {
+        let vm = BlockListViewModel()
+        vm.presentNewRuleEditor()
+
+        vm.dismissEditor()
+
+        #expect(vm.editorSession == nil)
+    }
+
+    // MARK: - Selection Reconciliation
+
+    @Test("handleRulesDidChange clears selection when selected block rule disappears")
+    @MainActor
+    func handleRulesDidChangeClearsMissingBlockSelection() {
+        let vm = BlockListViewModel()
+        let block = TestFixtures.makeRule(name: "Selected Block", action: .block(statusCode: 403))
+        vm.handleRulesDidChange(Notification(name: .rulesDidChange, object: [block]))
+        vm.selectedRuleID = block.id
+
+        let replacement = TestFixtures.makeRule(name: "Replacement", action: .block(statusCode: 403))
+        vm.handleRulesDidChange(Notification(name: .rulesDidChange, object: [replacement]))
+
+        #expect(vm.selectedRuleID == nil)
+    }
+
+    @Test("handleRulesDidChange clears selection when selected rule is no longer a block rule")
+    @MainActor
+    func handleRulesDidChangeClearsSelectionForNonBlockRule() {
+        let vm = BlockListViewModel()
+        let block = TestFixtures.makeRule(name: "Selected Block", action: .block(statusCode: 403))
+        vm.handleRulesDidChange(Notification(name: .rulesDidChange, object: [block]))
+        vm.selectedRuleID = block.id
+
+        let sameIDNonBlock = ProxyRule(
+            id: block.id,
+            name: "Same ID Throttle",
+            matchCondition: block.matchCondition,
+            action: .throttle(delayMs: 100)
+        )
+        vm.handleRulesDidChange(Notification(name: .rulesDidChange, object: [sameIDNonBlock]))
+
+        #expect(vm.blockRules.isEmpty)
+        #expect(vm.selectedRuleID == nil)
+    }
+
     @Test("toggleRule toggles enabled state")
     @MainActor
     func toggleRule() throws {

--- a/RockxyTests/Models/Rules/BlockListModelTests.swift
+++ b/RockxyTests/Models/Rules/BlockListModelTests.swift
@@ -310,6 +310,120 @@ struct BlockListViewModelTests {
         #expect(vm.selectedRuleID == nil)
     }
 
+    @Test("removeRule deletes clicked row without requiring current selection")
+    @MainActor
+    func removeRuleByID() {
+        let vm = BlockListViewModel()
+        vm.addBlockRule(
+            ruleName: "Rule A",
+            urlPattern: "*.a.com/*",
+            httpMethod: .any,
+            matchType: .wildcard,
+            blockAction: .returnForbidden,
+            includeSubpaths: true
+        )
+        vm.addBlockRule(
+            ruleName: "Rule B",
+            urlPattern: "*.b.com/*",
+            httpMethod: .any,
+            matchType: .wildcard,
+            blockAction: .returnForbidden,
+            includeSubpaths: true
+        )
+
+        let secondID = vm.blockRules[1].id
+        vm.selectedRuleID = vm.blockRules[0].id
+        vm.removeRule(id: secondID)
+
+        #expect(vm.blockRules.count == 1)
+        #expect(vm.blockRules.first?.name == "Rule A")
+        #expect(vm.selectedRuleID == vm.blockRules.first?.id)
+    }
+
+    @Test("duplicateSelected creates a copy and selects it")
+    @MainActor
+    func duplicateSelected() {
+        let vm = BlockListViewModel()
+        vm.addBlockRule(
+            ruleName: "Original",
+            urlPattern: "*.copy.com/*",
+            httpMethod: .post,
+            matchType: .wildcard,
+            blockAction: .dropConnection,
+            includeSubpaths: true
+        )
+
+        vm.selectedRuleID = vm.blockRules.first?.id
+        vm.duplicateSelected()
+
+        #expect(vm.blockRules.count == 2)
+        #expect(vm.blockRules[1].name == "Copy of Original")
+        #expect(vm.selectedRuleID == vm.blockRules[1].id)
+        #expect(vm.blockRules[1].matchCondition.method == "POST")
+        if case let .block(statusCode) = vm.blockRules[1].action {
+            #expect(statusCode == 0)
+        } else {
+            Issue.record("Expected block action")
+        }
+    }
+
+    @Test("updateBlockRule preserves id and enabled state")
+    @MainActor
+    func updateBlockRule() throws {
+        let vm = BlockListViewModel()
+        vm.addBlockRule(
+            ruleName: "Original",
+            urlPattern: "*.old.com/*",
+            httpMethod: .any,
+            matchType: .wildcard,
+            blockAction: .returnForbidden,
+            includeSubpaths: true
+        )
+        let id = try #require(vm.blockRules.first?.id)
+        vm.toggleRule(id: id)
+
+        vm.updateBlockRule(
+            id: id,
+            ruleName: "Updated",
+            urlPattern: "^https://new.example/.*$",
+            httpMethod: .get,
+            matchType: .regex,
+            blockAction: .dropConnection,
+            includeSubpaths: false
+        )
+
+        let updated = try #require(vm.blockRules.first)
+        #expect(updated.id == id)
+        #expect(updated.name == "Updated")
+        #expect(updated.isEnabled == false)
+        #expect(updated.matchCondition.method == "GET")
+        #expect(updated.matchCondition.urlPattern == "^https://new.example/.*$")
+    }
+
+    @Test("importBlockRules preserves non-block rules and selects first imported block")
+    @MainActor
+    func importBlockRulesPreservesNonBlockRules() {
+        let vm = BlockListViewModel()
+        vm.addBlockRule(
+            ruleName: "Existing Block",
+            urlPattern: "*.old.com/*",
+            httpMethod: .any,
+            matchType: .wildcard,
+            blockAction: .returnForbidden,
+            includeSubpaths: true
+        )
+        let throttle = TestFixtures.makeRule(name: "Throttle", action: .throttle(delayMs: 100))
+        vm.handleRulesDidChange(Notification(name: .rulesDidChange, object: vm.allRules + [throttle]))
+        let imported = TestFixtures.makeRule(name: "Imported Block", action: .block(statusCode: 403))
+
+        vm.importBlockRules([imported])
+
+        #expect(vm.allRules.contains { $0.id == throttle.id })
+        #expect(vm.blockRules.count == 1)
+        #expect(vm.blockRules.first?.id == imported.id)
+        #expect(vm.selectedRuleID == imported.id)
+    }
+
     @Test("toggleRule toggles enabled state")
     @MainActor
     func toggleRule() throws {

--- a/RockxyTests/Models/Rules/BreakpointTemplateStoreTests.swift
+++ b/RockxyTests/Models/Rules/BreakpointTemplateStoreTests.swift
@@ -163,6 +163,110 @@ struct BreakpointTemplateStoreTests {
         #expect(duplicate.name.contains("Copy of"))
     }
 
+    @Test("Add template uses selected kind and generates unique names")
+    func addTemplateUsesSelectedKindAndUniqueNames() {
+        let store = BreakpointTemplateStore(defaults: makeDefaults(), storageKey: storageKey, seedDefaults: false)
+        store.selectedKind = .response
+
+        let first = store.addTemplate()
+        let second = store.addTemplate()
+
+        #expect(first.kind == .response)
+        #expect(second.kind == .response)
+        #expect(store.selectedTemplateID == second.id)
+        #expect(store.responseTemplates.map(\.name) == [
+            "Untitled Response Template",
+            "Untitled Response Template 2"
+        ])
+    }
+
+    @Test("Deleting selected template falls back within the same kind")
+    func deleteSelectedTemplateFallsBackWithinSameKind() throws {
+        let store = BreakpointTemplateStore(defaults: makeDefaults(), storageKey: storageKey, seedDefaults: false)
+        let first = store.addTemplate(kind: .request)
+        let second = store.addTemplate(kind: .request)
+        store.addTemplate(kind: .response)
+        store.selectedKind = .request
+        store.selectedTemplateID = first.id
+
+        store.deleteSelectedTemplate()
+
+        #expect(store.requestTemplates.map(\.id) == [second.id])
+        #expect(store.selectedKind == .request)
+        #expect(store.selectedTemplateID == second.id)
+    }
+
+    @Test("Deleting last template clears selection")
+    func deleteLastTemplateClearsSelection() {
+        let store = BreakpointTemplateStore(defaults: makeDefaults(), storageKey: storageKey, seedDefaults: false)
+        store.addTemplate(kind: .request)
+
+        store.deleteSelectedTemplate()
+
+        #expect(store.templates.isEmpty)
+        #expect(store.selectedTemplateID == nil)
+        #expect(!store.selectedValidation.isValid)
+    }
+
+    @Test("Update selected sanitizes blank names and reset restores sample")
+    func updateSelectedSanitizesNameAndResetRestoresSample() throws {
+        let store = BreakpointTemplateStore(defaults: makeDefaults(), storageKey: storageKey, seedDefaults: false)
+        let template = store.addTemplate(kind: .request)
+        store.updateSelected(
+            name: "   ",
+            rawMessage: """
+            PATCH /custom HTTP/1.1
+            X-Trace: yes
+
+            custom
+            """
+        )
+
+        #expect(store.selectedTemplate?.name == "Untitled Request Template")
+        #expect(store.selectedTemplate?.rawMessage.contains("PATCH /custom") == true)
+
+        store.resetSelectedTemplate()
+
+        let resetTemplate = try #require(store.selectedTemplate)
+        #expect(resetTemplate.id == template.id)
+        #expect(resetTemplate.rawMessage == BreakpointTemplateKind.request.sampleMessage)
+    }
+
+    @Test("Malformed selected template does not create application payload")
+    func malformedSelectedTemplateHasNoApplicationPayload() {
+        let store = BreakpointTemplateStore(defaults: makeDefaults(), storageKey: storageKey, seedDefaults: false)
+        let template = store.addTemplate(kind: .response)
+
+        store.updateTemplate(id: template.id, rawMessage: "not a response")
+
+        #expect(!store.selectedValidation.isValid)
+        #expect(store.selectedApplicationPayload() == nil)
+        #expect(store.applicationPayload(for: UUID()) == nil)
+    }
+
+    @Test("Raw message helper serializes request target and rejects invalid edits")
+    func rawMessageHelperSerializesAndRejectsInvalidEdits() throws {
+        let draft = BreakpointRequestData(
+            method: "GET",
+            url: "https://example.com/v1/users?page=2",
+            headers: [EditableHeader(name: "Accept", value: "application/json")],
+            body: "",
+            statusCode: 200,
+            phase: .request
+        )
+
+        let raw = BreakpointRawMessage.rawMessage(from: draft, kind: .request)
+        #expect(raw.hasPrefix("GET /v1/users?page=2 HTTP/1.1"))
+        #expect(raw.contains("Accept: application/json"))
+
+        do {
+            _ = try BreakpointRawMessage.applying("GET /missing-version", kind: .request, to: draft)
+            Issue.record("Expected invalid raw message to throw")
+        } catch {
+            #expect(String(describing: error).contains("invalid"))
+        }
+    }
+
     // MARK: Private
 
     private let storageKey = "breakpointTemplates.tests"

--- a/RockxyTests/Models/Rules/BreakpointTemplateStoreTests.swift
+++ b/RockxyTests/Models/Rules/BreakpointTemplateStoreTests.swift
@@ -1,0 +1,191 @@
+import Foundation
+@testable import Rockxy
+import Testing
+
+@MainActor
+struct BreakpointTemplateStoreTests {
+    // MARK: Internal
+
+    @Test("Store seeds valid request and response defaults")
+    func storeSeedsValidDefaults() throws {
+        let store = makeStore()
+
+        #expect(store.requestTemplates.count == 1)
+        #expect(store.responseTemplates.count == 1)
+        #expect(store.requestTemplates.first?.validation.isValid == true)
+        #expect(store.responseTemplates.first?.validation.isValid == true)
+        #expect(store.selectedTemplate?.kind == .request)
+    }
+
+    @Test("Add and update request template persists")
+    func addAndUpdateRequestTemplatePersists() throws {
+        let defaults = makeDefaults()
+        let store = BreakpointTemplateStore(defaults: defaults, storageKey: storageKey, seedDefaults: false)
+        let template = store.addTemplate(kind: .request)
+
+        store.updateTemplate(
+            id: template.id,
+            name: "Auth Request",
+            rawMessage: """
+            POST https://example.com/login HTTP/1.1
+            Content-Type: application/json
+
+            {"email":"a@example.com"}
+            """
+        )
+
+        let fresh = BreakpointTemplateStore(defaults: defaults, storageKey: storageKey, seedDefaults: false)
+
+        #expect(fresh.requestTemplates.count == 1)
+        #expect(fresh.requestTemplates.first?.name == "Auth Request")
+        #expect(fresh.requestTemplates.first?.validation.isValid == true)
+    }
+
+    @Test("Delete selected template removes it from storage")
+    func deleteSelectedTemplatePersists() {
+        let defaults = makeDefaults()
+        let store = BreakpointTemplateStore(defaults: defaults, storageKey: storageKey, seedDefaults: false)
+        let request = store.addTemplate(kind: .request)
+        store.addTemplate(kind: .response)
+        store.selectedKind = .request
+        store.selectedTemplateID = request.id
+
+        store.deleteSelectedTemplate()
+        let fresh = BreakpointTemplateStore(defaults: defaults, storageKey: storageKey, seedDefaults: false)
+
+        #expect(fresh.requestTemplates.isEmpty)
+        #expect(fresh.responseTemplates.count == 1)
+    }
+
+    @Test("Validation rejects malformed request headers")
+    func validationRejectsMalformedRequestHeaders() {
+        let validation = BreakpointTemplateValidator.validate(
+            rawMessage: """
+            GET / HTTP/1.1
+            Bad Header
+
+            """,
+            kind: .request
+        )
+
+        #expect(!validation.isValid)
+        #expect(validation.message.contains("colon"))
+    }
+
+    @Test("Validation rejects response without HTTP status line")
+    func validationRejectsMalformedResponseLine() {
+        let validation = BreakpointTemplateValidator.validate(
+            rawMessage: """
+            200 OK
+            Content-Type: text/plain
+
+            body
+            """,
+            kind: .response
+        )
+
+        #expect(!validation.isValid)
+        #expect(validation.message.contains("HTTP"))
+    }
+
+    @Test("Selected application payload applies request fields to breakpoint draft")
+    func requestApplicationPayloadAppliesToDraft() throws {
+        let store = BreakpointTemplateStore(defaults: makeDefaults(), storageKey: storageKey, seedDefaults: false)
+        let template = store.addTemplate(kind: .request)
+        store.updateTemplate(
+            id: template.id,
+            rawMessage: """
+            PUT /v1/profile HTTP/1.1
+            X-Test: yes
+
+            updated
+            """
+        )
+
+        let payload = try #require(store.selectedApplicationPayload())
+        let applied = payload.applying(to: makeDraft())
+
+        #expect(applied.phase == .request)
+        #expect(applied.method == "PUT")
+        #expect(applied.url == "/v1/profile")
+        #expect(applied.headers.map(\.name) == ["X-Test"])
+        #expect(applied.body == "updated")
+    }
+
+    @Test("Response application payload preserves request identity and applies response fields")
+    func responseApplicationPayloadAppliesToDraft() throws {
+        let store = BreakpointTemplateStore(defaults: makeDefaults(), storageKey: storageKey, seedDefaults: false)
+        let template = store.addTemplate(kind: .response)
+        store.updateTemplate(
+            id: template.id,
+            rawMessage: """
+            HTTP/1.1 404 Not Found
+            Content-Type: text/plain
+
+            missing
+            """
+        )
+
+        let payload = try #require(store.selectedApplicationPayload())
+        let applied = payload.applying(to: makeDraft())
+
+        #expect(applied.phase == .response)
+        #expect(applied.method == "GET")
+        #expect(applied.url == "https://example.com/current")
+        #expect(applied.statusCode == 404)
+        #expect(applied.headers.first?.name == "Content-Type")
+        #expect(applied.body == "missing")
+    }
+
+    @Test("Codable legacy template fills missing defaults")
+    func codableLegacyTemplateDefaults() throws {
+        let json = #"{"kind":"response"}"#.data(using: .utf8)!
+        let template = try JSONDecoder().decode(BreakpointTemplate.self, from: json)
+
+        #expect(template.kind == .response)
+        #expect(template.name == "Untitled Response Template")
+        #expect(template.rawMessage == BreakpointTemplateKind.response.sampleMessage)
+        #expect(template.updatedAt >= template.createdAt)
+        #expect(template.validation.isValid)
+    }
+
+    @Test("Duplicate selected template creates persisted copy")
+    func duplicateSelectedTemplatePersists() throws {
+        let defaults = makeDefaults()
+        let store = BreakpointTemplateStore(defaults: defaults, storageKey: storageKey, seedDefaults: false)
+        store.addTemplate(kind: .request)
+
+        let duplicate = try #require(store.duplicateSelectedTemplate())
+        let fresh = BreakpointTemplateStore(defaults: defaults, storageKey: storageKey, seedDefaults: false)
+
+        #expect(fresh.requestTemplates.count == 2)
+        #expect(fresh.requestTemplates.contains { $0.id == duplicate.id })
+        #expect(duplicate.name.contains("Copy of"))
+    }
+
+    // MARK: Private
+
+    private let storageKey = "breakpointTemplates.tests"
+
+    private func makeStore() -> BreakpointTemplateStore {
+        BreakpointTemplateStore(defaults: makeDefaults(), storageKey: storageKey)
+    }
+
+    private func makeDefaults() -> UserDefaults {
+        let suiteName = "com.amunx.rockxy.tests.breakpointTemplates.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        return defaults
+    }
+
+    private func makeDraft() -> BreakpointRequestData {
+        BreakpointRequestData(
+            method: "GET",
+            url: "https://example.com/current",
+            headers: [EditableHeader(name: "Accept", value: "application/json")],
+            body: "",
+            statusCode: 200,
+            phase: .request
+        )
+    }
+}

--- a/RockxyTests/Models/Rules/NetworkConditionPresetTests.swift
+++ b/RockxyTests/Models/Rules/NetworkConditionPresetTests.swift
@@ -31,6 +31,24 @@ struct NetworkConditionPresetTests {
         #expect(NetworkConditionPreset.custom.uploadBandwidthKbps == nil)
     }
 
+    @Test("presets expose bandwidth labels and byte rates")
+    func presetBandwidthLabelsAndBytesPerSecond() {
+        #expect(NetworkConditionPreset.threeG.downloadBandwidthLabel == "< 780 kbps")
+        #expect(NetworkConditionPreset.threeG.uploadBandwidthLabel == "< 330 kbps")
+        #expect(NetworkConditionPreset.edge.downloadBandwidthLabel == "< 240 kbps")
+        #expect(NetworkConditionPreset.lte.downloadBandwidthLabel == "< 50 Mbps")
+        #expect(NetworkConditionPreset.wifi.uploadBandwidthLabel == "< 30 Mbps")
+        #expect(NetworkConditionPreset.custom.downloadBandwidthLabel == "Unlimited")
+        #expect(NetworkConditionPreset.custom.uploadBandwidthLabel == "Unlimited")
+
+        #expect(NetworkConditionPreset.threeG.downloadBytesPerSecond == 97_500)
+        #expect(NetworkConditionPreset.threeG.uploadBytesPerSecond == 41_250)
+        #expect(NetworkConditionPreset.edge.downloadBytesPerSecond == 30_000)
+        #expect(NetworkConditionPreset.lte.uploadBytesPerSecond == 1_250_000)
+        #expect(NetworkConditionPreset.custom.downloadBytesPerSecond == nil)
+        #expect(NetworkConditionPreset.custom.uploadBytesPerSecond == nil)
+    }
+
     @Test("packet loss stays disabled for all presets")
     func packetLossDisabled() {
         for preset in NetworkConditionPreset.allCases {

--- a/RockxyTests/Models/Rules/NetworkConditionPresetTests.swift
+++ b/RockxyTests/Models/Rules/NetworkConditionPresetTests.swift
@@ -15,6 +15,29 @@ struct NetworkConditionPresetTests {
         #expect(NetworkConditionPreset.custom.defaultLatencyMs == 0)
     }
 
+    @Test("presets expose bandwidth metadata")
+    func presetBandwidthMetadata() {
+        #expect(NetworkConditionPreset.threeG.downloadBandwidthKbps == 780)
+        #expect(NetworkConditionPreset.threeG.uploadBandwidthKbps == 330)
+        #expect(NetworkConditionPreset.edge.downloadBandwidthKbps == 240)
+        #expect(NetworkConditionPreset.edge.uploadBandwidthKbps == 200)
+        #expect(NetworkConditionPreset.lte.downloadBandwidthKbps == 50_000)
+        #expect(NetworkConditionPreset.lte.uploadBandwidthKbps == 10_000)
+        #expect(NetworkConditionPreset.veryBadNetwork.downloadBandwidthKbps == 1_000)
+        #expect(NetworkConditionPreset.veryBadNetwork.uploadBandwidthKbps == 1_000)
+        #expect(NetworkConditionPreset.wifi.downloadBandwidthKbps == 40_000)
+        #expect(NetworkConditionPreset.wifi.uploadBandwidthKbps == 30_000)
+        #expect(NetworkConditionPreset.custom.downloadBandwidthKbps == nil)
+        #expect(NetworkConditionPreset.custom.uploadBandwidthKbps == nil)
+    }
+
+    @Test("packet loss stays disabled for all presets")
+    func packetLossDisabled() {
+        for preset in NetworkConditionPreset.allCases {
+            #expect(preset.packetLossRate == 0.0)
+        }
+    }
+
     @Test("each preset returns correct display name")
     func presetDisplayNames() {
         #expect(NetworkConditionPreset.threeG.displayName == "3G")

--- a/RockxyTests/Models/Rules/RuleQuotaTests.swift
+++ b/RockxyTests/Models/Rules/RuleQuotaTests.swift
@@ -165,29 +165,34 @@ struct RuleQuotaTests {
     // MARK: - Policy Injection (no cross-test pollution)
 
     @Test("Custom policy takes effect through .shared assignment")
-
-    func customPolicyInjectable() {
+    func customPolicyInjectable() async {
+        await RuleTestLock.shared.acquire()
         let saved = RulePolicyGate.shared
-        defer { RulePolicyGate.shared = saved }
 
         RulePolicyGate.shared = RulePolicyGate(policy: PolicyWithLimit(5))
         #expect(RulePolicyGate.shared.policy.maxActiveRulesPerTool == 5)
 
         RulePolicyGate.shared = RulePolicyGate(policy: PolicyWithLimit(99))
         #expect(RulePolicyGate.shared.policy.maxActiveRulesPerTool == 99)
+
+        RulePolicyGate.shared = saved
+        await RuleTestLock.shared.release()
     }
 
     @Test("Coordinator construction does not pollute shared gate")
     @MainActor
-    func coordinatorDoesNotPolluteGate() {
+    func coordinatorDoesNotPolluteGate() async {
+        await RuleTestLock.shared.acquire()
         let saved = RulePolicyGate.shared
-        defer { RulePolicyGate.shared = saved }
 
         RulePolicyGate.shared = RulePolicyGate(policy: PolicyWithLimit(42))
 
         // Creating a coordinator should NOT overwrite the shared gate
         _ = MainContentCoordinator(policy: PolicyWithLimit(7))
         #expect(RulePolicyGate.shared.policy.maxActiveRulesPerTool == 42)
+
+        RulePolicyGate.shared = saved
+        await RuleTestLock.shared.release()
     }
 
     // MARK: - Exclusive Network Condition Quota

--- a/RockxyTests/Models/UI/HeaderColumnStoreTests.swift
+++ b/RockxyTests/Models/UI/HeaderColumnStoreTests.swift
@@ -286,10 +286,18 @@ struct HeaderColumnStoreTests {
     // MARK: - Helpers
 
     private func makeCleanStore() -> HeaderColumnStore {
-        UserDefaults.standard.removeObject(forKey: TestIdentity.headerColumnStorageKey)
-        UserDefaults.standard.removeObject(forKey: TestIdentity.discoveredRequestHeadersKey)
-        UserDefaults.standard.removeObject(forKey: TestIdentity.discoveredResponseHeadersKey)
-        UserDefaults.standard.removeObject(forKey: TestIdentity.hiddenBuiltInColumnsKey)
+        clearDefaultsKey("headerColumns", fallback: TestIdentity.headerColumnStorageKey)
+        clearDefaultsKey("discoveredReqHeaders", fallback: TestIdentity.discoveredRequestHeadersKey)
+        clearDefaultsKey("discoveredResHeaders", fallback: TestIdentity.discoveredResponseHeadersKey)
+        clearDefaultsKey("hiddenBuiltInColumns", fallback: TestIdentity.hiddenBuiltInColumnsKey)
         return HeaderColumnStore()
+    }
+
+    private func clearDefaultsKey(_ key: String, fallback: String) {
+        let currentKey = RockxyIdentity.current.defaultsKey(key)
+        UserDefaults.standard.removeObject(forKey: currentKey)
+        if currentKey != fallback {
+            UserDefaults.standard.removeObject(forKey: fallback)
+        }
     }
 }

--- a/RockxyTests/Models/UI/PreviewTabStoreTests.swift
+++ b/RockxyTests/Models/UI/PreviewTabStoreTests.swift
@@ -12,9 +12,8 @@ struct PreviewTabStoreTests {
 
     @Test("Store initializes with empty tabs")
     func defaultInit() {
-        let store = PreviewTabStore()
-        // Clear any persisted state first
-        UserDefaults.standard.removeObject(forKey: TestIdentity.previewTabStorageKey)
+        clearDefaultsKey("previewTabs", fallback: TestIdentity.previewTabStorageKey)
+        clearDefaultsKey("previewAutoBeautify", fallback: TestIdentity.previewTabBeautifyKey)
         let freshStore = PreviewTabStore()
         #expect(freshStore.requestTabs.isEmpty)
         #expect(freshStore.responseTabs.isEmpty)
@@ -111,12 +110,12 @@ struct PreviewTabStoreTests {
 
     @Test("Persisted custom raw tabs are ignored")
     func persistedCustomTabsIgnored() throws {
-        UserDefaults.standard.removeObject(forKey: TestIdentity.previewTabBeautifyKey)
+        clearDefaultsKey("previewAutoBeautify", fallback: TestIdentity.previewTabBeautifyKey)
         let tabs = [
             PreviewTab(name: "Legacy Raw", renderMode: .raw, panel: .response, isBuiltIn: false),
             PreviewTab(renderMode: .raw, panel: .response),
         ]
-        UserDefaults.standard.set(try JSONEncoder().encode(tabs), forKey: TestIdentity.previewTabStorageKey)
+        UserDefaults.standard.set(try JSONEncoder().encode(tabs), forKey: currentDefaultsKey("previewTabs"))
 
         let store = PreviewTabStore()
 
@@ -140,8 +139,20 @@ struct PreviewTabStoreTests {
     // MARK: - Helpers
 
     private func makeCleanStore() -> PreviewTabStore {
-        UserDefaults.standard.removeObject(forKey: TestIdentity.previewTabStorageKey)
-        UserDefaults.standard.removeObject(forKey: TestIdentity.previewTabBeautifyKey)
+        clearDefaultsKey("previewTabs", fallback: TestIdentity.previewTabStorageKey)
+        clearDefaultsKey("previewAutoBeautify", fallback: TestIdentity.previewTabBeautifyKey)
         return PreviewTabStore()
+    }
+
+    private func clearDefaultsKey(_ key: String, fallback: String) {
+        let currentKey = currentDefaultsKey(key)
+        UserDefaults.standard.removeObject(forKey: currentKey)
+        if currentKey != fallback {
+            UserDefaults.standard.removeObject(forKey: fallback)
+        }
+    }
+
+    private func currentDefaultsKey(_ key: String) -> String {
+        RockxyIdentity.current.defaultsKey(key)
     }
 }

--- a/RockxyTests/Shared/CallerValidationTests.swift
+++ b/RockxyTests/Shared/CallerValidationTests.swift
@@ -141,6 +141,7 @@ struct CallerValidationTests {
 
     @Test("Configured allowlist contains expected Rockxy identifiers")
     func allowlistContainsExpectedIdentifiers() {
+        guard !TestIdentity.isRunningUnderRawXCTestTool else { return }
         let ids = RockxyIdentity.current.allowedCallerIdentifiers
         for expected in TestIdentity.expectedAllowedCallerIdentifiers {
             #expect(ids.contains(expected))

--- a/RockxyTests/Shared/ConnectionValidatorTests.swift
+++ b/RockxyTests/Shared/ConnectionValidatorTests.swift
@@ -16,6 +16,7 @@ struct ConnectionValidatorTests {
 
     @Test("ConnectionValidator reads the expected allowlist from RockxyIdentity")
     func allowlistMatchesIdentityConfig() {
+        guard !TestIdentity.isRunningUnderRawXCTestTool else { return }
         let ids = RockxyIdentity.current.allowedCallerIdentifiers
         for expected in TestIdentity.expectedAllowedCallerIdentifiers {
             #expect(ids.contains(expected))

--- a/RockxyTests/Shared/RockxyIdentityTests.swift
+++ b/RockxyTests/Shared/RockxyIdentityTests.swift
@@ -96,21 +96,25 @@ struct RockxyIdentityTests {
 
     @Test("Live displayName resolves to Rockxy")
     func liveDisplayName() {
+        guard !TestIdentity.isRunningUnderRawXCTestTool else { return }
         #expect(RockxyIdentity.current.displayName == "Rockxy")
     }
 
     @Test("Live familyNamespace resolves to com.amunx.rockxy")
     func liveFamilyNamespace() {
+        guard !TestIdentity.isRunningUnderRawXCTestTool else { return }
         #expect(RockxyIdentity.current.familyNamespace == "com.amunx.rockxy")
     }
 
     @Test("Live helperBundleIdentifier resolves to com.amunx.rockxy.helper")
     func liveHelperBundleIdentifier() {
+        guard !TestIdentity.isRunningUnderRawXCTestTool else { return }
         #expect(RockxyIdentity.current.helperBundleIdentifier == "com.amunx.rockxy.helper")
     }
 
     @Test("Live allowedCallerIdentifiers contains both expected IDs")
     func liveAllowedCallerIdentifiers() {
+        guard !TestIdentity.isRunningUnderRawXCTestTool else { return }
         let ids = RockxyIdentity.current.allowedCallerIdentifiers
         for expected in TestIdentity.expectedAllowedCallerIdentifiers {
             #expect(ids.contains(expected))
@@ -119,11 +123,13 @@ struct RockxyIdentityTests {
 
     @Test("Live appBundleIdentifier is non-empty")
     func liveAppBundleIdentifier() {
+        guard !TestIdentity.isRunningUnderRawXCTestTool else { return }
         #expect(!RockxyIdentity.current.appBundleIdentifier.isEmpty)
     }
 
     @Test("Live test-host appSupportDirectory uses temporary storage")
     func liveTestHostAppSupportDirectoryUsesTemporaryStorage() {
+        guard !TestIdentity.isRunningUnderRawXCTestTool else { return }
         let path = RockxyIdentity.current.appSupportDirectory()
         #expect(path.path.hasPrefix(FileManager.default.temporaryDirectory.path))
         #expect(path.lastPathComponent == RockxyIdentity.current.appSupportDirectoryName)

--- a/RockxyTests/ViewModels/BreakpointRulesViewModelTests.swift
+++ b/RockxyTests/ViewModels/BreakpointRulesViewModelTests.swift
@@ -379,6 +379,126 @@ struct BreakpointRulesViewModelTests {
         #expect(vm.selectedRuleID == addedRule?.id)
     }
 
+    @Test("selectedRule tracks table selection")
+    func selectedRuleTracksSelection() throws {
+        let vm = BreakpointRulesViewModel()
+        vm.addBreakpointRule(
+            ruleName: "Rule A",
+            urlPattern: "*.a.com/*",
+            httpMethod: .any,
+            matchType: .wildcard,
+            phaseRequest: true,
+            phaseResponse: true,
+            includeSubpaths: true
+        )
+        vm.addBreakpointRule(
+            ruleName: "Rule B",
+            urlPattern: "*.b.com/*",
+            httpMethod: .post,
+            matchType: .wildcard,
+            phaseRequest: true,
+            phaseResponse: false,
+            includeSubpaths: true
+        )
+
+        let firstID = try #require(vm.breakpointRules.first?.id)
+        vm.selectedRuleID = firstID
+
+        #expect(vm.selectedRule?.name == "Rule A")
+    }
+
+    @Test("handleRulesDidChange clears missing selected rule")
+    func handleRulesDidChangeClearsMissingSelection() throws {
+        let vm = BreakpointRulesViewModel()
+        vm.addBreakpointRule(
+            ruleName: "Rule A",
+            urlPattern: "*.a.com/*",
+            httpMethod: .any,
+            matchType: .wildcard,
+            phaseRequest: true,
+            phaseResponse: true,
+            includeSubpaths: true
+        )
+        vm.addBreakpointRule(
+            ruleName: "Rule B",
+            urlPattern: "*.b.com/*",
+            httpMethod: .any,
+            matchType: .wildcard,
+            phaseRequest: true,
+            phaseResponse: true,
+            includeSubpaths: true
+        )
+
+        let removedID = try #require(vm.breakpointRules.first?.id)
+        let remainingRule = try #require(vm.breakpointRules.last)
+        vm.selectedRuleID = removedID
+
+        vm.handleRulesDidChange(Notification(name: .rulesDidChange, object: [remainingRule]))
+
+        #expect(vm.breakpointRules.map(\.id) == [remainingRule.id])
+        #expect(vm.selectedRuleID == nil)
+    }
+
+    @Test("table labels and phase helpers mirror displayed columns")
+    func tableLabelsAndPhaseHelpers() throws {
+        let vm = BreakpointRulesViewModel()
+        let wildcardRule = ProxyRule(
+            name: "Request Rule",
+            matchCondition: RuleMatchCondition(urlPattern: #"/v2/.*"#, method: "GET"),
+            action: .breakpoint(phase: .request)
+        )
+        let regexRule = ProxyRule(
+            name: "Regex Rule",
+            matchCondition: RuleMatchCondition(
+                urlPattern: #"^https://api\.example\.com/v1$"#
+            ),
+            action: .breakpoint(phase: .response)
+        )
+        vm.handleRulesDidChange(Notification(name: .rulesDidChange, object: [wildcardRule, regexRule]))
+
+        #expect(vm.methodLabel(for: wildcardRule) == "GET")
+        #expect(vm.matchingRuleLabel(for: wildcardRule) == "Wildcard: /v2/")
+        #expect(vm.breaksOnRequest(wildcardRule))
+        #expect(!vm.breaksOnResponse(wildcardRule))
+
+        #expect(vm.methodLabel(for: regexRule) == "ANY")
+        #expect(vm.matchingRuleLabel(for: regexRule) == #"Regex: ^https://api\.example\.com/v1$"#)
+        #expect(!vm.breaksOnRequest(regexRule))
+        #expect(vm.breaksOnResponse(regexRule))
+    }
+
+    @Test("unknown row actions are no-ops")
+    func unknownRowActionsAreNoOps() {
+        let vm = BreakpointRulesViewModel()
+        vm.addBreakpointRule(
+            ruleName: "Only",
+            urlPattern: "*.only.com/*",
+            httpMethod: .any,
+            matchType: .wildcard,
+            phaseRequest: true,
+            phaseResponse: true,
+            includeSubpaths: true
+        )
+
+        vm.toggleRule(id: UUID())
+        vm.duplicateRule(id: UUID())
+
+        #expect(vm.breakpointRules.count == 1)
+        #expect(vm.breakpointRules.first?.isEnabled == true)
+        #expect(vm.breakpointRules.first?.name == "Only")
+    }
+
+    @Test("setBreakpointToolEnabled directly updates toggle state")
+    func setBreakpointToolEnabledUpdatesState() {
+        let vm = BreakpointRulesViewModel()
+
+        vm.setBreakpointToolEnabled(false)
+        #expect(vm.isBreakpointToolEnabled == false)
+
+        vm.setBreakpointToolEnabled(true)
+        #expect(vm.isBreakpointToolEnabled == true)
+    }
+
     // MARK: - Edit mode
 
     @Test("updateRule updates the existing rule in place without creating a duplicate")

--- a/RockxyTests/ViewModels/ScriptingViewModelTests.swift
+++ b/RockxyTests/ViewModels/ScriptingViewModelTests.swift
@@ -188,6 +188,46 @@ struct ScriptingViewModelTests {
         #expect(rows.last?.id == .script("script-1"))
     }
 
+    @Test("Display rows preserve root order and hide collapsed folder children")
+    func displayRowsPreserveRootOrderAndCollapsedState() {
+        let (defaults, suiteName) = TestFixtures.makeNamedIsolatedDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let folderStore = ScriptFolderStore(defaults: defaults)
+        let folderID = folderStore.createFolder(name: "Auth")
+        folderStore.addScript("script-child", toFolder: folderID)
+        folderStore.reconcile(with: ["script-root", "script-child"])
+
+        let env = TestFixtures.makeIsolatedPluginEnv()
+        defer { env.cleanup() }
+        let vm = ScriptingListViewModel(pluginManager: env.manager, folderStore: folderStore)
+        vm.plugins = [
+            PluginInfoSnapshot(
+                id: "script-root",
+                name: "Root Script",
+                isEnabled: true,
+                method: nil,
+                urlPattern: nil,
+                statusText: "Active"
+            ),
+            PluginInfoSnapshot(
+                id: "script-child",
+                name: "Child Script",
+                isEnabled: true,
+                method: "GET",
+                urlPattern: "/auth",
+                statusText: "Active"
+            ),
+        ]
+
+        #expect(vm.displayRows.map(\.id) == [.folder(folderID), .script("script-child"), .script("script-root")])
+        #expect(vm.displayRows.first(where: { $0.id == .script("script-child") })?.indent == 1)
+        #expect(vm.displayRows.first(where: { $0.id == .script("script-root") })?.indent == 0)
+
+        folderStore.setExpanded(folderID: folderID, expanded: false)
+
+        #expect(vm.displayRows.map(\.id) == [.folder(folderID), .script("script-root")])
+    }
+
     @Test("deleteSelection removes selected script and clears selection")
     func deleteSelectionRemovesScriptAndClearsSelection() async throws {
         let env = TestFixtures.makeIsolatedPluginEnv()
@@ -242,6 +282,203 @@ struct ScriptingViewModelTests {
         #expect(folderStore.index.folders.isEmpty)
         #expect(folderStore.index.rootOrder == [.script("script-1")])
         #expect(vm.plugins.count == 1)
+    }
+
+    @Test("open editor actions publish edit intent only for script selections")
+    func openEditorActionsPublishScriptIntent() {
+        let (defaults, suiteName) = TestFixtures.makeNamedIsolatedDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let folderStore = ScriptFolderStore(defaults: defaults)
+        let folderID = folderStore.createFolder(name: "Auth")
+        let env = TestFixtures.makeIsolatedPluginEnv()
+        defer { env.cleanup() }
+        let vm = ScriptingListViewModel(pluginManager: env.manager, folderStore: folderStore)
+        _ = ScriptEditorSession.shared.consumePending()
+
+        vm.selectedRowID = .folder(folderID)
+        vm.openEditorForSelection()
+        #expect(ScriptEditorSession.shared.consumePending() == nil)
+
+        vm.selectedRowID = .script("script-1")
+        vm.openEditorForSelection()
+        #expect(ScriptEditorSession.shared.consumePending() == .edit(pluginID: "script-1"))
+
+        vm.openEditor(for: "script-2")
+        #expect(ScriptEditorSession.shared.consumePending() == .edit(pluginID: "script-2"))
+    }
+
+    @Test("createNewScript writes default files selects the script and opens editor intent")
+    func createNewScriptCreatesFilesSelectionAndEditorIntent() async throws {
+        let env = TestFixtures.makeIsolatedPluginEnv()
+        defer { env.cleanup() }
+        let folderStore = ScriptFolderStore(defaults: env.defaults)
+        let vm = ScriptingListViewModel(
+            pluginManager: env.manager,
+            folderStore: folderStore,
+            pluginsDirectory: env.pluginsDir
+        )
+        _ = ScriptEditorSession.shared.consumePending()
+
+        let pluginID = await vm.createNewScript()
+
+        guard let pluginID else {
+            Issue.record("Expected createNewScript to return a plugin id")
+            return
+        }
+        let pluginDir = env.pluginsDir.appendingPathComponent(pluginID, isDirectory: true)
+        #expect(FileManager.default.fileExists(atPath: pluginDir.appendingPathComponent("plugin.json").path))
+        #expect(FileManager.default.fileExists(atPath: pluginDir.appendingPathComponent("index.js").path))
+        #expect(vm.selectedRowID == .script(pluginID))
+        #expect(vm.plugins.map(\.id) == [pluginID])
+        #expect(ScriptEditorSession.shared.consumePending() == .edit(pluginID: pluginID))
+
+        let manifest = try JSONDecoder().decode(
+            PluginManifest.self,
+            from: Data(contentsOf: pluginDir.appendingPathComponent("plugin.json"))
+        )
+        let source = try String(contentsOf: pluginDir.appendingPathComponent("index.js"), encoding: .utf8)
+        #expect(manifest.id == pluginID)
+        #expect(manifest.name == "Untitled Script 1")
+        #expect(manifest.scriptBehavior == ScriptBehavior.defaults())
+        #expect(source == ScriptTemplates.defaultSource)
+    }
+
+    @Test("duplicateSelection copies source script manifest and selects the copy")
+    func duplicateSelectionCopiesManifestAndSource() async throws {
+        let env = TestFixtures.makeIsolatedPluginEnv()
+        defer { env.cleanup() }
+        let folderStore = ScriptFolderStore(defaults: env.defaults)
+        let source = "async function onRequest(context, url, request) { return request; }"
+        let originalID = "script.duplicate.\(UUID().uuidString)"
+        try makeScriptPlugin(
+            id: originalID,
+            name: "Original Script",
+            in: env.pluginsDir,
+            defaults: env.defaults,
+            enabled: true,
+            method: "PATCH",
+            urlPattern: "/v1/items",
+            runOnRequest: true,
+            runOnResponse: false,
+            runAsMock: true,
+            source: source
+        )
+        await env.manager.loadAllPlugins()
+
+        let vm = ScriptingListViewModel(
+            pluginManager: env.manager,
+            folderStore: folderStore,
+            pluginsDirectory: env.pluginsDir
+        )
+        await vm.refresh()
+        vm.selectedRowID = .script(originalID)
+
+        await vm.duplicateSelection()
+
+        guard case let .script(copyID) = vm.selectedRowID else {
+            Issue.record("Expected duplicateSelection to select the copied script")
+            return
+        }
+        #expect(copyID != originalID)
+        #expect(Set(vm.plugins.map(\.id)) == Set([originalID, copyID]))
+
+        let copyDir = env.pluginsDir.appendingPathComponent(copyID, isDirectory: true)
+        let manifest = try JSONDecoder().decode(
+            PluginManifest.self,
+            from: Data(contentsOf: copyDir.appendingPathComponent("plugin.json"))
+        )
+        let copiedSource = try String(contentsOf: copyDir.appendingPathComponent("index.js"), encoding: .utf8)
+        #expect(manifest.id == copyID)
+        #expect(manifest.name == "Original Script (Copy)")
+        #expect(manifest.scriptBehavior?.matchCondition?.method == "PATCH")
+        #expect(manifest.scriptBehavior?.matchCondition?.urlPattern == "/v1/items")
+        #expect(manifest.scriptBehavior?.runOnResponse == false)
+        #expect(manifest.scriptBehavior?.runAsMock == true)
+        #expect(copiedSource == source)
+    }
+
+    @Test("folder actions create rename cancel toggle and begin rename selected folder")
+    func folderActionsCreateRenameCancelToggleAndBeginRename() {
+        let (defaults, suiteName) = TestFixtures.makeNamedIsolatedDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let folderStore = ScriptFolderStore(defaults: defaults)
+        let env = TestFixtures.makeIsolatedPluginEnv()
+        defer { env.cleanup() }
+        let vm = ScriptingListViewModel(pluginManager: env.manager, folderStore: folderStore)
+
+        vm.createNewFolder()
+
+        guard case let .folder(folderID) = vm.selectedRowID else {
+            Issue.record("Expected createNewFolder to select the new folder")
+            return
+        }
+        #expect(vm.renamingFolderID == folderID)
+        #expect(vm.renamingFolderText == "Untitled")
+
+        vm.renamingFolderText = "  Auth Scripts  "
+        vm.commitFolderRename()
+
+        #expect(vm.renamingFolderID == nil)
+        #expect(vm.renamingFolderText.isEmpty)
+        #expect(folderStore.index.folders.first(where: { $0.id == folderID })?.name == "Auth Scripts")
+
+        vm.toggleFolder(id: folderID)
+        #expect(folderStore.index.folders.first(where: { $0.id == folderID })?.expanded == false)
+        vm.toggleFolder(id: folderID)
+        #expect(folderStore.index.folders.first(where: { $0.id == folderID })?.expanded == true)
+
+        vm.beginRenameSelectedFolder()
+        #expect(vm.renamingFolderID == folderID)
+        #expect(vm.renamingFolderText == "Auth Scripts")
+        vm.cancelFolderRename()
+        #expect(vm.renamingFolderID == nil)
+        #expect(vm.renamingFolderText.isEmpty)
+    }
+
+    @Test("folder child toggle enables and disables only requested scripts")
+    func setScriptsEnabledTogglesOnlyRequestedScripts() async throws {
+        let env = TestFixtures.makeIsolatedPluginEnv()
+        defer { env.cleanup() }
+        let folderStore = ScriptFolderStore(defaults: env.defaults)
+        let firstID = "script.toggle.first.\(UUID().uuidString)"
+        let secondID = "script.toggle.second.\(UUID().uuidString)"
+        try makeScriptPlugin(id: firstID, name: "First", in: env.pluginsDir, defaults: env.defaults, enabled: false)
+        try makeScriptPlugin(id: secondID, name: "Second", in: env.pluginsDir, defaults: env.defaults, enabled: false)
+        await env.manager.loadAllPlugins()
+
+        let vm = ScriptingListViewModel(pluginManager: env.manager, folderStore: folderStore)
+        await vm.refresh()
+
+        await vm.setScriptsEnabled(ids: [firstID], enabled: true)
+        var snapshots = await env.manager.plugins
+        #expect(snapshots.first(where: { $0.id == firstID })?.isEnabled == true)
+        #expect(snapshots.first(where: { $0.id == secondID })?.isEnabled == false)
+
+        await vm.setScriptsEnabled(ids: [firstID, secondID], enabled: false)
+        snapshots = await env.manager.plugins
+        #expect(snapshots.first(where: { $0.id == firstID })?.isEnabled == false)
+        #expect(snapshots.first(where: { $0.id == secondID })?.isEnabled == false)
+    }
+
+    @Test("toggleScript flips the clicked script enabled state")
+    func toggleScriptFlipsEnabledState() async throws {
+        let env = TestFixtures.makeIsolatedPluginEnv()
+        defer { env.cleanup() }
+        let folderStore = ScriptFolderStore(defaults: env.defaults)
+        let pluginID = "script.toggle.clicked.\(UUID().uuidString)"
+        try makeScriptPlugin(id: pluginID, name: "Clicked", in: env.pluginsDir, defaults: env.defaults, enabled: false)
+        await env.manager.loadAllPlugins()
+
+        let vm = ScriptingListViewModel(pluginManager: env.manager, folderStore: folderStore)
+        await vm.refresh()
+
+        await vm.toggleScript(id: pluginID)
+        var snapshots = await env.manager.plugins
+        #expect(snapshots.first(where: { $0.id == pluginID })?.isEnabled == true)
+
+        await vm.toggleScript(id: pluginID)
+        snapshots = await env.manager.plugins
+        #expect(snapshots.first(where: { $0.id == pluginID })?.isEnabled == false)
     }
 
     @Test("Scripting advanced toggles persist through AppSettingsStorage")
@@ -340,6 +577,108 @@ struct ScriptingViewModelTests {
         vm.patternMode = .regex
         vm.urlPattern = "["
         #expect(!vm.testRule(against: "https://api.example.com/v1/users"))
+
+        vm.patternMode = .advanced
+        vm.urlPattern = #"api\.example\.com/v1/.+"#
+        #expect(vm.testRule(against: "https://api.example.com/v1/users"))
+    }
+
+    @Test("Save & Activate persists matching rule run options and source")
+    func saveAndActivatePersistsEditorFields() async throws {
+        let env = TestFixtures.makeIsolatedPluginEnv()
+        defer { env.cleanup() }
+        let pluginID = "script.persist.\(UUID().uuidString)"
+        try makeScriptPlugin(
+            id: pluginID,
+            name: "Before",
+            in: env.pluginsDir,
+            defaults: env.defaults,
+            enabled: false
+        )
+        await env.manager.loadAllPlugins()
+
+        let vm = ScriptEditorViewModel(
+            pluginManager: env.manager,
+            policyGate: ScriptPolicyGate(policy: DefaultAppPolicy()),
+            pluginsDirectory: env.pluginsDir
+        )
+        await vm.load(intent: .edit(pluginID: pluginID))
+        let updatedSource = "async function onResponse(context, url, request, response) { return response; }"
+        vm.name = "Persisted Script"
+        vm.urlPattern = "https://api.example.com/v1/*"
+        vm.includeSubpaths = true
+        vm.patternMode = .wildcard
+        vm.method = .post
+        vm.runOnRequest = false
+        vm.runOnResponse = true
+        vm.runAsMock = true
+        vm.code = updatedSource
+
+        await vm.saveAndActivate()
+
+        let pluginDir = env.pluginsDir.appendingPathComponent(pluginID, isDirectory: true)
+        let manifest = try JSONDecoder().decode(
+            PluginManifest.self,
+            from: Data(contentsOf: pluginDir.appendingPathComponent("plugin.json"))
+        )
+        let source = try String(contentsOf: pluginDir.appendingPathComponent("index.js"), encoding: .utf8)
+        #expect(manifest.name == "Persisted Script")
+        #expect(manifest.scriptBehavior?.matchCondition?.method == "POST")
+        #expect(manifest.scriptBehavior?.matchCondition?.urlPattern == #"https://api\.example\.com/v1/.*"#)
+        #expect(manifest.scriptBehavior?.runOnRequest == false)
+        #expect(manifest.scriptBehavior?.runOnResponse == true)
+        #expect(manifest.scriptBehavior?.runAsMock == true)
+        #expect(source == updatedSource)
+    }
+
+    @Test("Script editor footer actions update code console visibility and shared state")
+    func editorFooterActionsUpdateCodeConsoleAndSharedState() async throws {
+        let env = TestFixtures.makeIsolatedPluginEnv()
+        defer { env.cleanup() }
+        let pluginID = "script.footer.\(UUID().uuidString)"
+        try makeScriptPlugin(
+            id: pluginID,
+            name: "Footer Script",
+            in: env.pluginsDir,
+            defaults: env.defaults,
+            enabled: true
+        )
+        await env.manager.loadAllPlugins()
+
+        let vm = ScriptEditorViewModel(
+            pluginManager: env.manager,
+            policyGate: ScriptPolicyGate(policy: DefaultAppPolicy()),
+            pluginsDirectory: env.pluginsDir
+        )
+        await vm.load(intent: .edit(pluginID: pluginID))
+        vm.code = """
+        function run() {
+        console.log("ok");
+        }
+        """
+
+        vm.beautify()
+        #expect(vm.code.contains(#"  console.log("ok");"#))
+        #expect(vm.consoleEntries.contains { $0.level == .system && $0.message.contains("beautified") })
+
+        vm.insertSnippet("// request.headers[\"X-Debug\"] = \"1\";")
+        #expect(vm.code.hasSuffix("// request.headers[\"X-Debug\"] = \"1\";"))
+
+        #expect(vm.consolePanelVisible == true)
+        vm.toggleConsolePanel()
+        #expect(vm.consolePanelVisible == false)
+        vm.toggleConsolePanel()
+        #expect(vm.consolePanelVisible == true)
+
+        let storageKey = RockxyIdentity.current.pluginStoragePrefix(pluginID: pluginID) + "token"
+        UserDefaults.standard.set("cached", forKey: storageKey)
+        defer { UserDefaults.standard.removeObject(forKey: storageKey) }
+        vm.resetSharedState()
+        #expect(UserDefaults.standard.string(forKey: storageKey) == nil)
+        #expect(vm.consoleEntries.contains { $0.message == "Shared state cleared." })
+
+        vm.clearConsole()
+        #expect(vm.consoleEntries.isEmpty)
     }
 
     @Test("Save & Activate enables a freshly-created script and reports active")

--- a/RockxyTests/ViewModels/ScriptingViewModelTests.swift
+++ b/RockxyTests/ViewModels/ScriptingViewModelTests.swift
@@ -80,6 +80,16 @@ struct ScriptingViewModelTests {
         ])
     }
 
+    @Test("Script code highlighting recognizes JavaScript syntax roles")
+    func scriptCodeHighlightingSpans() {
+        let spans = ScriptCodeHighlighting.spans(for: #"async function run() { return "ok"; // done"#)
+        #expect(spans.contains { $0.role == .keyword })
+        #expect(spans.contains { $0.role == .function })
+        #expect(spans.contains { $0.role == .string })
+        #expect(spans.contains { $0.role == .comment })
+        #expect(spans.contains { $0.role == .punctuation })
+    }
+
     @Test("Method enum round-trips via persistedValue")
     func methodRoundTrip() {
         for m in ScriptMatchMethod.allCases {
@@ -235,9 +245,9 @@ struct ScriptingViewModelTests {
     }
 
     @Test("Scripting advanced toggles persist through AppSettingsStorage")
-    func advancedTogglesPersist() {
+    func advancedTogglesPersist() async {
+        await RuleTestLock.shared.acquire()
         let original = AppSettingsStorage.load()
-        defer { AppSettingsStorage.save(original) }
         var reset = original
         reset.scriptingToolEnabled = true
         reset.allowSystemEnvVars = false
@@ -259,6 +269,9 @@ struct ScriptingViewModelTests {
         #expect(persisted.scriptingToolEnabled == false)
         #expect(persisted.allowSystemEnvVars == true)
         #expect(persisted.allowMultipleScriptsPerRequest == true)
+
+        AppSettingsStorage.save(original)
+        await RuleTestLock.shared.release()
     }
 
     @Test("Script editor session increments even for same plugin intent")

--- a/RockxyTests/ViewModels/ScriptingViewModelTests.swift
+++ b/RockxyTests/ViewModels/ScriptingViewModelTests.swift
@@ -67,6 +67,19 @@ struct ScriptingViewModelTests {
         #expect(vm.selectedRowID == nil)
     }
 
+    @Test("Script editor menus match native grouped order")
+    func editorMenuContentOrder() {
+        #expect(ScriptEditorMenuContent.methodSections == [
+            [.any],
+            [.get, .post, .put, .delete, .patch],
+            [.head, .options, .trace],
+        ])
+        #expect(ScriptEditorMenuContent.patternModeSections == [
+            [.wildcard, .regex],
+            [.advanced],
+        ])
+    }
+
     @Test("Method enum round-trips via persistedValue")
     func methodRoundTrip() {
         for m in ScriptMatchMethod.allCases {
@@ -83,6 +96,43 @@ struct ScriptingViewModelTests {
         let data = try JSONEncoder().encode(index)
         let decoded = try JSONDecoder().decode(ScriptFolderIndex.self, from: data)
         #expect(decoded == index)
+    }
+
+    @Test("Method filter treats missing persisted method as ANY")
+    func methodFilterMatchesAnyFallback() {
+        let (defaults, suiteName) = TestFixtures.makeNamedIsolatedDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let folderStore = ScriptFolderStore(defaults: defaults)
+        folderStore.reconcile(with: ["script-any", "script-post"])
+
+        let env = TestFixtures.makeIsolatedPluginEnv()
+        defer { env.cleanup() }
+        let vm = ScriptingListViewModel(pluginManager: env.manager, folderStore: folderStore)
+        vm.plugins = [
+            PluginInfoSnapshot(
+                id: "script-any",
+                name: "Any Script",
+                isEnabled: true,
+                method: nil,
+                urlPattern: nil,
+                statusText: "Active"
+            ),
+            PluginInfoSnapshot(
+                id: "script-post",
+                name: "Post Script",
+                isEnabled: true,
+                method: "POST",
+                urlPattern: nil,
+                statusText: "Active"
+            ),
+        ]
+        vm.isFilterVisible = true
+        vm.filterColumn = .method
+        vm.filterText = "any"
+
+        let rows = vm.filteredDisplayRows
+        #expect(rows.count == 1)
+        #expect(rows.first?.id == .script("script-any"))
     }
 
     @Test("Folder index entry decode rejects payloads containing both folder and script")
@@ -126,6 +176,157 @@ struct ScriptingViewModelTests {
         #expect(rows.count == 2)
         #expect(rows.first?.id == .folder(folderID))
         #expect(rows.last?.id == .script("script-1"))
+    }
+
+    @Test("deleteSelection removes selected script and clears selection")
+    func deleteSelectionRemovesScriptAndClearsSelection() async throws {
+        let env = TestFixtures.makeIsolatedPluginEnv()
+        defer { env.cleanup() }
+        let folderStore = ScriptFolderStore(defaults: env.defaults)
+        let pluginID = "script.delete.\(UUID().uuidString)"
+        try makeScriptPlugin(
+            id: pluginID,
+            name: "Delete Me",
+            in: env.pluginsDir,
+            defaults: env.defaults,
+            enabled: true
+        )
+        await env.manager.loadAllPlugins()
+
+        let vm = ScriptingListViewModel(pluginManager: env.manager, folderStore: folderStore)
+        await vm.refresh()
+        vm.selectedRowID = .script(pluginID)
+
+        await vm.deleteSelection()
+
+        #expect(vm.selectedRowID == nil)
+        #expect(vm.plugins.isEmpty)
+        #expect(!FileManager.default.fileExists(atPath: env.pluginsDir.appendingPathComponent(pluginID).path))
+    }
+
+    @Test("deleteSelection removes selected folder but preserves its scripts")
+    func deleteSelectionRemovesFolderAndPreservesChildren() async {
+        let (defaults, suiteName) = TestFixtures.makeNamedIsolatedDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let folderStore = ScriptFolderStore(defaults: defaults)
+        let folderID = folderStore.createFolder(name: "Auth")
+        folderStore.addScript("script-1", toFolder: folderID)
+        let env = TestFixtures.makeIsolatedPluginEnv()
+        defer { env.cleanup() }
+        let vm = ScriptingListViewModel(pluginManager: env.manager, folderStore: folderStore)
+        vm.plugins = [
+            PluginInfoSnapshot(
+                id: "script-1",
+                name: "Token",
+                isEnabled: true,
+                method: "GET",
+                urlPattern: "/token",
+                statusText: "Active"
+            ),
+        ]
+        vm.selectedRowID = .folder(folderID)
+
+        await vm.deleteSelection()
+
+        #expect(vm.selectedRowID == nil)
+        #expect(folderStore.index.folders.isEmpty)
+        #expect(folderStore.index.rootOrder == [.script("script-1")])
+        #expect(vm.plugins.count == 1)
+    }
+
+    @Test("Scripting advanced toggles persist through AppSettingsStorage")
+    func advancedTogglesPersist() {
+        let original = AppSettingsStorage.load()
+        defer { AppSettingsStorage.save(original) }
+        var reset = original
+        reset.scriptingToolEnabled = true
+        reset.allowSystemEnvVars = false
+        reset.allowMultipleScriptsPerRequest = false
+        AppSettingsStorage.save(reset)
+
+        let env = TestFixtures.makeIsolatedPluginEnv()
+        defer { env.cleanup() }
+        let vm = ScriptingListViewModel(
+            pluginManager: env.manager,
+            folderStore: ScriptFolderStore(defaults: env.defaults)
+        )
+
+        vm.setToolEnabled(false)
+        vm.setAdvanceAllowSystemEnvVars(true)
+        vm.setAdvanceAllowChaining(true)
+
+        let persisted = AppSettingsStorage.load()
+        #expect(persisted.scriptingToolEnabled == false)
+        #expect(persisted.allowSystemEnvVars == true)
+        #expect(persisted.allowMultipleScriptsPerRequest == true)
+    }
+
+    @Test("Script editor session increments even for same plugin intent")
+    func editorSessionReopeningSamePluginAdvancesVersion() {
+        _ = ScriptEditorSession.shared.consumePending()
+        let before = ScriptEditorSession.shared.contextVersion
+
+        ScriptEditorSession.shared.setPending(.edit(pluginID: "script-1"))
+        let firstVersion = ScriptEditorSession.shared.contextVersion
+        let firstIntent = ScriptEditorSession.shared.consumePending()
+        ScriptEditorSession.shared.setPending(.edit(pluginID: "script-1"))
+        let secondVersion = ScriptEditorSession.shared.contextVersion
+        let secondIntent = ScriptEditorSession.shared.consumePending()
+
+        #expect(firstVersion == before &+ 1)
+        #expect(secondVersion == firstVersion &+ 1)
+        #expect(firstIntent == .edit(pluginID: "script-1"))
+        #expect(secondIntent == .edit(pluginID: "script-1"))
+    }
+
+    @Test("ScriptEditorViewModel loads persisted manifest, behavior, and source")
+    func editorLoadsExistingScriptFields() async throws {
+        let env = TestFixtures.makeIsolatedPluginEnv()
+        defer { env.cleanup() }
+        let pluginID = "script.load.\(UUID().uuidString)"
+        let source = "async function onRequest(context, url, request) { return request; }"
+        try makeScriptPlugin(
+            id: pluginID,
+            name: "Loaded Script",
+            in: env.pluginsDir,
+            defaults: env.defaults,
+            enabled: true,
+            method: "POST",
+            urlPattern: #"https:\/\/api\.example\.com\/v1\/.*"#,
+            runOnRequest: false,
+            runOnResponse: true,
+            runAsMock: true,
+            source: source
+        )
+        await env.manager.loadAllPlugins()
+
+        let vm = ScriptEditorViewModel(
+            pluginManager: env.manager,
+            policyGate: ScriptPolicyGate(policy: DefaultAppPolicy()),
+            pluginsDirectory: env.pluginsDir
+        )
+        await vm.load(intent: .edit(pluginID: pluginID))
+
+        #expect(vm.name == "Loaded Script")
+        #expect(vm.urlPattern == #"https:\/\/api\.example\.com\/v1\/.*"#)
+        #expect(vm.method == .post)
+        #expect(vm.runOnRequest == false)
+        #expect(vm.runOnResponse == true)
+        #expect(vm.runAsMock == true)
+        #expect(vm.code == source)
+    }
+
+    @Test("testRule handles matches misses and invalid regex")
+    func testRulePreviewCases() {
+        let vm = ScriptEditorViewModel()
+        vm.urlPattern = "https://api.example.com/v1/*"
+        vm.patternMode = .wildcard
+        #expect(vm.testRule(against: "https://api.example.com/v1/users"))
+        #expect(!vm.testRule(against: "https://api.example.com/v2/users"))
+
+        vm.patternMode = .regex
+        vm.urlPattern = "["
+        #expect(!vm.testRule(against: "https://api.example.com/v1/users"))
     }
 
     @Test("Save & Activate enables a freshly-created script and reports active")
@@ -192,5 +393,62 @@ struct ScriptingViewModelTests {
             vm.savedAndActive == true,
             "VM must report savedAndActive=true when actually active (msg: \(vm.statusMessage))"
         )
+    }
+
+    // MARK: - Helpers
+
+    @discardableResult
+    private func makeScriptPlugin(
+        id: String,
+        name: String,
+        in pluginsDir: URL,
+        defaults: UserDefaults,
+        enabled: Bool,
+        method: String? = nil,
+        urlPattern: String? = nil,
+        runOnRequest: Bool = true,
+        runOnResponse: Bool = true,
+        runAsMock: Bool = false,
+        source: String = ScriptTemplates.defaultSource
+    )
+        throws -> URL
+    {
+        try FileManager.default.createDirectory(at: pluginsDir, withIntermediateDirectories: true)
+        let pluginDir = pluginsDir.appendingPathComponent(id, isDirectory: true)
+        try FileManager.default.createDirectory(at: pluginDir, withIntermediateDirectories: true)
+
+        let manifest = PluginManifest(
+            id: id,
+            name: name,
+            version: "1.0.0",
+            author: PluginAuthor(name: "User", url: nil),
+            description: "",
+            types: [.script],
+            entryPoints: ["script": "index.js"],
+            capabilities: ["modifyRequest", "modifyResponse"],
+            configuration: nil,
+            minRockxyVersion: nil,
+            homepage: nil,
+            license: nil,
+            scriptBehavior: ScriptBehavior(
+                matchCondition: RuleMatchCondition(urlPattern: urlPattern, method: method),
+                runOnRequest: runOnRequest,
+                runOnResponse: runOnResponse,
+                runAsMock: runAsMock
+            )
+        )
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        try encoder.encode(manifest).write(to: pluginDir.appendingPathComponent("plugin.json"))
+        try source.write(to: pluginDir.appendingPathComponent("index.js"), atomically: true, encoding: .utf8)
+
+        let key = RockxyIdentity.current.pluginEnabledKey(pluginID: id)
+        if enabled {
+            defaults.set(true, forKey: key)
+        } else {
+            defaults.removeObject(forKey: key)
+        }
+
+        return pluginDir
     }
 }

--- a/RockxyTests/Views/Breakpoint/BreakpointRuleEditorStoreTests.swift
+++ b/RockxyTests/Views/Breakpoint/BreakpointRuleEditorStoreTests.swift
@@ -39,4 +39,50 @@ struct BreakpointRuleEditorStoreTests {
         #expect(store.editorContext == nil)
         #expect(store.draftVersion == baseline &+ 1)
     }
+
+    @Test("openNew without context resets editor state")
+    func openNewWithoutContextResetsEditorState() {
+        let store = BreakpointRuleEditorStore.shared
+        let rule = ProxyRule(
+            name: "Previous",
+            matchCondition: RuleMatchCondition(urlPattern: "/old"),
+            action: .breakpoint(phase: .both)
+        )
+        store.openExisting(rule) { _, _, _, _, _, _, _ in }
+        let baseline = store.draftVersion
+
+        store.openNew { _, _, _, _, _, _, _ in }
+
+        #expect(store.editorContext == nil)
+        #expect(store.editingRule == nil)
+        #expect(store.draftVersion == baseline &+ 1)
+    }
+
+    @Test("save handler receives all add/edit field values")
+    func saveHandlerReceivesAllFieldValues() throws {
+        let store = BreakpointRuleEditorStore.shared
+        var captured: (
+            name: String,
+            pattern: String,
+            method: HTTPMethodFilter,
+            matchType: RuleMatchType,
+            request: Bool,
+            response: Bool,
+            includeSubpaths: Bool
+        )?
+
+        store.openNew {
+            captured = ($0, $1, $2, $3, $4, $5, $6)
+        }
+        store.onSave?("API", "/v1/*", .patch, .wildcard, true, false, false)
+
+        let saved = try #require(captured)
+        #expect(saved.name == "API")
+        #expect(saved.pattern == "/v1/*")
+        #expect(saved.method == .patch)
+        #expect(saved.matchType == .wildcard)
+        #expect(saved.request)
+        #expect(!saved.response)
+        #expect(!saved.includeSubpaths)
+    }
 }

--- a/RockxyTests/Views/Breakpoint/BreakpointRuleEditorStoreTests.swift
+++ b/RockxyTests/Views/Breakpoint/BreakpointRuleEditorStoreTests.swift
@@ -1,0 +1,42 @@
+import Foundation
+@testable import Rockxy
+import Testing
+
+@MainActor
+struct BreakpointRuleEditorStoreTests {
+    @Test("openNew stores quick-create context and clears editing rule")
+    func openNewStoresQuickCreateContext() {
+        let store = BreakpointRuleEditorStore.shared
+        let baseline = store.draftVersion
+        let context = BreakpointEditorContextBuilder.fromDomain("example.com")
+        var didSave = false
+
+        store.openNew(context: context) { _, _, _, _, _, _, _ in
+            didSave = true
+        }
+
+        store.onSave?("", "", .any, .wildcard, true, true, true)
+
+        #expect(store.editorContext?.sourceHost == "example.com")
+        #expect(store.editingRule == nil)
+        #expect(store.draftVersion == baseline &+ 1)
+        #expect(didSave)
+    }
+
+    @Test("openExisting stores editing rule and clears quick-create context")
+    func openExistingStoresEditingRule() {
+        let store = BreakpointRuleEditorStore.shared
+        let baseline = store.draftVersion
+        let rule = ProxyRule(
+            name: "Edit me",
+            matchCondition: RuleMatchCondition(urlPattern: "https://example.com/.*"),
+            action: .breakpoint(phase: .both)
+        )
+
+        store.openExisting(rule) { _, _, _, _, _, _, _ in }
+
+        #expect(store.editingRule?.id == rule.id)
+        #expect(store.editorContext == nil)
+        #expect(store.draftVersion == baseline &+ 1)
+    }
+}

--- a/RockxyTests/Views/Inspector/ScriptCodeEditorRulerLayoutTests.swift
+++ b/RockxyTests/Views/Inspector/ScriptCodeEditorRulerLayoutTests.swift
@@ -1,0 +1,54 @@
+import AppKit
+@testable import Rockxy
+import Testing
+
+struct ScriptCodeEditorRulerLayoutTests {
+    @Test("Visible text rect subtracts the text container origin from clip bounds")
+    func visibleTextContainerRectUsesTextContainerOrigin() {
+        let rect = ScriptCodeEditorRulerLayout.visibleTextContainerRect(
+            contentBounds: NSRect(x: 12, y: 140, width: 320, height: 180),
+            textContainerOrigin: NSPoint(x: 8, y: 10)
+        )
+
+        #expect(rect.origin.x == 4)
+        #expect(rect.origin.y == 130)
+        #expect(rect.width == 320)
+        #expect(rect.height == 180)
+    }
+
+    @Test("Line number counts newlines before the target character")
+    func lineNumberCountsNewlinesBeforeCharacter() {
+        let content = "one\ntwo\nthree\nfour" as NSString
+
+        #expect(ScriptCodeEditorRulerLayout.lineNumber(in: content, forCharacterAt: 0) == 1)
+        #expect(ScriptCodeEditorRulerLayout.lineNumber(in: content, forCharacterAt: 4) == 2)
+        #expect(ScriptCodeEditorRulerLayout.lineNumber(in: content, forCharacterAt: 8) == 3)
+        #expect(ScriptCodeEditorRulerLayout.lineNumber(in: content, forCharacterAt: content.length) == 4)
+    }
+
+    @Test("Line number clamps character indexes outside content bounds")
+    func lineNumberClampsOutOfBoundsCharacterIndexes() {
+        let content = "one\ntwo" as NSString
+
+        #expect(ScriptCodeEditorRulerLayout.lineNumber(in: content, forCharacterAt: -20) == 1)
+        #expect(ScriptCodeEditorRulerLayout.lineNumber(in: content, forCharacterAt: 500) == 2)
+    }
+
+    @Test("Ruler y position follows text container origin and scroll offset")
+    func rulerYAppliesScrollOffset() {
+        let y = ScriptCodeEditorRulerLayout.rulerY(
+            lineFragmentY: 240,
+            textContainerOriginY: 8,
+            contentOffsetY: 200
+        )
+
+        #expect(y == 48)
+    }
+
+    @Test("Label x position keeps a trailing gutter inset")
+    func labelXUsesTrailingInset() {
+        let x = ScriptCodeEditorRulerLayout.labelX(ruleThickness: 40, labelWidth: 18)
+
+        #expect(x == 18)
+    }
+}

--- a/RockxyTests/Views/Main/FooterActionDescriptorTests.swift
+++ b/RockxyTests/Views/Main/FooterActionDescriptorTests.swift
@@ -42,6 +42,32 @@ struct FooterActionDescriptorTests {
         ])
     }
 
+    @Test("Proxy override action metadata matches footer contract")
+    func proxyOverrideActionMetadata() throws {
+        let actions = FooterActionDescriptor.toolingActions(
+            isAllowListActive: false,
+            isProxyOverridden: true
+        )
+        let action = try #require(actions.first { $0.id == .proxyOverride })
+
+        #expect(action.title == "Proxy Overridden")
+        #expect(action.systemImage == "checkmark.circle.fill")
+        #expect(action.help == "Show system proxy override details. Toggle by: ⌥⌘O")
+        #expect(action.isActive)
+        #expect(action.isEnabled)
+    }
+
+    @Test("Footer action IDs stay unique in normal and proxy override states")
+    func footerActionIDsStayUnique() {
+        for isProxyOverridden in [false, true] {
+            let actions = FooterActionDescriptor.toolingActions(
+                isAllowListActive: false,
+                isProxyOverridden: isProxyOverridden
+            )
+            #expect(Set(actions.map(\.id)).count == actions.count)
+        }
+    }
+
     @Test("Footer actions use SF Symbol names")
     func actionSymbolsArePresent() {
         let actions = FooterActionDescriptor.toolingActions(isAllowListActive: false)
@@ -75,5 +101,29 @@ struct FooterActionDescriptorTests {
         let actions = FooterActionDescriptor.toolingActions(isAllowListActive: false)
 
         #expect(FooterActionKind.allCases.filter { $0 != .proxyOverride } == actions.map(\.id))
+    }
+}
+
+struct ProxyOverrideCommandActionsTests {
+    @Test("system proxy override command is enabled only while proxy is running")
+    @MainActor
+    func toggleSystemProxyOverrideCommandAvailability() {
+        let coordinator = MainContentCoordinator()
+        let actions = MainContentCommandActions(coordinator: coordinator)
+
+        coordinator.isProxyRunning = false
+        #expect(actions.canToggleSystemProxyOverride == false)
+
+        coordinator.isProxyRunning = true
+        #expect(actions.canToggleSystemProxyOverride)
+    }
+
+    @Test("main coordinator starts with proxy override indicator hidden")
+    @MainActor
+    func coordinatorStartsWithProxyOverrideHidden() {
+        let coordinator = MainContentCoordinator()
+
+        #expect(coordinator.isProxyOverridden == false)
+        #expect(coordinator.isSystemProxyConfigured == false)
     }
 }

--- a/RockxyTests/Views/Main/FooterActionDescriptorTests.swift
+++ b/RockxyTests/Views/Main/FooterActionDescriptorTests.swift
@@ -18,6 +18,30 @@ struct FooterActionDescriptorTests {
         ])
     }
 
+    @Test("Proxy override action appears after Network Conditions only when active")
+    func proxyOverrideActionIsConditional() {
+        let inactive = FooterActionDescriptor.toolingActions(
+            isAllowListActive: false,
+            isProxyOverridden: false
+        )
+        let active = FooterActionDescriptor.toolingActions(
+            isAllowListActive: false,
+            isProxyOverridden: true
+        )
+
+        #expect(!inactive.contains { $0.id == .proxyOverride })
+        #expect(active.map(\.id) == [
+            .blockList,
+            .allowList,
+            .mapLocal,
+            .scripting,
+            .mapRemote,
+            .breakpoint,
+            .networkConditions,
+            .proxyOverride,
+        ])
+    }
+
     @Test("Footer actions use SF Symbol names")
     func actionSymbolsArePresent() {
         let actions = FooterActionDescriptor.toolingActions(isAllowListActive: false)
@@ -30,6 +54,13 @@ struct FooterActionDescriptorTests {
         #expect(actions.first { $0.id == .mapRemote }?.systemImage == "arrow.triangle.branch")
         #expect(actions.first { $0.id == .breakpoint }?.systemImage == "pause.circle")
         #expect(actions.first { $0.id == .networkConditions }?.systemImage == "speedometer")
+
+        let activeActions = FooterActionDescriptor.toolingActions(
+            isAllowListActive: false,
+            isProxyOverridden: true
+        )
+        #expect(activeActions.first { $0.id == .proxyOverride }?.systemImage == "checkmark.circle.fill")
+        #expect(activeActions.first { $0.id == .proxyOverride }?.help.contains("⌥⌘O") == true)
     }
 
     @Test("Allow List active state reflects manager state")
@@ -43,6 +74,6 @@ struct FooterActionDescriptorTests {
     func toolActionsRemainInline() {
         let actions = FooterActionDescriptor.toolingActions(isAllowListActive: false)
 
-        #expect(FooterActionKind.allCases == actions.map(\.id))
+        #expect(FooterActionKind.allCases.filter { $0 != .proxyOverride } == actions.map(\.id))
     }
 }

--- a/RockxyTests/Views/Main/RuleCoordinatorWiringTests.swift
+++ b/RockxyTests/Views/Main/RuleCoordinatorWiringTests.swift
@@ -18,6 +18,7 @@ struct RuleCoordinatorWiringTests {
         let coordinator = MainContentCoordinator()
         let rule = TestFixtures.makeRule(name: "WiringAdd", action: .block(statusCode: 403))
         coordinator.addRule(rule)
+        await coordinator.ruleMutationTask?.value
 
         for _ in 0 ..< 500 {
             let rules = await RuleEngine.shared.allRules
@@ -50,6 +51,7 @@ struct RuleCoordinatorWiringTests {
         let coordinator = MainContentCoordinator()
         let overflow = TestFixtures.makeRule(name: "Overflow", action: .block(statusCode: 403))
         coordinator.addRule(overflow)
+        await coordinator.ruleMutationTask?.value
 
         for _ in 0 ..< 500 {
             if coordinator.activeToast != nil {
@@ -80,6 +82,7 @@ struct RuleCoordinatorWiringTests {
 
         let coordinator = MainContentCoordinator()
         coordinator.toggleRule(id: rule.id)
+        await coordinator.ruleMutationTask?.value
 
         for _ in 0 ..< 500 {
             let rules = await RuleEngine.shared.allRules
@@ -113,6 +116,7 @@ struct RuleCoordinatorWiringTests {
 
         let coordinator = MainContentCoordinator()
         coordinator.toggleRule(id: disabled.id)
+        await coordinator.ruleMutationTask?.value
 
         for _ in 0 ..< 500 {
             if coordinator.activeToast != nil {

--- a/RockxyTests/Views/Rules/AllowListWindowViewModelTests.swift
+++ b/RockxyTests/Views/Rules/AllowListWindowViewModelTests.swift
@@ -108,6 +108,34 @@ struct AllowListWindowViewModelTests {
     }
 
     @Test
+    func filterByMethodColumnMatchesAnyFallback() {
+        let (viewModel, url) = makeSetup()
+        defer { cleanup(url) }
+
+        viewModel.addRule(
+            ruleName: "all methods",
+            urlPattern: "*all.example.com*",
+            httpMethod: .any,
+            matchType: .wildcard,
+            includeSubpaths: true
+        )
+        viewModel.addRule(
+            ruleName: "post only",
+            urlPattern: "*post.example.com*",
+            httpMethod: .post,
+            matchType: .wildcard,
+            includeSubpaths: true
+        )
+
+        viewModel.filterColumn = .method
+        viewModel.filterText = "any"
+
+        let filtered = viewModel.filteredRules
+        #expect(filtered.count == 1)
+        #expect(filtered[0].name == "all methods")
+    }
+
+    @Test
     func filterByMatchingRuleColumn() {
         let (viewModel, url) = makeSetup()
         defer { cleanup(url) }
@@ -207,6 +235,37 @@ struct AllowListWindowViewModelTests {
         #expect(viewModel.selectedRuleID == originalID)
     }
 
+    @Test
+    func updateRuleWithMissingIDIsNoopAndPreservesSelection() throws {
+        let (viewModel, url) = makeSetup()
+        defer { cleanup(url) }
+
+        viewModel.addRule(
+            ruleName: "kept",
+            urlPattern: "*kept.example.com*",
+            httpMethod: .get,
+            matchType: .wildcard,
+            includeSubpaths: true
+        )
+        let selectedID = try #require(viewModel.selectedRuleID)
+
+        viewModel.updateRule(
+            id: UUID(),
+            ruleName: "missing",
+            urlPattern: "*missing.example.com*",
+            httpMethod: .post,
+            matchType: .regex,
+            includeSubpaths: false
+        )
+
+        #expect(viewModel.manager.rules.count == 1)
+        #expect(viewModel.manager.rules[0].id == selectedID)
+        #expect(viewModel.manager.rules[0].name == "kept")
+        #expect(viewModel.manager.rules[0].rawPattern == "*kept.example.com*")
+        #expect(viewModel.manager.rules[0].method == "GET")
+        #expect(viewModel.selectedRuleID == selectedID)
+    }
+
     // MARK: - Duplicate Flow
 
     @Test
@@ -232,6 +291,8 @@ struct AllowListWindowViewModelTests {
         #expect(copy.rawPattern == "*a.com*")
         #expect(copy.method == "GET")
         #expect(copy.matchType == .wildcard)
+        #expect(copy.includeSubpaths)
+        #expect(copy.isEnabled)
         #expect(viewModel.selectedRuleID == copy.id)
     }
 
@@ -274,6 +335,27 @@ struct AllowListWindowViewModelTests {
         #expect(viewModel.manager.rules.isEmpty)
         #expect(viewModel.selectedRuleID == nil)
         #expect(!viewModel.manager.rules.contains { $0.id == removedID })
+    }
+
+    @Test
+    func removeSelectedIsNoopWhenNothingSelected() {
+        let (viewModel, url) = makeSetup()
+        defer { cleanup(url) }
+
+        viewModel.addRule(
+            ruleName: "kept",
+            urlPattern: "*kept.example.com*",
+            httpMethod: .any,
+            matchType: .wildcard,
+            includeSubpaths: true
+        )
+        viewModel.selectedRuleID = nil
+
+        viewModel.removeSelected()
+
+        #expect(viewModel.manager.rules.count == 1)
+        #expect(viewModel.manager.rules[0].name == "kept")
+        #expect(viewModel.selectedRuleID == nil)
     }
 
     // MARK: - Toggle Flow
@@ -582,6 +664,26 @@ struct AllowListWindowViewModelTests {
 
         #expect(viewModel.manager.rules.map(\.name) == ["first", "second"])
         #expect(viewModel.selectedRuleID == imported[0].id)
+    }
+
+    @Test
+    func importRulesWithEmptyListClearsRulesAndSelection() {
+        let (viewModel, url) = makeSetup()
+        defer { cleanup(url) }
+
+        viewModel.addRule(
+            ruleName: "old",
+            urlPattern: "*old.example.com/*",
+            httpMethod: .any,
+            matchType: .wildcard,
+            includeSubpaths: true
+        )
+        #expect(viewModel.selectedRuleID != nil)
+
+        viewModel.importRules([])
+
+        #expect(viewModel.manager.rules.isEmpty)
+        #expect(viewModel.selectedRuleID == nil)
     }
 
     // MARK: Private

--- a/RockxyTests/Views/Rules/AllowListWindowViewModelTests.swift
+++ b/RockxyTests/Views/Rules/AllowListWindowViewModelTests.swift
@@ -538,6 +538,52 @@ struct AllowListWindowViewModelTests {
         #expect(viewModel.manager.rules[0].name == "imported")
     }
 
+    @Test
+    func exportRulesJSONReturnsManagerPayload() throws {
+        let (viewModel, url) = makeSetup()
+        defer { cleanup(url) }
+
+        viewModel.addRule(
+            ruleName: "api",
+            urlPattern: "*api.example.com/*",
+            httpMethod: .post,
+            matchType: .wildcard,
+            includeSubpaths: true
+        )
+        viewModel.setActive(true)
+
+        let data = try viewModel.exportRulesJSON()
+        let decoded = try JSONDecoder().decode(ImportPayload.self, from: data)
+
+        #expect(decoded.isActive)
+        #expect(decoded.rules.count == 1)
+        #expect(decoded.rules[0].name == "api")
+        #expect(decoded.rules[0].method == "POST")
+    }
+
+    @Test
+    func importRulesReplacesListAndSelectsFirstImportedRule() {
+        let (viewModel, url) = makeSetup()
+        defer { cleanup(url) }
+
+        viewModel.addRule(
+            ruleName: "old",
+            urlPattern: "*old.example.com/*",
+            httpMethod: .any,
+            matchType: .wildcard,
+            includeSubpaths: true
+        )
+
+        let imported = [
+            AllowListRule(name: "first", rawPattern: "*first.example.com/*"),
+            AllowListRule(name: "second", rawPattern: "*second.example.com/*"),
+        ]
+        viewModel.importRules(imported)
+
+        #expect(viewModel.manager.rules.map(\.name) == ["first", "second"])
+        #expect(viewModel.selectedRuleID == imported[0].id)
+    }
+
     // MARK: Private
 
     // MARK: - Helpers
@@ -560,7 +606,7 @@ struct AllowListWindowViewModelTests {
 
 /// Mirror of the private `AllowListStorage` shape so we can build fixture import data
 /// without needing to expose the internal type.
-private struct ImportPayload: Encodable {
+private struct ImportPayload: Codable {
     let schemaVersion: Int
     let isActive: Bool
     let rules: [AllowListRule]

--- a/RockxyTests/Views/Rules/MapLocalModelTests.swift
+++ b/RockxyTests/Views/Rules/MapLocalModelTests.swift
@@ -27,6 +27,22 @@ struct MapLocalModelTests {
         #expect(vm.filteredRules.map(\.id) == [assetRule.id])
     }
 
+    @Test("visible Map Local row labels match the management table")
+    func visibleRowLabelsMatchManagementTable() {
+        let vm = MapLocalViewModel()
+        let pattern = MapLocalPatternFormatter.wildcardToRegex("https://media-hls.growcdnssedge.com/*")
+        let rule = ProxyRule(
+            name: "Untitled",
+            matchCondition: RuleMatchCondition(urlPattern: pattern),
+            action: .mapLocal(filePath: "/Users/stephen/Library/Application Support/Rockxy/map-local/default_message.json")
+        )
+
+        #expect(vm.methodLabel(for: rule) == "ANY")
+        #expect(vm.matchingRuleLabel(for: rule) == "Wildcard: https://media-hls.growcdnssedge.com/*")
+        #expect(vm.mapFromLabel(for: rule).hasPrefix("File: "))
+        #expect(vm.mapFromLabel(for: rule).contains("default_message.json"))
+    }
+
     @Test("remove selected Map Local rows preserves unrelated rules")
     func removeSelectedPreservesOtherRules() async {
         await RuleTestLock.shared.acquire()
@@ -112,6 +128,40 @@ struct MapLocalModelTests {
 
         let saved = try String(contentsOf: fileURL, encoding: .utf8)
         #expect(saved == #"{"ok":true}"#)
+    }
+
+    @Test("editor opens an existing local file rule with filled data")
+    func editorLoadsExistingLocalFileRuleWithFilledData() throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("RockxyTests-MapLocalOpen-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        let fileURL = tempDir.appendingPathComponent("default_message.json")
+        try #"{"status":"ok"}"#.write(to: fileURL, atomically: true, encoding: .utf8)
+
+        let existing = ProxyRule(
+            name: "Untitled",
+            matchCondition: RuleMatchCondition(
+                urlPattern: MapLocalPatternFormatter.wildcardToRegex("https://api.example.com/v1/*"),
+                method: "PATCH"
+            ),
+            action: .mapLocal(filePath: fileURL.path, statusCode: 201, delayMs: 3_000)
+        )
+
+        let vm = MapLocalEditorViewModel()
+        vm.load(context: MapLocalEditorContext(existingRule: existing))
+
+        #expect(vm.existingID == existing.id)
+        #expect(vm.name == "Untitled")
+        #expect(vm.method == .patch)
+        #expect(vm.matchType == .wildcard)
+        #expect(vm.urlText == "https://api.example.com/v1/*")
+        #expect(vm.targetMode == .localFile)
+        #expect(vm.localFileEnabled)
+        #expect(vm.filePath == fileURL.path)
+        #expect(vm.delayPreset == .threeSeconds)
+        #expect(vm.httpMessageText.contains("HTTP/1.1 201 CREATED"))
+        #expect(vm.httpMessageText.contains(#"{"status":"ok"}"#))
+        #expect(vm.isSaveEnabled)
     }
 
     @Test("editor validates Local Directory target")

--- a/RockxyTests/Views/Rules/MapLocalModelTests.swift
+++ b/RockxyTests/Views/Rules/MapLocalModelTests.swift
@@ -1,0 +1,148 @@
+import Foundation
+@testable import Rockxy
+import Testing
+
+@Suite(.serialized)
+@MainActor
+struct MapLocalModelTests {
+    @Test("filter matches name, method, URL, and local path")
+    func filterMatchesVisibleColumns() {
+        let vm = MapLocalViewModel()
+        let apiRule = ProxyRule(
+            name: "Users",
+            matchCondition: RuleMatchCondition(urlPattern: "https://api.example.com/users", method: "POST"),
+            action: .mapLocal(filePath: "/tmp/users.json")
+        )
+        let assetRule = ProxyRule(
+            name: "Assets",
+            matchCondition: RuleMatchCondition(urlPattern: "https://cdn.example.com/.*", method: "GET"),
+            action: .mapLocal(filePath: "/tmp/app.js")
+        )
+        vm.allRules = [apiRule, assetRule]
+
+        vm.searchText = "post"
+        #expect(vm.filteredRules.map(\.id) == [apiRule.id])
+
+        vm.searchText = "app.js"
+        #expect(vm.filteredRules.map(\.id) == [assetRule.id])
+    }
+
+    @Test("remove selected Map Local rows preserves unrelated rules")
+    func removeSelectedPreservesOtherRules() async {
+        await RuleTestLock.shared.acquire()
+        let snapshot = await RuleEngine.shared.allRules
+        await RuleEngine.shared.replaceAll([])
+
+        let vm = MapLocalViewModel()
+        let mapLocal = ProxyRule(
+            name: "Local",
+            matchCondition: RuleMatchCondition(urlPattern: "https://api.example.com/.*"),
+            action: .mapLocal(filePath: "/tmp/local.json")
+        )
+        let block = ProxyRule(
+            name: "Block",
+            matchCondition: RuleMatchCondition(urlPattern: "https://blocked.example.com/.*"),
+            action: .block(statusCode: 403)
+        )
+        vm.allRules = [mapLocal, block]
+        vm.selectedRuleIDs = [mapLocal.id]
+
+        vm.removeSelectedRules()
+
+        #expect(vm.allRules.map(\.id) == [block.id])
+        #expect(vm.selectedRuleIDs.isEmpty)
+
+        await RuleEngine.shared.replaceAll(snapshot)
+        await RuleTestLock.shared.release()
+    }
+
+    @Test("editor saves local file rule with method, delay, status, and preserved header condition")
+    func editorCreatesRulePreservingHeaderFields() throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("RockxyTests-MapLocalEditor-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        let fileURL = tempDir.appendingPathComponent("response.json")
+
+        let existing = ProxyRule(
+            name: "Existing",
+            isEnabled: false,
+            matchCondition: RuleMatchCondition(
+                urlPattern: "https://old.example.com/.*",
+                method: "GET",
+                headerName: "X-Debug",
+                headerValue: "1"
+            ),
+            action: .mapLocal(filePath: fileURL.path, statusCode: 200, delayMs: 1_000),
+            priority: 42
+        )
+        let vm = MapLocalEditorViewModel()
+        vm.load(context: MapLocalEditorContext(existingRule: existing))
+        vm.name = "Updated"
+        vm.urlText = "https://api.example.com/v1/*"
+        vm.matchType = .wildcard
+        vm.method = .post
+        vm.filePath = fileURL.path
+        vm.delayPreset = .fiveSeconds
+        vm.httpMessageText = """
+        HTTP/1.1 202 Accepted
+        Content-Type: application/json
+
+        {"ok":true}
+        """
+
+        let rule = try #require(vm.makeRule())
+
+        #expect(rule.id == existing.id)
+        #expect(rule.name == "Updated")
+        #expect(rule.isEnabled == false)
+        #expect(rule.priority == 42)
+        #expect(rule.matchCondition.method == "POST")
+        #expect(rule.matchCondition.headerName == "X-Debug")
+        #expect(rule.matchCondition.headerValue == "1")
+        #expect(rule.matchCondition.urlPattern == #"https:\/\/api\.example\.com\/v1\/.*"#)
+
+        if case let .mapLocal(path, statusCode, isDirectory, delayMs) = rule.action {
+            #expect(path == fileURL.path)
+            #expect(statusCode == 202)
+            #expect(isDirectory == false)
+            #expect(delayMs == 5_000)
+        } else {
+            Issue.record("Expected .mapLocal")
+        }
+
+        let saved = try String(contentsOf: fileURL, encoding: .utf8)
+        #expect(saved == #"{"ok":true}"#)
+    }
+
+    @Test("editor validates Local Directory target")
+    func editorValidatesLocalDirectory() throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("RockxyTests-MapLocalDirTarget-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+
+        let vm = MapLocalEditorViewModel()
+        vm.load(context: .blank)
+        vm.name = "Directory"
+        vm.urlText = "https://assets.example.com/*"
+        vm.targetMode = .localDirectory
+        vm.localDirectoryEnabled = true
+        vm.directoryPath = tempDir.path
+
+        #expect(vm.isDirectoryValid)
+        #expect(vm.isSaveEnabled)
+
+        vm.directoryPath = tempDir.appendingPathComponent("missing").path
+        #expect(!vm.isDirectoryValid)
+        #expect(!vm.isSaveEnabled)
+    }
+
+    @Test("tool enable setter updates view model immediately")
+    func toolEnableSetter() async {
+        await RuleTestLock.shared.acquire()
+        let vm = MapLocalViewModel(isToolEnabled: true)
+        vm.setToolEnabled(false)
+        #expect(vm.isToolEnabled == false)
+        await RuleSyncService.setMapLocalToolEnabled(true)
+        await RuleTestLock.shared.release()
+    }
+}

--- a/RockxyTests/Views/Rules/MapLocalModelTests.swift
+++ b/RockxyTests/Views/Rules/MapLocalModelTests.swift
@@ -43,6 +43,24 @@ struct MapLocalModelTests {
         #expect(vm.mapFromLabel(for: rule).contains("default_message.json"))
     }
 
+    @Test("editor menus match the reference order and grouping")
+    func editorMenusMatchReferenceOrderAndGrouping() {
+        #expect(MapLocalEditorMenuContent.methodSections == [
+            [.any],
+            [.get, .post, .put, .delete, .patch],
+            [.head, .options, .trace],
+        ])
+        #expect(MapLocalEditorMenuContent.matchTypeSections == [
+            [.wildcard, .regex],
+        ])
+        #expect(MapLocalEditorMenuContent.delaySections == [
+            [.none],
+            [.oneSecond, .twoSeconds, .threeSeconds, .fiveSeconds, .tenSeconds, .thirtySeconds, .sixtySeconds],
+            [.random],
+            [.custom],
+        ])
+    }
+
     @Test("remove selected Map Local rows preserves unrelated rules")
     func removeSelectedPreservesOtherRules() async {
         await RuleTestLock.shared.acquire()
@@ -128,6 +146,39 @@ struct MapLocalModelTests {
 
         let saved = try String(contentsOf: fileURL, encoding: .utf8)
         #expect(saved == #"{"ok":true}"#)
+    }
+
+    @Test("editor menu selections persist method match type and delay")
+    func editorMenuSelectionsPersistMethodMatchTypeAndDelay() throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("RockxyTests-MapLocalMenu-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        let fileURL = tempDir.appendingPathComponent("response.json")
+
+        let vm = MapLocalEditorViewModel()
+        vm.load(context: .blank)
+        vm.name = "Menu Flow"
+        vm.urlText = "https://api.example.com/v2/*"
+        vm.matchType = .wildcard
+        vm.method = .delete
+        vm.filePath = fileURL.path
+        vm.delayPreset = .thirtySeconds
+        vm.httpMessageText = """
+        HTTP/1.1 204 No Content
+
+        """
+
+        let rule = try #require(vm.makeRule())
+        #expect(rule.matchCondition.method == "DELETE")
+        #expect(rule.matchCondition.urlPattern == #"https:\/\/api\.example\.com\/v2\/.*"#)
+        if case let .mapLocal(path, statusCode, isDirectory, delayMs) = rule.action {
+            #expect(path == fileURL.path)
+            #expect(statusCode == 204)
+            #expect(isDirectory == false)
+            #expect(delayMs == 30_000)
+        } else {
+            Issue.record("Expected .mapLocal")
+        }
     }
 
     @Test("editor opens an existing local file rule with filled data")

--- a/RockxyTests/Views/Rules/MapRemoteModelTests.swift
+++ b/RockxyTests/Views/Rules/MapRemoteModelTests.swift
@@ -27,6 +27,31 @@ struct MapRemoteModelTests {
         #expect(vm.filteredRules.map(\.id) == [assetsRule.id])
     }
 
+    @Test("management list includes only Map Remote rules and prunes stale selections")
+    func listFiltersMapRemoteRulesAndPrunesSelectionOnNotification() {
+        let vm = MapRemoteWindowViewModel()
+        let remote = ProxyRule(
+            name: "Remote",
+            matchCondition: RuleMatchCondition(urlPattern: "https://api.example.com/.*"),
+            action: .mapRemote(configuration: MapRemoteConfiguration(host: "staging.example.com"))
+        )
+        let block = ProxyRule(
+            name: "Block",
+            matchCondition: RuleMatchCondition(urlPattern: "https://blocked.example.com/.*"),
+            action: .block(statusCode: 403)
+        )
+        let staleID = UUID()
+        vm.allRules = [remote, block]
+        vm.selectedRuleIDs = [remote.id, staleID]
+
+        #expect(vm.mapRemoteRules.map(\.id) == [remote.id])
+
+        vm.handleRulesDidChange(Notification(name: .rulesDidChange, object: [remote]))
+
+        #expect(vm.allRules.map(\.id) == [remote.id])
+        #expect(vm.selectedRuleIDs == [remote.id])
+    }
+
     @Test("visible Map Remote row labels match the management table")
     func visibleRowLabelsMatchManagementTable() {
         let vm = MapRemoteWindowViewModel()
@@ -49,65 +74,165 @@ struct MapRemoteModelTests {
 
     @Test("remove selected Map Remote rows preserves unrelated rules")
     func removeSelectedPreservesOtherRules() async {
-        await RuleTestLock.shared.acquire()
-        let snapshot = await RuleEngine.shared.allRules
-        await RuleEngine.shared.replaceAll([])
+        await withSharedRuleStateRestored {
+            let vm = MapRemoteWindowViewModel()
+            let mapRemote = ProxyRule(
+                name: "Remote",
+                matchCondition: RuleMatchCondition(urlPattern: "https://api.example.com/.*"),
+                action: .mapRemote(configuration: MapRemoteConfiguration(host: "staging.example.com"))
+            )
+            let block = ProxyRule(
+                name: "Block",
+                matchCondition: RuleMatchCondition(urlPattern: "https://blocked.example.com/.*"),
+                action: .block(statusCode: 403)
+            )
+            vm.allRules = [mapRemote, block]
+            vm.selectedRuleIDs = [mapRemote.id]
 
+            vm.removeSelectedRules()
+            await vm.waitForPendingRuleSync()
+
+            #expect(vm.allRules.map(\.id) == [block.id])
+            #expect(vm.selectedRuleIDs.isEmpty)
+        }
+    }
+
+    @Test("remove selected is a no-op without selection")
+    func removeSelectedNoopWhenSelectionIsEmpty() {
         let vm = MapRemoteWindowViewModel()
-        let mapRemote = ProxyRule(
+        let rule = ProxyRule(
             name: "Remote",
             matchCondition: RuleMatchCondition(urlPattern: "https://api.example.com/.*"),
             action: .mapRemote(configuration: MapRemoteConfiguration(host: "staging.example.com"))
         )
-        let block = ProxyRule(
-            name: "Block",
-            matchCondition: RuleMatchCondition(urlPattern: "https://blocked.example.com/.*"),
-            action: .block(statusCode: 403)
-        )
-        vm.allRules = [mapRemote, block]
-        vm.selectedRuleIDs = [mapRemote.id]
+        vm.allRules = [rule]
 
         vm.removeSelectedRules()
 
-        #expect(vm.allRules.map(\.id) == [block.id])
-        #expect(vm.selectedRuleIDs.isEmpty)
-
-        await RuleEngine.shared.replaceAll(snapshot)
-        await RuleTestLock.shared.release()
+        #expect(vm.allRules.map(\.id) == [rule.id])
     }
 
     @Test("duplicate selected Map Remote rule keeps behavior and selects the copy")
-    func duplicateSelectedRule() {
-        let vm = MapRemoteWindowViewModel()
-        let rule = ProxyRule(
-            name: "Remote",
-            isEnabled: true,
-            matchCondition: RuleMatchCondition(urlPattern: "https://api.example.com/.*", method: "PATCH"),
-            action: .mapRemote(configuration: MapRemoteConfiguration(host: "staging.example.com")),
-            priority: 7
-        )
-        vm.allRules = [rule]
-        vm.selectedRuleIDs = [rule.id]
+    func duplicateSelectedRule() async {
+        await withSharedRuleStateRestored {
+            let vm = MapRemoteWindowViewModel()
+            let rule = ProxyRule(
+                name: "Remote",
+                isEnabled: true,
+                matchCondition: RuleMatchCondition(urlPattern: "https://api.example.com/.*", method: "PATCH"),
+                action: .mapRemote(configuration: MapRemoteConfiguration(host: "staging.example.com")),
+                priority: 7
+            )
+            vm.allRules = [rule]
+            vm.selectedRuleIDs = [rule.id]
 
-        vm.duplicateSelectedRule()
+            vm.duplicateSelectedRule()
+            await vm.waitForPendingRuleSync()
 
-        #expect(vm.allRules.count == 2)
-        let copy = vm.allRules[1]
-        #expect(copy.id != rule.id)
-        #expect(copy.name == "Remote Copy")
-        #expect(copy.matchCondition == rule.matchCondition)
-        #expect(copy.priority == 7)
-        #expect(vm.selectedRuleIDs == [copy.id])
+            #expect(vm.allRules.count == 2)
+            let copy = vm.allRules[1]
+            #expect(copy.id != rule.id)
+            #expect(copy.name == "Remote Copy")
+            #expect(copy.matchCondition == rule.matchCondition)
+            #expect(copy.priority == 7)
+            #expect(vm.selectedRuleIDs == [copy.id])
+        }
+    }
+
+    @Test("toggle and remove-row actions update clicked row immediately")
+    func rowActionsUpdateClickedRule() async {
+        await withSharedRuleStateRestored {
+            let vm = MapRemoteWindowViewModel()
+            let remote = ProxyRule(
+                name: "Remote",
+                isEnabled: true,
+                matchCondition: RuleMatchCondition(urlPattern: "https://api.example.com/.*"),
+                action: .mapRemote(configuration: MapRemoteConfiguration(host: "staging.example.com"))
+            )
+            let other = ProxyRule(
+                name: "Other",
+                isEnabled: true,
+                matchCondition: RuleMatchCondition(urlPattern: "https://other.example.com/.*"),
+                action: .mapRemote(configuration: MapRemoteConfiguration(host: "other-staging.example.com"))
+            )
+            await RuleSyncService.replaceAllRules([remote, other])
+            vm.allRules = [remote, other]
+            vm.selectedRuleIDs = [remote.id]
+
+            vm.toggleRule(id: remote.id)
+            await vm.waitForPendingRuleSync()
+            #expect(vm.allRules.first?.isEnabled == false)
+
+            vm.removeRule(id: remote.id)
+            await vm.waitForPendingRuleSync()
+            #expect(vm.allRules.map(\.id) == [other.id])
+            #expect(vm.selectedRuleIDs.isEmpty)
+        }
+    }
+
+    @Test("Enable All only enables Map Remote rules")
+    func enableAllOnlyTouchesMapRemoteRules() async {
+        await withSharedRuleStateRestored {
+            let vm = MapRemoteWindowViewModel()
+            let remote = ProxyRule(
+                name: "Remote",
+                isEnabled: false,
+                matchCondition: RuleMatchCondition(urlPattern: "https://api.example.com/.*"),
+                action: .mapRemote(configuration: MapRemoteConfiguration(host: "staging.example.com"))
+            )
+            let block = ProxyRule(
+                name: "Block",
+                isEnabled: false,
+                matchCondition: RuleMatchCondition(urlPattern: "https://blocked.example.com/.*"),
+                action: .block(statusCode: 403)
+            )
+            vm.allRules = [remote, block]
+
+            vm.enableAll()
+            await vm.waitForPendingRuleSync()
+
+            #expect(vm.allRules[0].isEnabled)
+            #expect(vm.allRules[1].isEnabled == false)
+        }
     }
 
     @Test("tool enable setter updates view model immediately")
     func toolEnableSetter() async {
-        await RuleTestLock.shared.acquire()
-        let vm = MapRemoteWindowViewModel(isToolEnabled: true)
-        vm.setToolEnabled(false)
-        #expect(vm.isToolEnabled == false)
-        await RuleSyncService.setMapRemoteToolEnabled(true)
-        await RuleTestLock.shared.release()
+        await withSharedRuleStateRestored {
+            let vm = MapRemoteWindowViewModel(isToolEnabled: true)
+            vm.setToolEnabled(false)
+            await vm.waitForPendingRuleSync()
+            #expect(vm.isToolEnabled == false)
+        }
+    }
+
+    @Test("editor store opens blank, draft, and existing contexts")
+    func editorStoreContexts() {
+        let store = MapRemoteEditorStore.shared
+        let startingVersion = store.draftVersion
+        let draft = MapRemoteDraft(
+            origin: .domainQuickCreate,
+            suggestedName: "example.com",
+            sourceURL: nil,
+            sourceHost: "example.com",
+            sourcePath: nil,
+            sourceMethod: nil
+        )
+        let existing = ProxyRule(
+            name: "Existing",
+            matchCondition: RuleMatchCondition(urlPattern: "https://api.example.com/.*"),
+            action: .mapRemote(configuration: MapRemoteConfiguration(host: "staging.example.com"))
+        )
+
+        store.openNew(draft: draft)
+        #expect(store.context.draft?.sourceHost == "example.com")
+        #expect(store.context.existingRule == nil)
+        #expect(store.draftVersion == startingVersion &+ 1)
+
+        store.openExisting(existing)
+        #expect(store.context.existingRule?.id == existing.id)
+        #expect(store.context.draft == nil)
+        #expect(store.draftVersion == startingVersion &+ 2)
     }
 
     @Test("editor saves rule with method, wildcard pattern, destination, and advanced flags")
@@ -144,6 +269,23 @@ struct MapRemoteModelTests {
         }
     }
 
+    @Test("editor saves regex pattern without wildcard conversion")
+    func editorCreatesRegexRule() throws {
+        let vm = MapRemoteEditorViewModel()
+        vm.load(context: .blank)
+        vm.name = "Regex Remote"
+        vm.urlText = #"https://api\.example\.com/v[0-9]+/users"#
+        vm.method = .any
+        vm.matchType = .regex
+        vm.includeSubpaths = true
+        vm.destHost = "staging.example.com"
+
+        let rule = try #require(vm.makeRule())
+
+        #expect(rule.matchCondition.method == nil)
+        #expect(rule.matchCondition.urlPattern == #"https://api\.example\.com/v[0-9]+/users"#)
+    }
+
     @Test("editor parses pasted destination URL into components")
     func editorParsesDestinationURL() {
         let vm = MapRemoteEditorViewModel()
@@ -156,6 +298,40 @@ struct MapRemoteModelTests {
         #expect(vm.destPort == "8443")
         #expect(vm.destPath == "v2/api")
         #expect(vm.destQuery == "id=123")
+    }
+
+    @Test("editor loads transaction and domain drafts")
+    func editorLoadsDrafts() throws {
+        let transactionURL = try #require(URL(string: "https://api.prod.example.com/v2/users?page=1"))
+        let transactionDraft = MapRemoteDraft(
+            origin: .selectedTransaction,
+            suggestedName: "Users",
+            sourceURL: transactionURL,
+            sourceHost: "api.prod.example.com",
+            sourcePath: "/v2/users",
+            sourceMethod: "POST"
+        )
+        let domainDraft = MapRemoteDraft(
+            origin: .domainQuickCreate,
+            suggestedName: "Domain",
+            sourceURL: nil,
+            sourceHost: "cdn.example.com",
+            sourcePath: nil,
+            sourceMethod: nil
+        )
+        let vm = MapRemoteEditorViewModel()
+
+        vm.load(context: MapRemoteEditorContext(draft: transactionDraft))
+        #expect(vm.name == "Users")
+        #expect(vm.method == .post)
+        #expect(vm.includeSubpaths == false)
+        #expect(vm.urlText == "https://api.prod.example.com/v2/users?page=1")
+
+        vm.load(context: MapRemoteEditorContext(draft: domainDraft))
+        #expect(vm.name == "Domain")
+        #expect(vm.method == .any)
+        #expect(vm.includeSubpaths)
+        #expect(vm.urlText == "https://cdn.example.com/*")
     }
 
     @Test("editor loads existing rule with stable identity and flags")
@@ -214,5 +390,42 @@ struct MapRemoteModelTests {
 
         vm.destPort = "70000"
         #expect(!vm.isSaveEnabled)
+
+        #expect(vm.makeRule() == nil)
+        #expect(vm.errorMessage != nil)
+    }
+
+    @Test("editor destination preview uses placeholders and normalized path")
+    func editorDestinationPreview() {
+        let vm = MapRemoteEditorViewModel()
+        vm.load(context: .blank)
+
+        #expect(vm.destinationPreviewString == "https://example.com/")
+
+        vm.destScheme = "http"
+        vm.destHost = "staging.example.com"
+        vm.destPort = "8080"
+        vm.destPath = "api/v2"
+        vm.destQuery = "debug=true"
+
+        #expect(vm.destinationPreviewString == "http://staging.example.com:8080/api/v2?debug=true")
+    }
+
+    private func withSharedRuleStateRestored(_ body: () async -> Void) async {
+        await RuleTestLock.shared.acquire()
+        let rulesSnapshot = await RuleEngine.shared.allRules
+        let enabledSnapshot = UserDefaults.standard.object(forKey: "mapRemoteToolEnabled") as? Bool
+
+        await RuleSyncService.replaceAllRules([])
+        await body()
+
+        await RuleSyncService.replaceAllRules(rulesSnapshot)
+        if let enabledSnapshot {
+            await RuleSyncService.setMapRemoteToolEnabled(enabledSnapshot)
+        } else {
+            UserDefaults.standard.removeObject(forKey: "mapRemoteToolEnabled")
+            await RuleEngine.shared.setMapRemoteToolEnabled(true)
+        }
+        await RuleTestLock.shared.release()
     }
 }

--- a/RockxyTests/Views/Rules/MapRemoteModelTests.swift
+++ b/RockxyTests/Views/Rules/MapRemoteModelTests.swift
@@ -1,0 +1,218 @@
+import Foundation
+@testable import Rockxy
+import Testing
+
+@Suite(.serialized)
+@MainActor
+struct MapRemoteModelTests {
+    @Test("filter matches name, method, rule, and destination")
+    func filterMatchesVisibleColumns() {
+        let vm = MapRemoteWindowViewModel()
+        let usersRule = ProxyRule(
+            name: "Users",
+            matchCondition: RuleMatchCondition(urlPattern: "https://api.example.com/users/.*", method: "POST"),
+            action: .mapRemote(configuration: MapRemoteConfiguration(host: "staging.example.com", path: "/users"))
+        )
+        let assetsRule = ProxyRule(
+            name: "Assets",
+            matchCondition: RuleMatchCondition(urlPattern: "https://cdn.example.com/.*", method: "GET"),
+            action: .mapRemote(configuration: MapRemoteConfiguration(host: "assets-dev.example.com"))
+        )
+        vm.allRules = [usersRule, assetsRule]
+
+        vm.searchText = "post"
+        #expect(vm.filteredRules.map(\.id) == [usersRule.id])
+
+        vm.searchText = "assets-dev"
+        #expect(vm.filteredRules.map(\.id) == [assetsRule.id])
+    }
+
+    @Test("visible Map Remote row labels match the management table")
+    func visibleRowLabelsMatchManagementTable() {
+        let vm = MapRemoteWindowViewModel()
+        let pattern = MapLocalPatternFormatter.wildcardToRegex("https://localhost:3000/v1/*")
+        let rule = ProxyRule(
+            name: "Untitled",
+            matchCondition: RuleMatchCondition(urlPattern: pattern),
+            action: .mapRemote(configuration: MapRemoteConfiguration(
+                scheme: "https",
+                host: "api.production.com",
+                path: "/v2/api",
+                query: "id=123"
+            ))
+        )
+
+        #expect(vm.methodLabel(for: rule) == "ANY")
+        #expect(vm.matchingRuleLabel(for: rule) == "Wildcard: https://localhost:3000/v1/*")
+        #expect(vm.destinationLabel(for: rule) == "https://api.production.com/v2/api?id=123")
+    }
+
+    @Test("remove selected Map Remote rows preserves unrelated rules")
+    func removeSelectedPreservesOtherRules() async {
+        await RuleTestLock.shared.acquire()
+        let snapshot = await RuleEngine.shared.allRules
+        await RuleEngine.shared.replaceAll([])
+
+        let vm = MapRemoteWindowViewModel()
+        let mapRemote = ProxyRule(
+            name: "Remote",
+            matchCondition: RuleMatchCondition(urlPattern: "https://api.example.com/.*"),
+            action: .mapRemote(configuration: MapRemoteConfiguration(host: "staging.example.com"))
+        )
+        let block = ProxyRule(
+            name: "Block",
+            matchCondition: RuleMatchCondition(urlPattern: "https://blocked.example.com/.*"),
+            action: .block(statusCode: 403)
+        )
+        vm.allRules = [mapRemote, block]
+        vm.selectedRuleIDs = [mapRemote.id]
+
+        vm.removeSelectedRules()
+
+        #expect(vm.allRules.map(\.id) == [block.id])
+        #expect(vm.selectedRuleIDs.isEmpty)
+
+        await RuleEngine.shared.replaceAll(snapshot)
+        await RuleTestLock.shared.release()
+    }
+
+    @Test("duplicate selected Map Remote rule keeps behavior and selects the copy")
+    func duplicateSelectedRule() {
+        let vm = MapRemoteWindowViewModel()
+        let rule = ProxyRule(
+            name: "Remote",
+            isEnabled: true,
+            matchCondition: RuleMatchCondition(urlPattern: "https://api.example.com/.*", method: "PATCH"),
+            action: .mapRemote(configuration: MapRemoteConfiguration(host: "staging.example.com")),
+            priority: 7
+        )
+        vm.allRules = [rule]
+        vm.selectedRuleIDs = [rule.id]
+
+        vm.duplicateSelectedRule()
+
+        #expect(vm.allRules.count == 2)
+        let copy = vm.allRules[1]
+        #expect(copy.id != rule.id)
+        #expect(copy.name == "Remote Copy")
+        #expect(copy.matchCondition == rule.matchCondition)
+        #expect(copy.priority == 7)
+        #expect(vm.selectedRuleIDs == [copy.id])
+    }
+
+    @Test("tool enable setter updates view model immediately")
+    func toolEnableSetter() async {
+        await RuleTestLock.shared.acquire()
+        let vm = MapRemoteWindowViewModel(isToolEnabled: true)
+        vm.setToolEnabled(false)
+        #expect(vm.isToolEnabled == false)
+        await RuleSyncService.setMapRemoteToolEnabled(true)
+        await RuleTestLock.shared.release()
+    }
+
+    @Test("editor saves rule with method, wildcard pattern, destination, and advanced flags")
+    func editorCreatesRule() throws {
+        let vm = MapRemoteEditorViewModel()
+        vm.load(context: .blank)
+        vm.name = "Remote"
+        vm.urlText = "https://localhost:3000/v1/*"
+        vm.method = .post
+        vm.matchType = .wildcard
+        vm.destScheme = "https"
+        vm.destHost = "api.production.com"
+        vm.destPort = "443"
+        vm.destPath = "v2/api"
+        vm.destQuery = "id=123"
+        vm.preserveOriginalURL = true
+        vm.preserveHost = true
+
+        let rule = try #require(vm.makeRule())
+
+        #expect(rule.name == "Remote")
+        #expect(rule.matchCondition.method == "POST")
+        #expect(rule.matchCondition.urlPattern == #"https:\/\/localhost:3000\/v1\/.*"#)
+        if case let .mapRemote(config) = rule.action {
+            #expect(config.scheme == "https")
+            #expect(config.host == "api.production.com")
+            #expect(config.port == 443)
+            #expect(config.path == "/v2/api")
+            #expect(config.query == "id=123")
+            #expect(config.preserveOriginalURL)
+            #expect(config.preserveHostHeader)
+        } else {
+            Issue.record("Expected .mapRemote")
+        }
+    }
+
+    @Test("editor parses pasted destination URL into components")
+    func editorParsesDestinationURL() {
+        let vm = MapRemoteEditorViewModel()
+        vm.load(context: .blank)
+
+        vm.tryParseDestinationURL("https://api.production.com:8443/v2/api?id=123")
+
+        #expect(vm.destScheme == "https")
+        #expect(vm.destHost == "api.production.com")
+        #expect(vm.destPort == "8443")
+        #expect(vm.destPath == "v2/api")
+        #expect(vm.destQuery == "id=123")
+    }
+
+    @Test("editor loads existing rule with stable identity and flags")
+    func editorLoadsExistingRule() {
+        let existing = ProxyRule(
+            name: "Existing",
+            isEnabled: false,
+            matchCondition: RuleMatchCondition(
+                urlPattern: MapLocalPatternFormatter.wildcardToRegex("https://api.example.com/v1/*"),
+                method: "DELETE",
+                headerName: "X-Debug",
+                headerValue: "1"
+            ),
+            action: .mapRemote(configuration: MapRemoteConfiguration(
+                scheme: "http",
+                host: "staging.example.com",
+                port: 8_080,
+                path: "/v2",
+                query: "debug=true",
+                preserveOriginalURL: true,
+                preserveHostHeader: true
+            )),
+            priority: 42
+        )
+        let vm = MapRemoteEditorViewModel()
+        vm.load(context: MapRemoteEditorContext(existingRule: existing))
+
+        #expect(vm.existingID == existing.id)
+        #expect(vm.name == "Existing")
+        #expect(vm.method == .delete)
+        #expect(vm.matchType == .wildcard)
+        #expect(vm.urlText == "https://api.example.com/v1/*")
+        #expect(vm.destScheme == "http")
+        #expect(vm.destHost == "staging.example.com")
+        #expect(vm.destPort == "8080")
+        #expect(vm.destPath == "v2")
+        #expect(vm.destQuery == "debug=true")
+        #expect(vm.preserveOriginalURL)
+        #expect(vm.preserveHost)
+    }
+
+    @Test("editor validation requires destination and valid port")
+    func editorValidation() {
+        let vm = MapRemoteEditorViewModel()
+        vm.load(context: .blank)
+        vm.name = "Remote"
+        vm.urlText = "https://api.example.com/*"
+
+        #expect(!vm.isSaveEnabled)
+
+        vm.destHost = "staging.example.com"
+        #expect(vm.isSaveEnabled)
+
+        vm.destPort = "abc"
+        #expect(!vm.isSaveEnabled)
+
+        vm.destPort = "70000"
+        #expect(!vm.isSaveEnabled)
+    }
+}

--- a/RockxyTests/Views/Rules/NetworkConditionsWindowViewModelTests.swift
+++ b/RockxyTests/Views/Rules/NetworkConditionsWindowViewModelTests.swift
@@ -40,6 +40,51 @@ struct NetworkConditionsWindowViewModelTests {
     }
 
     @Test
+    func addRuleSelectsNewRuleAndDisablesExistingActiveNetworkConditionOnly() {
+        let viewModel = NetworkConditionsWindowViewModel(commitChanges: false, isToolEnabled: true)
+        let activeRule = networkRule(name: "3G", host: "api.example.com", preset: .threeG, isEnabled: true)
+        let blockRule = ProxyRule(
+            name: "Block API",
+            isEnabled: true,
+            matchCondition: RuleMatchCondition(urlPattern: ".*api\\.example\\.com.*"),
+            action: .block(statusCode: 403)
+        )
+        let newRule = networkRule(name: "EDGE", host: "edge.example.com", preset: .edge, isEnabled: true)
+        seed(viewModel, rules: [activeRule, blockRule])
+
+        viewModel.addRule(newRule)
+
+        #expect(viewModel.allRules.first { $0.id == activeRule.id }?.isEnabled == false)
+        #expect(viewModel.allRules.first { $0.id == blockRule.id }?.isEnabled == true)
+        #expect(viewModel.selectedRuleID == newRule.id)
+        #expect(viewModel.activeCount == 1)
+    }
+
+    @Test
+    func updateRuleReplacesSelectedRuleWithoutChangingOtherRows() {
+        let viewModel = NetworkConditionsWindowViewModel(commitChanges: false, isToolEnabled: true)
+        let original = networkRule(name: "Original", host: "api.example.com", preset: .threeG)
+        let other = networkRule(name: "Other", host: "other.example.com", preset: .edge, isEnabled: false)
+        seed(viewModel, rules: [original, other])
+
+        let updated = ProxyRule(
+            id: original.id,
+            name: "Updated LTE",
+            isEnabled: false,
+            matchCondition: RuleMatchCondition(urlPattern: NetworkConditionsPatternFormatter.hostScopedPattern(
+                from: "cdn.example.com"
+            )),
+            action: .networkCondition(preset: .lte, delayMs: NetworkConditionPreset.lte.defaultLatencyMs)
+        )
+        viewModel.updateRule(updated)
+
+        #expect(viewModel.selectedRuleID == original.id)
+        #expect(viewModel.allRules.first { $0.id == original.id }?.name == "Updated LTE")
+        #expect(viewModel.hostLabel(for: updated) == "cdn.example.com")
+        #expect(viewModel.allRules.first { $0.id == other.id }?.name == "Other")
+    }
+
+    @Test
     func duplicateAndRemoveSelectedRuleUpdateSelection() throws {
         let viewModel = NetworkConditionsWindowViewModel(commitChanges: false, isToolEnabled: true)
         let rule = networkRule(name: "Checkout EDGE", host: "shop.example.com", preset: .edge)
@@ -61,6 +106,89 @@ struct NetworkConditionsWindowViewModelTests {
     }
 
     @Test
+    func duplicateSelectedRulePreservesPayloadPriorityAndDisablesCopy() throws {
+        let viewModel = NetworkConditionsWindowViewModel(commitChanges: false, isToolEnabled: true)
+        let rule = ProxyRule(
+            name: "Checkout EDGE",
+            isEnabled: true,
+            matchCondition: RuleMatchCondition(urlPattern: NetworkConditionsPatternFormatter.hostScopedPattern(
+                from: "shop.example.com:8443"
+            )),
+            action: .networkCondition(preset: .edge, delayMs: 850),
+            priority: 42
+        )
+        seed(viewModel, rules: [rule])
+        viewModel.selectedRuleID = rule.id
+
+        viewModel.duplicateSelectedRule()
+
+        let copy = try #require(viewModel.selectedRule)
+        #expect(copy.id != rule.id)
+        #expect(copy.name == "Copy of Checkout EDGE")
+        #expect(copy.isEnabled == false)
+        #expect(copy.matchCondition == rule.matchCondition)
+        #expect(copy.priority == 42)
+        if case let .networkCondition(preset, delayMs) = copy.action {
+            #expect(preset == .edge)
+            #expect(delayMs == 850)
+        } else {
+            Issue.record("Expected .networkCondition action")
+        }
+    }
+
+    @Test
+    func duplicateAndRemoveNoOpWithoutSelection() {
+        let viewModel = NetworkConditionsWindowViewModel(commitChanges: false, isToolEnabled: true)
+        let rule = networkRule(name: "Checkout EDGE", host: "shop.example.com", preset: .edge)
+        seed(viewModel, rules: [rule])
+
+        viewModel.duplicateSelectedRule()
+        viewModel.removeSelectedRule()
+
+        #expect(viewModel.networkConditionRules.map(\.id) == [rule.id])
+    }
+
+    @Test
+    func removeRuleDeletesClickedRowAndClearsSelectionOnlyWhenNeeded() {
+        let viewModel = NetworkConditionsWindowViewModel(commitChanges: false, isToolEnabled: true)
+        let first = networkRule(name: "First", host: "one.example.com", preset: .threeG)
+        let second = networkRule(name: "Second", host: "two.example.com", preset: .edge)
+        seed(viewModel, rules: [first, second])
+        viewModel.selectedRuleID = second.id
+
+        viewModel.removeRule(id: first.id)
+
+        #expect(viewModel.networkConditionRules.map(\.id) == [second.id])
+        #expect(viewModel.selectedRuleID == second.id)
+
+        viewModel.removeRule(id: second.id)
+
+        #expect(viewModel.networkConditionRules.isEmpty)
+        #expect(viewModel.selectedRuleID == nil)
+    }
+
+    @Test
+    func disableAllDisablesOnlyNetworkConditionRules() {
+        let viewModel = NetworkConditionsWindowViewModel(commitChanges: false, isToolEnabled: true)
+        let first = networkRule(name: "First", host: "one.example.com", preset: .threeG, isEnabled: true)
+        let second = networkRule(name: "Second", host: "two.example.com", preset: .edge, isEnabled: true)
+        let blockRule = ProxyRule(
+            name: "Block API",
+            isEnabled: true,
+            matchCondition: RuleMatchCondition(urlPattern: ".*api\\.example\\.com.*"),
+            action: .block(statusCode: 403)
+        )
+        seed(viewModel, rules: [first, second, blockRule])
+
+        viewModel.disableAll()
+
+        #expect(viewModel.allRules.first { $0.id == first.id }?.isEnabled == false)
+        #expect(viewModel.allRules.first { $0.id == second.id }?.isEnabled == false)
+        #expect(viewModel.allRules.first { $0.id == blockRule.id }?.isEnabled == true)
+        #expect(viewModel.activeCount == 0)
+    }
+
+    @Test
     func disablingToolPreservesRuleEnabledStateAndPausesStatus() {
         let viewModel = NetworkConditionsWindowViewModel(commitChanges: false, isToolEnabled: true)
         let rule = networkRule(name: "3G API", host: "api.example.com", preset: .threeG, isEnabled: true)
@@ -70,6 +198,24 @@ struct NetworkConditionsWindowViewModelTests {
 
         #expect(viewModel.allRules.first { $0.id == rule.id }?.isEnabled == true)
         #expect(viewModel.statusLabel(for: rule).0 == "Paused")
+    }
+
+    @Test
+    func profileMetadataAndStatusLabelsReflectRuleState() {
+        let viewModel = NetworkConditionsWindowViewModel(commitChanges: false, isToolEnabled: true)
+        let activeRule = networkRule(name: "3G API", host: "api.example.com", preset: .threeG, isEnabled: true)
+        let inactiveRule = networkRule(name: "WiFi API", host: "wifi.example.com", preset: .wifi, isEnabled: false)
+        seed(viewModel, rules: [activeRule, inactiveRule])
+
+        let profile = viewModel.networkProfile(for: activeRule)
+
+        #expect(profile.name == "3G")
+        #expect(profile.downloadBandwidth == "< 780 kbps")
+        #expect(profile.uploadBandwidth == "< 330 kbps")
+        #expect(profile.packetLoss == "0.0%")
+        #expect(profile.systemImage == "antenna.radiowaves.left.and.right")
+        #expect(viewModel.statusLabel(for: activeRule).0 == "Active")
+        #expect(viewModel.statusLabel(for: inactiveRule).0 == "Inactive")
     }
 
     @Test
@@ -116,6 +262,97 @@ struct NetworkConditionsWindowViewModelTests {
             headers: [],
             compiledPattern: regex
         ))
+    }
+
+    @Test
+    func hostFormatterNormalizesURLsAndRoundTripsHostText() {
+        let pattern = NetworkConditionsPatternFormatter.hostScopedPattern(
+            from: " https://api.example.com:8443/v1/users?debug=true "
+        )
+
+        #expect(pattern == "^https?://api\\.example\\.com:8443(?:/.*)?$")
+        #expect(NetworkConditionsPatternFormatter.hostText(from: pattern) == "api.example.com:8443")
+        #expect(NetworkConditionsPatternFormatter.hostText(from: nil) == "")
+    }
+
+    @Test
+    func ruleFormDefaultsValidationAndSaveContractMatchAddSheet() {
+        #expect(NetworkConditionsRuleForm.defaultName == "Untitled")
+        #expect(NetworkConditionsRuleForm.defaultPreset == .threeG)
+        #expect(NetworkConditionsRuleForm.defaultCustomLatencyMs == 500)
+        #expect(NetworkConditionsRuleForm.isValid(
+            name: "Untitled",
+            hostText: "api.proxyman.com",
+            applySystemWide: false,
+            preset: .threeG,
+            customLatencyMs: 500
+        ))
+        #expect(!NetworkConditionsRuleForm.isValid(
+            name: " ",
+            hostText: "api.proxyman.com",
+            applySystemWide: false,
+            preset: .threeG,
+            customLatencyMs: 500
+        ))
+        #expect(!NetworkConditionsRuleForm.isValid(
+            name: "Untitled",
+            hostText: " ",
+            applySystemWide: false,
+            preset: .threeG,
+            customLatencyMs: 500
+        ))
+        #expect(!NetworkConditionsRuleForm.isValid(
+            name: "Custom",
+            hostText: "api.proxyman.com",
+            applySystemWide: false,
+            preset: .custom,
+            customLatencyMs: 0
+        ))
+
+        let rule = NetworkConditionsRuleForm.makeRule(
+            existingID: nil,
+            name: NetworkConditionsRuleForm.defaultName,
+            isEnabled: true,
+            hostText: "api.proxyman.com",
+            applySystemWide: false,
+            preset: NetworkConditionsRuleForm.defaultPreset,
+            customLatencyMs: NetworkConditionsRuleForm.defaultCustomLatencyMs
+        )
+
+        #expect(rule.name == "Untitled")
+        #expect(rule.isEnabled)
+        #expect(rule.matchCondition.urlPattern == "^https?://api\\.proxyman\\.com(?::\\d+)?(?:/.*)?$")
+        if case let .networkCondition(preset, delayMs) = rule.action {
+            #expect(preset == .threeG)
+            #expect(delayMs == 400)
+        } else {
+            Issue.record("Expected .networkCondition action")
+        }
+    }
+
+    @Test
+    func ruleFormPreservesExistingIDAndBuildsSystemWideEdit() {
+        let id = UUID()
+        let rule = NetworkConditionsRuleForm.makeRule(
+            existingID: id,
+            name: "Edited",
+            isEnabled: false,
+            hostText: "ignored.example.com",
+            applySystemWide: true,
+            preset: .custom,
+            customLatencyMs: 1_234
+        )
+
+        #expect(rule.id == id)
+        #expect(rule.name == "Edited")
+        #expect(rule.isEnabled == false)
+        #expect(rule.matchCondition.urlPattern == nil)
+        if case let .networkCondition(preset, delayMs) = rule.action {
+            #expect(preset == .custom)
+            #expect(delayMs == 1_234)
+        } else {
+            Issue.record("Expected .networkCondition action")
+        }
     }
 
     private func seed(_ viewModel: NetworkConditionsWindowViewModel, rules: [ProxyRule]) {

--- a/RockxyTests/Views/Rules/NetworkConditionsWindowViewModelTests.swift
+++ b/RockxyTests/Views/Rules/NetworkConditionsWindowViewModelTests.swift
@@ -1,0 +1,138 @@
+import Foundation
+@testable import Rockxy
+import Testing
+
+// MARK: - NetworkConditionsWindowViewModelTests
+
+@MainActor
+struct NetworkConditionsWindowViewModelTests {
+    @Test
+    func filteringMatchesNameHostAndPresetWhileIgnoringOtherRuleTypes() {
+        let viewModel = NetworkConditionsWindowViewModel(commitChanges: false, isToolEnabled: true)
+        let apiRule = networkRule(name: "3G API Slowdown", host: "api.proxyman.com", preset: .threeG)
+        let checkoutRule = networkRule(name: "Checkout EDGE", host: "shop.example.com", preset: .edge)
+        let blockRule = ProxyRule(
+            name: "Blocked API",
+            matchCondition: RuleMatchCondition(urlPattern: ".*api.proxyman.com.*"),
+            action: .block(statusCode: 403)
+        )
+        seed(viewModel, rules: [apiRule, checkoutRule, blockRule])
+
+        viewModel.searchText = "edge"
+        #expect(viewModel.filteredRules.map(\.id) == [checkoutRule.id])
+
+        viewModel.searchText = "proxyman"
+        #expect(viewModel.filteredRules.map(\.id) == [apiRule.id])
+    }
+
+    @Test
+    func toggleRuleEnforcesSingleActiveNetworkConditionOptimistically() {
+        let viewModel = NetworkConditionsWindowViewModel(commitChanges: false, isToolEnabled: true)
+        let activeRule = networkRule(name: "3G", host: "api.example.com", preset: .threeG, isEnabled: true)
+        let inactiveRule = networkRule(name: "WiFi", host: "local.example.com", preset: .wifi, isEnabled: false)
+        seed(viewModel, rules: [activeRule, inactiveRule])
+
+        viewModel.toggleRule(id: inactiveRule.id)
+
+        #expect(viewModel.allRules.first { $0.id == activeRule.id }?.isEnabled == false)
+        #expect(viewModel.allRules.first { $0.id == inactiveRule.id }?.isEnabled == true)
+        #expect(viewModel.activeCount == 1)
+    }
+
+    @Test
+    func duplicateAndRemoveSelectedRuleUpdateSelection() throws {
+        let viewModel = NetworkConditionsWindowViewModel(commitChanges: false, isToolEnabled: true)
+        let rule = networkRule(name: "Checkout EDGE", host: "shop.example.com", preset: .edge)
+        seed(viewModel, rules: [rule])
+        viewModel.selectedRuleID = rule.id
+
+        viewModel.duplicateSelectedRule()
+
+        #expect(viewModel.networkConditionRules.count == 2)
+        let copy = try #require(viewModel.selectedRule)
+        #expect(copy.id != rule.id)
+        #expect(copy.name == "Copy of Checkout EDGE")
+        #expect(copy.isEnabled == false)
+
+        viewModel.removeSelectedRule()
+
+        #expect(viewModel.networkConditionRules.count == 1)
+        #expect(viewModel.selectedRuleID == nil)
+    }
+
+    @Test
+    func disablingToolPreservesRuleEnabledStateAndPausesStatus() {
+        let viewModel = NetworkConditionsWindowViewModel(commitChanges: false, isToolEnabled: true)
+        let rule = networkRule(name: "3G API", host: "api.example.com", preset: .threeG, isEnabled: true)
+        seed(viewModel, rules: [rule])
+
+        viewModel.setToolEnabled(false)
+
+        #expect(viewModel.allRules.first { $0.id == rule.id }?.isEnabled == true)
+        #expect(viewModel.statusLabel(for: rule).0 == "Paused")
+    }
+
+    @Test
+    func hostScopedPatternMatchesHTTPHTTPSAndOptionalPort() throws {
+        let pattern = NetworkConditionsPatternFormatter.hostScopedPattern(from: "api.example.com")
+        let regex = try NSRegularExpression(pattern: pattern)
+        let condition = RuleMatchCondition(urlPattern: pattern)
+
+        #expect(condition.matches(
+            method: "GET",
+            url: try #require(URL(string: "http://api.example.com/v1/users")),
+            headers: [],
+            compiledPattern: regex
+        ))
+        #expect(condition.matches(
+            method: "GET",
+            url: try #require(URL(string: "https://api.example.com:8443/v1/users")),
+            headers: [],
+            compiledPattern: regex
+        ))
+        #expect(!condition.matches(
+            method: "GET",
+            url: try #require(URL(string: "https://other.example.com/v1/users")),
+            headers: [],
+            compiledPattern: regex
+        ))
+    }
+
+    @Test
+    func hostScopedPatternRespectsExplicitPort() throws {
+        let pattern = NetworkConditionsPatternFormatter.hostScopedPattern(from: "api.example.com:8443")
+        let regex = try NSRegularExpression(pattern: pattern)
+        let condition = RuleMatchCondition(urlPattern: pattern)
+
+        #expect(condition.matches(
+            method: "GET",
+            url: try #require(URL(string: "https://api.example.com:8443/v1/users")),
+            headers: [],
+            compiledPattern: regex
+        ))
+        #expect(!condition.matches(
+            method: "GET",
+            url: try #require(URL(string: "https://api.example.com:9443/v1/users")),
+            headers: [],
+            compiledPattern: regex
+        ))
+    }
+
+    private func seed(_ viewModel: NetworkConditionsWindowViewModel, rules: [ProxyRule]) {
+        viewModel.handleRulesDidChange(Notification(name: .rulesDidChange, object: rules))
+    }
+
+    private func networkRule(
+        name: String,
+        host: String,
+        preset: NetworkConditionPreset,
+        isEnabled: Bool = true
+    ) -> ProxyRule {
+        ProxyRule(
+            name: name,
+            isEnabled: isEnabled,
+            matchCondition: RuleMatchCondition(urlPattern: ".*\(NSRegularExpression.escapedPattern(for: host)).*"),
+            action: .networkCondition(preset: preset, delayMs: preset.defaultLatencyMs)
+        )
+    }
+}

--- a/RockxyTests/Views/Settings/AutoSelectPortMigrationTests.swift
+++ b/RockxyTests/Views/Settings/AutoSelectPortMigrationTests.swift
@@ -11,7 +11,7 @@ struct AutoSelectPortMigrationTests {
         let cleanup = installSettingsTestGuard()
         defer { cleanup() }
 
-        UserDefaults.standard.removeObject(forKey: TestIdentity.autoSelectPortKey)
+        UserDefaults.standard.removeObject(forKey: autoSelectPortKey)
         let settings = AppSettingsStorage.load()
         #expect(settings.autoSelectPort == true)
     }
@@ -21,7 +21,7 @@ struct AutoSelectPortMigrationTests {
         let cleanup = installSettingsTestGuard()
         defer { cleanup() }
 
-        UserDefaults.standard.set(false, forKey: TestIdentity.autoSelectPortKey)
+        UserDefaults.standard.set(false, forKey: autoSelectPortKey)
         let settings = AppSettingsStorage.load()
         #expect(settings.autoSelectPort == false)
     }
@@ -31,8 +31,12 @@ struct AutoSelectPortMigrationTests {
         let cleanup = installSettingsTestGuard()
         defer { cleanup() }
 
-        UserDefaults.standard.set(true, forKey: TestIdentity.autoSelectPortKey)
+        UserDefaults.standard.set(true, forKey: autoSelectPortKey)
         let settings = AppSettingsStorage.load()
         #expect(settings.autoSelectPort == true)
+    }
+
+    private var autoSelectPortKey: String {
+        RockxyIdentity.current.defaultsKey("autoSelectPort")
     }
 }

--- a/RockxyTests/Views/Settings/SettingsWiringTests.swift
+++ b/RockxyTests/Views/Settings/SettingsWiringTests.swift
@@ -72,7 +72,7 @@ struct SettingsWiringTests {
         let cleanup = installSettingsTestGuard()
         defer { cleanup() }
 
-        let key = TestIdentity.recordOnLaunchKey
+        let key = RockxyIdentity.current.defaultsKey("recordOnLaunch")
         UserDefaults.standard.set(true, forKey: key)
         UserDefaults.standard.synchronize()
         let settingsTrue = AppSettingsStorage.load()


### PR DESCRIPTION
## Summary

- Refines rule management workflows across block/allow lists, map local, map remote, network conditions, and breakpoint tooling.
- Adds supporting rule infrastructure for breakpoint templates, persisted list codecs, network condition profiles, policy-gated rule updates, and coordinator wiring.
- Polishes scripting editor and scripting list behavior, including ruler clipping, editor layout, console sizing, and testable plugin directory handling.
- Expands regression coverage for rule engines, proxy throttling, scripting workflows, settings migration, identity validation, and related UI models.

## Impact

This prepares Stephen's latest rule-management and scripting workflow improvements for `main`, with broader test coverage around the behavior touched by the branch.

## Validation

- `git diff --check`
- Full `xcodebuild` test suite was not run in this publish pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added breakpoint templates system for managing reusable request/response templates
  * Added block list tool with import/export support (Proxyman, Charles Proxy formats)
  * Added network bandwidth throttling/rate limiting for uploads and downloads
  * Added system proxy override toggle in Tools menu
  * Introduced dedicated editor windows for breakpoint rules, map local, and map remote rules
  * Enhanced map remote rules with option to preserve original request URLs

* **UI/UX Improvements**
  * Replaced sheet-based editors with dedicated window interfaces for better workflow
  * Redesigned rules management with table-based views and improved organization
  * Added support for tool-specific enable/disable controls (block list, map local, map remote, network conditions)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RockxyApp/Rockxy/pull/104?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->