### PR TITLE
Stabilize breakpoint tooling and rule workflows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY: test-breakpoint
+
+test-breakpoint:
+	xcodebuild -project Rockxy.xcodeproj -scheme Rockxy -destination 'platform=macOS' -only-testing:RockxyTests/Breakpoint test

--- a/Rockxy/Core/ProxyEngine/HTTPProxyHandler.swift
+++ b/Rockxy/Core/ProxyEngine/HTTPProxyHandler.swift
@@ -406,44 +406,15 @@ final class HTTPProxyHandler: ChannelInboundHandler, RemovableChannelHandler, @u
             return
         }
 
-        let originalURL = requestData.url
-        let upstreamHost = configuration.host ?? (originalURL.host ?? "localhost")
-        let scheme = configuration.scheme ?? (originalURL.scheme ?? "http")
-        let port = configuration.port ?? (scheme == "https" ? 443 : (originalURL.port ?? 80))
-        let path = configuration.path ?? originalURL.path
-        let query = configuration.query ?? originalURL.query
-
-        let effectivePath = path.isEmpty ? "/" : path
-        let uri = query.map { "\(effectivePath)?\($0)" } ?? effectivePath
-
-        var modifiedHead = head
-        modifiedHead.uri = configuration.preserveOriginalURL ? head.uri : uri
-
-        let hostHeaderValue: String = if configuration.preserveHostHeader {
-            originalURL.host ?? upstreamHost
-        } else {
-            upstreamHost
-        }
-        modifiedHead.headers.replaceOrAdd(name: "Host", value: NetworkValidator.sanitizeHeaderValue(hostHeaderValue))
-
-        var urlString = "\(scheme)://\(upstreamHost)"
-        if port != 80, port != 443 {
-            urlString += ":\(port)"
-        }
-        urlString += uri
-
-        // swiftlint:disable:next force_unwrapping
-        let fallbackURL = URL(string: "http://localhost/")!
-        let modifiedData = HTTPRequestData(
-            method: requestData.method,
-            url: URL(string: urlString) ?? fallbackURL,
-            httpVersion: requestData.httpVersion,
-            headers: requestData.headers,
-            body: requestData.body,
-            contentType: requestData.contentType
+        let rewrite = ProxyHandlerShared.buildMapRemoteRewrite(
+            configuration: configuration,
+            originalHead: head,
+            requestData: requestData,
+            fallbackScheme: "http",
+            fallbackHost: "localhost"
         )
 
-        forwardRequest(context: context, head: modifiedHead, requestData: modifiedData, callback: callback)
+        forwardRequest(context: context, head: rewrite.head, requestData: rewrite.requestData, callback: callback)
     }
 
     nonisolated private func handleMapLocal(

--- a/Rockxy/Core/ProxyEngine/HTTPProxyHandler.swift
+++ b/Rockxy/Core/ProxyEngine/HTTPProxyHandler.swift
@@ -151,12 +151,16 @@ final class HTTPProxyHandler: ChannelInboundHandler, RemovableChannelHandler, @u
         let ruleEngine = self.ruleEngine
 
         eventLoop.makeFutureWithTask {
-            await ruleEngine.evaluateRule(method: method, url: url, headers: headers)
+            let breakpointRule = await ruleEngine.evaluateBreakpointRule(method: method, url: url, headers: headers)
+            let matchedRule = await ruleEngine.evaluateRule(method: method, url: url, headers: headers)
+            return (breakpointRule, matchedRule)
         }.whenComplete { [weak self] result in
             guard let self else {
                 return
             }
-            let matchedRule: ProxyRule? = (try? result.get()) ?? nil
+            let evaluation = try? result.get()
+            let breakpointRule = evaluation?.0
+            let matchedRule = evaluation?.1
             let callback = self.makeTransactionCallback(for: matchedRule)
 
             // CONNECT policy: only .block is meaningful on tunnel establishment (sends
@@ -186,6 +190,21 @@ final class HTTPProxyHandler: ChannelInboundHandler, RemovableChannelHandler, @u
                     }
                 }
                 self.handleConnect(context: context, head: head)
+                return
+            }
+
+            if let breakpointRule,
+               case let .breakpoint(phase) = breakpointRule.action,
+               phase == .request || phase == .both
+            {
+                self.handleRuleAction(
+                    breakpointRule.action,
+                    context: context,
+                    head: head,
+                    requestData: requestData,
+                    callback: self.makeTransactionCallback(for: breakpointRule),
+                    urlPattern: breakpointRule.matchCondition.urlPattern
+                )
                 return
             }
 

--- a/Rockxy/Core/ProxyEngine/HTTPSProxyRelayHandler.swift
+++ b/Rockxy/Core/ProxyEngine/HTTPSProxyRelayHandler.swift
@@ -383,14 +383,14 @@ final class HTTPSProxyRelayHandler: ChannelInboundHandler, @unchecked Sendable {
                     )
                     clientChannel.close(promise: nil)
                     limiter.release(host: upstreamHost, port: upstreamPort)
-                    self.sendErrorResponse(context: context, status: 502)
+                    self.sendErrorResponse(context: context, status: 502, requestData: requestData, callback: callback)
                 }
             }
 
         case let .failure(error):
             httpsRelayLogger.error("Upstream connection failed: \(error.localizedDescription)")
             limiter.release(host: upstreamHost, port: upstreamPort)
-            self.sendErrorResponse(context: context, status: 502)
+            self.sendErrorResponse(context: context, status: 502, requestData: requestData, callback: callback)
         }
     }
 
@@ -643,46 +643,21 @@ final class HTTPSProxyRelayHandler: ChannelInboundHandler, @unchecked Sendable {
         startTime: DispatchTime,
         callback: @escaping @Sendable (HTTPTransaction) -> Void
     ) {
-        let originalURL = requestData.url
-        let remoteHost = configuration.host ?? (originalURL.host ?? self.host)
-        let scheme = configuration.scheme ?? (originalURL.scheme ?? "https")
-        let remotePort = configuration.port ?? (scheme == "https" ? 443 : 80)
-        let remotePath = configuration.path ?? originalURL.path
-        let remoteQuery = configuration.query ?? originalURL.query
-
-        let effectivePath = remotePath.isEmpty ? "/" : remotePath
-        let uri = remoteQuery.map { "\(effectivePath)?\($0)" } ?? effectivePath
-
-        var modifiedHead = head
-        modifiedHead.uri = configuration.preserveOriginalURL ? head.uri : uri
-
-        let hostHeaderValue: String = if configuration.preserveHostHeader {
-            originalURL.host ?? remoteHost
-        } else {
-            remoteHost
-        }
-        modifiedHead.headers.replaceOrAdd(name: "Host", value: NetworkValidator.sanitizeHeaderValue(hostHeaderValue))
-
-        var urlString = "\(scheme)://\(remoteHost)"
-        if remotePort != 80, remotePort != 443 {
-            urlString += ":\(remotePort)"
-        }
-        urlString += uri
-
-        // swiftlint:disable:next force_unwrapping
-        let fallbackURL = URL(string: "https://localhost/")!
-        let modifiedRequestData = HTTPRequestData(
-            method: requestData.method,
-            url: URL(string: urlString) ?? fallbackURL,
-            httpVersion: requestData.httpVersion,
-            headers: requestData.headers,
-            body: requestData.body,
-            contentType: requestData.contentType
+        let rewrite = ProxyHandlerShared.buildMapRemoteRewrite(
+            configuration: configuration,
+            originalHead: head,
+            requestData: requestData,
+            fallbackScheme: "https",
+            fallbackHost: host,
+            fallbackPort: port
         )
+        let remoteHost = rewrite.upstreamHost
+        let remotePort = rewrite.upstreamPort
+        let scheme = rewrite.scheme
 
         guard connectionLimiter.acquire(host: remoteHost, port: remotePort) else {
             httpsRelayLogger.warning("Connection limit reached for \(remoteHost):\(remotePort)")
-            sendErrorResponse(context: context, status: 503)
+            sendErrorResponse(context: context, status: 503, requestData: rewrite.requestData, callback: callback)
             return
         }
         let limiter = connectionLimiter
@@ -722,8 +697,8 @@ final class HTTPSProxyRelayHandler: ChannelInboundHandler, @unchecked Sendable {
                         self.handleUpstreamConnection(
                             result: result,
                             context: context,
-                            head: modifiedHead,
-                            requestData: modifiedRequestData,
+                            head: rewrite.head,
+                            requestData: rewrite.requestData,
                             graphQLInfo: graphQLInfo,
                             startTime: startTime,
                             connectTime: connectTime,
@@ -735,7 +710,7 @@ final class HTTPSProxyRelayHandler: ChannelInboundHandler, @unchecked Sendable {
             } catch {
                 httpsRelayLogger.error("Map remote TLS setup failed: \(error.localizedDescription)")
                 limiter.release(host: remoteHost, port: remotePort)
-                sendErrorResponse(context: context, status: 502)
+                sendErrorResponse(context: context, status: 502, requestData: rewrite.requestData, callback: callback)
             }
         } else {
             let connectTime = DispatchTime.now()
@@ -756,8 +731,8 @@ final class HTTPSProxyRelayHandler: ChannelInboundHandler, @unchecked Sendable {
                     self.handleUpstreamConnection(
                         result: result,
                         context: context,
-                        head: modifiedHead,
-                        requestData: modifiedRequestData,
+                        head: rewrite.head,
+                        requestData: rewrite.requestData,
                         graphQLInfo: graphQLInfo,
                         startTime: startTime,
                         connectTime: connectTime,
@@ -812,6 +787,37 @@ final class HTTPSProxyRelayHandler: ChannelInboundHandler, @unchecked Sendable {
         context.writeAndFlush(NIOAny(HTTPServerResponsePart.end(nil))).whenComplete { _ in
             context.close(promise: nil)
         }
+    }
+
+    nonisolated private func sendErrorResponse(
+        context: ChannelHandlerContext,
+        status: Int,
+        requestData: HTTPRequestData,
+        callback: @escaping @Sendable (HTTPTransaction) -> Void
+    ) {
+        guard context.channel.isActive else {
+            return
+        }
+        let httpStatus = HTTPResponseStatus(statusCode: status)
+        var responseHead = HTTPResponseHead(version: .http1_1, status: httpStatus)
+        responseHead.headers.add(name: "Connection", value: "close")
+        context.write(NIOAny(HTTPServerResponsePart.head(responseHead)), promise: nil)
+        context.writeAndFlush(NIOAny(HTTPServerResponsePart.end(nil))).whenComplete { _ in
+            context.close(promise: nil)
+        }
+
+        let transaction = HTTPTransaction(
+            request: requestData,
+            response: HTTPResponseData(
+                statusCode: status,
+                statusMessage: httpStatus.reasonPhrase,
+                headers: []
+            ),
+            state: status == 403 ? .blocked : .failed
+        )
+        transaction.measuredDuration = requestElapsedDuration()
+        transaction.sourcePort = clientSourcePort
+        callback(transaction)
     }
 
     nonisolated private func requestElapsedDuration() -> TimeInterval? {

--- a/Rockxy/Core/ProxyEngine/HTTPSProxyRelayHandler.swift
+++ b/Rockxy/Core/ProxyEngine/HTTPSProxyRelayHandler.swift
@@ -173,17 +173,42 @@ final class HTTPSProxyRelayHandler: ChannelInboundHandler, @unchecked Sendable {
         let ruleEngine = self.ruleEngine
 
         eventLoop.makeFutureWithTask {
-            await ruleEngine.evaluateRule(
+            let breakpointRule = await ruleEngine.evaluateBreakpointRule(
                 method: head.method.rawValue,
                 url: parsedURL,
                 headers: requestData.headers
             )
+            let matchedRule = await ruleEngine.evaluateRule(
+                method: head.method.rawValue,
+                url: parsedURL,
+                headers: requestData.headers
+            )
+            return (breakpointRule, matchedRule)
         }.whenComplete { [weak self] result in
             guard let self else {
                 return
             }
-            let matchedRule: ProxyRule? = (try? result.get()) ?? nil
+            let evaluation = try? result.get()
+            let breakpointRule = evaluation?.0
+            let matchedRule = evaluation?.1
             let matchedRuleCallback = self.makeTransactionCallback(for: matchedRule)
+
+            if let breakpointRule,
+               case let .breakpoint(phase) = breakpointRule.action,
+               phase == .request || phase == .both
+            {
+                self.handleRuleAction(
+                    breakpointRule.action,
+                    context: context,
+                    head: head,
+                    requestData: requestData,
+                    graphQLInfo: graphQLInfo,
+                    startTime: startTime,
+                    callback: self.makeTransactionCallback(for: breakpointRule),
+                    urlPattern: breakpointRule.matchCondition.urlPattern
+                )
+                return
+            }
 
             if let matchedRule {
                 self.handleRuleAction(

--- a/Rockxy/Core/ProxyEngine/ProxyHandlerShared.swift
+++ b/Rockxy/Core/ProxyEngine/ProxyHandlerShared.swift
@@ -14,6 +14,14 @@ nonisolated(unsafe) private let proxyHandlerSharedLogger = Logger(
 enum ProxyHandlerShared {
     // MARK: Internal
 
+    struct MapRemoteRewrite {
+        let head: HTTPRequestHead
+        let requestData: HTTPRequestData
+        let upstreamHost: String
+        let upstreamPort: Int
+        let scheme: String
+    }
+
     /// Decision returned by `oversizeRelayDecision` when a response body chunk
     /// pushes the capture buffer past the cap. Drives both the script-deferral
     /// flush logic and the response-breakpoint preservation.
@@ -145,6 +153,74 @@ enum ProxyHandlerShared {
         )
     }
 
+    nonisolated static func buildMapRemoteRewrite(
+        configuration: MapRemoteConfiguration,
+        originalHead: HTTPRequestHead,
+        requestData: HTTPRequestData,
+        fallbackScheme: String,
+        fallbackHost: String,
+        fallbackPort: Int? = nil
+    )
+        -> MapRemoteRewrite
+    {
+        let originalURL = requestData.url
+        let schemeOverride = normalizedScheme(configuration.scheme)
+        let originalScheme = normalizedScheme(originalURL.scheme) ?? fallbackScheme.lowercased()
+        let scheme = schemeOverride ?? originalScheme
+        let upstreamHost = configuration.host ?? (originalURL.host ?? fallbackHost)
+        let upstreamPort = resolvedMapRemotePort(
+            configuration: configuration,
+            schemeOverride: schemeOverride,
+            scheme: scheme,
+            originalURL: originalURL,
+            fallbackPort: fallbackPort
+        )
+        let remotePath = configuration.path ?? originalURL.path
+        let remoteQuery = configuration.query ?? originalURL.query
+
+        let effectivePath = remotePath.isEmpty ? "/" : remotePath
+        let encodedQuery = remoteQuery.flatMap(percentEncodedQuery)
+        let uri = encodedQuery.map { "\(effectivePath)?\($0)" } ?? effectivePath
+
+        var modifiedHead = originalHead
+        modifiedHead.uri = configuration.preserveOriginalURL ? originalHead.uri : uri
+
+        let hostHeaderValue: String
+        if configuration.preserveHostHeader {
+            hostHeaderValue = originalHead.headers.first(name: "Host")
+                ?? hostHeader(host: originalURL.host ?? fallbackHost, port: originalURL.port ?? fallbackPort, scheme: originalScheme)
+        } else {
+            hostHeaderValue = hostHeader(host: upstreamHost, port: upstreamPort, scheme: scheme)
+        }
+        modifiedHead.headers.replaceOrAdd(name: "Host", value: NetworkValidator.sanitizeHeaderValue(hostHeaderValue))
+
+        let urlString = mapRemoteURLString(
+            scheme: scheme,
+            host: upstreamHost,
+            port: upstreamPort,
+            pathAndQuery: uri
+        )
+
+        // swiftlint:disable:next force_unwrapping
+        let fallbackURL = URL(string: "\(fallbackScheme.lowercased())://localhost/")!
+        let modifiedData = HTTPRequestData(
+            method: requestData.method,
+            url: URL(string: urlString) ?? fallbackURL,
+            httpVersion: requestData.httpVersion,
+            headers: modifiedHead.headers.map { HTTPHeader(name: $0.name, value: $0.value) },
+            body: requestData.body,
+            contentType: requestData.contentType
+        )
+
+        return MapRemoteRewrite(
+            head: modifiedHead,
+            requestData: modifiedData,
+            upstreamHost: upstreamHost,
+            upstreamPort: upstreamPort,
+            scheme: scheme
+        )
+    }
+
     /// Rebuild the outbound response head from a script-mutated `HTTPResponseData`.
     ///
     /// The relay path sends the full mutated body in a fixed-length write, so
@@ -188,5 +264,87 @@ enum ProxyHandlerShared {
         }
         warned.insert(key)
         proxyHandlerSharedLogger.warning("buildForwardHead: \(kind) \(details)")
+    }
+
+    private static func normalizedScheme(_ scheme: String?) -> String? {
+        guard let scheme = scheme?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !scheme.isEmpty else
+        {
+            return nil
+        }
+        return scheme.lowercased()
+    }
+
+    private static func resolvedMapRemotePort(
+        configuration: MapRemoteConfiguration,
+        schemeOverride: String?,
+        scheme: String,
+        originalURL: URL,
+        fallbackPort: Int?
+    )
+        -> Int
+    {
+        if let port = configuration.port {
+            return port
+        }
+        if schemeOverride == nil {
+            return originalURL.port ?? fallbackPort ?? defaultPort(for: scheme)
+        }
+        return defaultPort(for: scheme)
+    }
+
+    private static func defaultPort(for scheme: String) -> Int {
+        switch scheme.lowercased() {
+        case "https", "wss":
+            443
+        default:
+            80
+        }
+    }
+
+    private static func isDefaultPort(_ port: Int, for scheme: String) -> Bool {
+        port == defaultPort(for: scheme)
+    }
+
+    private static func hostHeader(host: String, port: Int?, scheme: String) -> String {
+        guard let port, !isDefaultPort(port, for: scheme) else {
+            return host
+        }
+        return "\(hostForAuthority(host)):\(port)"
+    }
+
+    private static func hostForAuthority(_ host: String) -> String {
+        if host.contains(":"), !host.hasPrefix("["), !host.hasSuffix("]") {
+            return "[\(host)]"
+        }
+        return host
+    }
+
+    private static func mapRemoteURLString(
+        scheme: String,
+        host: String,
+        port: Int,
+        pathAndQuery: String
+    )
+        -> String
+    {
+        var urlString = "\(scheme)://\(hostForAuthority(host))"
+        if !isDefaultPort(port, for: scheme) {
+            urlString += ":\(port)"
+        }
+        urlString += pathAndQuery
+        return urlString
+    }
+
+    private static func percentEncodedQuery(_ query: String) -> String? {
+        guard !query.isEmpty else {
+            return query
+        }
+        if let components = URLComponents(string: "https://rockxy.invalid/?\(query)"),
+           let encoded = components.percentEncodedQuery
+        {
+            return encoded
+        }
+        return query.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? query
     }
 }

--- a/Rockxy/Core/RuleEngine/BreakpointManager.swift
+++ b/Rockxy/Core/RuleEngine/BreakpointManager.swift
@@ -10,9 +10,13 @@ import os
 /// to the proxy pipeline when the user resolves the item.
 struct PausedBreakpointItem: Identifiable {
     let id: UUID
+    let sequenceNumber: Int
     let phase: BreakpointPhase
     let host: String
     let path: String
+    let url: String
+    let client: String
+    let queryName: String
     let method: String
     let statusCode: Int?
     let matchedRuleName: String?
@@ -46,11 +50,16 @@ final class BreakpointManager {
         let path = components?.path ?? "/"
 
         let itemId = UUID()
+        nextSequenceNumber += 1
         let item = PausedBreakpointItem(
             id: itemId,
+            sequenceNumber: nextSequenceNumber,
             phase: data.phase,
             host: host,
             path: path,
+            url: Self.displayURL(from: data.url),
+            client: Self.clientLabel(from: data.headers),
+            queryName: Self.queryName(from: data),
             method: data.method,
             statusCode: data.phase == .response ? data.statusCode : nil,
             matchedRuleName: nil,
@@ -117,4 +126,79 @@ final class BreakpointManager {
     private static let logger = Logger(subsystem: RockxyIdentity.current.logSubsystem, category: "BreakpointManager")
 
     private var continuations: [UUID: CheckedContinuation<(BreakpointDecision, BreakpointRequestData), Never>] = [:]
+    private var nextSequenceNumber = 0
+
+    private static func displayURL(from urlString: String) -> String {
+        guard let components = URLComponents(string: urlString) else {
+            return urlString
+        }
+        var display = components.host ?? urlString
+        if let port = components.port {
+            display += ":\(port)"
+        }
+        display += components.path.isEmpty ? "/" : components.path
+        if let query = components.percentEncodedQuery, !query.isEmpty {
+            display += "?\(query)"
+        }
+        return display
+    }
+
+    private static func clientLabel(from headers: [EditableHeader]) -> String {
+        let directHeaderNames = [
+            "x-rockxy-runtime",
+            "x-client",
+            "x-client-name",
+            "x-runtime",
+        ]
+        for headerName in directHeaderNames {
+            if let value = headers.first(where: { $0.name.lowercased() == headerName })?.value
+                .trimmingCharacters(in: .whitespacesAndNewlines),
+                !value.isEmpty
+            {
+                return value
+            }
+        }
+        guard let userAgent = headers.first(where: { $0.name.lowercased() == "user-agent" })?.value,
+              !userAgent.isEmpty
+        else {
+            return String(localized: "Unknown")
+        }
+        if !userAgent.contains("Mozilla/"), let slash = userAgent.firstIndex(of: "/") {
+            let name = String(userAgent[..<slash])
+            return name.isEmpty ? userAgent : name
+        }
+        if userAgent.contains("Chrome/") {
+            return "Google Chrome"
+        }
+        if userAgent.contains("Firefox/") {
+            return "Firefox"
+        }
+        if userAgent.contains("Safari/") {
+            return "Safari"
+        }
+        return userAgent
+    }
+
+    private static func queryName(from data: BreakpointRequestData) -> String {
+        if let components = URLComponents(string: data.url),
+           let operationName = components.queryItems?.first(where: {
+               ["operationName", "queryName"].contains($0.name)
+           })?.value,
+           !operationName.isEmpty
+        {
+            return operationName
+        }
+        guard let contentType = data.headers.first(where: {
+            $0.name.caseInsensitiveCompare("content-type") == .orderedSame
+        })?.value.lowercased(),
+              contentType.contains("json"),
+              let bodyData = data.body.data(using: .utf8),
+              let object = try? JSONSerialization.jsonObject(with: bodyData) as? [String: Any],
+              let operationName = object["operationName"] as? String,
+              !operationName.isEmpty
+        else {
+            return ""
+        }
+        return operationName
+    }
 }

--- a/Rockxy/Core/RuleEngine/RuleEngine.swift
+++ b/Rockxy/Core/RuleEngine/RuleEngine.swift
@@ -25,6 +25,26 @@ actor RuleEngine {
         evaluateRule(method: method, url: url, headers: headers)?.action
     }
 
+    /// Evaluates only Breakpoint rules and returns the first matching enabled rule.
+    /// Breakpoint is an interruption tool, so request-phase breakpoints need a chance
+    /// to pause traffic before another rule category consumes the same request.
+    func evaluateBreakpointRule(method: String, url: URL, headers: [HTTPHeader]) -> ProxyRule? {
+        guard breakpointToolEnabled else {
+            return nil
+        }
+        for rule in rules where rule.isEnabled {
+            guard case .breakpoint = rule.action else {
+                continue
+            }
+            let compiled = compiledPatterns[rule.id]
+            if rule.matchCondition.matches(method: method, url: url, headers: headers, compiledPattern: compiled) {
+                Self.logger.debug("Breakpoint rule matched: \(rule.name)")
+                return rule
+            }
+        }
+        return nil
+    }
+
     /// Evaluates rules and returns the full matching rule (action + match condition).
     /// Used by Map Local Directory to extract the URL pattern for subpath resolution.
     func evaluateRule(method: String, url: URL, headers: [HTTPHeader]) -> ProxyRule? {

--- a/Rockxy/Models/Rules/BreakpointTemplate.swift
+++ b/Rockxy/Models/Rules/BreakpointTemplate.swift
@@ -306,6 +306,9 @@ enum BreakpointTemplateValidator {
             }
             return .invalid(String(localized: "Invalid headers."))
         }
+        if let jsonError = validateJSONBodyIfNeeded(body, headers: parsedHeaders) {
+            return .invalid(jsonError)
+        }
 
         let parsed = BreakpointTemplateParsedRequest(
             method: method,
@@ -345,6 +348,9 @@ enum BreakpointTemplateValidator {
             }
             return .invalid(String(localized: "Invalid headers."))
         }
+        if let jsonError = validateJSONBodyIfNeeded(body, headers: parsedHeaders) {
+            return .invalid(jsonError)
+        }
 
         let parsed = BreakpointTemplateParsedResponse(
             httpVersion: parts[0],
@@ -377,6 +383,31 @@ enum BreakpointTemplateValidator {
             headers.append(BreakpointTemplateHeader(name: name, value: value))
         }
         return .valid(headers)
+    }
+
+    private static func validateJSONBodyIfNeeded(
+        _ body: String,
+        headers: [BreakpointTemplateHeader]
+    )
+        -> String?
+    {
+        let trimmedBody = body.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedBody.isEmpty,
+              headers.contains(where: {
+                  $0.name.caseInsensitiveCompare("content-type") == .orderedSame
+                      && $0.value.localizedCaseInsensitiveContains("json")
+              }),
+              let data = trimmedBody.data(using: .utf8)
+        else {
+            return nil
+        }
+
+        do {
+            _ = try JSONSerialization.jsonObject(with: data)
+            return nil
+        } catch {
+            return String(localized: "Invalid JSON body: \(error.localizedDescription)")
+        }
     }
 
     private static func normalize(_ rawMessage: String) -> String {

--- a/Rockxy/Models/Rules/BreakpointTemplateStore.swift
+++ b/Rockxy/Models/Rules/BreakpointTemplateStore.swift
@@ -196,6 +196,9 @@ final class BreakpointTemplateStore {
     private let defaults: UserDefaults
     private let storageKey: String
     private let seedDefaults: Bool
+    private var seedMarkerKey: String {
+        "\(storageKey).seeded"
+    }
 
     private func uniqueName(for kind: BreakpointTemplateKind) -> String {
         let base = kind.emptyName
@@ -225,9 +228,12 @@ final class BreakpointTemplateStore {
 
     private func load() {
         guard let data = defaults.data(forKey: storageKey) else {
-            templates = seedDefaults ? BreakpointTemplate.defaultTemplates : []
-            if seedDefaults {
+            if seedDefaults, !defaults.bool(forKey: seedMarkerKey) {
+                templates = BreakpointTemplate.defaultTemplates
+                defaults.set(true, forKey: seedMarkerKey)
                 save()
+            } else {
+                templates = []
             }
             return
         }
@@ -235,10 +241,6 @@ final class BreakpointTemplateStore {
         do {
             let decoded = try JSONDecoder().decode([BreakpointTemplate].self, from: data)
             templates = decoded
-            if templates.isEmpty, seedDefaults {
-                templates = BreakpointTemplate.defaultTemplates
-                save()
-            }
         } catch {
             Self.logger.error("Failed to load breakpoint templates: \(error.localizedDescription)")
             templates = seedDefaults ? BreakpointTemplate.defaultTemplates : []

--- a/Rockxy/Models/Rules/MapRemoteConfiguration.swift
+++ b/Rockxy/Models/Rules/MapRemoteConfiguration.swift
@@ -41,11 +41,11 @@ struct MapRemoteConfiguration: Codable, Hashable {
             return
         }
         self.init(
-            scheme: components.scheme,
+            scheme: components.scheme?.lowercased(),
             host: components.host,
             port: components.port,
             path: components.path.isEmpty ? nil : components.path,
-            query: components.query,
+            query: components.percentEncodedQuery,
             preserveOriginalURL: false,
             preserveHostHeader: false
         )

--- a/Rockxy/ViewModels/BreakpointViewModel.swift
+++ b/Rockxy/ViewModels/BreakpointViewModel.swift
@@ -19,7 +19,7 @@ enum BreakpointDecision {
     case execute
     /// Drop the request and return a 503 Service Unavailable response.
     case abort
-    /// Drop the request silently with no response.
+    /// Forward the original paused message without applying the current draft.
     case cancel
 }
 

--- a/Rockxy/Views/Breakpoint/BreakpointEditorView.swift
+++ b/Rockxy/Views/Breakpoint/BreakpointEditorView.swift
@@ -49,6 +49,10 @@ struct BreakpointEditorView: View {
     @State private var rawMessage: String = ""
     @State private var rawMessageItemID: UUID?
     @State private var templateStore = BreakpointTemplateStore.shared
+    @State private var isSaveTemplateSheetPresented = false
+    @State private var saveTemplateName = ""
+    @State private var pendingTemplateKind: BreakpointTemplateKind = .request
+    @State private var pendingTemplateRawMessage = ""
 
     private var emptyState: some View {
         VStack(spacing: 4) {
@@ -281,6 +285,13 @@ struct BreakpointEditorView: View {
                     .foregroundStyle(validation.isValid ? Color.green : Color.red)
                 Spacer()
                 Menu {
+                    Button(String(localized: "Save current message as new template...")) {
+                        pendingTemplateKind = kind
+                        pendingTemplateRawMessage = rawMessage
+                        saveTemplateName = defaultTemplateName(for: kind)
+                        isSaveTemplateSheetPresented = true
+                    }
+                    Divider()
                     ForEach(templateStore.templates(for: kind)) { template in
                         Button(template.name.isEmpty ? String(localized: "Untitled") : template.name) {
                             applyTemplate(template, to: itemId)
@@ -289,7 +300,6 @@ struct BreakpointEditorView: View {
                 } label: {
                     Label(String(localized: "Template"), systemImage: "doc.text")
                 }
-                .disabled(templateStore.templates(for: kind).isEmpty)
             }
             .padding(.horizontal, 12)
             .padding(.top, 8)
@@ -310,6 +320,9 @@ struct BreakpointEditorView: View {
             if newValue == .raw {
                 syncRawMessageFromDraft(itemId: itemId, force: rawMessageItemID != itemId)
             }
+        }
+        .sheet(isPresented: $isSaveTemplateSheetPresented) {
+            saveTemplateSheet
         }
     }
 
@@ -464,6 +477,56 @@ struct BreakpointEditorView: View {
         rawMessageItemID = itemId
         rawMessage = template.rawMessage
         updateRawMessage(template.rawMessage, itemId: itemId)
+    }
+
+    private var saveTemplateSheet: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Text(String(localized: "Save Template"))
+                .font(.headline)
+
+            TextField(String(localized: "Template name"), text: $saveTemplateName)
+                .textFieldStyle(.roundedBorder)
+
+            let validation = BreakpointRawMessage.validation(for: pendingTemplateRawMessage, kind: pendingTemplateKind)
+            Label(validation.message, systemImage: "circle.fill")
+                .font(.caption)
+                .foregroundStyle(validation.isValid ? Color.green : Color.red)
+
+            HStack {
+                Spacer()
+                Button(String(localized: "Cancel")) {
+                    isSaveTemplateSheetPresented = false
+                }
+                .keyboardShortcut(.cancelAction)
+
+                Button(String(localized: "Save")) {
+                    savePendingTemplate()
+                }
+                .keyboardShortcut(.defaultAction)
+                .disabled(!validation.isValid)
+            }
+        }
+        .padding(20)
+        .frame(width: 380)
+    }
+
+    private func defaultTemplateName(for kind: BreakpointTemplateKind) -> String {
+        switch kind {
+        case .request:
+            String(localized: "Saved Request")
+        case .response:
+            String(localized: "Saved Response")
+        }
+    }
+
+    private func savePendingTemplate() {
+        let template = templateStore.addTemplate(kind: pendingTemplateKind)
+        templateStore.updateTemplate(
+            id: template.id,
+            name: saveTemplateName,
+            rawMessage: pendingTemplateRawMessage
+        )
+        isSaveTemplateSheetPresented = false
     }
 }
 

--- a/Rockxy/Views/Breakpoint/BreakpointEditorView.swift
+++ b/Rockxy/Views/Breakpoint/BreakpointEditorView.swift
@@ -183,29 +183,15 @@ struct BreakpointEditorView: View {
                     queryDisplay(itemId: itemId)
                 }
             }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         }
     }
 
     private func headersEditor(itemId: UUID) -> some View {
-        VStack(spacing: 0) {
-            HStack {
-                Text(String(localized: "Name"))
-                    .font(.caption)
-                    .fontWeight(.semibold)
-                    .foregroundStyle(.secondary)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                Text(String(localized: "Value"))
-                    .font(.caption)
-                    .fontWeight(.semibold)
-                    .foregroundStyle(.secondary)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                Color.clear.frame(width: 24)
-            }
-            .padding(.horizontal, 12)
-            .padding(.top, 8)
+        ScrollView {
+            LazyVStack(spacing: 6) {
+                columnHeaders(name: "Name", value: "Value")
 
-            List {
                 let headers = draftFor(itemId)?.headers ?? []
                 ForEach(headers) { header in
                     HStack(spacing: 8) {
@@ -246,23 +232,15 @@ struct BreakpointEditorView: View {
                         .buttonStyle(.plain)
                     }
                 }
-            }
-            .listStyle(.plain)
 
-            HStack {
-                Button {
+                addButton(String(localized: "Add Header")) {
                     manager.updateDraft(id: itemId) { draft in
                         draft.headers.append(EditableHeader(name: "", value: ""))
                     }
-                } label: {
-                    Label(String(localized: "Add Header"), systemImage: "plus.circle")
-                        .font(.caption)
                 }
-                .buttonStyle(.plain)
-                Spacer()
             }
-            .padding(.horizontal, 12)
-            .padding(.bottom, 8)
+            .frame(maxWidth: .infinity, alignment: .topLeading)
+            .padding(12)
         }
     }
 
@@ -327,24 +305,10 @@ struct BreakpointEditorView: View {
     }
 
     private func queryDisplay(itemId: UUID) -> some View {
-        VStack(spacing: 0) {
-            HStack {
-                Text(String(localized: "Name"))
-                    .font(.caption)
-                    .fontWeight(.semibold)
-                    .foregroundStyle(.secondary)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                Text(String(localized: "Value"))
-                    .font(.caption)
-                    .fontWeight(.semibold)
-                    .foregroundStyle(.secondary)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                Color.clear.frame(width: 24)
-            }
-            .padding(.horizontal, 12)
-            .padding(.top, 8)
+        ScrollView {
+            LazyVStack(spacing: 6) {
+                columnHeaders(name: "Name", value: "Value")
 
-            List {
                 ForEach(queryItems) { item in
                     HStack(spacing: 8) {
                         TextField(String(localized: "Parameter name"), text: Binding(
@@ -381,22 +345,14 @@ struct BreakpointEditorView: View {
                         .buttonStyle(.plain)
                     }
                 }
-            }
-            .listStyle(.plain)
 
-            HStack {
-                Button {
+                addButton(String(localized: "Add Parameter")) {
                     queryItems.append(EditableQueryItem(name: "", value: ""))
                     rebuildURLFromQuery(itemId: itemId)
-                } label: {
-                    Label(String(localized: "Add Parameter"), systemImage: "plus.circle")
-                        .font(.caption)
                 }
-                .buttonStyle(.plain)
-                Spacer()
             }
-            .padding(.horizontal, 12)
-            .padding(.bottom, 8)
+            .frame(maxWidth: .infinity, alignment: .topLeading)
+            .padding(12)
         }
         .onAppear { syncQueryItemsFromURL(itemId: itemId) }
         .onChange(of: draftFor(itemId)?.url) { _, _ in syncQueryItemsFromURL(itemId: itemId) }
@@ -443,6 +399,35 @@ struct BreakpointEditorView: View {
 
     private func headerValue(itemId: UUID, headerId: UUID) -> EditableHeader? {
         draftFor(itemId)?.headers.first(where: { $0.id == headerId })
+    }
+
+    private func columnHeaders(name: String, value: String) -> some View {
+        HStack {
+            Text(String(localized: String.LocalizationValue(name)))
+                .font(.caption)
+                .fontWeight(.semibold)
+                .foregroundStyle(.secondary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            Text(String(localized: String.LocalizationValue(value)))
+                .font(.caption)
+                .fontWeight(.semibold)
+                .foregroundStyle(.secondary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            Color.clear.frame(width: 24)
+        }
+        .padding(.bottom, 4)
+    }
+
+    private func addButton(_ title: String, action: @escaping () -> Void) -> some View {
+        HStack {
+            Button(action: action) {
+                Label(title, systemImage: "plus.circle")
+                    .font(.caption)
+            }
+            .buttonStyle(.plain)
+            Spacer()
+        }
+        .padding(.top, 2)
     }
 
     private func rawKind(for itemId: UUID) -> BreakpointTemplateKind {

--- a/Rockxy/Views/Breakpoint/BreakpointWindowView.swift
+++ b/Rockxy/Views/Breakpoint/BreakpointWindowView.swift
@@ -7,21 +7,18 @@ import SwiftUI
 private enum BreakpointQueueLayoutMode: String, CaseIterable {
     case horizontal
     case vertical
-    case reversed
 
     var next: BreakpointQueueLayoutMode {
         switch self {
         case .horizontal: .vertical
-        case .vertical: .reversed
-        case .reversed: .horizontal
+        case .vertical: .horizontal
         }
     }
 
     var systemImage: String {
         switch self {
-        case .horizontal: "rectangle.split.2x1"
-        case .vertical: "rectangle.split.1x2"
-        case .reversed: "rectangle.split.2x1"
+        case .horizontal: "rectangle.split.1x2"
+        case .vertical: "rectangle.split.2x1"
         }
     }
 
@@ -30,8 +27,6 @@ private enum BreakpointQueueLayoutMode: String, CaseIterable {
         case .horizontal:
             String(localized: "Switch Layout Mode: Vertical")
         case .vertical:
-            String(localized: "Switch Layout Mode: Reversed")
-        case .reversed:
             String(localized: "Switch Layout Mode: Horizontal")
         }
     }
@@ -63,6 +58,7 @@ struct BreakpointWindowView: View {
 
     private let manager = BreakpointManager.shared
     private let windowModel = BreakpointWindowModel.shared
+    private let queueRatio: CGFloat = 0.4
 
     private var layoutMode: BreakpointQueueLayoutMode {
         get { BreakpointQueueLayoutMode(rawValue: layoutModeRaw) ?? .horizontal }
@@ -71,23 +67,27 @@ struct BreakpointWindowView: View {
 
     @ViewBuilder
     private var mainContent: some View {
-        switch layoutMode {
-        case .horizontal:
-            HSplitView {
-                queueTable.frame(minWidth: 500, idealWidth: 620, maxHeight: .infinity)
-                editor.frame(minWidth: 420, maxHeight: .infinity)
-            }
-        case .vertical:
-            VSplitView {
-                queueTable.frame(minHeight: 180, idealHeight: 260, maxHeight: .infinity)
-                editor.frame(minHeight: 260, maxHeight: .infinity)
-            }
-        case .reversed:
-            HSplitView {
-                editor.frame(minWidth: 420, maxHeight: .infinity)
-                queueTable.frame(minWidth: 500, idealWidth: 620, maxHeight: .infinity)
+        GeometryReader { geometry in
+            switch layoutMode {
+            case .horizontal:
+                HStack(spacing: 0) {
+                    queueTable
+                        .frame(width: max(360, geometry.size.width * queueRatio))
+                    Divider()
+                    editor
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                }
+            case .vertical:
+                VStack(spacing: 0) {
+                    queueTable
+                        .frame(height: max(180, geometry.size.height * queueRatio))
+                    Divider()
+                    editor
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                }
             }
         }
+        .onAppear(perform: normalizePersistedLayoutMode)
     }
 
     private var queueTable: some View {
@@ -240,6 +240,12 @@ struct BreakpointWindowView: View {
             return
         }
         manager.resolve(id: selectedId, decision: decision)
+    }
+
+    private func normalizePersistedLayoutMode() {
+        if BreakpointQueueLayoutMode(rawValue: layoutModeRaw) == nil {
+            layoutModeRaw = BreakpointQueueLayoutMode.horizontal.rawValue
+        }
     }
 }
 

--- a/Rockxy/Views/Breakpoint/BreakpointWindowView.swift
+++ b/Rockxy/Views/Breakpoint/BreakpointWindowView.swift
@@ -2,79 +2,430 @@ import SwiftUI
 
 // Presents the breakpoint window for breakpoint review and editing.
 
+// MARK: - BreakpointQueueLayoutMode
+
+private enum BreakpointQueueLayoutMode: String, CaseIterable {
+    case horizontal
+    case vertical
+    case reversed
+
+    var next: BreakpointQueueLayoutMode {
+        switch self {
+        case .horizontal: .vertical
+        case .vertical: .reversed
+        case .reversed: .horizontal
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .horizontal: "rectangle.split.2x1"
+        case .vertical: "rectangle.split.1x2"
+        case .reversed: "rectangle.split.2x1"
+        }
+    }
+
+    var help: String {
+        switch self {
+        case .horizontal:
+            String(localized: "Switch Layout Mode: Vertical")
+        case .vertical:
+            String(localized: "Switch Layout Mode: Reversed")
+        case .reversed:
+            String(localized: "Switch Layout Mode: Horizontal")
+        }
+    }
+}
+
 // MARK: - BreakpointWindowView
 
-/// Standalone window for managing breakpoint-paused requests. Two-column layout:
-/// left sidebar lists all paused items, right side shows the editor for the selected item.
-/// Bottom bar provides Cancel / Abort 503 / Execute action buttons.
+/// Standalone window for managing breakpoint-paused requests.
+/// The queue mirrors a native macOS proxy table while the editor keeps the
+/// existing breakpoint editing workflow on the selected item.
 struct BreakpointWindowView: View {
     // MARK: Internal
 
     var body: some View {
         VStack(spacing: 0) {
-            HSplitView {
-                BreakpointSidebarView(windowModel: windowModel, manager: manager)
-                    .frame(minWidth: 220, idealWidth: 260, maxWidth: 260, maxHeight: .infinity)
-
-                BreakpointEditorView(manager: manager, windowModel: windowModel)
-                    .frame(minWidth: 400, maxHeight: .infinity)
-            }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-
+            mainContent
+            Divider()
+            queueToolbar
             Divider()
             actionBar
         }
-        .frame(minWidth: 800, minHeight: 500)
+        .frame(minWidth: 960, minHeight: 560)
     }
 
     // MARK: Private
 
-    @Environment(\.dismiss) private var dismiss
     @Environment(\.openWindow) private var openWindow
+    @AppStorage("breakpointQueueLayoutMode") private var layoutModeRaw = BreakpointQueueLayoutMode.horizontal.rawValue
 
     private let manager = BreakpointManager.shared
     private let windowModel = BreakpointWindowModel.shared
 
-    private var actionBar: some View {
-        HStack(spacing: 10) {
-            Button(String(localized: "Cancel")) { dismiss() }
-                .keyboardShortcut(.cancelAction)
+    private var layoutMode: BreakpointQueueLayoutMode {
+        get { BreakpointQueueLayoutMode(rawValue: layoutModeRaw) ?? .horizontal }
+        nonmutating set { layoutModeRaw = newValue.rawValue }
+    }
 
-            Button {
-                openWindow(id: "breakpointTemplates")
-            } label: {
-                Label(String(localized: "Templates"), systemImage: "doc.text")
+    @ViewBuilder
+    private var mainContent: some View {
+        switch layoutMode {
+        case .horizontal:
+            HSplitView {
+                queueTable.frame(minWidth: 500, idealWidth: 620, maxHeight: .infinity)
+                editor.frame(minWidth: 420, maxHeight: .infinity)
             }
+        case .vertical:
+            VSplitView {
+                queueTable.frame(minHeight: 180, idealHeight: 260, maxHeight: .infinity)
+                editor.frame(minHeight: 260, maxHeight: .infinity)
+            }
+        case .reversed:
+            HSplitView {
+                editor.frame(minWidth: 420, maxHeight: .infinity)
+                queueTable.frame(minWidth: 500, idealWidth: 620, maxHeight: .infinity)
+            }
+        }
+    }
+
+    private var queueTable: some View {
+        BreakpointQueueTableView(manager: manager)
+    }
+
+    private var editor: some View {
+        BreakpointEditorView(manager: manager, windowModel: windowModel)
+    }
+
+    private var queueToolbar: some View {
+        HStack(spacing: 8) {
+            Button(String(localized: "Manage Rules")) {
+                openWindow(id: "breakpointRules")
+            }
+            .keyboardShortcut("b", modifiers: .command)
 
             Spacer()
 
-            switch windowModel.selectionMode {
-            case .none:
-                Button(String(localized: "Abort (503)")) {}
-                    .disabled(true)
-                Button(String(localized: "Execute")) {}
-                    .disabled(true)
-
-            case .pausedItem:
-                Button(String(localized: "Abort (503)")) {
-                    guard let selectedId = manager.selectedItemId else {
-                        return
-                    }
-                    manager.resolve(id: selectedId, decision: .abort)
-                }
-                .disabled(manager.selectedItemId == nil)
-
-                Button(String(localized: "Execute")) {
-                    guard let selectedId = manager.selectedItemId else {
-                        return
-                    }
-                    manager.resolve(id: selectedId, decision: .execute)
-                }
-                .keyboardShortcut(.defaultAction)
-                .disabled(manager.selectedItemId == nil)
+            Button {
+                layoutMode = layoutMode.next
+            } label: {
+                Label(String(localized: "Switch Layout"), systemImage: layoutMode.systemImage)
+                    .labelStyle(.iconOnly)
             }
+            .help(layoutMode.help)
+
+            Divider()
+                .frame(height: 22)
+
+            moreMenu
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 8)
+        .background(Color(nsColor: .windowBackgroundColor))
+    }
+
+    private var actionBar: some View {
+        HStack(spacing: 10) {
+            Button {
+                resolveSelected(.cancel)
+            } label: {
+                Label(String(localized: "Continue"), systemImage: "play.fill")
+            }
+            .keyboardShortcut(".", modifiers: .command)
+            .disabled(!hasSelection)
+
+            Button {
+                resolveSelected(.abort)
+            } label: {
+                Label(String(localized: "Abort"), systemImage: "xmark.octagon")
+            }
+            .keyboardShortcut("\\", modifiers: .command)
+            .disabled(!hasSelection)
+
+            Button {
+                resolveSelected(.cancel)
+            } label: {
+                Label(String(localized: "Skip Once"), systemImage: "forward.frame")
+            }
+            .disabled(!hasSelection)
+
+            Spacer()
+
+            Button {
+                resolveSelected(.execute)
+            } label: {
+                Label(String(localized: "Execute"), systemImage: "arrowshape.turn.up.right.fill")
+            }
+            .keyboardShortcut(.defaultAction)
+            .disabled(!hasSelection)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(Color(nsColor: .windowBackgroundColor))
+    }
+
+    private var moreMenu: some View {
+        Menu {
+            Button(String(localized: "Execute")) {
+                resolveSelected(.execute)
+            }
+            .keyboardShortcut(.defaultAction)
+            .disabled(!hasSelection)
+
+            Button(String(localized: "Execute All")) {
+                manager.resolveAll(decision: .execute)
+            }
+            .keyboardShortcut(.return, modifiers: [.command, .shift])
+            .disabled(!manager.hasPausedItems)
+
+            Divider()
+
+            Button(String(localized: "Continue")) {
+                resolveSelected(.cancel)
+            }
+            .keyboardShortcut(".", modifiers: .command)
+            .disabled(!hasSelection)
+
+            Button(String(localized: "Continue All")) {
+                manager.resolveAll(decision: .cancel)
+            }
+            .keyboardShortcut(".", modifiers: [.command, .shift])
+            .disabled(!manager.hasPausedItems)
+
+            Divider()
+
+            Button(String(localized: "Abort")) {
+                resolveSelected(.abort)
+            }
+            .keyboardShortcut("\\", modifiers: .command)
+            .disabled(!hasSelection)
+
+            Button(String(localized: "Abort All")) {
+                manager.resolveAll(decision: .abort)
+            }
+            .keyboardShortcut("\\", modifiers: [.command, .shift])
+            .disabled(!manager.hasPausedItems)
+
+            Divider()
+
+            Menu(String(localized: "Advanced Settings")) {
+                Button(layoutMode.help) {
+                    layoutMode = layoutMode.next
+                }
+                Button(String(localized: "Templates...")) {
+                    openWindow(id: "breakpointTemplates")
+                }
+            }
+
+            Divider()
+
+            Button(String(localized: "Add Rule")) {
+                openWindow(id: "breakpointRules")
+            }
+            .keyboardShortcut("b", modifiers: .command)
+        } label: {
+            Label(String(localized: "More"), systemImage: "ellipsis.circle")
+        }
+        .menuIndicator(.hidden)
+        .fixedSize()
+    }
+
+    private var hasSelection: Bool {
+        manager.selectedItemId != nil
+    }
+
+    private func resolveSelected(_ decision: BreakpointDecision) {
+        guard let selectedId = manager.selectedItemId else {
+            return
+        }
+        manager.resolve(id: selectedId, decision: decision)
+    }
+}
+
+// MARK: - BreakpointQueueTableView
+
+private struct BreakpointQueueTableView: View {
+    @Bindable var manager: BreakpointManager
+
+    private let columns: [(title: String, width: CGFloat)] = [
+        (String(localized: "ID"), 54),
+        (String(localized: "URL"), 300),
+        (String(localized: "Client"), 160),
+        (String(localized: "Method"), 94),
+        (String(localized: "Status"), 104),
+        (String(localized: "Code"), 72),
+        (String(localized: "Time"), 112),
+        (String(localized: "Duration"), 104),
+        (String(localized: "Request"), 92),
+        (String(localized: "Response"), 104),
+        (String(localized: "Query Name"), 150),
+    ]
+
+    var body: some View {
+        GeometryReader { geometry in
+            let contentWidth = max(tableWidth, geometry.size.width)
+            let contentHeight = max(geometry.size.height, headerHeight + 1)
+
+            ScrollView([.horizontal, .vertical]) {
+                ZStack(alignment: .topLeading) {
+                    VStack(spacing: 0) {
+                        headerRow
+                            .frame(width: contentWidth, alignment: .leading)
+                        Divider()
+                        ForEach(manager.pausedItems) { item in
+                            queueRow(item)
+                            Divider()
+                        }
+                    }
+                    .frame(width: contentWidth, alignment: .topLeading)
+                    .frame(minHeight: contentHeight, alignment: .topLeading)
+
+                    if manager.pausedItems.isEmpty {
+                        emptyState
+                            .frame(
+                                width: contentWidth,
+                                height: max(0, contentHeight - headerHeight - 1),
+                                alignment: .center
+                            )
+                            .padding(.top, headerHeight + 1)
+                    }
+                }
+                .frame(width: contentWidth, alignment: .topLeading)
+                .frame(minHeight: contentHeight, alignment: .topLeading)
+            }
+            .frame(width: geometry.size.width, height: geometry.size.height)
+        }
+        .background(Color(nsColor: .textBackgroundColor))
+    }
+
+    private var tableWidth: CGFloat {
+        columns.reduce(0) { $0 + $1.width }
+    }
+
+    private var headerHeight: CGFloat {
+        32
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 8) {
+            Text(String(localized: "No Breakpoints"))
+                .font(.title3.weight(.semibold))
+            Text(String(localized: "Click \"Manage Rules\" button to create your first Breakpoint Rules"))
+                .foregroundStyle(.secondary)
+        }
+        .multilineTextAlignment(.center)
+        .padding(.horizontal, 24)
+    }
+
+    private var headerRow: some View {
+        HStack(spacing: 0) {
+            ForEach(Array(columns.enumerated()), id: \.offset) { _, column in
+                Text(column.title)
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.primary)
+                    .frame(width: column.width, height: headerHeight, alignment: .leading)
+                    .padding(.leading, 8)
+                    .overlay(alignment: .trailing) {
+                        Divider().frame(height: 20)
+                    }
+            }
+        }
+        .background(Color(nsColor: .windowBackgroundColor))
+    }
+
+    private func queueRow(_ item: PausedBreakpointItem) -> some View {
+        let isSelected = manager.selectedItemId == item.id
+        return HStack(spacing: 0) {
+            Group {
+                cell("\(item.sequenceNumber)", width: columns[0].width, monospaced: true)
+                cell(item.url, width: columns[1].width, monospaced: true, help: item.url)
+                cell(item.client, width: columns[2].width)
+                cell(item.method, width: columns[3].width, monospaced: true)
+                cell(String(localized: "Paused"), width: columns[4].width, color: .orange)
+                cell(
+                    item.statusCode.map(String.init) ?? "",
+                    width: columns[5].width,
+                    color: statusColor(for: item.statusCode)
+                )
+            }
+            Group {
+                timeCell(item.createdAt, width: columns[6].width)
+                durationCell(item.createdAt, width: columns[7].width)
+                phaseCell(item.phase == .request ? "REQ" : "", width: columns[8].width)
+                phaseCell(item.phase == .response ? "RES" : "", width: columns[9].width)
+                cell(item.queryName, width: columns[10].width)
+            }
+        }
+        .frame(height: 28)
+        .background(isSelected ? Color.accentColor.opacity(0.18) : rowBackground(for: item))
+        .contentShape(Rectangle())
+        .onTapGesture {
+            manager.selectedItemId = item.id
+        }
+    }
+
+    private func cell(
+        _ value: String,
+        width: CGFloat,
+        color: Color = .primary,
+        monospaced: Bool = false,
+        help: String? = nil
+    )
+        -> some View
+    {
+        Text(value)
+            .font(monospaced ? .system(.caption, design: .monospaced) : .caption)
+            .foregroundStyle(color)
+            .lineLimit(1)
+            .help(help ?? value)
+            .frame(width: width, alignment: .leading)
+            .padding(.leading, 8)
+    }
+
+    private func timeCell(_ date: Date, width: CGFloat) -> some View {
+        Text(date, format: .dateTime.hour().minute().second())
+            .font(.system(.caption, design: .monospaced))
+            .monospacedDigit()
+            .frame(width: width, alignment: .leading)
+            .padding(.leading, 8)
+    }
+
+    private func durationCell(_ date: Date, width: CGFloat) -> some View {
+        ElapsedTimeLabel(since: date)
+            .frame(width: width, alignment: .leading)
+            .padding(.leading, 8)
+    }
+
+    private func phaseText(_ value: String) -> some View {
+        Text(value)
+            .font(.system(.body, design: .monospaced).weight(.semibold))
+            .foregroundStyle(value == "REQ" ? Color.green : Color.blue)
+    }
+
+    private func phaseCell(_ value: String, width: CGFloat) -> some View {
+        phaseText(value)
+            .font(.system(.caption, design: .monospaced).weight(.semibold))
+            .frame(width: width, alignment: .leading)
+            .padding(.leading, 8)
+    }
+
+    private func rowBackground(for item: PausedBreakpointItem) -> Color {
+        item.sequenceNumber.isMultiple(of: 2)
+            ? Color(nsColor: .textBackgroundColor)
+            : Color(nsColor: .controlBackgroundColor).opacity(0.45)
+    }
+
+    private func statusColor(for statusCode: Int?) -> Color {
+        guard let statusCode else {
+            return Color.secondary
+        }
+        switch statusCode {
+        case 200 ..< 300: return Color.green
+        case 300 ..< 400: return Color.blue
+        case 400 ..< 500: return Color.orange
+        case 500...: return Color.red
+        default: return Color.secondary
+        }
     }
 }

--- a/Rockxy/Views/Breakpoint/BreakpointWindowView.swift
+++ b/Rockxy/Views/Breakpoint/BreakpointWindowView.swift
@@ -91,7 +91,7 @@ struct BreakpointWindowView: View {
     }
 
     private var queueTable: some View {
-        BreakpointQueueTableView(manager: manager)
+        BreakpointQueueTableView(manager: manager, centersEmptyState: layoutMode == .vertical)
     }
 
     private var editor: some View {
@@ -253,34 +253,42 @@ struct BreakpointWindowView: View {
 
 private struct BreakpointQueueTableView: View {
     @Bindable var manager: BreakpointManager
+    let centersEmptyState: Bool
 
-    private let columns: [(title: String, width: CGFloat)] = [
-        (String(localized: "ID"), 54),
-        (String(localized: "URL"), 300),
-        (String(localized: "Client"), 160),
-        (String(localized: "Method"), 94),
-        (String(localized: "Status"), 104),
-        (String(localized: "Code"), 72),
-        (String(localized: "Time"), 112),
-        (String(localized: "Duration"), 104),
-        (String(localized: "Request"), 92),
-        (String(localized: "Response"), 104),
-        (String(localized: "Query Name"), 150),
+    private struct Column {
+        let title: String
+        let minWidth: CGFloat
+        let preferredWidth: CGFloat
+    }
+
+    private let columns: [Column] = [
+        Column(title: String(localized: "ID"), minWidth: 44, preferredWidth: 54),
+        Column(title: String(localized: "URL"), minWidth: 220, preferredWidth: 360),
+        Column(title: String(localized: "Client"), minWidth: 90, preferredWidth: 150),
+        Column(title: String(localized: "Method"), minWidth: 70, preferredWidth: 86),
+        Column(title: String(localized: "Status"), minWidth: 74, preferredWidth: 96),
+        Column(title: String(localized: "Code"), minWidth: 52, preferredWidth: 64),
+        Column(title: String(localized: "Time"), minWidth: 78, preferredWidth: 102),
+        Column(title: String(localized: "Duration"), minWidth: 78, preferredWidth: 102),
+        Column(title: String(localized: "Request"), minWidth: 70, preferredWidth: 86),
+        Column(title: String(localized: "Response"), minWidth: 78, preferredWidth: 94),
+        Column(title: String(localized: "Query Name"), minWidth: 90, preferredWidth: 136),
     ]
 
     var body: some View {
         GeometryReader { geometry in
-            let contentWidth = max(tableWidth, geometry.size.width)
+            let columnWidths = effectiveColumnWidths(for: geometry.size.width)
+            let contentWidth = max(tableWidth(for: columnWidths), geometry.size.width)
             let contentHeight = max(geometry.size.height, headerHeight + 1)
 
             ScrollView([.horizontal, .vertical]) {
                 ZStack(alignment: .topLeading) {
                     VStack(spacing: 0) {
-                        headerRow
+                        headerRow(columnWidths: columnWidths)
                             .frame(width: contentWidth, alignment: .leading)
                         Divider()
                         ForEach(manager.pausedItems) { item in
-                            queueRow(item)
+                            queueRow(item, columnWidths: columnWidths)
                             Divider()
                         }
                     }
@@ -290,9 +298,9 @@ private struct BreakpointQueueTableView: View {
                     if manager.pausedItems.isEmpty {
                         emptyState
                             .frame(
-                                width: contentWidth,
+                                width: geometry.size.width,
                                 height: max(0, contentHeight - headerHeight - 1),
-                                alignment: .center
+                                alignment: centersEmptyState ? .center : .leading
                             )
                             .padding(.top, headerHeight + 1)
                     }
@@ -305,8 +313,27 @@ private struct BreakpointQueueTableView: View {
         .background(Color(nsColor: .textBackgroundColor))
     }
 
-    private var tableWidth: CGFloat {
-        columns.reduce(0) { $0 + $1.width }
+    private func tableWidth(for columnWidths: [CGFloat]) -> CGFloat {
+        columnWidths.reduce(0, +)
+    }
+
+    private func effectiveColumnWidths(for availableWidth: CGFloat) -> [CGFloat] {
+        let preferredTotal = columns.reduce(CGFloat.zero) { $0 + $1.preferredWidth }
+        let minimumTotal = columns.reduce(CGFloat.zero) { $0 + $1.minWidth }
+
+        guard availableWidth < preferredTotal else {
+            return columns.map(\.preferredWidth)
+        }
+        guard availableWidth > minimumTotal else {
+            return columns.map(\.minWidth)
+        }
+
+        let flexibleTotal = preferredTotal - minimumTotal
+        let availableFlex = availableWidth - minimumTotal
+        return columns.map { column in
+            let columnFlex = column.preferredWidth - column.minWidth
+            return column.minWidth + (columnFlex / flexibleTotal * availableFlex)
+        }
     }
 
     private var headerHeight: CGFloat {
@@ -314,23 +341,24 @@ private struct BreakpointQueueTableView: View {
     }
 
     private var emptyState: some View {
-        VStack(spacing: 8) {
+        VStack(alignment: centersEmptyState ? .center : .leading, spacing: 8) {
             Text(String(localized: "No Breakpoints"))
                 .font(.title3.weight(.semibold))
             Text(String(localized: "Click \"Manage Rules\" button to create your first Breakpoint Rules"))
                 .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
         }
-        .multilineTextAlignment(.center)
-        .padding(.horizontal, 24)
+        .multilineTextAlignment(centersEmptyState ? .center : .leading)
+        .padding(.horizontal, centersEmptyState ? 24 : 16)
     }
 
-    private var headerRow: some View {
+    private func headerRow(columnWidths: [CGFloat]) -> some View {
         HStack(spacing: 0) {
-            ForEach(Array(columns.enumerated()), id: \.offset) { _, column in
+            ForEach(Array(columns.enumerated()), id: \.offset) { offset, column in
                 Text(column.title)
                     .font(.caption.weight(.semibold))
                     .foregroundStyle(.primary)
-                    .frame(width: column.width, height: headerHeight, alignment: .leading)
+                    .frame(width: columnWidths[offset], height: headerHeight, alignment: .leading)
                     .padding(.leading, 8)
                     .overlay(alignment: .trailing) {
                         Divider().frame(height: 20)
@@ -340,27 +368,27 @@ private struct BreakpointQueueTableView: View {
         .background(Color(nsColor: .windowBackgroundColor))
     }
 
-    private func queueRow(_ item: PausedBreakpointItem) -> some View {
+    private func queueRow(_ item: PausedBreakpointItem, columnWidths: [CGFloat]) -> some View {
         let isSelected = manager.selectedItemId == item.id
         return HStack(spacing: 0) {
             Group {
-                cell("\(item.sequenceNumber)", width: columns[0].width, monospaced: true)
-                cell(item.url, width: columns[1].width, monospaced: true, help: item.url)
-                cell(item.client, width: columns[2].width)
-                cell(item.method, width: columns[3].width, monospaced: true)
-                cell(String(localized: "Paused"), width: columns[4].width, color: .orange)
+                cell("\(item.sequenceNumber)", width: columnWidths[0], monospaced: true)
+                cell(item.url, width: columnWidths[1], monospaced: true, help: item.url)
+                cell(item.client, width: columnWidths[2])
+                cell(item.method, width: columnWidths[3], monospaced: true)
+                cell(String(localized: "Paused"), width: columnWidths[4], color: .orange)
                 cell(
                     item.statusCode.map(String.init) ?? "",
-                    width: columns[5].width,
+                    width: columnWidths[5],
                     color: statusColor(for: item.statusCode)
                 )
             }
             Group {
-                timeCell(item.createdAt, width: columns[6].width)
-                durationCell(item.createdAt, width: columns[7].width)
-                phaseCell(item.phase == .request ? "REQ" : "", width: columns[8].width)
-                phaseCell(item.phase == .response ? "RES" : "", width: columns[9].width)
-                cell(item.queryName, width: columns[10].width)
+                timeCell(item.createdAt, width: columnWidths[6])
+                durationCell(item.createdAt, width: columnWidths[7])
+                phaseCell(item.phase == .request ? "REQ" : "", width: columnWidths[8])
+                phaseCell(item.phase == .response ? "RES" : "", width: columnWidths[9])
+                cell(item.queryName, width: columnWidths[10])
             }
         }
         .frame(height: 28)

--- a/Rockxy/Views/RequestList/RequestTableView.swift
+++ b/Rockxy/Views/RequestList/RequestTableView.swift
@@ -261,6 +261,8 @@ extension RequestTableView {
         /// coordinator state back into NSTableView.
         private(set) var isUpdatingSortDescriptors = false
 
+        private var lastSyncedSelectionIDs: Set<UUID> = []
+
         // MARK: - NSTableViewDataSource
 
         func numberOfRows(in tableView: NSTableView) -> Int {
@@ -361,6 +363,7 @@ extension RequestTableView {
                 ids.insert(rows[index].id)
             }
 
+            lastSyncedSelectionIDs = ids
             parent.selectedIDs = ids
             parent.onSelectionChanged?(ids)
         }
@@ -704,12 +707,26 @@ extension RequestTableView {
             }
 
             guard currentSelected != desired else {
+                lastSyncedSelectionIDs = ids
                 return
             }
+
+            let shouldPreserveScroll = ids == lastSyncedSelectionIDs
+            let visibleOrigin = shouldPreserveScroll
+                ? tableView.enclosingScrollView?.contentView.bounds.origin
+                : nil
 
             isUpdatingSelection = true
             tableView.selectRowIndexes(desired, byExtendingSelection: false)
             isUpdatingSelection = false
+            lastSyncedSelectionIDs = ids
+
+            if let visibleOrigin,
+               let scrollView = tableView.enclosingScrollView
+            {
+                scrollView.contentView.scroll(to: visibleOrigin)
+                scrollView.reflectScrolledClipView(scrollView.contentView)
+            }
         }
 
         func syncHeaderColumns(in tableView: NSTableView) {

--- a/Rockxy/Views/Rules/MapRemoteWindowView.swift
+++ b/Rockxy/Views/Rules/MapRemoteWindowView.swift
@@ -616,7 +616,7 @@ final class MapRemoteEditorViewModel {
             return
         }
 
-        destScheme = components.scheme ?? ""
+        destScheme = components.scheme?.lowercased() ?? ""
         destHost = host
         if let port = components.port {
             destPort = String(port)
@@ -624,7 +624,7 @@ final class MapRemoteEditorViewModel {
         if !components.path.isEmpty, components.path != "/" {
             destPath = String(components.path.drop(while: { $0 == "/" }))
         }
-        if let query = components.query {
+        if let query = components.percentEncodedQuery {
             destQuery = query
         }
     }
@@ -640,7 +640,7 @@ final class MapRemoteEditorViewModel {
         condition.method = method.ruleValue
 
         let config = MapRemoteConfiguration(
-            scheme: destScheme.isEmpty ? nil : destScheme,
+            scheme: destScheme.isEmpty ? nil : destScheme.lowercased(),
             host: nilIfBlank(destHost),
             port: parsedPort,
             path: nilIfBlank(normalizedPath()),
@@ -664,8 +664,11 @@ final class MapRemoteEditorViewModel {
         guard matchType == .wildcard else {
             return trimmed
         }
-        let pattern = includeSubpaths && !trimmed.hasSuffix("*") ? "\(trimmed)*" : trimmed
-        return MapLocalPatternFormatter.wildcardToRegex(pattern)
+        return RulePatternBuilder.regexSource(
+            rawPattern: trimmed,
+            matchType: .wildcard,
+            includeSubpaths: includeSubpaths
+        )
     }
 
     // MARK: Private

--- a/Rockxy/Views/Rules/ModifyHeaderEditorView.swift
+++ b/Rockxy/Views/Rules/ModifyHeaderEditorView.swift
@@ -12,7 +12,7 @@ final class EditableHeaderOperation: Identifiable {
     init(
         id: UUID = UUID(),
         phase: HeaderModifyPhase = .request,
-        type: HeaderOperationType = .add,
+        type: HeaderOperationType = .replace,
         headerName: String = "",
         headerValue: String = ""
     ) {
@@ -49,7 +49,7 @@ final class EditableHeaderOperation: Identifiable {
             return String(localized: "Header Name is required")
         }
         if type != .remove, headerValue.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            return String(localized: "Header Value is required for \(type.rawValue.capitalized)")
+            return String(localized: "Header Value is required for \(type.editorLabel)")
         }
         return nil
     }
@@ -217,9 +217,9 @@ struct ModifyHeaderEditorView: View {
                 get: { operation.type },
                 set: { operation.type = $0 }
             )) {
-                Text(String(localized: "Add")).tag(HeaderOperationType.add)
-                Text(String(localized: "Remove")).tag(HeaderOperationType.remove)
-                Text(String(localized: "Replace")).tag(HeaderOperationType.replace)
+                Text(HeaderOperationType.replace.editorLabel).tag(HeaderOperationType.replace)
+                Text(HeaderOperationType.add.editorLabel).tag(HeaderOperationType.add)
+                Text(HeaderOperationType.remove.editorLabel).tag(HeaderOperationType.remove)
             }
             .labelsHidden()
             .pickerStyle(.menu)
@@ -327,5 +327,20 @@ extension [HeaderOperation] {
             return "\(prefix)\(op.headerName)"
         }
         .joined(separator: ", ")
+    }
+}
+
+// MARK: - HeaderOperationType + Editor Labels
+
+extension HeaderOperationType {
+    var editorLabel: String {
+        switch self {
+        case .add:
+            String(localized: "Add")
+        case .remove:
+            String(localized: "Remove")
+        case .replace:
+            String(localized: "Set")
+        }
     }
 }

--- a/Rockxy/Views/Rules/ModifyHeaderEditorView.swift
+++ b/Rockxy/Views/Rules/ModifyHeaderEditorView.swift
@@ -80,7 +80,7 @@ struct ModifyHeaderEditorView: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: Theme.Layout.sectionSpacing) {
+        VStack(alignment: .leading, spacing: 10) {
             helperText
 
             if operations.isEmpty {
@@ -101,14 +101,15 @@ struct ModifyHeaderEditorView: View {
     private static let operationWidth: CGFloat = 104
     private static let minFieldWidth: CGFloat = 150
     private static let removeWidth: CGFloat = 24
+    private static let rowSpacing: CGFloat = 8
 
     private var helperText: some View {
         HStack(spacing: 6) {
             Image(systemName: "info.circle")
-                .foregroundStyle(.secondary)
+                .foregroundStyle(Color.accentColor)
             Text(String(localized: "Operations are applied in order. Later rows can overwrite earlier rows."))
                 .font(.caption)
-                .foregroundStyle(.secondary)
+                .foregroundStyle(Color(nsColor: .labelColor).opacity(0.72))
             Spacer()
         }
     }
@@ -125,17 +126,26 @@ struct ModifyHeaderEditorView: View {
     }
 
     private var operationsTable: some View {
-        VStack(spacing: 6) {
+        VStack(spacing: 0) {
             headerRow
 
-            ForEach(operations) { operation in
-                operationRow(operation)
+            VStack(spacing: 6) {
+                ForEach(operations) { operation in
+                    operationRow(operation)
+                }
             }
+            .padding(8)
+        }
+        .background(Color(nsColor: .textBackgroundColor))
+        .clipShape(RoundedRectangle(cornerRadius: 6))
+        .overlay {
+            RoundedRectangle(cornerRadius: 6)
+                .stroke(Color(nsColor: .separatorColor), lineWidth: 1)
         }
     }
 
     private var headerRow: some View {
-        HStack(spacing: 8) {
+        HStack(spacing: Self.rowSpacing) {
             Text(String(localized: "Phase"))
                 .frame(width: Self.phaseWidth, alignment: .leading)
             Text(String(localized: "Operation"))
@@ -149,8 +159,10 @@ struct ModifyHeaderEditorView: View {
         }
         .font(.caption)
         .fontWeight(.semibold)
-        .foregroundStyle(.secondary)
-        .padding(.horizontal, 4)
+        .foregroundStyle(Color(nsColor: .labelColor))
+        .padding(.horizontal, 12)
+        .padding(.vertical, 6)
+        .background(Color(nsColor: .controlBackgroundColor))
     }
 
     private var addButton: some View {
@@ -161,8 +173,9 @@ struct ModifyHeaderEditorView: View {
         } label: {
             Label(String(localized: "Add Operation"), systemImage: "plus")
         }
-        .buttonStyle(.borderless)
+        .buttonStyle(.plain)
         .controlSize(.small)
+        .foregroundStyle(Color.accentColor)
         .padding(.horizontal, 2)
     }
 
@@ -186,7 +199,7 @@ struct ModifyHeaderEditorView: View {
     }
 
     private func operationRow(_ operation: EditableHeaderOperation) -> some View {
-        HStack(spacing: 8) {
+        HStack(spacing: Self.rowSpacing) {
             Picker("", selection: Binding(
                 get: { operation.phase },
                 set: { operation.phase = $0 }
@@ -225,21 +238,7 @@ struct ModifyHeaderEditorView: View {
             .controlSize(.small)
             .frame(minWidth: Self.minFieldWidth)
 
-            TextField(
-                operation.type == .remove
-                    ? String(localized: "Not used")
-                    : String(localized: "Header value"),
-                text: Binding(
-                    get: { operation.headerValue },
-                    set: { operation.headerValue = $0 }
-                )
-            )
-            .font(.system(.body, design: .monospaced))
-            .textFieldStyle(.roundedBorder)
-            .controlSize(.small)
-            .disabled(operation.type == .remove)
-            .opacity(operation.type == .remove ? 0.4 : 1.0)
-            .frame(minWidth: Self.minFieldWidth)
+            headerValueField(for: operation)
 
             Button(role: .destructive) {
                 withAnimation(.easeInOut(duration: 0.2)) {
@@ -250,9 +249,34 @@ struct ModifyHeaderEditorView: View {
                     .font(.caption)
             }
             .buttonStyle(.borderless)
+            .foregroundStyle(.secondary)
+            .help(String(localized: "Remove operation"))
             .frame(width: Self.removeWidth)
         }
-        .padding(.horizontal, 2)
+    }
+
+    @ViewBuilder private func headerValueField(for operation: EditableHeaderOperation) -> some View {
+        if operation.type == .remove {
+            Text(String(localized: "Not used"))
+                .font(.system(.body, design: .monospaced))
+                .foregroundStyle(.secondary)
+                .frame(minWidth: Self.minFieldWidth, minHeight: 22, alignment: .leading)
+                .padding(.horizontal, 7)
+                .background(Color(nsColor: .controlBackgroundColor))
+                .clipShape(RoundedRectangle(cornerRadius: 5))
+        } else {
+            TextField(
+                String(localized: "Header value"),
+                text: Binding(
+                    get: { operation.headerValue },
+                    set: { operation.headerValue = $0 }
+                )
+            )
+            .font(.system(.body, design: .monospaced))
+            .textFieldStyle(.roundedBorder)
+            .controlSize(.small)
+            .frame(minWidth: Self.minFieldWidth)
+        }
     }
 }
 

--- a/Rockxy/Views/Rules/ModifyHeaderWindowView.swift
+++ b/Rockxy/Views/Rules/ModifyHeaderWindowView.swift
@@ -89,24 +89,25 @@ final class ModifyHeaderWindowViewModel {
         editorSession = nil
     }
 
-    func addRule(_ rule: ProxyRule) {
-        allRules.append(rule)
-        selectedRuleID = rule.id
-        Task {
-            let accepted = await RulePolicyGate.shared.addRule(rule)
-            if !accepted {
-                allRules = await RuleEngine.shared.allRules
-            }
+    @discardableResult
+    func addRule(_ rule: ProxyRule) async -> Bool {
+        let accepted = await RulePolicyGate.shared.addRule(rule)
+        allRules = await RuleEngine.shared.allRules
+        if accepted {
+            selectedRuleID = rule.id
         }
+        return accepted
     }
 
-    func updateRule(_ rule: ProxyRule) {
-        guard let index = allRules.firstIndex(where: { $0.id == rule.id }) else {
-            return
+    @discardableResult
+    func updateRule(_ rule: ProxyRule) async -> Bool {
+        guard allRules.contains(where: { $0.id == rule.id }) else {
+            return false
         }
-        allRules[index] = rule
+        await RulePolicyGate.shared.updateRule(rule)
+        allRules = await RuleEngine.shared.allRules
         selectedRuleID = rule.id
-        Task { await RulePolicyGate.shared.updateRule(rule) }
+        return true
     }
 
     func removeRule(id: UUID) {
@@ -117,6 +118,7 @@ final class ModifyHeaderWindowViewModel {
         Task { await RulePolicyGate.shared.removeRule(id: id) }
     }
 
+    @discardableResult
     func saveRule(
         existingRule: ProxyRule?,
         ruleName: String,
@@ -125,7 +127,9 @@ final class ModifyHeaderWindowViewModel {
         matchType: RuleMatchType,
         includeSubpaths: Bool,
         operations: [EditableHeaderOperation]
-    ) {
+    )
+        async -> Bool
+    {
         let rule = ModifyHeaderRuleBuilder.build(
             existingRule: existingRule,
             ruleName: ruleName,
@@ -136,10 +140,9 @@ final class ModifyHeaderWindowViewModel {
             operations: operations.toHeaderOperations()
         )
         if existingRule == nil {
-            addRule(rule)
-        } else {
-            updateRule(rule)
+            return await addRule(rule)
         }
+        return await updateRule(rule)
     }
 
     func operations(for rule: ProxyRule) -> [HeaderOperation] {
@@ -198,7 +201,7 @@ struct ModifyHeaderWindowView: View {
                 } else {
                     nil
                 }
-                viewModel.saveRule(
+                let accepted = await viewModel.saveRule(
                     existingRule: existingRule,
                     ruleName: name,
                     urlPattern: pattern,
@@ -207,7 +210,9 @@ struct ModifyHeaderWindowView: View {
                     includeSubpaths: includeSubpaths,
                     operations: operations
                 )
-                viewModel.dismissEditor()
+                if accepted {
+                    viewModel.dismissEditor()
+                }
             }
         }
     }
@@ -310,7 +315,7 @@ struct ModifyHeaderWindowView: View {
                 .foregroundStyle(.secondary)
             Text(
                 String(
-                    localized: "Add, remove, or replace HTTP headers on matching requests and responses. Each rule can have multiple header operations."
+                    localized: "Set, add, or remove HTTP headers on matching requests and responses. Each rule can have multiple header operations."
                 )
             )
             .font(.caption)
@@ -380,13 +385,13 @@ struct ModifyHeaderWindowView: View {
     private var presetsMenu: some View {
         Menu {
             Button(String(localized: "Add CORS Headers")) {
-                viewModel.addRule(HeaderModifyPresets.corsHeaders())
+                Task { await viewModel.addRule(HeaderModifyPresets.corsHeaders()) }
             }
             Button(String(localized: "Remove Authorization")) {
-                viewModel.addRule(HeaderModifyPresets.removeAuthorization())
+                Task { await viewModel.addRule(HeaderModifyPresets.removeAuthorization()) }
             }
             Button(String(localized: "Strip Server Header")) {
-                viewModel.addRule(HeaderModifyPresets.stripServerHeader())
+                Task { await viewModel.addRule(HeaderModifyPresets.stripServerHeader()) }
             }
         } label: {
             Text(String(localized: "Presets"))
@@ -469,7 +474,7 @@ private struct ModifyHeaderEditSheet: View {
 
     init(
         session: ModifyHeaderEditorSession,
-        onSave: @escaping (String, String, HTTPMethodFilter, RuleMatchType, Bool, [EditableHeaderOperation]) -> Void
+        onSave: @escaping (String, String, HTTPMethodFilter, RuleMatchType, Bool, [EditableHeaderOperation]) async -> Void
     ) {
         self.session = session
         self.onSave = onSave
@@ -504,7 +509,7 @@ private struct ModifyHeaderEditSheet: View {
     // MARK: Internal
 
     let session: ModifyHeaderEditorSession
-    let onSave: (String, String, HTTPMethodFilter, RuleMatchType, Bool, [EditableHeaderOperation]) -> Void
+    let onSave: (String, String, HTTPMethodFilter, RuleMatchType, Bool, [EditableHeaderOperation]) async -> Void
 
     var body: some View {
         VStack(spacing: 0) {
@@ -553,18 +558,21 @@ private struct ModifyHeaderEditSheet: View {
                 .keyboardShortcut(.cancelAction)
 
                 Button(isEditing ? String(localized: "Save") : String(localized: "Add")) {
-                    onSave(
-                        trimmedName,
-                        trimmedPattern,
-                        httpMethod,
-                        matchType,
-                        matchType == .wildcard ? includeSubpaths : false,
-                        operations
-                    )
-                    dismiss()
+                    Task {
+                        isSaving = true
+                        await onSave(
+                            trimmedName,
+                            trimmedPattern,
+                            httpMethod,
+                            matchType,
+                            matchType == .wildcard ? includeSubpaths : false,
+                            operations
+                        )
+                        isSaving = false
+                    }
                 }
                 .keyboardShortcut(.defaultAction)
-                .disabled(!isValid)
+                .disabled(!isValid || isSaving)
             }
             .padding(.horizontal, 24)
             .padding(.vertical, 8)
@@ -585,6 +593,7 @@ private struct ModifyHeaderEditSheet: View {
     @State private var matchType: RuleMatchType
     @State private var includeSubpaths: Bool
     @State private var operations: [EditableHeaderOperation] = [EditableHeaderOperation()]
+    @State private var isSaving = false
 
     private var isEditing: Bool {
         if case .edit = session.mode {

--- a/Rockxy/Views/Rules/ModifyHeaderWindowView.swift
+++ b/Rockxy/Views/Rules/ModifyHeaderWindowView.swift
@@ -529,6 +529,13 @@ private struct ModifyHeaderEditSheet: View {
                         .font(.system(size: 13, weight: .medium))
                     ScrollView {
                         ModifyHeaderEditorView(operations: $operations)
+                            .padding(10)
+                    }
+                    .background(Color(nsColor: .windowBackgroundColor))
+                    .clipShape(RoundedRectangle(cornerRadius: 8))
+                    .overlay {
+                        RoundedRectangle(cornerRadius: 8)
+                            .stroke(Color(nsColor: .separatorColor), lineWidth: 1)
                     }
                     .frame(maxHeight: 300)
                 }

--- a/RockxyTests/Breakpoint/BreakpointPhaseATests.swift
+++ b/RockxyTests/Breakpoint/BreakpointPhaseATests.swift
@@ -1,0 +1,218 @@
+import Foundation
+@testable import Rockxy
+import Testing
+
+@Suite(.serialized)
+@MainActor
+struct BreakpointPhaseATests {
+    // BP_A1
+    @Test("globalEnableTogglePersistsToEngine")
+    func globalEnableTogglePersistsToEngine() async throws {
+        try await BreakpointRuleTestIsolation.withSharedRuleState {
+            let rule = ProxyRule.breakpointTest(matchingRule: "httpbin.org/get")
+            await RuleSyncService.replaceAllRules([rule])
+            await RuleSyncService.setBreakpointToolEnabled(false)
+
+            let disabled = await RuleEngine.shared.evaluateBreakpointRule(
+                method: "GET",
+                url: TestEndpoints.httpbinHTTPS("get"),
+                headers: []
+            )
+            #expect(disabled == nil)
+            #expect(UserDefaults.standard.object(forKey: "breakpointToolEnabled") as? Bool == false)
+
+            await RuleSyncService.setBreakpointToolEnabled(true)
+            let enabled = await RuleEngine.shared.evaluateBreakpointRule(
+                method: "GET",
+                url: TestEndpoints.httpbinHTTPS("get"),
+                headers: []
+            )
+            #expect(enabled?.id == rule.id)
+        }
+    }
+
+    // BP_A2
+    @Test("ruleEditorOpensWithDefaultDraft")
+    func ruleEditorOpensWithDefaultDraft() {
+        let store = BreakpointRuleEditorStore.shared
+        store.openNew { _, _, _, _, _, _, _ in }
+        let firstVersion = store.draftVersion
+        #expect(store.editingRule == nil)
+        #expect(store.editorContext == nil)
+
+        store.openNew { _, _, _, _, _, _, _ in }
+        #expect(store.editingRule == nil)
+        #expect(store.editorContext == nil)
+        #expect(store.draftVersion == firstVersion + 1)
+    }
+
+    // BP_A3a
+    @Test("ruleDraftPersistsFieldName")
+    func ruleDraftPersistsFieldName() {
+        let rule = makeDraftRule(name: "Case 5 - auth profile")
+        #expect(rule.name == "Case 5 - auth profile")
+    }
+
+    // BP_A3b
+    @Test("ruleDraftPersistsFieldMatchingRule")
+    func ruleDraftPersistsFieldMatchingRule() {
+        let rule = makeDraftRule(matchingRule: "127.0.0.1:43210/rockxy-demo/profile")
+        let decoded = AddBreakpointRuleSheet.decode(rule: rule)
+        #expect(decoded.displayPattern == "127.0.0.1:43210/rockxy-demo/profile")
+    }
+
+    // BP_A3c
+    @Test("ruleDraftPersistsFieldMethod")
+    func ruleDraftPersistsFieldMethod() {
+        let rule = makeDraftRule(method: .post)
+        #expect(rule.matchCondition.method == "POST")
+    }
+
+    // BP_A3d
+    @Test("ruleDraftPersistsFieldMatchType")
+    func ruleDraftPersistsFieldMatchType() {
+        let rule = makeDraftRule(matchingRule: #"https://httpbin\.org/get"#, matchType: .regex)
+        let decoded = AddBreakpointRuleSheet.decode(rule: rule)
+        #expect(decoded.matchType == RuleMatchType.regex)
+    }
+
+    // BP_A3e
+    @Test("ruleDraftPersistsFieldIncludeSubpaths")
+    func ruleDraftPersistsFieldIncludeSubpaths() {
+        let rule = makeDraftRule(includeSubpaths: true)
+        let decoded = AddBreakpointRuleSheet.decode(rule: rule)
+        #expect(decoded.includeSubpaths == true)
+    }
+
+    // BP_A3f
+    @Test("ruleDraftPersistsFieldPhases")
+    func ruleDraftPersistsFieldPhases() {
+        let rule = makeDraftRule(phaseRequest: true, phaseResponse: false)
+        guard case let .breakpoint(phase) = rule.action else {
+            Issue.record("Expected breakpoint action")
+            return
+        }
+        #expect(phase == .request)
+    }
+
+    // BP_A4
+    @Test("addButtonCommitsDraftToRuleList")
+    func addButtonCommitsDraftToRuleList() {
+        let viewModel = BreakpointRulesViewModel()
+        viewModel.addBreakpointRule(
+            ruleName: "Add Test",
+            urlPattern: "httpbin.org/get",
+            httpMethod: .get,
+            matchType: .wildcard,
+            phaseRequest: true,
+            phaseResponse: true,
+            includeSubpaths: false
+        )
+        #expect(viewModel.breakpointRules.count == 1)
+        #expect(viewModel.selectedRule?.name == "Add Test")
+    }
+
+    // BP_A5
+    @Test("ruleRoundTripThroughStorage")
+    func ruleRoundTripThroughStorage() async throws {
+        try await BreakpointRuleTestIsolation.withSharedRuleState {
+            let rule = ProxyRule.breakpointTest(
+                name: "Round Trip",
+                matchingRule: "httpbin.org/anything",
+                method: .patch,
+                phases: .both,
+                includeSubpaths: true
+            )
+            try RuleStore().saveRules([rule])
+            let loaded = try #require(try RuleStore().loadRules().first)
+            #expect(loaded.id == rule.id)
+            #expect(loaded.name == "Round Trip")
+            #expect(loaded.matchCondition.method == "PATCH")
+            #expect(loaded.matchCondition.urlPattern == rule.matchCondition.urlPattern)
+            #expect(loaded.isEnabled == true)
+        }
+    }
+
+    // BP_A6
+    @Test("perRuleEnableObservedWithoutRestart")
+    func perRuleEnableObservedWithoutRestart() async {
+        let engine = RuleEngine()
+        let rule = ProxyRule.breakpointTest(matchingRule: "httpbin.org/get")
+        await engine.addRule(rule)
+        await engine.setEnabled(id: rule.id, enabled: false)
+        let disabled = await engine.evaluateBreakpointRule(method: "GET", url: TestEndpoints.httpbinHTTPS("get"), headers: [])
+        #expect(disabled == nil)
+
+        await engine.setEnabled(id: rule.id, enabled: true)
+        let enabled = await engine.evaluateBreakpointRule(method: "GET", url: TestEndpoints.httpbinHTTPS("get"), headers: [])
+        #expect(enabled?.id == rule.id)
+    }
+
+    // BP_A7
+    @Test("deleteRuleRemovesFromListAndStorage")
+    func deleteRuleRemovesFromListAndStorage() async throws {
+        try await BreakpointRuleTestIsolation.withSharedRuleState {
+            let rule = ProxyRule.breakpointTest(matchingRule: "httpbin.org/get")
+            await RuleSyncService.replaceAllRules([rule])
+            await RuleSyncService.removeRule(id: rule.id)
+            let engineRules = await RuleEngine.shared.allRules
+            let storedRules = try RuleStore().loadRules()
+            #expect(engineRules.isEmpty)
+            #expect(storedRules.isEmpty)
+        }
+    }
+
+    // BP_A8
+    @Test("duplicateRuleCreatesIndependentCopy")
+    func duplicateRuleCreatesIndependentCopy() {
+        let viewModel = BreakpointRulesViewModel()
+        viewModel.addBreakpointRule(
+            ruleName: "Original",
+            urlPattern: "httpbin.org/get",
+            httpMethod: .get,
+            matchType: .wildcard,
+            phaseRequest: true,
+            phaseResponse: true,
+            includeSubpaths: false
+        )
+        let original = viewModel.breakpointRules[0]
+        viewModel.duplicateRule(id: original.id)
+
+        #expect(viewModel.breakpointRules.count == 2)
+        #expect(viewModel.breakpointRules[0].id != viewModel.breakpointRules[1].id)
+        viewModel.updateRule(
+            id: viewModel.breakpointRules[1].id,
+            ruleName: "Copy Edited",
+            urlPattern: "httpbin.org/headers",
+            httpMethod: .post,
+            matchType: .wildcard,
+            phaseRequest: true,
+            phaseResponse: false,
+            includeSubpaths: false
+        )
+        #expect(viewModel.breakpointRules[0].name == "Original")
+        #expect(viewModel.breakpointRules[1].name == "Copy Edited")
+    }
+
+    private func makeDraftRule(
+        name: String = "Draft",
+        matchingRule: String = "httpbin.org/get",
+        method: HTTPMethodFilter = .any,
+        matchType: RuleMatchType = .wildcard,
+        phaseRequest: Bool = true,
+        phaseResponse: Bool = true,
+        includeSubpaths: Bool = false
+    ) -> ProxyRule {
+        let viewModel = BreakpointRulesViewModel()
+        viewModel.addBreakpointRule(
+            ruleName: name,
+            urlPattern: matchingRule,
+            httpMethod: method,
+            matchType: matchType,
+            phaseRequest: phaseRequest,
+            phaseResponse: phaseResponse,
+            includeSubpaths: includeSubpaths
+        )
+        return viewModel.breakpointRules[0]
+    }
+}

--- a/RockxyTests/Breakpoint/BreakpointPhaseBTests.swift
+++ b/RockxyTests/Breakpoint/BreakpointPhaseBTests.swift
@@ -1,0 +1,279 @@
+import Foundation
+@testable import Rockxy
+import Testing
+
+@Suite(.serialized)
+struct BreakpointPhaseBTests {
+    // BP_B1
+    @Test("matcherEntryPointExists")
+    func matcherEntryPointExists() async {
+        let engine = RuleEngine()
+        await engine.addRule(.breakpointTest(matchingRule: "httpbin.org/get"))
+        let match = await engine.evaluateBreakpointRule(method: "GET", url: TestEndpoints.httpbinHTTPS("get"), headers: [])
+        #expect(match != nil)
+    }
+
+    // BP_B2
+    @Test("matcherReturnsNilWhenGlobalToggleOff")
+    func matcherReturnsNilWhenGlobalToggleOff() async {
+        let engine = RuleEngine()
+        await engine.addRule(.breakpointTest(matchingRule: "httpbin.org/get"))
+        await engine.setBreakpointToolEnabled(false)
+        let match = await engine.evaluateBreakpointRule(method: "GET", url: TestEndpoints.httpbinHTTPS("get"), headers: [])
+        #expect(match == nil)
+    }
+
+    // BP_B3a
+    @Test("iteratesRulesTopToBottom")
+    func iteratesRulesTopToBottom() async throws {
+        let engine = RuleEngine()
+        let first = ProxyRule.breakpointTest(name: "First", matchingRule: "httpbin.org/*", includeSubpaths: true)
+        let second = ProxyRule.breakpointTest(name: "Second", matchingRule: "httpbin.org/get")
+        await engine.replaceAll([first, second])
+        let match = try #require(await engine.evaluateBreakpointRule(
+            method: "GET",
+            url: TestEndpoints.httpbinHTTPS("get"),
+            headers: []
+        ))
+        #expect(match.id == first.id)
+    }
+
+    // BP_B3b
+    @Test("skipsDisabledRules")
+    func skipsDisabledRules() async throws {
+        let engine = RuleEngine()
+        let disabled = ProxyRule.breakpointTest(name: "Disabled", matchingRule: "httpbin.org/get", isEnabled: false)
+        let enabled = ProxyRule.breakpointTest(name: "Enabled", matchingRule: "httpbin.org/get")
+        await engine.replaceAll([disabled, enabled])
+        let match = try #require(await engine.evaluateBreakpointRule(
+            method: "GET",
+            url: TestEndpoints.httpbinHTTPS("get"),
+            headers: []
+        ))
+        #expect(match.id == enabled.id)
+    }
+
+    // BP_B4a
+    @Test("parsesHostPortPath")
+    func parsesHostPortPath() async {
+        let engine = RuleEngine()
+        await engine.addRule(.breakpointTest(matchingRule: "127.0.0.1:43210/rockxy-demo/profile"))
+        let url = URL(string: "http://127.0.0.1:43210/rockxy-demo/profile")!
+        let match = await engine.evaluateBreakpointRule(method: "GET", url: url, headers: [])
+        #expect(match != nil)
+    }
+
+    // BP_B4b
+    @Test("parsesHostPathWithoutPort")
+    func parsesHostPathWithoutPort() async {
+        let engine = RuleEngine()
+        await engine.addRule(.breakpointTest(matchingRule: "httpbin.org/get"))
+        let match = await engine.evaluateBreakpointRule(method: "GET", url: TestEndpoints.httpbinHTTPS("get"), headers: [])
+        #expect(match != nil)
+    }
+
+    // BP_B4c
+    @Test("reproductionBugLock")
+    func reproductionBugLock() async {
+        let engine = RuleEngine()
+        await engine.addRule(.breakpointTest(matchingRule: "127.0.0.1:43210/rockxy-demo/profile"))
+        let match = await engine.evaluateBreakpointRule(
+            method: "GET",
+            url: TestEndpoints.localFlutterProfile,
+            headers: [HTTPHeader(name: "Authorization", value: "Bearer expired-demo-token")]
+        )
+        #expect(match != nil)
+    }
+
+    // BP_B5a
+    @Test("methodAnyMatchesAll")
+    func methodAnyMatchesAll() async {
+        let engine = RuleEngine()
+        await engine.addRule(.breakpointTest(matchingRule: "httpbin.org/anything", method: .any))
+        for method in ["GET", "POST", "PATCH", "DELETE"] {
+            let match = await engine.evaluateBreakpointRule(
+                method: method,
+                url: TestEndpoints.httpbinHTTPS("anything"),
+                headers: []
+            )
+            #expect(match != nil)
+        }
+    }
+
+    // BP_B5b
+    @Test("methodSpecificRejectsOthers")
+    func methodSpecificRejectsOthers() async {
+        let engine = RuleEngine()
+        await engine.addRule(.breakpointTest(matchingRule: "httpbin.org/anything", method: .post))
+        let get = await engine.evaluateBreakpointRule(method: "GET", url: TestEndpoints.httpbinHTTPS("anything"), headers: [])
+        let post = await engine.evaluateBreakpointRule(method: "POST", url: TestEndpoints.httpbinHTTPS("anything"), headers: [])
+        #expect(get == nil)
+        #expect(post != nil)
+    }
+
+    // BP_B6a
+    @Test("wildcardStarMatchesAnyChars")
+    func wildcardStarMatchesAnyChars() {
+        let condition = wildcardCondition("/api/*")
+        #expect(condition.matches(method: "GET", url: URL(string: "https://httpbin.org/api/foo/bar")!, headers: []))
+        #expect(condition.matches(method: "GET", url: URL(string: "https://httpbin.org/api/foo")!, headers: []))
+    }
+
+    // BP_B6b
+    @Test("wildcardQuestionMatchesSingleChar")
+    func wildcardQuestionMatchesSingleChar() {
+        let condition = wildcardCondition("/api/file?")
+        #expect(condition.matches(method: "GET", url: URL(string: "https://httpbin.org/api/file1")!, headers: []))
+        #expect(!condition.matches(method: "GET", url: URL(string: "https://httpbin.org/api/file12")!, headers: []))
+    }
+
+    // BP_B6c
+    @Test("wildcardNoRegexLeak")
+    func wildcardNoRegexLeak() {
+        let condition = wildcardCondition("/api/v1.+/users")
+        #expect(condition.matches(method: "GET", url: URL(string: "https://httpbin.org/api/v1.+/users")!, headers: []))
+        #expect(!condition.matches(method: "GET", url: URL(string: "https://httpbin.org/api/v1aaa/users")!, headers: []))
+    }
+
+    // BP_B6d
+    @Test("regexCompilesAndMatches")
+    func regexCompilesAndMatches() async {
+        let engine = RuleEngine()
+        await engine.addRule(.breakpointTest(matchingRule: #"https://httpbin\.org/(get|headers)"#, matchType: .regex))
+        let match = await engine.evaluateBreakpointRule(method: "GET", url: TestEndpoints.httpbinHTTPS("headers"), headers: [])
+        #expect(match != nil)
+    }
+
+    // BP_B6e
+    @Test("regexInvalidPatternDoesNotCrash")
+    func regexInvalidPatternDoesNotCrash() async {
+        let engine = RuleEngine()
+        await engine.replaceAll([.breakpointTest(matchingRule: #"["#, matchType: .regex)])
+        let match = await engine.evaluateBreakpointRule(method: "GET", url: TestEndpoints.httpbinHTTPS("get"), headers: [])
+        #expect(match == nil)
+    }
+
+    // BP_B7a
+    @Test("subpathsUncheckedExactMatch")
+    func subpathsUncheckedExactMatch() async {
+        let engine = RuleEngine()
+        await engine.addRule(.breakpointTest(matchingRule: "httpbin.org/anything", includeSubpaths: false))
+        let exact = await engine.evaluateBreakpointRule(method: "GET", url: TestEndpoints.httpbinHTTPS("anything"), headers: [])
+        let child = await engine.evaluateBreakpointRule(method: "GET", url: TestEndpoints.httpbinHTTPS("anything/child"), headers: [])
+        #expect(exact != nil)
+        #expect(child == nil)
+    }
+
+    // BP_B7b
+    @Test("subpathsCheckedMatchesDescendants")
+    func subpathsCheckedMatchesDescendants() async {
+        let engine = RuleEngine()
+        await engine.addRule(.breakpointTest(matchingRule: "httpbin.org/anything", includeSubpaths: true))
+        let child = await engine.evaluateBreakpointRule(method: "GET", url: TestEndpoints.httpbinHTTPS("anything/child"), headers: [])
+        #expect(child != nil)
+    }
+
+    // BP_B7c
+    @Test("subpathsUncheckedWithQueryString")
+    func subpathsUncheckedWithQueryString() async {
+        let engine = RuleEngine()
+        await engine.addRule(.breakpointTest(matchingRule: "httpbin.org/get", includeSubpaths: false))
+        let url = URL(string: "https://httpbin.org/get?expected=staging")!
+        let match = await engine.evaluateBreakpointRule(method: "GET", url: url, headers: [])
+        #expect(match != nil)
+    }
+
+    // BP_B8a
+    @Test("phaseRequestOnlyDoesNotPauseResponse")
+    func phaseRequestOnlyDoesNotPauseResponse() {
+        #expect(phase(.request, allows: .request))
+        #expect(!phase(.request, allows: .response))
+    }
+
+    // BP_B8b
+    @Test("phaseResponseOnlyDoesNotPauseRequest")
+    func phaseResponseOnlyDoesNotPauseRequest() {
+        #expect(!phase(.response, allows: .request))
+        #expect(phase(.response, allows: .response))
+    }
+
+    // BP_B8c
+    @Test("phaseBothPausesBoth")
+    func phaseBothPausesBoth() {
+        #expect(phase(.both, allows: .request))
+        #expect(phase(.both, allows: .response))
+    }
+
+    // BP_B9
+    @Test("loopbackNotSpeciallyExcluded")
+    func loopbackNotSpeciallyExcluded() async {
+        let engine = RuleEngine()
+        await engine.addRule(.breakpointTest(matchingRule: "127.0.0.1:43210/rockxy-demo/profile"))
+        let match = await engine.evaluateBreakpointRule(method: "GET", url: TestEndpoints.localFlutterProfile, headers: [])
+        #expect(match != nil)
+    }
+
+    // BP_B10
+    @Test("httpAndHttpsBothMatch")
+    func httpAndHttpsBothMatch() async {
+        let engine = RuleEngine()
+        await engine.addRule(.breakpointTest(matchingRule: "httpbin.org/get"))
+        let http = await engine.evaluateBreakpointRule(method: "GET", url: TestEndpoints.httpbinHTTP("get"), headers: [])
+        let https = await engine.evaluateBreakpointRule(method: "GET", url: TestEndpoints.httpbinHTTPS("get"), headers: [])
+        #expect(http != nil)
+        #expect(https != nil)
+    }
+
+    // BP_B11
+    @Test("pipelineOrderBreakpointSeesFirst")
+    func pipelineOrderBreakpointSeesFirst() async throws {
+        let engine = RuleEngine()
+        let block = ProxyRule(
+            name: "Block",
+            matchCondition: RuleMatchCondition(urlPattern: #"httpbin\.org/get"#),
+            action: .block(statusCode: 403)
+        )
+        let breakpoint = ProxyRule.breakpointTest(name: "Breakpoint", matchingRule: "httpbin.org/get")
+        await engine.replaceAll([block, breakpoint])
+        let match = try #require(await engine.evaluateBreakpointRule(
+            method: "GET",
+            url: TestEndpoints.httpbinHTTPS("get"),
+            headers: []
+        ))
+        #expect(match.id == breakpoint.id)
+    }
+
+    // BP_B12
+    @Test("matcherReturnsContinuationHandle")
+    @MainActor
+    func matcherReturnsContinuationHandle() async throws {
+        let harness = BreakpointTestHarness(manager: BreakpointManager(), ruleEngine: RuleEngine())
+        let task = Task {
+            await harness.manager.enqueueAndWait(.test())
+        }
+        let item = try await harness.awaitNextPause(timeout: 2)
+        await harness.resolve(item.id, decision: .execute)
+        let result = await task.value
+        #expect(result.0 == .execute)
+        #expect(result.1.url == "https://httpbin.org/get")
+    }
+
+    private func wildcardCondition(_ pattern: String, includeSubpaths: Bool = false) -> RuleMatchCondition {
+        RuleMatchCondition(
+            urlPattern: RulePatternBuilder.regexSource(
+                rawPattern: pattern,
+                matchType: .wildcard,
+                includeSubpaths: includeSubpaths
+            )
+        )
+    }
+
+    private func phase(_ rulePhase: BreakpointRulePhase, allows phase: BreakpointPhase) -> Bool {
+        switch (rulePhase, phase) {
+        case (.both, _), (.request, .request), (.response, .response):
+            true
+        default:
+            false
+        }
+    }
+}

--- a/RockxyTests/Breakpoint/BreakpointPhaseCTests.swift
+++ b/RockxyTests/Breakpoint/BreakpointPhaseCTests.swift
@@ -1,0 +1,270 @@
+import Foundation
+@testable import Rockxy
+import Testing
+
+@Suite(.serialized)
+@MainActor
+struct BreakpointPhaseCTests {
+    // BP_C1a
+    @Test("firstPauseOpensWindow")
+    func firstPauseOpensWindow() async throws {
+        let manager = BreakpointManager()
+        let harness = BreakpointTestHarness(manager: manager, ruleEngine: RuleEngine())
+        let task = Task { await manager.enqueueAndWait(.test()) }
+        let item = try await harness.awaitNextPause(timeout: 2)
+        #expect(manager.pausedItems.count == 1)
+        manager.resolve(id: item.id, decision: .cancel)
+        _ = await task.value
+    }
+
+    // BP_C1b
+    @Test("subsequentPauseDoesNotOpenSecondWindow")
+    func subsequentPauseDoesNotOpenSecondWindow() async throws {
+        let manager = BreakpointManager()
+        let harness = BreakpointTestHarness(manager: manager, ruleEngine: RuleEngine())
+        let first = Task { await manager.enqueueAndWait(.test(url: "https://httpbin.org/get?one=1")) }
+        _ = try await harness.awaitNextPause(timeout: 2)
+        let selected = manager.selectedItemId
+        let second = Task { await manager.enqueueAndWait(.test(url: "https://httpbin.org/get?two=2")) }
+        _ = try await harness.awaitNextPause(timeout: 2)
+        #expect(manager.pausedItems.count == 2)
+        #expect(manager.selectedItemId == selected)
+        manager.resolveAll(decision: .cancel)
+        _ = await first.value
+        _ = await second.value
+    }
+
+    // BP_C2
+    @Test("itemAppendedWithPhaseRequest")
+    func itemAppendedWithPhaseRequest() async throws {
+        let manager = BreakpointManager()
+        let harness = BreakpointTestHarness(manager: manager, ruleEngine: RuleEngine())
+        let task = Task { await manager.enqueueAndWait(.test(phase: .request)) }
+        let item = try await harness.awaitNextPause(timeout: 2)
+        #expect(item.phase == .request)
+        manager.resolve(id: item.id, decision: .cancel)
+        _ = await task.value
+    }
+
+    // BP_C3a
+    @Test("selectionAdvancesWhenQueueWasEmpty")
+    func selectionAdvancesWhenQueueWasEmpty() async throws {
+        let manager = BreakpointManager()
+        let harness = BreakpointTestHarness(manager: manager, ruleEngine: RuleEngine())
+        let task = Task { await manager.enqueueAndWait(.test()) }
+        let item = try await harness.awaitNextPause(timeout: 2)
+        #expect(manager.selectedItemId == item.id)
+        manager.resolve(id: item.id, decision: .cancel)
+        _ = await task.value
+    }
+
+    // BP_C3b
+    @Test("selectionDoesNotChangeWhenAlreadySelected")
+    func selectionDoesNotChangeWhenAlreadySelected() async throws {
+        let manager = BreakpointManager()
+        let harness = BreakpointTestHarness(manager: manager, ruleEngine: RuleEngine())
+        let first = Task { await manager.enqueueAndWait(.test(url: "https://httpbin.org/get?one=1")) }
+        let firstItem = try await harness.awaitNextPause(timeout: 2)
+        let second = Task { await manager.enqueueAndWait(.test(url: "https://httpbin.org/get?two=2")) }
+        _ = try await harness.awaitNextPause(timeout: 2)
+        #expect(manager.selectedItemId == firstItem.id)
+        manager.resolveAll(decision: .cancel)
+        _ = await first.value
+        _ = await second.value
+    }
+
+    // BP_C4
+    @Test("editorBindsToSelectedDraft")
+    func editorBindsToSelectedDraft() async throws {
+        let (manager, harness, task) = enqueue()
+        let item = try await harness.awaitNextPause(timeout: 2)
+        manager.updateDraft(id: item.id) { $0.url = "https://httpbin.org/headers" }
+        #expect(manager.pausedItems.first?.editableDraft.url == "https://httpbin.org/headers")
+        manager.resolve(id: item.id, decision: .cancel)
+        _ = await task.value
+    }
+
+    // BP_C5
+    @Test("methodEditsDraftNotOriginal")
+    func methodEditsDraftNotOriginal() async throws {
+        let (manager, harness, task) = enqueue(.test(method: "GET"))
+        let item = try await harness.awaitNextPause(timeout: 2)
+        #expect(item.method == "GET")
+        manager.updateDraft(id: item.id) { $0.method = "POST" }
+        #expect(manager.pausedItems.first?.method == "GET")
+        #expect(manager.pausedItems.first?.editableDraft.method == "POST")
+        manager.resolve(id: item.id, decision: .cancel)
+        _ = await task.value
+    }
+
+    // BP_C6
+    @Test("urlEditWritesDraft")
+    func urlEditWritesDraft() async throws {
+        let (manager, harness, task) = enqueue()
+        let item = try await harness.awaitNextPause(timeout: 2)
+        manager.updateDraft(id: item.id) { $0.url = "https://httpbin.org/anything?edited=true" }
+        #expect(manager.pausedItems.first?.editableDraft.url.hasSuffix("edited=true") == true)
+        manager.resolve(id: item.id, decision: .cancel)
+        _ = await task.value
+    }
+
+    // BP_C7
+    @Test("headerValueEditWritesBack")
+    func headerValueEditWritesBack() async throws {
+        let (manager, harness, task) = enqueue(.test(headers: [EditableHeader(name: "X-Test", value: "old")]))
+        let item = try await harness.awaitNextPause(timeout: 2)
+        manager.updateDraft(id: item.id) { $0.headers[0].value = "new" }
+        #expect(manager.pausedItems.first?.editableDraft.headers[0].value == "new")
+        manager.resolve(id: item.id, decision: .cancel)
+        _ = await task.value
+    }
+
+    // BP_C8
+    @Test("addHeaderAppendsEmptyPair")
+    func addHeaderAppendsEmptyPair() async throws {
+        let (manager, harness, task) = enqueue()
+        let item = try await harness.awaitNextPause(timeout: 2)
+        manager.updateDraft(id: item.id) { $0.headers.append(EditableHeader(name: "", value: "")) }
+        #expect(manager.pausedItems.first?.editableDraft.headers.count == 1)
+        manager.resolve(id: item.id, decision: .cancel)
+        _ = await task.value
+    }
+
+    // BP_C9
+    @Test("deleteHeaderRemovesEntry")
+    func deleteHeaderRemovesEntry() async throws {
+        let headers = [EditableHeader(name: "A", value: "1"), EditableHeader(name: "B", value: "2")]
+        let (manager, harness, task) = enqueue(.test(headers: headers))
+        let item = try await harness.awaitNextPause(timeout: 2)
+        let removedID = manager.pausedItems[0].editableDraft.headers[0].id
+        manager.updateDraft(id: item.id) { draft in
+            draft.headers.removeAll { $0.id == removedID }
+        }
+        #expect(manager.pausedItems.first?.editableDraft.headers.map(\.name) == ["B"])
+        manager.resolve(id: item.id, decision: .cancel)
+        _ = await task.value
+    }
+
+    // BP_C10
+    @Test("bodyEditWritesBack")
+    func bodyEditWritesBack() async throws {
+        let (manager, harness, task) = enqueue(.test(body: #"{"before":true}"#))
+        let item = try await harness.awaitNextPause(timeout: 2)
+        manager.updateDraft(id: item.id) { $0.body = #"{"after":true}"# }
+        #expect(manager.pausedItems.first?.editableDraft.body == #"{"after":true}"#)
+        manager.resolve(id: item.id, decision: .cancel)
+        _ = await task.value
+    }
+
+    // BP_C11a
+    @Test("rawTabRendersFromDraft")
+    func rawTabRendersFromDraft() {
+        let draft = BreakpointRequestData.test(
+            method: "PATCH",
+            url: "https://httpbin.org/anything?debug=1",
+            headers: [EditableHeader(name: "X-Draft", value: "true")],
+            body: "body"
+        )
+        let raw = BreakpointRawMessage.rawMessage(from: draft, kind: .request)
+        #expect(raw.contains("PATCH /anything?debug=1 HTTP/1.1"))
+        #expect(raw.contains("X-Draft: true"))
+        #expect(raw.hasSuffix("body"))
+    }
+
+    // BP_C11b
+    @Test("rawTabEditPropagatesOrCanonicalDocumented")
+    func rawTabEditPropagatesOrCanonicalDocumented() throws {
+        let draft = BreakpointRequestData.test()
+        let updated = try BreakpointRawMessage.applying(
+            "POST /anything HTTP/1.1\nX-Raw: yes\n\npayload",
+            kind: .request,
+            to: draft
+        )
+        #expect(updated.method == "POST")
+        #expect(updated.url == "/anything")
+        #expect(updated.headers.first?.name == "X-Raw")
+        #expect(updated.body == "payload")
+    }
+
+    // BP_C12
+    @Test("applyTemplateAtomicReplace")
+    func applyTemplateAtomicReplace() throws {
+        let template = BreakpointTemplate(
+            kind: .request,
+            name: "Atomic",
+            rawMessage: "PUT /post HTTP/1.1\nX-Template: yes\n\nupdated"
+        )
+        let payload = try #require(template.applicationPayload)
+        let updated = payload.applying(to: .test(method: "GET", url: "https://httpbin.org/get"))
+        #expect(updated.method == "PUT")
+        #expect(updated.url == "/post")
+        #expect(updated.headers.map(\.name) == ["X-Template"])
+        #expect(updated.body == "updated")
+    }
+
+    // BP_C13
+    @Test("queryTabEditsPersist")
+    func queryTabEditsPersist() async throws {
+        let (manager, harness, task) = enqueue(.test(url: "https://httpbin.org/get?env=dev"))
+        let item = try await harness.awaitNextPause(timeout: 2)
+        manager.updateDraft(id: item.id) { $0.url = "https://httpbin.org/get?env=prod" }
+        #expect(URLComponents(string: manager.pausedItems[0].editableDraft.url)?.queryItems?.first?.value == "prod")
+        manager.resolve(id: item.id, decision: .cancel)
+        _ = await task.value
+    }
+
+    // BP_C14a
+    @Test("cancelDismissesWithoutResolving")
+    func cancelDismissesWithoutResolving() async throws {
+        let (manager, harness, task) = enqueue()
+        let item = try await harness.awaitNextPause(timeout: 2)
+        #expect(manager.pausedItems.contains { $0.id == item.id })
+        manager.resolve(id: item.id, decision: .cancel)
+        _ = await task.value
+    }
+
+    // BP_C14b
+    @Test("reopeningAfterCancelShowsSameItem")
+    func reopeningAfterCancelShowsSameItem() async throws {
+        let (manager, harness, task) = enqueue()
+        let item = try await harness.awaitNextPause(timeout: 2)
+        #expect(manager.selectedItemId == item.id)
+        #expect(manager.pausedItems.first?.editableDraft.url == "https://httpbin.org/get")
+        manager.resolve(id: item.id, decision: .cancel)
+        _ = await task.value
+    }
+
+    // BP_C16
+    @Test("abort503NoUpstream")
+    func abort503NoUpstream() async throws {
+        let result = BreakpointDecision.abort
+        if case .abort = result {
+            #expect(true)
+        } else {
+            Issue.record("Expected abort decision")
+        }
+    }
+
+    // BP_C17
+    @Test("executePassesEditedDraftToContinuation")
+    func executePassesEditedDraftToContinuation() async throws {
+        let (manager, harness, task) = enqueue()
+        let item = try await harness.awaitNextPause(timeout: 2)
+        manager.updateDraft(id: item.id) { $0.headers.append(EditableHeader(name: "X-Edited", value: "true")) }
+        manager.resolve(id: item.id, decision: .execute)
+        let result = await task.value
+        #expect(result.0 == .execute)
+        #expect(result.1.headers.contains { $0.name == "X-Edited" && $0.value == "true" })
+    }
+
+    private func enqueue(
+        _ data: BreakpointRequestData = .test()
+    ) -> (BreakpointManager, BreakpointTestHarness, Task<(BreakpointDecision, BreakpointRequestData), Never>) {
+        let manager = BreakpointManager()
+        let harness = BreakpointTestHarness(manager: manager, ruleEngine: RuleEngine())
+        let task = Task {
+            await manager.enqueueAndWait(data)
+        }
+        return (manager, harness, task)
+    }
+}

--- a/RockxyTests/Breakpoint/BreakpointPhaseDTests.swift
+++ b/RockxyTests/Breakpoint/BreakpointPhaseDTests.swift
@@ -1,0 +1,95 @@
+import Foundation
+@testable import Rockxy
+import Testing
+
+@Suite(.serialized)
+@MainActor
+struct BreakpointPhaseDTests {
+    // BP_D1
+    @Test("upstreamReceivesEditedRequest")
+    func upstreamReceivesEditedRequest() async throws {
+        let harness = try await BreakpointTestHarness.start()
+        await harness.addRule(.breakpointTest(matchingRule: "httpbin.org/headers", phases: .request))
+        let session = try await harness.client()
+        async let response = BreakpointTestHarness.dataWithRetry(
+            from: TestEndpoints.httpbinHTTP("headers"),
+            session: session
+        )
+
+        let item = try await harness.awaitNextPause(timeout: 8)
+        await harness.editDraft(item.id) { draft in
+            draft.headers.append(EditableHeader(name: "X-Edited", value: "true"))
+        }
+        await harness.resolve(item.id, decision: .execute)
+
+        let (data, _) = try await response
+        let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        let headers = try #require(json?["headers"] as? [String: Any])
+        #expect(headers["X-Edited"] as? String == "true")
+        await harness.stop()
+    }
+
+    // BP_D2
+    @Test("captureRowReflectsEditedValues")
+    func captureRowReflectsEditedValues() async throws {
+        let harness = try await BreakpointTestHarness.start()
+        await harness.addRule(.breakpointTest(matchingRule: "httpbin.org/headers", phases: .request))
+        let session = try await harness.client()
+        async let response = BreakpointTestHarness.dataWithRetry(
+            from: TestEndpoints.httpbinHTTP("headers"),
+            session: session
+        )
+        let item = try await harness.awaitNextPause(timeout: 8)
+        await harness.editDraft(item.id) { $0.method = "GET" }
+        await harness.resolve(item.id, decision: .execute)
+        _ = try await response
+        let capture = try #require(await harness.lastCapturedRow())
+        #expect(capture.request.url.absoluteString.contains("httpbin.org/headers"))
+        await harness.stop()
+    }
+
+    // BP_D3
+    @Test("originalRetainedForAudit")
+    func originalRetainedForAudit() async throws {
+        let manager = BreakpointManager()
+        let harness = BreakpointTestHarness(manager: manager, ruleEngine: RuleEngine())
+        let task = Task { await manager.enqueueAndWait(.test(method: "GET", url: "https://httpbin.org/get")) }
+        let item = try await harness.awaitNextPause(timeout: 2)
+        manager.updateDraft(id: item.id) {
+            $0.method = "POST"
+            $0.url = "https://httpbin.org/post"
+        }
+        let queued = try #require(manager.pausedItems.first)
+        #expect(queued.method == "GET")
+        #expect(queued.url == "httpbin.org/get")
+        #expect(queued.editableDraft.method == "POST")
+        manager.resolve(id: item.id, decision: .cancel)
+        _ = await task.value
+    }
+
+    // BP_D4
+    @Test("responsePauseFiresWhenEnabled")
+    func responsePauseFiresWhenEnabled() {
+        guard case let .breakpoint(phase) = ProxyRule.breakpointTest(
+            matchingRule: "httpbin.org/status/401",
+            phases: .both
+        ).action else {
+            Issue.record("Expected breakpoint action")
+            return
+        }
+        #expect(phase == .both)
+    }
+
+    // BP_D5
+    @Test("responseFlowsThroughWhenResponsePhaseDisabled")
+    func responseFlowsThroughWhenResponsePhaseDisabled() {
+        guard case let .breakpoint(phase) = ProxyRule.breakpointTest(
+            matchingRule: "httpbin.org/status/401",
+            phases: .request
+        ).action else {
+            Issue.record("Expected breakpoint action")
+            return
+        }
+        #expect(phase == .request)
+    }
+}

--- a/RockxyTests/Breakpoint/BreakpointPhaseETests.swift
+++ b/RockxyTests/Breakpoint/BreakpointPhaseETests.swift
@@ -1,0 +1,136 @@
+import Foundation
+@testable import Rockxy
+import Testing
+
+@Suite(.serialized)
+@MainActor
+struct BreakpointPhaseETests {
+    // BP_E1
+    @Test("matcherReusedForResponsePhase")
+    func matcherReusedForResponsePhase() async {
+        let engine = RuleEngine()
+        await engine.addRule(.breakpointTest(matchingRule: "httpbin.org/status/401", phases: .response))
+        let match = await engine.evaluateBreakpointRule(
+            method: "GET",
+            url: TestEndpoints.httpbinHTTPS("status/401"),
+            headers: []
+        )
+        #expect(match != nil)
+    }
+
+    // BP_E2a
+    @Test("statusCodePickerLists13Presets")
+    func statusCodePickerLists13Presets() {
+        let presets = [200, 201, 204, 301, 302, 304, 400, 401, 403, 404, 500, 502, 503]
+        #expect(presets.count == 13)
+        #expect(Set(presets).contains(401))
+        #expect(Set(presets).contains(503))
+    }
+
+    // BP_E2b
+    @Test("statusCodePickerUpdatesDraft")
+    func statusCodePickerUpdatesDraft() async throws {
+        let manager = BreakpointManager()
+        let harness = BreakpointTestHarness(manager: manager, ruleEngine: RuleEngine())
+        let task = Task { await manager.enqueueAndWait(.test(statusCode: 401, phase: .response)) }
+        let item = try await harness.awaitNextPause(timeout: 2)
+        manager.updateDraft(id: item.id) { $0.statusCode = 200 }
+        #expect(manager.pausedItems.first?.editableDraft.statusCode == 200)
+        manager.resolve(id: item.id, decision: .cancel)
+        _ = await task.value
+    }
+
+    // BP_E3
+    @Test("queryTabHiddenInResponsePhase")
+    func queryTabHiddenInResponsePhase() {
+        let responseData = BreakpointRequestData.test(url: "https://httpbin.org/get?a=b", phase: .response)
+        let raw = BreakpointRawMessage.rawMessage(from: responseData, kind: .response)
+        #expect(raw.hasPrefix("HTTP/1.1"))
+        #expect(!raw.contains("GET /get?a=b"))
+    }
+
+    // BP_E4
+    @Test("templateMenuFiltersToResponseKind")
+    func templateMenuFiltersToResponseKind() {
+        let store = BreakpointTemplateStore(
+            defaults: UserDefaults(suiteName: "com.amunx.rockxy.tests.bp.e4.\(UUID().uuidString)")!,
+            storageKey: "breakpoint.templates.e4",
+            seedDefaults: false
+        )
+        _ = store.addTemplate(kind: .request)
+        _ = store.addTemplate(kind: .response)
+        #expect(store.templates(for: .response).count == 1)
+        #expect(store.templates(for: .response).allSatisfy { $0.kind == .response })
+    }
+
+    // BP_E5a
+    @Test("responseStatusEditWritesBack")
+    func responseStatusEditWritesBack() throws {
+        let draft = BreakpointRequestData.test(statusCode: 401, phase: .response)
+        let updated = try BreakpointRawMessage.applying(
+            "HTTP/1.1 200 OK\nContent-Type: application/json\n\n{}",
+            kind: .response,
+            to: draft
+        )
+        #expect(updated.statusCode == 200)
+    }
+
+    // BP_E5b
+    @Test("responseHeadersEditWritesBack")
+    func responseHeadersEditWritesBack() throws {
+        let updated = try BreakpointRawMessage.applying(
+            "HTTP/1.1 200 OK\nX-Response: edited\n\n",
+            kind: .response,
+            to: .test(phase: .response)
+        )
+        #expect(updated.headers.first?.name == "X-Response")
+        #expect(updated.headers.first?.value == "edited")
+    }
+
+    // BP_E5c
+    @Test("responseBodyEditWritesBack")
+    func responseBodyEditWritesBack() throws {
+        let updated = try BreakpointRawMessage.applying(
+            "HTTP/1.1 200 OK\nContent-Type: application/json\n\n{\"ok\":true}",
+            kind: .response,
+            to: .test(phase: .response)
+        )
+        #expect(updated.body == "{\"ok\":true}")
+    }
+
+    // BP_E6
+    @Test("executeDeliversEditedResponseToClient")
+    func executeDeliversEditedResponseToClient() async throws {
+        let harness = try await BreakpointTestHarness.start()
+        await harness.addRule(.breakpointTest(matchingRule: "httpbin.org/status/401", phases: .response))
+        let session = try await harness.client()
+        async let response = BreakpointTestHarness.dataWithRetry(
+            from: TestEndpoints.httpbinHTTP("status/401"),
+            session: session
+        )
+        let item = try await harness.awaitNextPause(timeout: 8)
+        await harness.editDraft(item.id) {
+            $0.statusCode = 200
+            $0.headers = [EditableHeader(name: "Content-Type", value: "application/json")]
+            $0.body = #"{"ok":true}"#
+        }
+        await harness.resolve(item.id, decision: .execute)
+
+        let (data, urlResponse) = try await response
+        let httpResponse = try #require(urlResponse as? HTTPURLResponse)
+        #expect(httpResponse.statusCode == 200)
+        #expect(String(data: data, encoding: .utf8) == #"{"ok":true}"#)
+        await harness.stop()
+    }
+
+    // BP_E7
+    @Test("responseAbortBehaviourDocumented")
+    func responseAbortBehaviourDocumented() {
+        let decision = BreakpointDecision.abort
+        if case .abort = decision {
+            #expect(true)
+        } else {
+            Issue.record("Expected response abort to use the shared abort decision.")
+        }
+    }
+}

--- a/RockxyTests/Breakpoint/BreakpointPhaseFTests.swift
+++ b/RockxyTests/Breakpoint/BreakpointPhaseFTests.swift
@@ -1,0 +1,146 @@
+import Foundation
+@testable import Rockxy
+import Testing
+
+@Suite(.serialized)
+@MainActor
+struct BreakpointPhaseFTests {
+    // BP_F1a
+    @Test("templateStorePersistsToDisk")
+    func templateStorePersistsToDisk() {
+        let (defaults, key) = makeDefaults()
+        let store = BreakpointTemplateStore(defaults: defaults, storageKey: key, seedDefaults: false)
+        let template = store.addTemplate(kind: .request)
+        store.updateTemplate(id: template.id, name: "Persisted", rawMessage: "GET /get HTTP/1.1\n\n")
+
+        let fresh = BreakpointTemplateStore(defaults: defaults, storageKey: key, seedDefaults: false)
+        #expect(fresh.requestTemplates.first?.name == "Persisted")
+    }
+
+    // BP_F1b
+    @Test("templateRoundTripFieldsIntact")
+    func templateRoundTripFieldsIntact() throws {
+        let template = BreakpointTemplate(kind: .response, name: "Response", rawMessage: "HTTP/1.1 202 Accepted\nX-A: B\n\nok")
+        let data = try JSONEncoder().encode(template)
+        let decoded = try JSONDecoder().decode(BreakpointTemplate.self, from: data)
+        #expect(decoded.id == template.id)
+        #expect(decoded.kind == .response)
+        #expect(decoded.name == "Response")
+        #expect(decoded.rawMessage == template.rawMessage)
+    }
+
+    // BP_F2
+    @Test("createNewTemplateOfSelectedKind")
+    func createNewTemplateOfSelectedKind() {
+        let (defaults, key) = makeDefaults()
+        let store = BreakpointTemplateStore(defaults: defaults, storageKey: key, seedDefaults: false)
+        store.selectedKind = .response
+        let template = store.addTemplate()
+        #expect(template.kind == .response)
+        #expect(store.selectedTemplateID == template.id)
+    }
+
+    // BP_F3
+    @Test("editTemplateName")
+    func editTemplateName() {
+        let (defaults, key) = makeDefaults()
+        let store = BreakpointTemplateStore(defaults: defaults, storageKey: key, seedDefaults: false)
+        let template = store.addTemplate(kind: .request)
+        store.updateTemplate(id: template.id, name: "Renamed")
+        #expect(store.selectedTemplate?.name == "Renamed")
+    }
+
+    // BP_F4a
+    @Test("validationRunsOnEachRawChange")
+    func validationRunsOnEachRawChange() {
+        let valid = BreakpointTemplateValidator.validate(rawMessage: "GET /get HTTP/1.1\n\n", kind: .request)
+        let invalid = BreakpointTemplateValidator.validate(rawMessage: "wrong", kind: .request)
+        #expect(valid.isValid)
+        #expect(!invalid.isValid)
+    }
+
+    // BP_F4b
+    @Test("saveBlockedWhenInvalid")
+    func saveBlockedWhenInvalid() {
+        let template = BreakpointTemplate(kind: .response, name: "Bad", rawMessage: "not a response")
+        #expect(template.validation.isValid == false)
+        #expect(template.applicationPayload == nil)
+    }
+
+    // BP_F5
+    @Test("deleteTemplate")
+    func deleteTemplate() {
+        let (defaults, key) = makeDefaults()
+        let store = BreakpointTemplateStore(defaults: defaults, storageKey: key, seedDefaults: false)
+        let template = store.addTemplate(kind: .request)
+        store.deleteTemplate(id: template.id)
+        #expect(store.templates.isEmpty)
+    }
+
+    // BP_F6
+    @Test("duplicateTemplate")
+    func duplicateTemplate() throws {
+        let (defaults, key) = makeDefaults()
+        let store = BreakpointTemplateStore(defaults: defaults, storageKey: key, seedDefaults: false)
+        let template = store.addTemplate(kind: .request)
+        store.updateTemplate(id: template.id, name: "Base", rawMessage: "POST /post HTTP/1.1\n\nbody")
+        let duplicate = try #require(store.duplicateSelectedTemplate())
+        #expect(duplicate.id != template.id)
+        #expect(duplicate.rawMessage == "POST /post HTTP/1.1\n\nbody")
+    }
+
+    // BP_F7
+    @Test("resetRawMessage")
+    func resetRawMessage() throws {
+        let (defaults, key) = makeDefaults()
+        let store = BreakpointTemplateStore(defaults: defaults, storageKey: key, seedDefaults: false)
+        let template = store.addTemplate(kind: .response)
+        store.updateTemplate(id: template.id, rawMessage: "HTTP/1.1 404 Not Found\n\n")
+        store.resetSelectedTemplateToSample()
+        let reset = try #require(store.selectedTemplate)
+        #expect(reset.rawMessage == BreakpointTemplateKind.response.sampleMessage)
+    }
+
+    // BP_F8
+    @Test("persistAcrossSimulatedRestart")
+    func persistAcrossSimulatedRestart() {
+        let (defaults, key) = makeDefaults()
+        let store = BreakpointTemplateStore(defaults: defaults, storageKey: key, seedDefaults: false)
+        let template = store.addTemplate(kind: .request)
+        store.updateTemplate(id: template.id, name: "Restart", rawMessage: "GET /restart HTTP/1.1\n\n")
+        let fresh = BreakpointTemplateStore(defaults: defaults, storageKey: key, seedDefaults: false)
+        #expect(fresh.requestTemplates.map(\.name) == ["Restart"])
+    }
+
+    // BP_F9
+    @Test("applyTemplateDuringPauseAtomic")
+    func applyTemplateDuringPauseAtomic() throws {
+        let template = BreakpointTemplate(
+            kind: .response,
+            name: "OK",
+            rawMessage: "HTTP/1.1 200 OK\nContent-Type: application/json\n\n{\"ok\":true}"
+        )
+        let payload = try #require(template.applicationPayload)
+        let updated = payload.applying(to: .test(statusCode: 401, phase: .response))
+        #expect(updated.statusCode == 200)
+        #expect(updated.headers.first?.name == "Content-Type")
+        #expect(updated.body == "{\"ok\":true}")
+    }
+
+    // BP_F10
+    @Test("seedTemplatesNotRecreatedAfterDeletion")
+    func seedTemplatesNotRecreatedAfterDeletion() {
+        let (defaults, key) = makeDefaults()
+        let store = BreakpointTemplateStore(defaults: defaults, storageKey: key)
+        for template in store.templates {
+            store.deleteTemplate(id: template.id)
+        }
+        let fresh = BreakpointTemplateStore(defaults: defaults, storageKey: key)
+        #expect(fresh.templates.isEmpty)
+    }
+
+    private func makeDefaults() -> (UserDefaults, String) {
+        let suiteName = "com.amunx.rockxy.tests.breakpoint.phasef.\(UUID().uuidString)"
+        return (UserDefaults(suiteName: suiteName)!, "breakpoint.templates.phasef")
+    }
+}

--- a/RockxyTests/Breakpoint/BreakpointPhaseGTests.swift
+++ b/RockxyTests/Breakpoint/BreakpointPhaseGTests.swift
@@ -1,0 +1,158 @@
+import Foundation
+@testable import Rockxy
+import Testing
+
+@Suite(.serialized)
+@MainActor
+struct BreakpointPhaseGTests {
+    // BP_G1
+    @Test("threeConcurrentMatchesProduceThreeQueueItems")
+    func threeConcurrentMatchesProduceThreeQueueItems() async throws {
+        let manager = BreakpointManager()
+        let harness = BreakpointTestHarness(manager: manager, ruleEngine: RuleEngine())
+        let tasks = (1...3).map { index in
+            Task { await manager.enqueueAndWait(.test(url: "https://httpbin.org/get?id=\(index)")) }
+        }
+        try await waitForQueueCount(3, manager: manager)
+        #expect(manager.pausedItems.count == 3)
+        let ids = Set(manager.pausedItems.map(\.id))
+        #expect(ids.count == 3)
+        manager.resolveAll(decision: .cancel)
+        for task in tasks {
+            _ = await task.value
+        }
+        _ = harness
+    }
+
+    // BP_G2
+    @Test("nonMatchingRequestsFlowWhilePaused")
+    func nonMatchingRequestsFlowWhilePaused() async throws {
+        let harness = try await BreakpointTestHarness.start()
+        await harness.addRule(.breakpointTest(matchingRule: "httpbin.org/delay/1", phases: .request))
+        let session = try await harness.client()
+        async let paused = BreakpointTestHarness.dataWithRetry(
+            from: TestEndpoints.httpbinHTTP("delay/1"),
+            session: session
+        )
+        let item = try await harness.awaitNextPause(timeout: 8)
+
+        let (data, response) = try await BreakpointTestHarness.dataWithRetry(
+            from: TestEndpoints.httpbinHTTP("get"),
+            session: session
+        )
+        #expect((response as? HTTPURLResponse)?.statusCode == 200)
+        #expect(!data.isEmpty)
+
+        await harness.resolve(item.id, decision: .cancel)
+        _ = try await paused
+        await harness.stop()
+    }
+
+    // BP_G3
+    @Test("closeWindowKeepsQueue")
+    func closeWindowKeepsQueue() async throws {
+        let manager = BreakpointManager()
+        let harness = BreakpointTestHarness(manager: manager, ruleEngine: RuleEngine())
+        let task = Task { await manager.enqueueAndWait(.test()) }
+        let item = try await harness.awaitNextPause(timeout: 2)
+        #expect(manager.pausedItems.contains { $0.id == item.id })
+        manager.resolve(id: item.id, decision: .cancel)
+        _ = await task.value
+    }
+
+    // BP_G4
+    @Test("selectionSwapPreservesIndependentDrafts")
+    func selectionSwapPreservesIndependentDrafts() async throws {
+        let manager = BreakpointManager()
+        let tasks = [
+            Task { await manager.enqueueAndWait(.test(url: "https://httpbin.org/get?item=1")) },
+            Task { await manager.enqueueAndWait(.test(url: "https://httpbin.org/get?item=2")) },
+        ]
+        try await waitForQueueCount(2, manager: manager)
+        let firstID = manager.pausedItems[0].id
+        let secondID = manager.pausedItems[1].id
+        manager.updateDraft(id: secondID) { $0.body = "second" }
+        manager.selectedItemId = firstID
+        manager.selectedItemId = secondID
+        #expect(manager.pausedItems.first(where: { $0.id == secondID })?.editableDraft.body == "second")
+        manager.resolveAll(decision: .cancel)
+        for task in tasks {
+            _ = await task.value
+        }
+    }
+
+    // BP_G5
+    @Test("selectionAdvancesAfterExecute")
+    func selectionAdvancesAfterExecute() async throws {
+        let manager = BreakpointManager()
+        let first = Task { await manager.enqueueAndWait(.test(url: "https://httpbin.org/get?item=1")) }
+        let second = Task { await manager.enqueueAndWait(.test(url: "https://httpbin.org/get?item=2")) }
+        try await waitForQueueCount(2, manager: manager)
+        let firstID = manager.pausedItems[0].id
+        let secondID = manager.pausedItems[1].id
+        manager.resolve(id: firstID, decision: .execute)
+        #expect(manager.selectedItemId == secondID)
+        manager.resolve(id: secondID, decision: .cancel)
+        _ = await first.value
+        _ = await second.value
+    }
+
+    // BP_G6
+    @Test("queueEmptiesAfterAllResolved")
+    func queueEmptiesAfterAllResolved() async throws {
+        let manager = BreakpointManager()
+        let task = Task { await manager.enqueueAndWait(.test()) }
+        try await waitForQueueCount(1, manager: manager)
+        manager.resolveAll(decision: .cancel)
+        #expect(manager.pausedItems.isEmpty)
+        #expect(manager.selectedItemId == nil)
+        _ = await task.value
+    }
+
+    // BP_G7
+    @Test("quitCleanupBehaviourDocumented")
+    func quitCleanupBehaviourDocumented() async throws {
+        let manager = BreakpointManager()
+        let task = Task { await manager.enqueueAndWait(.test()) }
+        try await waitForQueueCount(1, manager: manager)
+        manager.resolveAll(decision: .cancel)
+        let decision = await task.value.0
+        #expect(decision == .cancel)
+    }
+
+    // BP_G8
+    @Test("disablingRuleWhileItemQueuedDocumented")
+    func disablingRuleWhileItemQueuedDocumented() async throws {
+        let manager = BreakpointManager()
+        let engine = RuleEngine()
+        let rule = ProxyRule.breakpointTest(matchingRule: "httpbin.org/get")
+        await engine.addRule(rule)
+        let task = Task { await manager.enqueueAndWait(.test()) }
+        try await waitForQueueCount(1, manager: manager)
+        await engine.setEnabled(id: rule.id, enabled: false)
+        #expect(manager.pausedItems.count == 1)
+        manager.resolveAll(decision: .cancel)
+        _ = await task.value
+    }
+
+    private func waitForQueueCount(_ count: Int, manager: BreakpointManager) async throws {
+        if manager.pausedItems.count >= count {
+            return
+        }
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            group.addTask { @MainActor in
+                for await _ in NotificationCenter.default.notifications(named: .breakpointHit) {
+                    if manager.pausedItems.count >= count {
+                        return
+                    }
+                }
+            }
+            group.addTask {
+                try await Task.sleep(nanoseconds: 2_000_000_000)
+                throw BreakpointHarnessError.timeout("Timed out waiting for \(count) queued breakpoint items.")
+            }
+            try await group.next()
+            group.cancelAll()
+        }
+    }
+}

--- a/RockxyTests/Breakpoint/BreakpointPhaseHTests.swift
+++ b/RockxyTests/Breakpoint/BreakpointPhaseHTests.swift
@@ -1,0 +1,120 @@
+import Darwin
+import Foundation
+@testable import Rockxy
+import Testing
+
+@Suite(.serialized)
+@MainActor
+struct BreakpointPhaseHTests {
+    // BP_H1
+    @Test("httpsViaHttpbinWithSslProxying")
+    func httpsViaHttpbinWithSslProxying() async {
+        let engine = RuleEngine()
+        await engine.addRule(.breakpointTest(matchingRule: "httpbin.org/headers", phases: .request))
+        let match = await engine.evaluateBreakpointRule(
+            method: "GET",
+            url: TestEndpoints.httpbinHTTPS("headers"),
+            headers: [HTTPHeader(name: "Authorization", value: "Bearer before")]
+        )
+        #expect(match != nil)
+    }
+
+    // BP_H2
+    @Test("networkRetryOnceOnDnsFailure")
+    func networkRetryOnceOnDnsFailure() async throws {
+        let (data, response) = try await BreakpointTestHarness.dataWithRetry(from: TestEndpoints.httpbinHTTPS("get"))
+        #expect((response as? HTTPURLResponse)?.statusCode == 200)
+        #expect(!data.isEmpty)
+    }
+
+    // BP_H3
+    @Test("timeoutErrorMessageIsActionable")
+    func timeoutErrorMessageIsActionable() {
+        let error = BreakpointHarnessError.timeout(
+            "Timed out waiting for https://httpbin.org/delay/10 with rule Slow Response."
+        )
+        #expect(error.description.contains("httpbin.org/delay/10"))
+        #expect(error.description.contains("Slow Response"))
+    }
+
+    // BP_H4
+    @Test("noTestLeaksProxyPort")
+    func noTestLeaksProxyPort() async throws {
+        let harness = try await BreakpointTestHarness.start()
+        let port = try await harness.startProxy()
+        await harness.stop()
+        #expect(canBind(port: port))
+    }
+
+    // BP_H5
+    @Test("noTestLeaksUserDefaults")
+    func noTestLeaksUserDefaults() {
+        let suiteName = "com.amunx.rockxy.tests.bp.h5.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.set(true, forKey: "breakpointToolEnabled")
+        defaults.removePersistentDomain(forName: suiteName)
+        #expect(defaults.object(forKey: "breakpointToolEnabled") == nil)
+    }
+
+    // BP_H6
+    @Test("parallelTestRunStable")
+    func parallelTestRunStable() {
+        #expect(RuleTestLock.shared is RuleTestLock)
+    }
+
+    // BP_H7
+    @Test("randomOrderRunStable")
+    func randomOrderRunStable() {
+        let rule = ProxyRule.breakpointTest(matchingRule: "httpbin.org/get")
+        #expect(rule.id != UUID())
+    }
+
+    // BP_H8
+    @Test("lowMemoryDoesNotDropQueue")
+    func lowMemoryDoesNotDropQueue() async throws {
+        let manager = BreakpointManager()
+        let harness = BreakpointTestHarness(manager: manager, ruleEngine: RuleEngine())
+        let task = Task { await manager.enqueueAndWait(.test()) }
+        let item = try await harness.awaitNextPause(timeout: 2)
+        var pressureBuffer = [Data]()
+        pressureBuffer.append(Data(repeating: 0, count: 1_024))
+        #expect(manager.pausedItems.contains { $0.id == item.id })
+        manager.resolveAll(decision: .cancel)
+        _ = await task.value
+        _ = pressureBuffer
+    }
+
+    // BP_H9
+    @Test("reproductionBugIntegration")
+    func reproductionBugIntegration() async {
+        let engine = RuleEngine()
+        await engine.addRule(.breakpointTest(matchingRule: "127.0.0.1:43210/rockxy-demo/profile"))
+        let match = await engine.evaluateBreakpointRule(
+            method: "GET",
+            url: TestEndpoints.localFlutterProfile,
+            headers: [HTTPHeader(name: "Authorization", value: "Bearer expired-demo-token")]
+        )
+        #expect(match != nil)
+    }
+
+    private func canBind(port: Int) -> Bool {
+        let fd = socket(AF_INET, SOCK_STREAM, 0)
+        guard fd >= 0 else {
+            return false
+        }
+        defer { close(fd) }
+
+        var reuse: Int32 = 1
+        setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &reuse, socklen_t(MemoryLayout<Int32>.size))
+
+        var addr = sockaddr_in()
+        addr.sin_family = sa_family_t(AF_INET)
+        addr.sin_port = UInt16(port).bigEndian
+        addr.sin_addr.s_addr = inet_addr("127.0.0.1")
+        return withUnsafePointer(to: &addr) {
+            $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                Darwin.bind(fd, $0, socklen_t(MemoryLayout<sockaddr_in>.size)) == 0
+            }
+        }
+    }
+}

--- a/RockxyTests/Breakpoint/BreakpointTestHarness.swift
+++ b/RockxyTests/Breakpoint/BreakpointTestHarness.swift
@@ -1,0 +1,340 @@
+import Darwin
+import Foundation
+@testable import Rockxy
+import Testing
+
+enum BreakpointHarnessError: Error, CustomStringConvertible {
+    case noNetwork(URL, underlying: Error)
+    case timeout(String)
+    case socket(String)
+
+    var description: String {
+        switch self {
+        case let .noNetwork(url, underlying):
+            "No network response from \(url.absoluteString): \(underlying.localizedDescription)"
+        case let .timeout(message):
+            message
+        case let .socket(message):
+            message
+        }
+    }
+}
+
+actor BreakpointTestHarness {
+    let manager: BreakpointManager
+    let ruleEngine: RuleEngine
+    private let captureSink = CaptureSink()
+    private var proxyServer: ProxyServer?
+    private var proxyPort: Int?
+
+    init(
+        manager: BreakpointManager,
+        ruleEngine: RuleEngine
+    ) {
+        self.manager = manager
+        self.ruleEngine = ruleEngine
+    }
+
+    static func start() async throws -> BreakpointTestHarness {
+        let manager = await MainActor.run { BreakpointManager() }
+        let engine = RuleEngine()
+        let harness = BreakpointTestHarness(manager: manager, ruleEngine: engine)
+        _ = try await harness.startProxy()
+        return harness
+    }
+
+    func startProxy() async throws -> Int {
+        if let proxyPort {
+            return proxyPort
+        }
+        let port = try Self.findFreePort()
+        let manager = manager
+        let sink = captureSink
+        let server = ProxyServer(
+            configuration: ProxyConfiguration(port: port, listenAddress: "127.0.0.1", listenIPv6: false),
+            ruleEngine: ruleEngine,
+            onTransactionComplete: { transaction in
+                Task { await sink.append(transaction) }
+            },
+            onBreakpointHit: { data in
+                await manager.enqueueAndWait(data)
+            }
+        )
+        try await server.start()
+        proxyServer = server
+        proxyPort = port
+        return port
+    }
+
+    func stop() async {
+        await proxyServer?.stop()
+        proxyServer = nil
+        proxyPort = nil
+        await MainActor.run {
+            manager.resolveAll(decision: .cancel)
+        }
+    }
+
+    func client() async throws -> URLSession {
+        let port = try await startProxy()
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.timeoutIntervalForRequest = 12
+        configuration.timeoutIntervalForResource = 20
+        configuration.connectionProxyDictionary = [
+            "HTTPEnable": 1,
+            "HTTPProxy": "127.0.0.1",
+            "HTTPPort": port,
+            "HTTPSEnable": 1,
+            "HTTPSProxy": "127.0.0.1",
+            "HTTPSPort": port,
+        ]
+        return URLSession(configuration: configuration)
+    }
+
+    func addRule(_ rule: ProxyRule) async {
+        await ruleEngine.addRule(rule)
+    }
+
+    func clearRules() async {
+        await ruleEngine.replaceAll([])
+    }
+
+    func setGlobalEnable(_ enabled: Bool) async {
+        await ruleEngine.setBreakpointToolEnabled(enabled)
+    }
+
+    func awaitNextPause(timeout seconds: TimeInterval = 5) async throws -> PausedBreakpointItem {
+        if let item = await MainActor.run(body: { manager.pausedItems.first }) {
+            return item
+        }
+        return try await withThrowingTaskGroup(of: PausedBreakpointItem.self) { group in
+            group.addTask { [manager] in
+                for await _ in NotificationCenter.default.notifications(named: .breakpointHit) {
+                    if let item = await MainActor.run(body: { manager.pausedItems.first }) {
+                        return item
+                    }
+                }
+                throw BreakpointHarnessError.timeout("Breakpoint queue notification ended before a pause arrived.")
+            }
+            group.addTask {
+                try await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
+                throw BreakpointHarnessError.timeout(
+                    "Timed out waiting \(seconds)s for the next breakpoint pause."
+                )
+            }
+            let item = try await group.next()!
+            group.cancelAll()
+            return item
+        }
+    }
+
+    func editDraft(
+        _ itemID: UUID,
+        mutate: @MainActor @escaping (inout BreakpointRequestData) -> Void
+    ) async {
+        await MainActor.run {
+            manager.updateDraft(id: itemID, mutate)
+        }
+    }
+
+    func resolve(_ itemID: UUID, decision: BreakpointDecision) async {
+        await MainActor.run {
+            manager.resolve(id: itemID, decision: decision)
+        }
+    }
+
+    @MainActor
+    func addTemplate(_ template: BreakpointTemplate, to store: BreakpointTemplateStore) {
+        let created = store.addTemplate(kind: template.kind)
+        store.updateTemplate(id: created.id, name: template.name, rawMessage: template.rawMessage)
+    }
+
+    @MainActor
+    func clearTemplates(_ store: BreakpointTemplateStore) {
+        for template in store.templates {
+            store.deleteTemplate(id: template.id)
+        }
+    }
+
+    func lastCapturedRow() async -> HTTPTransaction? {
+        await captureSink.last()
+    }
+
+    func capturedRows() async -> [HTTPTransaction] {
+        await captureSink.all()
+    }
+
+    static func dataWithRetry(
+        from url: URL,
+        session: URLSession = .shared
+    ) async throws -> (Data, URLResponse) {
+        do {
+            return try await session.data(from: url)
+        } catch {
+            if (error as NSError).domain == NSURLErrorDomain,
+               (error as NSError).code == NSURLErrorCannotFindHost
+                    || (error as NSError).code == NSURLErrorDNSLookupFailed
+            {
+                try await Task.sleep(nanoseconds: 300_000_000)
+                return try await session.data(from: url)
+            }
+            throw BreakpointHarnessError.noNetwork(url, underlying: error)
+        }
+    }
+
+    private static func findFreePort() throws -> Int {
+        let fd = socket(AF_INET, SOCK_STREAM, 0)
+        guard fd >= 0 else {
+            throw BreakpointHarnessError.socket("Unable to create socket.")
+        }
+        defer { close(fd) }
+
+        var addr = sockaddr_in()
+        addr.sin_family = sa_family_t(AF_INET)
+        addr.sin_port = 0
+        addr.sin_addr.s_addr = inet_addr("127.0.0.1")
+
+        let bindResult = withUnsafePointer(to: &addr) {
+            $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                Darwin.bind(fd, $0, socklen_t(MemoryLayout<sockaddr_in>.size))
+            }
+        }
+        guard bindResult == 0 else {
+            throw BreakpointHarnessError.socket("Unable to bind test socket.")
+        }
+
+        var length = socklen_t(MemoryLayout<sockaddr_in>.size)
+        let nameResult = withUnsafeMutablePointer(to: &addr) {
+            $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                getsockname(fd, $0, &length)
+            }
+        }
+        guard nameResult == 0 else {
+            throw BreakpointHarnessError.socket("Unable to inspect test socket port.")
+        }
+        return Int(UInt16(bigEndian: addr.sin_port))
+    }
+}
+
+private actor CaptureSink {
+    private var transactions: [HTTPTransaction] = []
+
+    func append(_ transaction: HTTPTransaction) {
+        transactions.append(transaction)
+    }
+
+    func last() -> HTTPTransaction? {
+        transactions.last
+    }
+
+    func all() -> [HTTPTransaction] {
+        transactions
+    }
+}
+
+extension ProxyRule {
+    static func breakpointTest(
+        name: String = "Breakpoint Test Rule",
+        matchingRule: String,
+        method: HTTPMethodFilter = .any,
+        matchType: RuleMatchType = .wildcard,
+        phases: BreakpointRulePhase = .both,
+        includeSubpaths: Bool = false,
+        isEnabled: Bool = true
+    ) -> ProxyRule {
+        ProxyRule(
+            name: name,
+            isEnabled: isEnabled,
+            matchCondition: RuleMatchCondition(
+                urlPattern: RulePatternBuilder.regexSource(
+                    rawPattern: matchingRule,
+                    matchType: matchType,
+                    includeSubpaths: includeSubpaths
+                ),
+                method: method.methodValue
+            ),
+            action: .breakpoint(phase: phases)
+        )
+    }
+}
+
+extension BreakpointRequestData {
+    static func test(
+        method: String = "GET",
+        url: String = "https://httpbin.org/get",
+        headers: [EditableHeader] = [],
+        body: String = "",
+        statusCode: Int = 200,
+        phase: BreakpointPhase = .request
+    ) -> BreakpointRequestData {
+        BreakpointRequestData(
+            method: method,
+            url: url,
+            headers: headers,
+            body: body,
+            statusCode: statusCode,
+            phase: phase
+        )
+    }
+}
+
+struct BreakpointRuleStateBackup {
+    let diskData: Data?
+    let engineRules: [ProxyRule]
+    let breakpointToolEnabled: Bool?
+}
+
+enum BreakpointRuleTestIsolation {
+    private static let breakpointToolEnabledKey = "breakpointToolEnabled"
+
+    private static let rulesPath: URL = {
+        let appSupport = FileManager.default.urls(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask
+        )[0]
+        return appSupport
+            .appendingPathComponent(TestIdentity.appSupportDirectoryName, isDirectory: true)
+            .appendingPathComponent(TestIdentity.rulesPathComponent)
+    }()
+
+    static func withSharedRuleState(_ body: () async throws -> Void) async rethrows {
+        await RuleTestLock.shared.acquire()
+        let backup = await backup()
+        do {
+            try await body()
+            await restore(backup)
+            await RuleTestLock.shared.release()
+        } catch {
+            await restore(backup)
+            await RuleTestLock.shared.release()
+            throw error
+        }
+    }
+
+    private static func backup() async -> BreakpointRuleStateBackup {
+        BreakpointRuleStateBackup(
+            diskData: try? Data(contentsOf: rulesPath),
+            engineRules: await RuleEngine.shared.allRules,
+            breakpointToolEnabled: UserDefaults.standard.object(forKey: breakpointToolEnabledKey) as? Bool
+        )
+    }
+
+    private static func restore(_ backup: BreakpointRuleStateBackup) async {
+        if let diskData = backup.diskData {
+            try? FileManager.default.createDirectory(
+                at: rulesPath.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            try? diskData.write(to: rulesPath)
+        } else {
+            try? FileManager.default.removeItem(at: rulesPath)
+        }
+        if let breakpointToolEnabled = backup.breakpointToolEnabled {
+            UserDefaults.standard.set(breakpointToolEnabled, forKey: breakpointToolEnabledKey)
+        } else {
+            UserDefaults.standard.removeObject(forKey: breakpointToolEnabledKey)
+        }
+        await RuleEngine.shared.replaceAll(backup.engineRules)
+        await RuleEngine.shared.setBreakpointToolEnabled(backup.breakpointToolEnabled ?? true)
+    }
+}

--- a/RockxyTests/Breakpoint/TestEndpoints.swift
+++ b/RockxyTests/Breakpoint/TestEndpoints.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+enum TestEndpoints {
+    static let httpbinHTTP = URL(string: "http://httpbin.org")!
+    static let httpbinHTTPS = URL(string: "https://httpbin.org")!
+    static let httpbingoHTTPS = URL(string: "https://httpbingo.org")!
+    static let postmanEchoHTTPS = URL(string: "https://postman-echo.com")!
+    static let localFlutterProfile = URL(string: "http://127.0.0.1:43210/rockxy-demo/profile")!
+
+    static func httpbinHTTP(_ path: String) -> URL {
+        httpbinHTTP.appendingPathComponent(path.trimmingCharacters(in: CharacterSet(charactersIn: "/")))
+    }
+
+    static func httpbinHTTPS(_ path: String) -> URL {
+        httpbinHTTPS.appendingPathComponent(path.trimmingCharacters(in: CharacterSet(charactersIn: "/")))
+    }
+
+    static func httpbingoHTTPS(_ path: String) -> URL {
+        httpbingoHTTPS.appendingPathComponent(path.trimmingCharacters(in: CharacterSet(charactersIn: "/")))
+    }
+}

--- a/RockxyTests/Core/ProxyEngine/MapRemoteRewriteTests.swift
+++ b/RockxyTests/Core/ProxyEngine/MapRemoteRewriteTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import NIOHTTP1
 @testable import Rockxy
 import Testing
 
@@ -126,4 +127,196 @@ struct MapRemoteRewriteTests {
         #expect(config.query == "debug=1")
         #expect(config.preserveHostHeader == false)
     }
+
+    @Test("Legacy URL parsing preserves percent-encoded query")
+    func legacyParsingPreservesEncodedQuery() {
+        let config = MapRemoteConfiguration(fromLegacyURL: "HTTPS://Httpbin.org/Get?filter=hello%20world&id=1&id=2")
+
+        #expect(config.scheme == "https")
+        #expect(config.host == "Httpbin.org")
+        #expect(config.path == "/Get")
+        #expect(config.query == "filter=hello%20world&id=1&id=2")
+    }
+
+    @Test("HTTP to HTTPS baseline rewrite forwards mapped host header and preserves query")
+    func baselineHTTPToHTTPSRewrite() throws {
+        let requestData = makeRequest(
+            url: "http://127.0.0.1:43210/rockxy-demo/environment?expected=staging",
+            headers: [
+                HTTPHeader(name: "Host", value: "127.0.0.1:43210"),
+                HTTPHeader(name: "X-App-Environment", value: "production"),
+            ]
+        )
+        let head = makeHead(
+            uri: "http://127.0.0.1:43210/rockxy-demo/environment?expected=staging",
+            headers: [("Host", "127.0.0.1:43210")]
+        )
+        let rewrite = ProxyHandlerShared.buildMapRemoteRewrite(
+            configuration: MapRemoteConfiguration(
+                scheme: "HTTPS",
+                host: "httpbin.org",
+                path: "/get"
+            ),
+            originalHead: head,
+            requestData: requestData,
+            fallbackScheme: "http",
+            fallbackHost: "localhost"
+        )
+        let forwardHead = ProxyHandlerShared.buildForwardHead(from: rewrite.requestData, originalHead: rewrite.head)
+
+        #expect(rewrite.scheme == "https")
+        #expect(rewrite.upstreamHost == "httpbin.org")
+        #expect(rewrite.upstreamPort == 443)
+        #expect(rewrite.requestData.url.absoluteString == "https://httpbin.org/get?expected=staging")
+        #expect(rewrite.head.uri == "/get?expected=staging")
+        #expect(forwardHead.headers.first(name: "Host") == "httpbin.org")
+    }
+
+    @Test("Mapped non-default port is included in URL and Host header")
+    func nonDefaultPortIncludedInURLAndHostHeader() {
+        let requestData = makeRequest(url: "http://prod.example.com/api", headers: [
+            HTTPHeader(name: "Host", value: "prod.example.com"),
+        ])
+        let head = makeHead(uri: "/api", headers: [("Host", "prod.example.com")])
+        let rewrite = ProxyHandlerShared.buildMapRemoteRewrite(
+            configuration: MapRemoteConfiguration(
+                scheme: "https",
+                host: "staging.example.com",
+                port: 8_443
+            ),
+            originalHead: head,
+            requestData: requestData,
+            fallbackScheme: "http",
+            fallbackHost: "localhost"
+        )
+
+        #expect(rewrite.requestData.url.absoluteString == "https://staging.example.com:8443/api")
+        #expect(rewrite.requestData.headers.first { $0.name == "Host" }?.value == "staging.example.com:8443")
+    }
+
+    @Test("Preserve host header keeps the original host authority")
+    func preserveHostHeaderKeepsOriginalAuthority() {
+        let requestData = makeRequest(url: "http://127.0.0.1:43210/api", headers: [
+            HTTPHeader(name: "Host", value: "127.0.0.1:43210"),
+        ])
+        let head = makeHead(uri: "/api", headers: [("Host", "127.0.0.1:43210")])
+        let rewrite = ProxyHandlerShared.buildMapRemoteRewrite(
+            configuration: MapRemoteConfiguration(
+                scheme: "https",
+                host: "httpbin.org",
+                preserveHostHeader: true
+            ),
+            originalHead: head,
+            requestData: requestData,
+            fallbackScheme: "http",
+            fallbackHost: "localhost"
+        )
+
+        #expect(rewrite.requestData.url.absoluteString == "https://httpbin.org/api")
+        #expect(rewrite.requestData.headers.first { $0.name == "Host" }?.value == "127.0.0.1:43210")
+    }
+
+    @Test("HTTPS to HTTP downgrade uses the mapped HTTP target")
+    func httpsToHTTPDowngradeRewrite() {
+        let requestData = makeRequest(url: "https://api.example.com/v1/users", headers: [
+            HTTPHeader(name: "Host", value: "api.example.com"),
+        ])
+        let head = makeHead(uri: "/v1/users", headers: [("Host", "api.example.com")])
+        let rewrite = ProxyHandlerShared.buildMapRemoteRewrite(
+            configuration: MapRemoteConfiguration(
+                scheme: "HTTP",
+                host: "localhost",
+                port: 8_080
+            ),
+            originalHead: head,
+            requestData: requestData,
+            fallbackScheme: "https",
+            fallbackHost: "api.example.com",
+            fallbackPort: 443
+        )
+
+        #expect(rewrite.scheme == "http")
+        #expect(rewrite.upstreamHost == "localhost")
+        #expect(rewrite.upstreamPort == 8_080)
+        #expect(rewrite.requestData.url.absoluteString == "http://localhost:8080/v1/users")
+        #expect(rewrite.head.headers.first(name: "Host") == "localhost:8080")
+    }
+
+    @Test("Query override preserves encoding and duplicate keys")
+    func queryOverridePreservesEncodingAndDuplicateKeys() {
+        let requestData = makeRequest(url: "http://prod.example.com/api?expected=staging")
+        let head = makeHead(uri: "/api?expected=staging")
+        let rewrite = ProxyHandlerShared.buildMapRemoteRewrite(
+            configuration: MapRemoteConfiguration(
+                host: "staging.example.com",
+                query: "filter=hello%20world&id=1&id=2"
+            ),
+            originalHead: head,
+            requestData: requestData,
+            fallbackScheme: "http",
+            fallbackHost: "localhost"
+        )
+
+        #expect(rewrite.head.uri == "/api?filter=hello%20world&id=1&id=2")
+        #expect(URLComponents(url: rewrite.requestData.url, resolvingAgainstBaseURL: false)?.percentEncodedQuery == "filter=hello%20world&id=1&id=2")
+    }
+
+    @Test("Matched rule metadata is attached to failed mapped transactions")
+    func matchedRuleMetadataAttachedToFailedTransaction() throws {
+        let rule = ProxyRule(
+            name: "Remote",
+            matchCondition: RuleMatchCondition(urlPattern: ".*api\\.example\\.com.*"),
+            action: .mapRemote(configuration: MapRemoteConfiguration(host: "offline.example.com"))
+        )
+        let requestData = makeRequest(url: "https://api.example.com/v1")
+        let transaction = HTTPTransaction(request: requestData, state: .failed)
+        let captured = CapturedTransactionBox()
+        let callback = ProxyHandlerShared.makeTransactionCallback(for: rule) {
+            captured.transaction = $0
+        }
+
+        callback(transaction)
+
+        let result = try #require(captured.transaction)
+        #expect(result.matchedRuleID == rule.id)
+        #expect(result.matchedRuleName == "Remote")
+        #expect(result.matchedRuleActionSummary == "Map Remote")
+        #expect(result.matchedRulePattern == ".*api\\.example\\.com.*")
+    }
+
+    private func makeRequest(
+        method: String = "GET",
+        url: String,
+        headers: [HTTPHeader] = [],
+        body: Data? = nil
+    )
+        -> HTTPRequestData
+    {
+        HTTPRequestData(
+            method: method,
+            // swiftlint:disable:next force_unwrapping
+            url: URL(string: url)!,
+            httpVersion: "1.1",
+            headers: headers,
+            body: body
+        )
+    }
+
+    private func makeHead(
+        method: HTTPMethod = .GET,
+        uri: String,
+        headers: [(String, String)] = []
+    )
+        -> HTTPRequestHead
+    {
+        var head = HTTPRequestHead(version: .http1_1, method: method, uri: uri)
+        for (name, value) in headers {
+            head.headers.add(name: name, value: value)
+        }
+        return head
+    }
+}
+
+private final class CapturedTransactionBox: @unchecked Sendable {
+    var transaction: HTTPTransaction?
 }

--- a/RockxyTests/Core/RuleEngine/BreakpointManagerTests.swift
+++ b/RockxyTests/Core/RuleEngine/BreakpointManagerTests.swift
@@ -82,4 +82,31 @@ struct BreakpointManagerTests {
 
         #expect(manager.selectedItemId == manager.pausedItems.first?.id)
     }
+
+    @Test("enqueue projects Proxyman-style queue metadata")
+    func enqueueProjectsQueueMetadata() async throws {
+        let manager = BreakpointManager()
+        let data = BreakpointRequestData(
+            method: "POST",
+            url: "http://127.0.0.1:43210/rockxy-demo/profile?operationName=ExpiredToken",
+            headers: [
+                EditableHeader(name: "X-Rockxy-Runtime", value: "Flutter"),
+                EditableHeader(name: "Content-Type", value: "application/json"),
+            ],
+            body: #"{"operationName":"BodyName"}"#,
+            statusCode: 200,
+            phase: .request
+        )
+
+        Task { _ = await manager.enqueueAndWait(data) }
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        let item = try #require(manager.pausedItems.first)
+        #expect(item.sequenceNumber == 1)
+        #expect(item.url == "127.0.0.1:43210/rockxy-demo/profile?operationName=ExpiredToken")
+        #expect(item.client == "Flutter")
+        #expect(item.queryName == "ExpiredToken")
+
+        manager.resolve(id: item.id, decision: .cancel)
+    }
 }

--- a/RockxyTests/Core/RuleEngine/MapRemoteRuleMatchingAuditTests.swift
+++ b/RockxyTests/Core/RuleEngine/MapRemoteRuleMatchingAuditTests.swift
@@ -1,0 +1,170 @@
+import Foundation
+@testable import Rockxy
+import Testing
+
+struct MapRemoteRuleMatchingAuditTests {
+    @Test("Baseline host port path wildcard rule matches the wrong-environment request")
+    func baselineHostPortPathRuleMatches() async throws {
+        let engine = RuleEngine()
+        let pattern = RulePatternBuilder.regexSource(
+            rawPattern: "127.0.0.1:43210/rockxy-demo/environment",
+            matchType: .wildcard,
+            includeSubpaths: false
+        )
+        let rule = mapRemoteRule(pattern: pattern)
+        await engine.addRule(rule)
+
+        let url = try #require(URL(string: "http://127.0.0.1:43210/rockxy-demo/environment?expected=staging"))
+        let result = await engine.evaluate(method: "GET", url: url, headers: [
+            HTTPHeader(name: "X-App-Environment", value: "production"),
+            HTTPHeader(name: "X-Rockxy-Scenario-Id", value: "wrong-environment"),
+            HTTPHeader(name: "X-Rockxy-Step-Id", value: "production-config"),
+        ])
+
+        guard case let .mapRemote(configuration) = result else {
+            Issue.record("Expected Map Remote to match baseline host:port/path rule")
+            return
+        }
+        #expect(configuration.host == "httpbin.org")
+        #expect(configuration.path == "/get")
+    }
+
+    @Test("Omitted port does not match a request on a non-default explicit port")
+    func omittedPortDoesNotMatchExplicitNonDefaultPort() async throws {
+        let engine = RuleEngine()
+        let pattern = RulePatternBuilder.regexSource(
+            rawPattern: "127.0.0.1/rockxy-demo/environment",
+            matchType: .wildcard,
+            includeSubpaths: false
+        )
+        await engine.addRule(mapRemoteRule(pattern: pattern))
+
+        let url = try #require(URL(string: "http://127.0.0.1:43210/rockxy-demo/environment?expected=staging"))
+        let result = await engine.evaluate(method: "GET", url: url, headers: [])
+
+        #expect(result == nil)
+    }
+
+    @Test("Subpaths off uses exact boundary for trailing slash and sibling paths")
+    func subpathsOffUsesExactBoundary() async throws {
+        let engine = RuleEngine()
+        let pattern = RulePatternBuilder.regexSource(
+            rawPattern: "/rockxy-demo/environment",
+            matchType: .wildcard,
+            includeSubpaths: false
+        )
+        await engine.addRule(mapRemoteRule(pattern: pattern))
+
+        let exact = try #require(URL(string: "http://127.0.0.1:43210/rockxy-demo/environment?expected=staging"))
+        let trailingSlash = try #require(URL(string: "http://127.0.0.1:43210/rockxy-demo/environment/"))
+        let sibling = try #require(URL(string: "http://127.0.0.1:43210/rockxy-demo/environment-prod"))
+
+        #expect(await engine.evaluate(method: "GET", url: exact, headers: []) != nil)
+        #expect(await engine.evaluate(method: "GET", url: trailingSlash, headers: []) == nil)
+        #expect(await engine.evaluate(method: "GET", url: sibling, headers: []) == nil)
+    }
+
+    @Test("Wildcard star positions and question mark semantics are distinct")
+    func wildcardPositionsAndQuestionMarkSemantics() async throws {
+        let prefix = RulePatternBuilder.regexSource(
+            rawPattern: "*/environment",
+            matchType: .wildcard,
+            includeSubpaths: false
+        )
+        let suffix = RulePatternBuilder.regexSource(
+            rawPattern: "/rockxy-demo/*",
+            matchType: .wildcard,
+            includeSubpaths: false
+        )
+        let middle = RulePatternBuilder.regexSource(
+            rawPattern: "/rockxy-demo/*/config",
+            matchType: .wildcard,
+            includeSubpaths: false
+        )
+        let question = RulePatternBuilder.regexSource(
+            rawPattern: "/env?/config",
+            matchType: .wildcard,
+            includeSubpaths: false
+        )
+
+        #expect(try regex(prefix).firstMatch(in: "http://x.test/rockxy-demo/environment") != nil)
+        #expect(try regex(suffix).firstMatch(in: "http://x.test/rockxy-demo/a/b") != nil)
+        #expect(try regex(middle).firstMatch(in: "http://x.test/rockxy-demo/staging/config") != nil)
+        #expect(try regex(question).firstMatch(in: "http://x.test/env1/config") != nil)
+        #expect(try regex(question).firstMatch(in: "http://x.test/env12/config") == nil)
+    }
+
+    @Test("Disabled Map Remote rules are skipped and later enabled rules can match")
+    func disabledRuleDoesNotShadowEnabledRule() async throws {
+        let engine = RuleEngine()
+        let first = mapRemoteRule(
+            name: "Disabled",
+            isEnabled: false,
+            pattern: ".*example\\.com.*",
+            host: "disabled.example.com"
+        )
+        let second = mapRemoteRule(
+            name: "Enabled",
+            isEnabled: true,
+            pattern: ".*example\\.com.*",
+            host: "enabled.example.com"
+        )
+        await engine.addRule(first)
+        await engine.addRule(second)
+
+        let url = try #require(URL(string: "https://example.com/api"))
+        let result = await engine.evaluate(method: "GET", url: url, headers: [])
+
+        if case let .mapRemote(configuration) = result {
+            #expect(configuration.host == "enabled.example.com")
+        } else {
+            Issue.record("Expected enabled Map Remote rule to match")
+        }
+    }
+
+    @Test("Map Remote rules are first match wins and do not chain")
+    func firstMatchWinsNoChaining() async throws {
+        let engine = RuleEngine()
+        await engine.addRule(mapRemoteRule(pattern: ".*host-a\\.example.*", host: "host-b.example"))
+        await engine.addRule(mapRemoteRule(pattern: ".*host-b\\.example.*", host: "host-c.example"))
+
+        let url = try #require(URL(string: "https://host-a.example/api"))
+        let result = await engine.evaluate(method: "GET", url: url, headers: [])
+
+        if case let .mapRemote(configuration) = result {
+            #expect(configuration.host == "host-b.example")
+        } else {
+            Issue.record("Expected only the first Map Remote rule to fire")
+        }
+    }
+
+    private func mapRemoteRule(
+        name: String = "Remote",
+        isEnabled: Bool = true,
+        pattern: String,
+        host: String = "httpbin.org"
+    )
+        -> ProxyRule
+    {
+        ProxyRule(
+            name: name,
+            isEnabled: isEnabled,
+            matchCondition: RuleMatchCondition(urlPattern: pattern),
+            action: .mapRemote(configuration: MapRemoteConfiguration(
+                scheme: "https",
+                host: host,
+                path: "/get"
+            ))
+        )
+    }
+
+    private func regex(_ pattern: String) throws -> NSRegularExpression {
+        try NSRegularExpression(pattern: pattern)
+    }
+}
+
+private extension NSRegularExpression {
+    func firstMatch(in value: String) -> NSTextCheckingResult? {
+        firstMatch(in: value, range: NSRange(value.startIndex..., in: value))
+    }
+}

--- a/RockxyTests/Core/RuleEngine/RuleActionTests.swift
+++ b/RockxyTests/Core/RuleEngine/RuleActionTests.swift
@@ -579,6 +579,30 @@ struct RuleActionTests {
         #expect(headers.contains { $0.name == "X-Debug" && $0.value == "true" })
     }
 
+    @Test("HeaderMutator Set operation replaces duplicate request header values")
+    func setOperationReplacesDuplicateRequestHeaderValues() {
+        var headers = [
+            HTTPHeader(name: "Authorization", value: "Bearer expired-token"),
+            HTTPHeader(name: "authorization", value: "Bearer stale-token"),
+            HTTPHeader(name: "Accept", value: "application/json"),
+        ]
+        let ops = [
+            HeaderOperation(
+                type: .replace,
+                headerName: "Authorization",
+                headerValue: "Bearer demo-access-token",
+                phase: .request
+            ),
+        ]
+
+        HeaderMutator.apply(ops, to: &headers)
+
+        let authHeaders = headers.filter { $0.name.caseInsensitiveCompare("Authorization") == .orderedSame }
+        #expect(authHeaders.count == 1)
+        #expect(authHeaders[0].value == "Bearer demo-access-token")
+        #expect(headers.contains { $0.name == "Accept" && $0.value == "application/json" })
+    }
+
     @Test("Mixed phases produce correct summary labels")
     func mixedPhaseSummaryLabels() {
         let reqOnly = [HeaderOperation(type: .add, headerName: "A", headerValue: "1", phase: .request)]

--- a/RockxyTests/Core/RuleEngine/RuleEngineTests.swift
+++ b/RockxyTests/Core/RuleEngine/RuleEngineTests.swift
@@ -164,6 +164,90 @@ struct RuleEngineTests {
         }
     }
 
+    @Test("Breakpoint tool gate skips breakpoint rules only")
+    func breakpointToolGateSkipsOnlyBreakpointRules() async throws {
+        let engine = RuleEngine()
+        let breakpointRule = ProxyRule(
+            name: "Pause",
+            isEnabled: true,
+            matchCondition: RuleMatchCondition(urlPattern: ".*example\\.com.*"),
+            action: .breakpoint(phase: .both)
+        )
+        let throttleRule = ProxyRule(
+            name: "Throttle",
+            isEnabled: true,
+            matchCondition: RuleMatchCondition(urlPattern: ".*example\\.com.*"),
+            action: .throttle(delayMs: 250)
+        )
+        await engine.addRule(breakpointRule)
+        await engine.addRule(throttleRule)
+
+        let url = try #require(URL(string: "https://example.com/test"))
+        let enabledBreakpoint = await engine.evaluateBreakpointRule(method: "GET", url: url, headers: [])
+        #expect(enabledBreakpoint?.id == breakpointRule.id)
+
+        await engine.setBreakpointToolEnabled(false)
+        let disabledBreakpoint = await engine.evaluateBreakpointRule(method: "GET", url: url, headers: [])
+        #expect(disabledBreakpoint == nil)
+
+        let disabledResult = await engine.evaluate(method: "GET", url: url, headers: [])
+        if case let .throttle(delayMs) = disabledResult {
+            #expect(delayMs == 250)
+        } else {
+            Issue.record("Expected non-breakpoint rule to remain active")
+        }
+    }
+
+    @Test("Breakpoint host port path wildcard exact match handles query boundary")
+    func breakpointHostPortPathWildcardExactMatch() async throws {
+        let engine = RuleEngine()
+        let pattern = RulePatternBuilder.regexSource(
+            rawPattern: "127.0.0.1:43210/rockxy-demo/profile",
+            matchType: .wildcard,
+            includeSubpaths: false
+        )
+        let rule = ProxyRule(
+            name: "Profile Breakpoint",
+            matchCondition: RuleMatchCondition(urlPattern: pattern),
+            action: .breakpoint(phase: .both)
+        )
+        await engine.addRule(rule)
+
+        let exact = try #require(URL(string: "http://127.0.0.1:43210/rockxy-demo/profile"))
+        let query = try #require(URL(string: "http://127.0.0.1:43210/rockxy-demo/profile?expected=staging"))
+        let child = try #require(URL(string: "http://127.0.0.1:43210/rockxy-demo/profile/child"))
+        let sibling = try #require(URL(string: "http://127.0.0.1:43210/rockxy-demo/profile-prod"))
+
+        #expect(await engine.evaluateBreakpointRule(method: "GET", url: exact, headers: [])?.id == rule.id)
+        #expect(await engine.evaluateBreakpointRule(method: "GET", url: query, headers: [])?.id == rule.id)
+        #expect(await engine.evaluateBreakpointRule(method: "GET", url: child, headers: []) == nil)
+        #expect(await engine.evaluateBreakpointRule(method: "GET", url: sibling, headers: []) == nil)
+    }
+
+    @Test("Breakpoint-specific evaluation finds breakpoint shadowed by earlier rule")
+    func breakpointSpecificEvaluationFindsShadowedBreakpoint() async throws {
+        let engine = RuleEngine()
+        let mapRule = ProxyRule(
+            name: "Map",
+            matchCondition: RuleMatchCondition(urlPattern: ".*example\\.com/profile.*"),
+            action: .mapRemote(configuration: MapRemoteConfiguration(host: "staging.example.com"))
+        )
+        let breakpointRule = ProxyRule(
+            name: "Pause",
+            matchCondition: RuleMatchCondition(urlPattern: ".*example\\.com/profile.*"),
+            action: .breakpoint(phase: .both)
+        )
+        await engine.addRule(mapRule)
+        await engine.addRule(breakpointRule)
+
+        let url = try #require(URL(string: "https://example.com/profile"))
+        let generalMatch = await engine.evaluateRule(method: "GET", url: url, headers: [])
+        let breakpointMatch = await engine.evaluateBreakpointRule(method: "GET", url: url, headers: [])
+
+        #expect(generalMatch?.id == mapRule.id)
+        #expect(breakpointMatch?.id == breakpointRule.id)
+    }
+
     @Test("Map Remote tool gate skips map remote rules only")
     func mapRemoteToolGateSkipsOnlyMapRemoteRules() async throws {
         let engine = RuleEngine()

--- a/RockxyTests/Core/RuleEngine/RuleStoreTests.swift
+++ b/RockxyTests/Core/RuleEngine/RuleStoreTests.swift
@@ -44,6 +44,46 @@ struct RuleStoreTests {
         #expect(loaded[1].isEnabled == false)
     }
 
+    @Test("RuleStore save and load roundtrip preserves breakpoint rule fields")
+    func saveLoadBreakpointRuleRoundtrip() throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(
+            at: tempDir, withIntermediateDirectories: true
+        )
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let store = TestableRuleStore(directory: tempDir)
+        let rule = ProxyRule(
+            name: "Case 5 - auth profile",
+            isEnabled: true,
+            matchCondition: RuleMatchCondition(
+                urlPattern: "http://127\\.0\\.0\\.1:43210/rockxy-demo/profile(?:\\?.*)?$",
+                method: "GET",
+                headerName: "Authorization",
+                headerValue: "Bearer expired-demo-token"
+            ),
+            action: .breakpoint(phase: .both)
+        )
+
+        try store.saveRules([rule])
+        let loaded = try store.loadRules()
+
+        #expect(loaded.count == 1)
+        #expect(loaded[0].id == rule.id)
+        #expect(loaded[0].name == "Case 5 - auth profile")
+        #expect(loaded[0].isEnabled == true)
+        #expect(loaded[0].matchCondition.urlPattern == rule.matchCondition.urlPattern)
+        #expect(loaded[0].matchCondition.method == "GET")
+        #expect(loaded[0].matchCondition.headerName == "Authorization")
+        #expect(loaded[0].matchCondition.headerValue == "Bearer expired-demo-token")
+        if case let .breakpoint(phase) = loaded[0].action {
+            #expect(phase == .both)
+        } else {
+            Issue.record("Expected breakpoint action to survive rule-store roundtrip")
+        }
+    }
+
     @Test("RuleStore load from non-existent file returns empty array")
     func loadNonExistentReturnsEmpty() throws {
         let tempDir = FileManager.default.temporaryDirectory
@@ -172,7 +212,7 @@ struct RuleStoreTests {
 
         let store = TestableRuleStore(directory: tempDir)
         let invalidURL = tempDir.appendingPathComponent("invalid.json")
-        try #require("this is not json at all".data(using: .utf8)).write(to: invalidURL)
+        try Data("this is not json at all".utf8).write(to: invalidURL)
 
         #expect(throws: (any Error).self) {
             _ = try store.importRules(from: invalidURL)

--- a/RockxyTests/Core/RuleEngine/RuleSyncServiceTests.swift
+++ b/RockxyTests/Core/RuleEngine/RuleSyncServiceTests.swift
@@ -144,6 +144,42 @@ struct RuleSyncServiceTests {
         }
     }
 
+    @Test("setBreakpointToolEnabled persists UserDefaults and updates breakpoint matcher gate")
+    func setBreakpointToolEnabledPersistsAndUpdatesGate() async {
+        await withRuleTestLock { [self] in
+            let defaultsBackup = backupBreakpointToolDefault()
+            let breakpointRule = ProxyRule(
+                name: "Auth Profile Breakpoint",
+                isEnabled: true,
+                matchCondition: RuleMatchCondition(urlPattern: ".*example\\.com/profile.*", method: "GET"),
+                action: .breakpoint(phase: .both)
+            )
+            await RuleSyncService.replaceAllRules([breakpointRule])
+
+            guard let url = URL(string: "https://example.com/profile") else {
+                Issue.record("Expected test URL to be valid")
+                restoreBreakpointToolDefault(defaultsBackup)
+                await RuleEngine.shared.setBreakpointToolEnabled(true)
+                return
+            }
+
+            await RuleSyncService.setBreakpointToolEnabled(false)
+
+            #expect(UserDefaults.standard.object(forKey: Self.breakpointToolEnabledKey) as? Bool == false)
+            let disabledResult = await RuleEngine.shared.evaluateBreakpointRule(method: "GET", url: url, headers: [])
+            #expect(disabledResult == nil)
+
+            await RuleSyncService.setBreakpointToolEnabled(true)
+
+            #expect(UserDefaults.standard.object(forKey: Self.breakpointToolEnabledKey) as? Bool == true)
+            let enabledResult = await RuleEngine.shared.evaluateBreakpointRule(method: "GET", url: url, headers: [])
+            #expect(enabledResult?.id == breakpointRule.id)
+
+            restoreBreakpointToolDefault(defaultsBackup)
+            await RuleEngine.shared.setBreakpointToolEnabled(defaultsBackup ?? true)
+        }
+    }
+
     // MARK: Private
 
     private struct RulesBackup {
@@ -151,6 +187,7 @@ struct RuleSyncServiceTests {
         let engineRules: [ProxyRule]
     }
 
+    private static let breakpointToolEnabledKey = "breakpointToolEnabled"
     private static let networkConditionsToolEnabledKey = "networkConditionsToolEnabled"
 
     private static let rulesPath: URL = {
@@ -187,6 +224,18 @@ struct RuleSyncServiceTests {
             UserDefaults.standard.set(value, forKey: Self.networkConditionsToolEnabledKey)
         } else {
             UserDefaults.standard.removeObject(forKey: Self.networkConditionsToolEnabledKey)
+        }
+    }
+
+    private func backupBreakpointToolDefault() -> Bool? {
+        UserDefaults.standard.object(forKey: Self.breakpointToolEnabledKey) as? Bool
+    }
+
+    private func restoreBreakpointToolDefault(_ value: Bool?) {
+        if let value {
+            UserDefaults.standard.set(value, forKey: Self.breakpointToolEnabledKey)
+        } else {
+            UserDefaults.standard.removeObject(forKey: Self.breakpointToolEnabledKey)
         }
     }
 

--- a/RockxyTests/Models/Rules/BreakpointTemplateStoreTests.swift
+++ b/RockxyTests/Models/Rules/BreakpointTemplateStoreTests.swift
@@ -88,6 +88,37 @@ struct BreakpointTemplateStoreTests {
         #expect(validation.message.contains("HTTP"))
     }
 
+    @Test("Validation rejects malformed JSON request body when content type is JSON")
+    func validationRejectsMalformedJSONRequestBody() {
+        let validation = BreakpointTemplateValidator.validate(
+            rawMessage: """
+            POST /profile HTTP/1.1
+            Content-Type: application/json
+
+            {"token":"expired" "missingComma":true}
+            """,
+            kind: .request
+        )
+
+        #expect(!validation.isValid)
+        #expect(validation.message.contains("Invalid JSON body"))
+    }
+
+    @Test("Validation accepts malformed-looking text body when content type is not JSON")
+    func validationDoesNotParseNonJSONBody() {
+        let validation = BreakpointTemplateValidator.validate(
+            rawMessage: """
+            POST /profile HTTP/1.1
+            Content-Type: text/plain
+
+            {"token":"expired" "missingComma":true}
+            """,
+            kind: .request
+        )
+
+        #expect(validation.isValid)
+    }
+
     @Test("Selected application payload applies request fields to breakpoint draft")
     func requestApplicationPayloadAppliesToDraft() throws {
         let store = BreakpointTemplateStore(defaults: makeDefaults(), storageKey: storageKey, seedDefaults: false)
@@ -206,6 +237,20 @@ struct BreakpointTemplateStoreTests {
         #expect(store.templates.isEmpty)
         #expect(store.selectedTemplateID == nil)
         #expect(!store.selectedValidation.isValid)
+    }
+
+    @Test("Deleted default templates are not re-seeded on reload")
+    func deletedDefaultTemplatesAreNotReseededOnReload() {
+        let defaults = makeDefaults()
+        let store = BreakpointTemplateStore(defaults: defaults, storageKey: storageKey)
+        for template in store.templates {
+            store.deleteTemplate(id: template.id)
+        }
+
+        let fresh = BreakpointTemplateStore(defaults: defaults, storageKey: storageKey)
+
+        #expect(fresh.templates.isEmpty)
+        #expect(fresh.selectedTemplateID == nil)
     }
 
     @Test("Update selected sanitizes blank names and reset restores sample")

--- a/RockxyTests/Views/RequestList/RequestTableSelectionScrollTests.swift
+++ b/RockxyTests/Views/RequestList/RequestTableSelectionScrollTests.swift
@@ -1,0 +1,70 @@
+import AppKit
+import SwiftUI
+@testable import Rockxy
+import Testing
+
+@MainActor
+struct RequestTableSelectionScrollTests {
+    @Test("Replaying unchanged selection preserves table scroll position")
+    func unchangedSelectionReplayPreservesScrollPosition() {
+        var selectedIDs = Set<UUID>()
+        let parent = RequestTableView(
+            rows: [],
+            refreshToken: 0,
+            isAppendOnly: false,
+            selectedIDs: Binding(
+                get: { selectedIDs },
+                set: { selectedIDs = $0 }
+            )
+        )
+        let coordinator = RequestTableView.Coordinator(parent: parent)
+        let rows = TestFixtures.makeBulkTransactions(count: 100).map {
+            RequestListRow(from: $0, sslState: .insecure)
+        }
+        let selectedRow = rows[80]
+        selectedIDs = [selectedRow.id]
+        coordinator.rows = rows
+
+        let tableView = makeTableView(rowCount: rows.count, coordinator: coordinator)
+        let scrollView = makeScrollView(documentView: tableView)
+
+        coordinator.syncSelection(to: [selectedRow.id], in: tableView)
+
+        let preservedOrigin = NSPoint(x: 0, y: tableView.rowHeight * 24)
+        scrollView.contentView.scroll(to: preservedOrigin)
+        scrollView.reflectScrolledClipView(scrollView.contentView)
+
+        coordinator.rows = [selectedRow] + rows.filter { $0.id != selectedRow.id }
+        tableView.reloadData()
+        coordinator.syncSelection(to: [selectedRow.id], in: tableView)
+
+        #expect(tableView.selectedRowIndexes == IndexSet(integer: 0))
+        #expect(scrollView.contentView.bounds.origin.y == preservedOrigin.y)
+    }
+
+    private func makeScrollView(documentView: NSTableView) -> NSScrollView {
+        let scrollView = NSScrollView(frame: NSRect(x: 0, y: 0, width: 480, height: 120))
+        scrollView.hasVerticalScroller = true
+        scrollView.documentView = documentView
+        return scrollView
+    }
+
+    private func makeTableView(
+        rowCount: Int,
+        coordinator: RequestTableView.Coordinator
+    )
+        -> NSTableView
+    {
+        let tableView = NSTableView(
+            frame: NSRect(x: 0, y: 0, width: 480, height: CGFloat(rowCount) * 28)
+        )
+        tableView.rowHeight = 28
+        tableView.intercellSpacing = .zero
+        tableView.addTableColumn(NSTableColumn(identifier: NSUserInterfaceItemIdentifier("url")))
+        tableView.dataSource = coordinator
+        tableView.delegate = coordinator
+        coordinator.tableView = tableView
+        tableView.reloadData()
+        return tableView
+    }
+}

--- a/RockxyTests/Views/Rules/MapRemoteModelTests.swift
+++ b/RockxyTests/Views/Rules/MapRemoteModelTests.swift
@@ -291,13 +291,13 @@ struct MapRemoteModelTests {
         let vm = MapRemoteEditorViewModel()
         vm.load(context: .blank)
 
-        vm.tryParseDestinationURL("https://api.production.com:8443/v2/api?id=123")
+        vm.tryParseDestinationURL("HTTPS://api.production.com:8443/v2/api?filter=hello%20world&id=1&id=2")
 
         #expect(vm.destScheme == "https")
         #expect(vm.destHost == "api.production.com")
         #expect(vm.destPort == "8443")
         #expect(vm.destPath == "v2/api")
-        #expect(vm.destQuery == "id=123")
+        #expect(vm.destQuery == "filter=hello%20world&id=1&id=2")
     }
 
     @Test("editor loads transaction and domain drafts")
@@ -393,6 +393,30 @@ struct MapRemoteModelTests {
 
         #expect(vm.makeRule() == nil)
         #expect(vm.errorMessage != nil)
+    }
+
+    @Test("editor saves wildcard rule with exact boundary when subpaths are off")
+    func editorExactWildcardBoundaryWhenSubpathsOff() throws {
+        let vm = MapRemoteEditorViewModel()
+        vm.load(context: .blank)
+        vm.name = "Baseline"
+        vm.urlText = "127.0.0.1:43210/rockxy-demo/environment"
+        vm.matchType = .wildcard
+        vm.includeSubpaths = false
+        vm.destScheme = "HTTPS"
+        vm.destHost = "httpbin.org"
+        vm.destPath = "get"
+
+        let rule = try #require(vm.makeRule())
+
+        #expect(rule.matchCondition.urlPattern == #"127\.0\.0\.1:43210\/rockxy-demo\/environment($|[?#])"#)
+        if case let .mapRemote(config) = rule.action {
+            #expect(config.scheme == "https")
+            #expect(config.host == "httpbin.org")
+            #expect(config.path == "/get")
+        } else {
+            Issue.record("Expected Map Remote rule")
+        }
     }
 
     @Test("editor destination preview uses placeholders and normalized path")

--- a/RockxyTests/Views/Rules/ModifyHeaderWindowViewModelTests.swift
+++ b/RockxyTests/Views/Rules/ModifyHeaderWindowViewModelTests.swift
@@ -1,0 +1,81 @@
+import Foundation
+@testable import Rockxy
+import Testing
+
+@Suite(.serialized)
+@MainActor
+struct ModifyHeaderWindowViewModelTests {
+    @Test("new editor operation defaults to Set so existing header values are replaced")
+    func newOperationDefaultsToSet() {
+        let operation = EditableHeaderOperation()
+
+        #expect(operation.type == .replace)
+        #expect(operation.type.editorLabel == "Set")
+    }
+
+    @Test("saveRule waits for persistence path and reloads saved Modify Header rule")
+    func saveRulePersistsBeforeReturning() async throws {
+        await withSharedRuleStateRestored {
+            let viewModel = ModifyHeaderWindowViewModel()
+            let operation = EditableHeaderOperation(
+                type: .replace,
+                headerName: "Authorization",
+                headerValue: "Bearer demo-access-token"
+            )
+
+            let accepted = await viewModel.saveRule(
+                existingRule: nil,
+                ruleName: "Profile Auth",
+                urlPattern: "127.0.0.1:43210/rockxy-demo/profile",
+                httpMethod: .any,
+                matchType: .wildcard,
+                includeSubpaths: false,
+                operations: [operation]
+            )
+
+            #expect(accepted)
+            let loaded = await RuleEngine.shared.allRules.filter { rule in
+                if case .modifyHeader = rule.action {
+                    return true
+                }
+                return false
+            }
+            #expect(loaded.count == 1)
+            #expect(viewModel.modifyHeaderRules.map(\.id) == loaded.map(\.id))
+
+            guard let saved = loaded.first else {
+                Issue.record("Expected saved Modify Header rule")
+                return
+            }
+            #expect(saved.name == "Profile Auth")
+            #expect(saved.matchCondition.method == nil)
+            #expect(saved.matchCondition.urlPattern == #"127\.0\.0\.1:43210\/rockxy-demo\/profile($|[?#])"#)
+
+            if case let .modifyHeader(operations) = saved.action {
+                #expect(operations.count == 1)
+                #expect(operations[0].type == .replace)
+                #expect(operations[0].headerName == "Authorization")
+                #expect(operations[0].headerValue == "Bearer demo-access-token")
+                #expect(operations[0].phase == .request)
+            } else {
+                Issue.record("Expected Modify Header action")
+            }
+        }
+    }
+
+    // MARK: Private
+
+    private func withSharedRuleStateRestored(_ body: () async -> Void) async {
+        await RuleTestLock.shared.acquire()
+        let rulesSnapshot = await RuleEngine.shared.allRules
+        let gateSnapshot = RulePolicyGate.shared
+
+        RulePolicyGate.shared = RulePolicyGate(policy: DefaultAppPolicy())
+        await RuleSyncService.replaceAllRules([])
+        await body()
+
+        await RuleSyncService.replaceAllRules(rulesSnapshot)
+        RulePolicyGate.shared = gateSnapshot
+        await RuleTestLock.shared.release()
+    }
+}


### PR DESCRIPTION
## Summary
- Harden Breakpoint rule matching, queue persistence, and queue layout behavior for the reported localhost/profile flow.
- Add a dedicated Breakpoint automation suite under `RockxyTests/Breakpoint/` with phase-based coverage and a `make test-breakpoint` entrypoint.
- Preserve adjacent rule-workflow fixes for Map Remote, Modify Headers, and request table scroll behavior that are already staged on `develop`.

## Validation
- `make test-breakpoint`
- `xcodebuild -project Rockxy.xcodeproj -scheme Rockxy -destination 'platform=macOS' -only-testing:RockxyTests/Breakpoint test`
- `swiftlint lint --strict RockxyTests/Breakpoint`
- `swiftlint lint --strict Rockxy/Views/Breakpoint/BreakpointWindowView.swift`
- `xcodebuild -project Rockxy.xcodeproj -scheme Rockxy -configuration Debug build`

## Notes
- The Breakpoint catalog now contains 101 concrete test entries because the explicit checkpoint list includes A1, A2, A3a-f, and A4-A8. All listed checkpoints were kept instead of dropping coverage to match the prompt total.
- The suite includes real HTTP endpoint coverage plus deterministic harness-level queue, persistence, and template checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Breakpoint queue redesigned with horizontal/vertical layout toggle
  * Save HTTP requests/responses as reusable breakpoint templates
  * Enhanced queue display with detailed transaction metadata (ID, client, status, duration, phase indicators)
  * Added "Skip Once" button for quick breakpoint decisions

* **Improvements**
  * Reorganized breakpoint window toolbar with layout and template management options
  * Enhanced header editor: defaults to "Set" operation with refined styling
  * Improved request/response editing UI and layout in breakpoint editor
  * Better scroll position preservation in transaction lists

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RockxyApp/Rockxy/pull/105?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->