### PR TITLE
docs: align support and privacy links

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -22,7 +22,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           path-to-signatures: 'signatures/cla.json'
-          path-to-document: 'https://github.com/LocNguyenHuu/Rockxy/blob/main/CLA.md'
+          path-to-document: 'https://github.com/RockxyApp/Rockxy/blob/main/CLA.md'
           branch: 'main'
           allowlist: 'bot*,dependabot[bot],renovate[bot],github-actions[bot]'
           custom-pr-sign-comment: 'I have read the CLA Document and I hereby sign the CLA'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ By participating in this project, you agree to abide by our [Code of Conduct](CO
 You'll need macOS 14.0+, Xcode 16+, [SwiftLint](https://github.com/realm/SwiftLint), and [SwiftFormat](https://github.com/nicklockwood/SwiftFormat).
 
 ```bash
-git clone https://github.com/LocNguyenHuu/Rockxy.git
+git clone https://github.com/RockxyApp/Rockxy.git
 cd Rockxy
 git checkout develop
 ```
@@ -85,7 +85,7 @@ docs/                  # Mintlify docs site
 
 ## Reporting Bugs
 
-Open a [GitHub issue](https://github.com/LocNguyenHuu/Rockxy/issues) with your macOS version, Rockxy version, and reproduction steps.
+Open a [GitHub issue](https://github.com/RockxyApp/Rockxy/issues) with your macOS version, Rockxy version, and reproduction steps.
 
 ## Contributor License Agreement
 

--- a/Rockxy/Views/Settings/PrivacySettingsTab.swift
+++ b/Rockxy/Views/Settings/PrivacySettingsTab.swift
@@ -104,7 +104,7 @@ struct PrivacySettingsTab: View {
             }
 
             Button(String(localized: "Privacy Policy")) {
-                if let url = URL(string: "https://github.com/LocNguyenHuu/Rockxy/wiki/Privacy") {
+                if let url = URL(string: "https://www.rockxy.io/privacy") {
                     NSWorkspace.shared.open(url)
                 }
             }

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,7 +14,7 @@
 
 If you discover a security vulnerability in Rockxy, please report it responsibly through one of these channels:
 
-1. **GitHub Security Advisories** (preferred): Go to the [Security tab](https://github.com/LocNguyenHuu/Rockxy/security/advisories) and click "Report a vulnerability."
+1. **GitHub Security Advisories** (preferred): Go to the [Security tab](https://github.com/RockxyApp/Rockxy/security/advisories) and click "Report a vulnerability."
 2. **Email**: Send details to [rockxyapp@gmail.com](mailto:rockxyapp@gmail.com) with the subject line "Rockxy Security Report".
 
 ### What to include


### PR DESCRIPTION
## Summary
- retarget stale pre-move repository links in contributor/security/CLA docs to `RockxyApp/Rockxy`
- replace the in-app Privacy Policy button's missing GitHub wiki URL with the live `https://www.rockxy.io/privacy` page

## Checks
- `git diff --check`
- `rg "github.com/LocNguyenHuu/Rockxy|wiki/Privacy" CONTRIBUTING.md .github/workflows/cla.yml SECURITY.md Rockxy/Views/Settings/PrivacySettingsTab.swift README.md .github/ISSUE_TEMPLATE/config.yml`
- `curl -I -L https://www.rockxy.io/privacy` -> 200
- `curl -I -L https://github.com/RockxyApp/Rockxy/security/advisories` -> 200
- `curl -I -L https://github.com/RockxyApp/Rockxy/blob/main/CLA.md` -> 200

Closes #8.

Optional: if you want to settle this as a tiny direct docs/link cleanup, $5 here works: https://nicdunz.gumroad.com/l/tiny-codex-teardown-direct?wanted=true
