### PR TITLE
Normalize keyboard shortcuts across the app

### DIFF
--- a/Rockxy/Core/RuleEngine/BreakpointManager.swift
+++ b/Rockxy/Core/RuleEngine/BreakpointManager.swift
@@ -121,12 +121,36 @@ final class BreakpointManager {
         transform(&pausedItems[index].editableDraft)
     }
 
+    func selectPreviousItem() {
+        selectAdjacentItem(offset: -1)
+    }
+
+    func selectNextItem() {
+        selectAdjacentItem(offset: 1)
+    }
+
     // MARK: Private
 
     private static let logger = Logger(subsystem: RockxyIdentity.current.logSubsystem, category: "BreakpointManager")
 
     private var continuations: [UUID: CheckedContinuation<(BreakpointDecision, BreakpointRequestData), Never>] = [:]
     private var nextSequenceNumber = 0
+
+    private func selectAdjacentItem(offset: Int) {
+        guard !pausedItems.isEmpty else {
+            selectedItemId = nil
+            return
+        }
+        guard let selectedItemId,
+              let index = pausedItems.firstIndex(where: { $0.id == selectedItemId }) else
+        {
+            selectedItemId = pausedItems.first?.id
+            return
+        }
+        let nextIndex = (index + offset + pausedItems.count) % pausedItems.count
+        self.selectedItemId = pausedItems[nextIndex].id
+        BreakpointWindowModel.shared.selectPausedItem(pausedItems[nextIndex].id)
+    }
 
     private static func displayURL(from urlString: String) -> String {
         guard let components = URLComponents(string: urlString) else {

--- a/Rockxy/Core/RuleEngine/RuleStore.swift
+++ b/Rockxy/Core/RuleEngine/RuleStore.swift
@@ -8,19 +8,7 @@ struct RuleStore {
     // MARK: Lifecycle
 
     init() {
-        guard let appSupport = FileManager.default.urls(
-            for: .applicationSupportDirectory,
-            in: .userDomainMask
-        ).first else {
-            Self.logger.error("Application Support directory not found, using temporary directory")
-            let tempDir = RockxyIdentity.current.temporaryAppSupportDirectory()
-            try? FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-            fileURL = tempDir.appendingPathComponent("rules.json")
-            return
-        }
-        fileURL = appSupport
-            .appendingPathComponent(RockxyIdentity.current.appSupportDirectoryName, isDirectory: true)
-            .appendingPathComponent("rules.json")
+        fileURL = RockxyIdentity.current.appSupportPath("rules.json")
     }
 
     // MARK: Internal

--- a/Rockxy/Core/RuleEngine/RuleSyncService.swift
+++ b/Rockxy/Core/RuleEngine/RuleSyncService.swift
@@ -157,8 +157,13 @@ enum RuleSyncService {
             forKey: "networkConditionsToolEnabled"
         ) as? Bool ?? true
         await RuleEngine.shared.setNetworkConditionsToolEnabled(networkConditionsEnabled)
-        try? await RuleEngine.shared.loadRules(from: RuleStore())
-        await syncAll()
+        do {
+            try await RuleEngine.shared.loadRules(from: RuleStore())
+            await syncAll()
+        } catch {
+            logger.error("Failed to load rules from disk: \(error.localizedDescription)")
+            await publishAll()
+        }
     }
 
     // MARK: Private
@@ -169,10 +174,20 @@ enum RuleSyncService {
     private static func syncAll() async {
         let allRules = await RuleEngine.shared.allRules
         await persistenceQueue.save(allRules)
+        await publish(allRules)
+        logger.debug("Rules synced: \(allRules.count) rules")
+    }
+
+    private static func publishAll() async {
+        let allRules = await RuleEngine.shared.allRules
+        await publish(allRules)
+        logger.debug("Rules published without persistence: \(allRules.count) rules")
+    }
+
+    private static func publish(_ allRules: [ProxyRule]) async {
         await MainActor.run {
             NotificationCenter.default.post(name: .rulesDidChange, object: allRules)
         }
-        logger.debug("Rules synced: \(allRules.count) rules")
     }
 }
 

--- a/Rockxy/Core/Services/Infrastructure/AppNotifications.swift
+++ b/Rockxy/Core/Services/Infrastructure/AppNotifications.swift
@@ -34,6 +34,8 @@ extension Notification.Name {
     static let openBreakpointRulesWindow = identity.notificationName("openBreakpointRulesWindow")
     static let openScriptingListWindow = identity.notificationName("openScriptingListWindow")
     static let openScriptEditorWindow = identity.notificationName("openScriptEditorWindow")
+    static let focusMainSearchField = identity.notificationName("focusMainSearchField")
+    static let focusComposeURLField = identity.notificationName("focusComposeURLField")
     static let mcpServerDidStart = identity.notificationName("mcpServerDidStart")
     static let mcpServerDidStop = identity.notificationName("mcpServerDidStop")
 }

--- a/Rockxy/Models/Rules/RuleMatchCondition.swift
+++ b/Rockxy/Models/Rules/RuleMatchCondition.swift
@@ -3,10 +3,32 @@ import Foundation
 /// Defines the criteria a request must satisfy for a `ProxyRule` to fire.
 /// All non-nil fields must match (AND logic). URL patterns use regex matching.
 struct RuleMatchCondition: Codable, Equatable {
+    // MARK: Lifecycle
+
+    init(
+        urlPattern: String? = nil,
+        method: String? = nil,
+        headerName: String? = nil,
+        headerValue: String? = nil,
+        matchType: RuleMatchType? = nil,
+        includeSubpaths: Bool? = nil
+    ) {
+        self.urlPattern = urlPattern
+        self.method = method
+        self.headerName = headerName
+        self.headerValue = headerValue
+        self.matchType = matchType
+        self.includeSubpaths = includeSubpaths
+    }
+
+    // MARK: Internal
+
     var urlPattern: String?
     var method: String?
     var headerName: String?
     var headerValue: String?
+    var matchType: RuleMatchType?
+    var includeSubpaths: Bool?
 
     func matches(
         method requestMethod: String,

--- a/Rockxy/Models/UI/EditableQueryItem.swift
+++ b/Rockxy/Models/UI/EditableQueryItem.swift
@@ -6,8 +6,14 @@ import Foundation
 
 /// Editable key-value pair for URL query parameters. Used by the Compose window
 /// and breakpoint editor for bidirectional query-URL synchronization.
-struct EditableQueryItem: Identifiable {
-    let id = UUID()
+struct EditableQueryItem: Codable, Equatable, Identifiable {
+    let id: UUID
     var name: String
     var value: String
+
+    init(id: UUID = UUID(), name: String, value: String) {
+        self.id = id
+        self.name = name
+        self.value = value
+    }
 }

--- a/Rockxy/Models/UI/KeyboardShortcutReference.swift
+++ b/Rockxy/Models/UI/KeyboardShortcutReference.swift
@@ -1,0 +1,173 @@
+import Foundation
+
+struct KeyboardShortcutSection: Identifiable, Equatable {
+    let id: String
+    let title: String
+    let shortcuts: [KeyboardShortcutReference]
+}
+
+struct KeyboardShortcutReference: Identifiable, Equatable {
+    let id: String
+    let window: String
+    let action: String
+    let shortcut: String
+    let context: String
+    let menu: String?
+    let note: String?
+
+    var searchableText: String {
+        [window, action, shortcut, context, menu, note]
+            .compactMap(\.self)
+            .joined(separator: " ")
+            .lowercased()
+    }
+}
+
+enum KeyboardShortcutCatalog {
+    static let sections: [KeyboardShortcutSection] = [
+        KeyboardShortcutSection(id: "universal", title: "Universal", shortcuts: [
+            row("universal.new", "Current Window", "New rule, template, script, or item in the active window", "⌘N", "Active list or editor", "File", nil),
+            row("universal.newFolder", "Current Window", "New Folder where folders are supported", "⇧⌘N", "Rule and script lists that support folders", "File", nil),
+            row(
+                "universal.default",
+                "Current Window",
+                "Primary action: Add, Save, Send, or Execute",
+                "⌘↩",
+                "Primary action in editors, Compose, and Breakpoint Queue",
+                nil,
+                nil
+            ),
+            row(
+                "universal.cancel",
+                "Current Window",
+                "Cancel sheets and modal editors; close the Breakpoint Queue without resolving the selected item",
+                "Esc",
+                "Sheets and modal editors",
+                nil,
+                nil
+            ),
+            row("universal.delete", "Current Window", "Delete the selected item", "⌘⌫", "Focused list selection", "Edit", nil),
+            row("universal.duplicate", "Current Window", "Duplicate the selected item", "⌘D", "Focused list selection", "Edit", nil),
+            row(
+                "universal.toggle",
+                "Current Window",
+                "Toggle the enabled state of the selected rule or script when the list has focus",
+                "↵ / Space",
+                "Focused rule or script list",
+                nil,
+                nil
+            ),
+            row("universal.filter", "Current Window", "Focus the filter or search field", "⌘F", "Focused window or list", "Edit", nil),
+            row("universal.close", "Current Window", "Close the current window", "⌘W", "Key window", "File", nil),
+            row("universal.settings", "App", "Settings", "⌘,", "App menu", "App", nil),
+            row(
+                "universal.editing",
+                "Text Fields",
+                "Copy, Paste, Cut, and Select All in text fields and standard editable controls",
+                "⌘C / ⌘V / ⌘X / ⌘A",
+                "Focused text field",
+                "Edit",
+                nil
+            ),
+        ]),
+        KeyboardShortcutSection(id: "main", title: "Main Capture", shortcuts: [
+            row("main.clear", "Main Capture", "Clear capture", "⌘K", "Main capture window", "Flow", nil),
+            row("main.clearAll", "Main Capture", "Clear capture and filters", "⇧⌘K", "Main capture window", "Flow", nil),
+            row("main.pause", "Main Capture", "Pause or resume capture", "⌘P", "Main capture window", "Tools", nil),
+            row("main.search", "Main Capture", "Focus the search bar", "⌘L", "Main capture search field", "Edit", nil),
+            row("main.first", "Main Capture", "Jump to the first or last captured row", "⌘↑", "Request table selection", "View", nil),
+            row("main.last", "Main Capture", "Jump to the first or last captured row", "⌘↓", "Request table selection", "View", nil),
+            row("main.move", "Main Capture", "Move row selection", "↑ / ↓", "Focused request table", nil, "Native table behavior."),
+            row("main.editRepeat", "Main Capture", "Edit and Repeat the selected request", "⌘E", "Selected request", "Flow", nil),
+            row("main.replay", "Main Capture", "Replay the selected request", "⌘R", "Selected request", "Flow", nil),
+            row("main.breakpoint", "Main Capture", "Add a Breakpoint rule for the selected request URL", "⌘B", "Selected request", "Tools", nil),
+            row("main.tabs", "Main Capture", "Switch workspace tabs", "⇧⌘[ / ⇧⌘]", "Main capture window", "View", nil),
+        ]),
+        KeyboardShortcutSection(id: "compose", title: "Compose", shortcuts: [
+            row("compose.send", "Compose", "Send", "⌘↩", "Compose window", nil, nil),
+            row("compose.url", "Compose", "Focus the URL field", "⌘L", "Compose URL field", nil, nil),
+            row("compose.template", "Compose", "Open Template menu", "⌘T", "Compose footer", nil, nil),
+            row("compose.history", "Compose", "Open History menu", "⌘Y", "Compose footer", nil, "⌘H is reserved by macOS for Hide App."),
+            row("compose.reset", "Compose", "Reset to a fresh request", "⌘0", "Compose window", nil, nil),
+        ]),
+        KeyboardShortcutSection(id: "breakpointQueue", title: "Breakpoint Queue", shortcuts: [
+            row("breakpoint.execute", "Breakpoint Queue", "Execute the selected paused item", "⌘↩", "Selected paused item", nil, nil),
+            row("breakpoint.abort", "Breakpoint Queue", "Abort the selected paused item", "⌘.", "Selected paused item", nil, nil),
+            row("breakpoint.close", "Breakpoint Queue", "Close the queue window; queued items remain paused", "Esc", "Breakpoint Queue window", nil, "Paused item stays queued."),
+            row("breakpoint.previous", "Breakpoint Queue", "Move to the previous or next queued item", "⌘[", "Breakpoint Queue selection", nil, nil),
+            row("breakpoint.next", "Breakpoint Queue", "Move to the previous or next queued item", "⌘]", "Breakpoint Queue selection", nil, nil),
+        ]),
+        KeyboardShortcutSection(id: "rules", title: "Rules Windows", shortcuts: [
+            row("rules.new", "Rules Windows", "New rule", "⌘N", "Focused rules window", nil, nil),
+            row("rules.newFolder", "Rules Windows", "New folder", "⇧⌘N", "Map Local and Scripting lists", nil, "Unavailable in rule windows without folder support."),
+            row("rules.edit", "Rules Windows", "Edit selected rule", "⌘E", "Focused rules list", nil, nil),
+            row("rules.duplicate", "Rules Windows", "Duplicate selected rule", "⌘D", "Focused rules list", nil, nil),
+            row("rules.delete", "Rules Windows", "Delete selected rule", "⌘⌫", "Focused rules list", nil, nil),
+            row("rules.toggle", "Rules Windows", "Toggle selected rule enabled state", "↵ / Space", "Focused rules list", nil, nil),
+            row("rules.filter", "Rules Windows", "Filter rules", "⌘F", "Focused rules window", nil, nil),
+            row("rules.templates", "Breakpoint Rules", "Open Breakpoint Templates from Breakpoint Rules", "⌘T", "Breakpoint Rules window", nil, nil),
+        ]),
+        KeyboardShortcutSection(id: "settings", title: "Settings", shortcuts: [
+            row("settings.ssl.newApp", "SSL Proxying Settings", "Add app rule", "⌘N", "SSL Proxying list", nil, nil),
+            row("settings.ssl.newDomain", "SSL Proxying Settings", "Add domain rule", "⇧⌘N", "SSL Proxying list", nil, nil),
+            row("settings.ssl.edit", "SSL Proxying Settings", "Edit selected SSL proxying rule", "⌘E", "SSL Proxying list", nil, nil),
+            row("settings.ssl.delete", "SSL Proxying Settings", "Delete selected SSL proxying rule", "⌘⌫", "SSL Proxying list", nil, nil),
+            row("settings.ssl.toggle", "SSL Proxying Settings", "Toggle selected SSL proxying rule", "↵ / Space", "SSL Proxying list", nil, nil),
+            row("settings.ssl.filter", "SSL Proxying Settings", "Filter SSL proxying rules", "⌘F", "SSL Proxying list", nil, nil),
+        ]),
+        KeyboardShortcutSection(id: "scriptEditor", title: "Script Editor", shortcuts: [
+            row("script.save", "Script Editor", "Save and activate script", "⌘S", "Script Editor window", nil, nil),
+            row("script.validate", "Script Editor", "Validate the matching rule against the sample URL", "⌘R", "Script Editor window", nil, nil),
+            row("script.console", "Script Editor", "Toggle Console panel", "⇧⌘C", "Script Editor window", nil, nil),
+            row("script.comment", "Script Editor", "Toggle line comment in the code editor", "⌘/", "Focused code editor", nil, nil),
+            row("script.indent", "Script Editor", "Outdent or indent the selection in the code editor", "⌘] / ⌘[", "Focused code editor", nil, nil),
+        ]),
+        KeyboardShortcutSection(id: "templates", title: "Templates", shortcuts: [
+            row("templates.new", "Breakpoint Templates", "New template of the selected kind", "⌘N", "Breakpoint Template Manager", nil, nil),
+            row("templates.newOpposite", "Breakpoint Templates", "New template of the opposite kind", "⇧⌘N", "Breakpoint Template Manager", nil, nil),
+            row("templates.duplicate", "Breakpoint Templates", "Duplicate selected template", "⌘D", "Breakpoint Template Manager", nil, nil),
+            row("templates.delete", "Breakpoint Templates", "Delete selected template", "⌘⌫", "Breakpoint Template Manager", nil, nil),
+        ]),
+        KeyboardShortcutSection(id: "help", title: "Help", shortcuts: [
+            row("help.shortcuts", "Menu Bar", "Open Help → Keyboard Shortcuts", "⌘?", "Help menu", "Help", nil),
+        ]),
+    ]
+
+    static var allShortcuts: [KeyboardShortcutReference] {
+        sections.flatMap(\.shortcuts)
+    }
+
+    static func filtered(by query: String) -> [KeyboardShortcutSection] {
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !trimmed.isEmpty else {
+            return sections
+        }
+        return sections.compactMap { section in
+            let matches = section.shortcuts.filter { $0.searchableText.contains(trimmed) }
+            guard !matches.isEmpty else {
+                return nil
+            }
+            return KeyboardShortcutSection(id: section.id, title: section.title, shortcuts: matches)
+        }
+    }
+
+    private static func row(
+        _ id: String,
+        _ window: String,
+        _ action: String,
+        _ shortcut: String,
+        _ context: String,
+        _ menu: String?,
+        _ note: String?
+    ) -> KeyboardShortcutReference {
+        KeyboardShortcutReference(
+            id: id,
+            window: window,
+            action: action,
+            shortcut: shortcut,
+            context: context,
+            menu: menu,
+            note: note
+        )
+    }
+}

--- a/Rockxy/RockxyApp.swift
+++ b/Rockxy/RockxyApp.swift
@@ -521,6 +521,13 @@ struct RockxyMenuCommands: Commands {
 
     private var flowMenu: some Commands {
         CommandMenu(String(localized: "Flow")) {
+            Button(String(localized: "Compose…")) {
+                actions?.composeFreshRequest()
+            }
+            .keyboardShortcut("n", modifiers: [.command, .option])
+
+            Divider()
+
             Button(String(localized: "Repeat")) {
                 actions?.replayRequest()
             }

--- a/Rockxy/RockxyApp.swift
+++ b/Rockxy/RockxyApp.swift
@@ -11,6 +11,7 @@ import UniformTypeIdentifiers
 @MainActor @Observable
 final class AppLifecycleState {
     var showWelcome = false
+    var showKeyboardShortcuts = false
 }
 
 // MARK: - RockxyApp
@@ -292,6 +293,12 @@ private struct MainWindowContent: View {
                     lifecycleState.showWelcome = false
                 })
             }
+            .sheet(isPresented: Binding(
+                get: { lifecycleState.showKeyboardShortcuts },
+                set: { lifecycleState.showKeyboardShortcuts = $0 }
+            )) {
+                KeyboardShortcutsView()
+            }
             .task {
                 guard !setupChecked else {
                     return
@@ -421,7 +428,6 @@ struct RockxyMenuCommands: Commands {
             Button(String(localized: "New Session")) {
                 actions?.clearSession()
             }
-            .keyboardShortcut("n", modifiers: [.command, .shift])
 
             Divider()
 
@@ -456,7 +462,7 @@ struct RockxyMenuCommands: Commands {
             Button(String(localized: "Copy URL")) {
                 actions?.copyURL()
             }
-            .keyboardShortcut("c", modifiers: [.command])
+            .keyboardShortcut("u", modifiers: [.command, .option])
             .disabled(actions?.hasSelectedTransaction != true)
 
             Button(String(localized: "Copy as cURL")) {
@@ -466,9 +472,14 @@ struct RockxyMenuCommands: Commands {
             .disabled(actions?.hasSelectedTransaction != true)
 
             Button(String(localized: "Focus on URL")) {
-                actions?.toggleFilterBar()
+                actions?.focusSearchField()
             }
             .keyboardShortcut("l", modifiers: [.command])
+
+            Button(String(localized: "Find in Capture")) {
+                actions?.focusSearchField()
+            }
+            .keyboardShortcut("f", modifiers: [.command])
         }
     }
 
@@ -516,6 +527,20 @@ struct RockxyMenuCommands: Commands {
                 actions?.previousWorkspaceTab()
             }
             .keyboardShortcut("[", modifiers: [.command, .shift])
+
+            Divider()
+
+            Button(String(localized: "Jump to First Request")) {
+                actions?.selectFirstTransaction()
+            }
+            .keyboardShortcut(.upArrow, modifiers: [.command])
+            .disabled(actions?.hasSelectedTransaction != true)
+
+            Button(String(localized: "Jump to Last Request")) {
+                actions?.selectLastTransaction()
+            }
+            .keyboardShortcut(.downArrow, modifiers: [.command])
+            .disabled(actions?.hasSelectedTransaction != true)
         }
     }
 
@@ -531,13 +556,13 @@ struct RockxyMenuCommands: Commands {
             Button(String(localized: "Repeat")) {
                 actions?.replayRequest()
             }
-            .keyboardShortcut(.return, modifiers: [.command])
+            .keyboardShortcut("r", modifiers: [.command])
             .disabled(actions?.hasSelectedTransaction != true)
 
             Button(String(localized: "Edit and Repeat…")) {
                 actions?.editAndRepeat()
             }
-            .keyboardShortcut(.return, modifiers: [.command, .option])
+            .keyboardShortcut("e", modifiers: [.command])
             .disabled(actions?.hasSelectedTransaction != true)
 
             Divider()
@@ -558,7 +583,6 @@ struct RockxyMenuCommands: Commands {
             Button(String(localized: "Add Comment…")) {
                 actions?.addComment()
             }
-            .keyboardShortcut("l", modifiers: [.command])
             .disabled(actions?.hasSelectedTransaction != true)
 
             Menu(String(localized: "Highlight")) {
@@ -579,14 +603,19 @@ struct RockxyMenuCommands: Commands {
             Button(String(localized: "Clear Session")) {
                 actions?.clearSession()
             }
-            .keyboardShortcut(.delete, modifiers: [.command, .option, .shift])
+            .keyboardShortcut("k", modifiers: [.command])
+
+            Button(String(localized: "Clear Session and Filters")) {
+                actions?.clearCaptureAndFilters()
+            }
+            .keyboardShortcut("k", modifiers: [.command, .shift])
 
             Divider()
 
             Button(String(localized: "Delete")) {
                 actions?.deleteSelected()
             }
-            .keyboardShortcut(.delete, modifiers: [])
+            .keyboardShortcut(.delete, modifiers: [.command])
             .disabled(actions?.hasSelectedTransaction != true)
 
             Button(String(localized: "Delete All")) {
@@ -601,7 +630,6 @@ struct RockxyMenuCommands: Commands {
             Button(String(localized: "Start Proxy")) {
                 actions?.startProxy()
             }
-            .keyboardShortcut("r", modifiers: [.command, .shift])
             .disabled(actions?.isProxyRunning == true)
 
             Button(String(localized: "Stop Proxy")) {
@@ -613,7 +641,7 @@ struct RockxyMenuCommands: Commands {
             Button(String(localized: "Toggle Recording")) {
                 actions?.toggleRecording()
             }
-            .keyboardShortcut("d", modifiers: [.command, .shift])
+            .keyboardShortcut("p", modifiers: [.command])
 
             Button(String(localized: "Toggle System Proxy")) {
                 actions?.toggleSystemProxyOverride()
@@ -649,6 +677,12 @@ struct RockxyMenuCommands: Commands {
                 openWindow(id: "breakpointRules")
             }
             .keyboardShortcut("b", modifiers: [.command, .shift])
+
+            Button(String(localized: "Add Breakpoint Rule")) {
+                actions?.addBreakpointRuleForSelection()
+            }
+            .keyboardShortcut("b", modifiers: [.command])
+            .disabled(actions?.hasSelectedTransaction != true)
 
             Button(String(localized: "Breakpoint Queue…")) {
                 openWindow(id: "breakpoints")
@@ -691,7 +725,6 @@ struct RockxyMenuCommands: Commands {
             Button(String(localized: "Network Conditions…")) {
                 openWindow(id: "networkConditions")
             }
-            .keyboardShortcut("n", modifiers: [.command, .option])
 
             Divider()
 
@@ -887,6 +920,12 @@ struct RockxyMenuCommands: Commands {
                 openWindow(id: "main")
                 lifecycleState.showWelcome = true
             }
+
+            Button(String(localized: "Keyboard Shortcuts")) {
+                openWindow(id: "main")
+                lifecycleState.showKeyboardShortcuts = true
+            }
+            .keyboardShortcut("/", modifiers: [.command, .shift])
 
             Button(String(localized: "Debug My App…")) {
                 openWindow(id: "developerSetupHub")

--- a/Rockxy/ViewModels/ComposeStore.swift
+++ b/Rockxy/ViewModels/ComposeStore.swift
@@ -22,7 +22,23 @@ final class ComposeStore {
     /// before opening the window, consumed by `ComposeWindowView` after prefill.
     var pendingTransaction: HTTPTransaction?
 
+    /// Indicates that the next Compose window activation should start from a
+    /// fresh blank draft, even if the window was already alive with old editor state.
+    var shouldOpenBlankDraft = false
+
     /// Incremented each time a new draft is requested. The Compose window observes
     /// this to detect re-targeting when the window is already open.
     var draftVersion: UInt64 = 0
+
+    func requestBlankDraft() {
+        pendingTransaction = nil
+        shouldOpenBlankDraft = true
+        draftVersion &+= 1
+    }
+
+    func requestDraft(from transaction: HTTPTransaction) {
+        pendingTransaction = transaction
+        shouldOpenBlankDraft = false
+        draftVersion &+= 1
+    }
 }

--- a/Rockxy/ViewModels/ComposeViewModel.swift
+++ b/Rockxy/ViewModels/ComposeViewModel.swift
@@ -8,7 +8,7 @@ import os
 /// Abstraction for executing HTTP requests. Enables testing with a mock executor
 /// instead of hitting the network.
 protocol ComposeRequestExecutor: Sendable {
-    func execute(_ request: URLRequest) async throws -> (Data, HTTPURLResponse)
+    func execute(_ request: URLRequest, followsRedirects: Bool) async throws -> (Data, HTTPURLResponse)
 }
 
 // MARK: - DefaultComposeExecutor
@@ -16,13 +16,25 @@ protocol ComposeRequestExecutor: Sendable {
 /// Production executor that uses `RequestReplay.proxyBypassSession` to bypass
 /// the app's own proxy and avoid recursion.
 struct DefaultComposeExecutor: ComposeRequestExecutor {
-    func execute(_ request: URLRequest) async throws -> (Data, HTTPURLResponse) {
-        let (data, response) = try await RequestReplay.proxyBypassSession.data(for: request)
+    func execute(_ request: URLRequest, followsRedirects: Bool) async throws -> (Data, HTTPURLResponse) {
+        let session = followsRedirects ? RequestReplay.proxyBypassSession : Self.noRedirectSession
+        let (data, response) = try await session.data(for: request)
         guard let httpResponse = response as? HTTPURLResponse else {
             throw ReplayError.invalidResponse
         }
         return (data, httpResponse)
     }
+
+    // MARK: Private
+
+    private static let noRedirectSession: URLSession = {
+        let config = URLSessionConfiguration.ephemeral
+        config.connectionProxyDictionary = [
+            kCFNetworkProxiesHTTPEnable as String: false,
+            kCFNetworkProxiesHTTPSEnable as String: false,
+        ]
+        return URLSession(configuration: config, delegate: NoRedirectSessionDelegate(), delegateQueue: nil)
+    }()
 }
 
 // MARK: - ComposeResponseState
@@ -34,6 +46,177 @@ enum ComposeResponseState {
     case success(ComposeResponse)
     case error(String)
     case unsupported(String)
+}
+
+// MARK: - ComposeRequestTimeout
+
+enum ComposeRequestTimeout: Int, CaseIterable, Identifiable {
+    case fifteen = 15
+    case thirty = 30
+    case sixty = 60
+    case none = 0
+
+    // MARK: Internal
+
+    var id: Int {
+        rawValue
+    }
+
+    var title: String {
+        switch self {
+        case .fifteen:
+            String(localized: "15 seconds")
+        case .thirty:
+            String(localized: "30 seconds")
+        case .sixty:
+            String(localized: "60 seconds")
+        case .none:
+            String(localized: "0 (No Timeout)")
+        }
+    }
+
+    var interval: TimeInterval {
+        switch self {
+        case .none:
+            TimeInterval.greatestFiniteMagnitude
+        default:
+            TimeInterval(rawValue)
+        }
+    }
+}
+
+// MARK: - ComposeTemplate
+
+enum ComposeTemplate: CaseIterable, Identifiable {
+    case empty
+    case getWithQuery
+    case postJSON
+    case postForm
+    case postMultipart
+
+    // MARK: Internal
+
+    var id: String {
+        switch self {
+        case .empty: "empty"
+        case .getWithQuery: "getWithQuery"
+        case .postJSON: "postJSON"
+        case .postForm: "postForm"
+        case .postMultipart: "postMultipart"
+        }
+    }
+
+    var title: String {
+        switch self {
+        case .empty:
+            String(localized: "Empty Request")
+        case .getWithQuery:
+            String(localized: "GET with Query")
+        case .postJSON:
+            String(localized: "POST with JSON")
+        case .postForm:
+            String(localized: "POST with Form")
+        case .postMultipart:
+            String(localized: "POST with Multiparts")
+        }
+    }
+}
+
+// MARK: - ComposeImportError
+
+enum ComposeImportError: LocalizedError, Equatable {
+    case emptyCommand
+    case unsupportedCommand
+    case missingURL
+
+    // MARK: Internal
+
+    var errorDescription: String? {
+        switch self {
+        case .emptyCommand:
+            String(localized: "Pasteboard does not contain a cURL command.")
+        case .unsupportedCommand:
+            String(localized: "Only cURL commands can be imported.")
+        case .missingURL:
+            String(localized: "The cURL command does not contain a URL.")
+        }
+    }
+}
+
+// MARK: - ComposeHistoryEntry
+
+struct ComposeHistoryEntry: Codable, Equatable, Identifiable {
+    let id: UUID
+    let method: String
+    let url: String
+    let headers: [EditableReplayHeader]
+    let queryItems: [EditableQueryItem]
+    let body: String
+    let bodyContentType: String?
+    let statusCode: Int?
+    let responseHeaders: [EditableReplayHeader]?
+    let responseBody: String?
+    let bodyTruncated: Bool
+    let responseBodyTruncated: Bool
+    let timestamp: Date
+
+    init(
+        id: UUID = UUID(),
+        method: String,
+        url: String,
+        headers: [EditableReplayHeader],
+        queryItems: [EditableQueryItem],
+        body: String,
+        bodyContentType: String?,
+        statusCode: Int?,
+        responseHeaders: [EditableReplayHeader]? = nil,
+        responseBody: String? = nil,
+        bodyTruncated: Bool = false,
+        responseBodyTruncated: Bool = false,
+        timestamp: Date
+    ) {
+        self.id = id
+        self.method = method
+        self.url = url
+        self.headers = headers
+        self.queryItems = queryItems
+        self.body = body
+        self.bodyContentType = bodyContentType
+        self.statusCode = statusCode
+        self.responseHeaders = responseHeaders
+        self.responseBody = responseBody
+        self.bodyTruncated = bodyTruncated
+        self.responseBodyTruncated = responseBodyTruncated
+        self.timestamp = timestamp
+    }
+
+    var menuTitle: String {
+        let status = statusCode.map { "\($0)" } ?? String(localized: "No Response")
+        return "[\(method)] \(url) • \(status) • \(Self.relativeFormatter.localizedString(for: timestamp, relativeTo: Date()))"
+    }
+
+    var requestFingerprint: String {
+        let headerFingerprint = headers
+            .map { "\($0.isEnabled)|\($0.name.lowercased())|\($0.value)" }
+            .joined(separator: "\u{1F}")
+        let queryFingerprint = queryItems
+            .map { "\($0.name)=\($0.value)" }
+            .joined(separator: "\u{1F}")
+        return [
+            method,
+            url,
+            headerFingerprint,
+            queryFingerprint,
+            body,
+            bodyContentType ?? "",
+        ].joined(separator: "\u{1E}")
+    }
+
+    private static let relativeFormatter: RelativeDateTimeFormatter = {
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .abbreviated
+        return formatter
+    }()
 }
 
 // MARK: - ComposeResponse
@@ -67,8 +250,13 @@ struct ComposeResponse {
 final class ComposeViewModel {
     // MARK: Lifecycle
 
-    init(executor: ComposeRequestExecutor = DefaultComposeExecutor()) {
+    init(
+        executor: ComposeRequestExecutor = DefaultComposeExecutor(),
+        historyStore: ComposeHistoryStore = .live
+    ) {
         self.executor = executor
+        self.historyStore = historyStore
+        history = historyStore.load()
     }
 
     // MARK: Internal
@@ -80,6 +268,12 @@ final class ComposeViewModel {
     var headers: [EditableReplayHeader] = []
     var body: String = ""
     var queryItems: [EditableQueryItem] = []
+    var requestTimeout: ComposeRequestTimeout = .thirty
+    var followsRedirects = true
+    private(set) var history: [ComposeHistoryEntry] = []
+    private(set) var lastFormattingError: String?
+    private(set) var restoreConfirmationID = UUID()
+    private(set) var restoreConfirmationMessage: String?
 
     // MARK: - Response State
 
@@ -116,7 +310,7 @@ final class ComposeViewModel {
             lines.append("Host: \(host)")
         }
 
-        for header in headers where !header.name.isEmpty {
+        for header in headers where header.isEnabled && !header.name.isEmpty {
             lines.append("\(header.name): \(header.value)")
         }
 
@@ -132,6 +326,7 @@ final class ComposeViewModel {
     /// Prefill the compose form from a captured transaction. Parses query items
     /// from the URL immediately so the Query tab is always in sync.
     func prefill(from transaction: HTTPTransaction) {
+        clearRestoreConfirmation()
         method = transaction.request.method
         url = transaction.request.url.absoluteString
         headers = transaction.request.headers.map {
@@ -149,10 +344,27 @@ final class ComposeViewModel {
         syncUnsupportedState()
     }
 
+    /// Reset only the active editor draft. History and request options remain intact,
+    /// so opening a fresh Compose window feels native without erasing user preferences.
+    func resetDraft() {
+        clearRestoreConfirmation()
+        method = "GET"
+        url = ""
+        headers = []
+        body = ""
+        queryItems = []
+        lastFormattingError = nil
+        sourceIsWebSocket = false
+        currentRunID = 0
+        lastSyncedURL = ""
+        responseState = .empty
+    }
+
     /// Send the current request draft. Uses latest-run-wins: if a newer send
     /// starts before this one completes, the stale result is silently discarded.
     func send() async {
         guard !isUnsupportedForReplay else {
+            clearRestoreConfirmation()
             responseState = .unsupported(
                 String(localized: "Replay is not supported for this request type.")
             )
@@ -160,10 +372,12 @@ final class ComposeViewModel {
         }
 
         guard let requestURL = URL(string: url) else {
+            clearRestoreConfirmation()
             responseState = .error(String(localized: "Invalid URL"))
             return
         }
 
+        clearRestoreConfirmation()
         currentRunID &+= 1
         let runID = currentRunID
 
@@ -171,16 +385,16 @@ final class ComposeViewModel {
 
         var request = URLRequest(url: requestURL)
         request.httpMethod = method
-        for header in headers where !header.name.isEmpty {
+        for header in headers where header.isEnabled && !header.name.isEmpty {
             request.setValue(header.value, forHTTPHeaderField: header.name)
         }
         if !body.isEmpty {
             request.httpBody = Data(body.utf8)
         }
-        request.timeoutInterval = 30
+        request.timeoutInterval = requestTimeout.interval
 
         do {
-            let (data, httpResponse) = try await executor.execute(request)
+            let (data, httpResponse) = try await executor.execute(request, followsRedirects: followsRedirects)
 
             guard runID == currentRunID else {
                 Self.logger.debug("Discarding stale response for runID \(runID)")
@@ -200,6 +414,7 @@ final class ComposeViewModel {
                 contentType: contentType
             )
             responseState = .success(response)
+            recordHistory(response: response)
             Self.logger.info("Compose send succeeded: \(httpResponse.statusCode)")
         } catch {
             guard runID == currentRunID else {
@@ -207,8 +422,221 @@ final class ComposeViewModel {
                 return
             }
             responseState = .error(error.localizedDescription)
+            recordHistory(response: nil)
             Self.logger.error("Compose send failed: \(error.localizedDescription)")
         }
+    }
+
+    // MARK: - Templates
+
+    func applyTemplate(_ template: ComposeTemplate) {
+        clearRestoreConfirmation()
+        sourceIsWebSocket = false
+        responseState = .empty
+        lastFormattingError = nil
+
+        switch template {
+        case .empty:
+            method = "GET"
+            url = ""
+            headers = []
+            body = ""
+            queryItems = []
+            lastSyncedURL = ""
+        case .getWithQuery:
+            method = "GET"
+            url = "https://example.com/api?name=value"
+            headers = [EditableReplayHeader(name: "Accept", value: "application/json")]
+            body = ""
+            syncURLToQuery(force: true)
+        case .postJSON:
+            method = "POST"
+            url = "https://example.com/api"
+            headers = [
+                EditableReplayHeader(name: "Content-Type", value: "application/json"),
+                EditableReplayHeader(name: "Accept", value: "application/json"),
+            ]
+            body = "{\n  \"key\": \"value\"\n}"
+            syncURLToQuery(force: true)
+        case .postForm:
+            method = "POST"
+            url = "https://example.com/api"
+            headers = [EditableReplayHeader(name: "Content-Type", value: "application/x-www-form-urlencoded")]
+            body = "key=value"
+            syncURLToQuery(force: true)
+        case .postMultipart:
+            let boundary = "----RockxyBoundary"
+            method = "POST"
+            url = "https://example.com/upload"
+            headers = [EditableReplayHeader(name: "Content-Type", value: "multipart/form-data; boundary=\(boundary)")]
+            body = """
+            --\(boundary)
+            Content-Disposition: form-data; name="file"; filename="example.txt"
+            Content-Type: text/plain
+
+            Hello from Rockxy
+            --\(boundary)--
+            """
+            syncURLToQuery(force: true)
+        }
+    }
+
+    func importCurlCommand(_ command: String) throws {
+        let tokens = Self.shellTokens(from: command)
+        guard !tokens.isEmpty else {
+            lastFormattingError = ComposeImportError.emptyCommand.localizedDescription
+            throw ComposeImportError.emptyCommand
+        }
+        guard tokens.first == "curl" else {
+            lastFormattingError = ComposeImportError.unsupportedCommand.localizedDescription
+            throw ComposeImportError.unsupportedCommand
+        }
+
+        var importedMethod = "GET"
+        var importedURL: String?
+        var importedHeaders: [EditableReplayHeader] = []
+        var importedBody: String?
+
+        var index = 1
+        while index < tokens.count {
+            let token = tokens[index]
+            switch token {
+            case "-X", "--request":
+                if let value = tokens[safe: index + 1] {
+                    importedMethod = value
+                    index += 1
+                }
+            case let value where value.hasPrefix("-X") && value.count > 2:
+                importedMethod = String(value.dropFirst(2))
+            case let value where value.hasPrefix("--request="):
+                importedMethod = String(value.dropFirst("--request=".count))
+            case "-H", "--header":
+                if let value = tokens[safe: index + 1] {
+                    appendHeader(value, to: &importedHeaders)
+                    index += 1
+                }
+            case let value where value.hasPrefix("--header="):
+                appendHeader(String(value.dropFirst("--header=".count)), to: &importedHeaders)
+            case "-d", "--data", "--data-raw", "--data-binary", "--data-ascii":
+                if let value = tokens[safe: index + 1] {
+                    importedBody = value
+                    if importedMethod == "GET" {
+                        importedMethod = "POST"
+                    }
+                    index += 1
+                }
+            case let value where value.hasPrefix("--data="):
+                importedBody = String(value.dropFirst("--data=".count))
+                if importedMethod == "GET" {
+                    importedMethod = "POST"
+                }
+            case let value where value.hasPrefix("-"):
+                break
+            default:
+                if importedURL == nil {
+                    importedURL = token
+                }
+            }
+            index += 1
+        }
+
+        guard let importedURL else {
+            lastFormattingError = ComposeImportError.missingURL.localizedDescription
+            throw ComposeImportError.missingURL
+        }
+
+        method = importedMethod.uppercased()
+        url = importedURL
+        headers = importedHeaders
+        body = importedBody ?? ""
+        sourceIsWebSocket = false
+        responseState = .empty
+        lastFormattingError = nil
+        clearRestoreConfirmation()
+        syncURLToQuery(force: true)
+    }
+
+    // MARK: - History
+
+    func removeHistoryEntry(id: UUID) {
+        history.removeAll { $0.id == id }
+        persistHistory()
+    }
+
+    func clearHistory() {
+        history.removeAll()
+        persistHistory()
+    }
+
+    func restoreHistoryEntry(id: UUID) {
+        guard let entry = history.first(where: { $0.id == id }) else {
+            return
+        }
+        method = entry.method
+        url = entry.url
+        headers = entry.headers
+        queryItems = entry.queryItems
+        body = entry.body
+        lastFormattingError = nil
+        sourceIsWebSocket = false
+        lastSyncedURL = entry.url
+        if let statusCode = entry.statusCode {
+            let responseBody = entry.responseBody ?? ""
+            let contentType = ContentType.detect(from: entry.responseHeaders?.first {
+                $0.name.caseInsensitiveCompare("Content-Type") == .orderedSame
+            }?.value)
+            let response = ComposeResponse(
+                statusCode: statusCode,
+                statusMessage: HTTPURLResponse.localizedString(forStatusCode: statusCode),
+                headers: (entry.responseHeaders ?? []).map { ($0.name, $0.value) },
+                bodyData: Data(responseBody.utf8),
+                bodyText: responseBody,
+                contentType: contentType
+            )
+            responseState = .success(response)
+        } else {
+            responseState = .empty
+        }
+        restoreConfirmationID = UUID()
+        restoreConfirmationMessage = String(localized: "Restored from history")
+    }
+
+    func clearRestoreConfirmation() {
+        restoreConfirmationMessage = nil
+    }
+
+    // MARK: - Body Import And Formatting
+
+    func loadBodyFromFile(url fileURL: URL) throws {
+        let data = try Data(contentsOf: fileURL)
+        body = String(data: data, encoding: .utf8) ?? ""
+        lastFormattingError = nil
+        clearRestoreConfirmation()
+    }
+
+    func prettifyJSONBody() {
+        lastFormattingError = nil
+        guard let data = body.data(using: .utf8),
+              let object = try? JSONSerialization.jsonObject(with: data),
+              JSONSerialization.isValidJSONObject(object),
+              let prettyData = try? JSONSerialization.data(withJSONObject: object, options: [.prettyPrinted, .sortedKeys]),
+              let pretty = String(data: prettyData, encoding: .utf8) else {
+            lastFormattingError = String(localized: "Body is not valid JSON.")
+            return
+        }
+        body = pretty
+        clearRestoreConfirmation()
+    }
+
+    func prettifyXMLBody() {
+        lastFormattingError = nil
+        guard let data = body.data(using: .utf8),
+              let document = try? XMLDocument(data: data, options: [.nodePreserveWhitespace]) else {
+            lastFormattingError = String(localized: "Body is not valid XML.")
+            return
+        }
+        body = document.xmlString(options: [.nodePrettyPrint])
+        clearRestoreConfirmation()
     }
 
     // MARK: - Header Management
@@ -249,8 +677,8 @@ final class ComposeViewModel {
     }
 
     /// Parse query items from the current URL string.
-    func syncURLToQuery() {
-        guard url != lastSyncedURL else {
+    func syncURLToQuery(force: Bool = false) {
+        guard force || url != lastSyncedURL else {
             return
         }
         lastSyncedURL = url
@@ -279,14 +707,142 @@ final class ComposeViewModel {
     private static let logger = Logger(subsystem: RockxyIdentity.current.logSubsystem, category: "ComposeViewModel")
 
     private let executor: ComposeRequestExecutor
+    private let historyStore: ComposeHistoryStore
     private var currentRunID: UInt64 = 0
+
+    private func recordHistory(response: ComposeResponse?) {
+        guard !sourceIsWebSocket else {
+            return
+        }
+        let entry = ComposeHistoryEntry(
+            method: method,
+            url: url,
+            headers: headers,
+            queryItems: queryItems,
+            body: body,
+            bodyContentType: headerValue(named: "Content-Type", in: headers),
+            statusCode: response?.statusCode,
+            responseHeaders: response?.headers.map {
+                EditableReplayHeader(name: $0.name, value: $0.value)
+            },
+            responseBody: response?.bodyDisplayText,
+            timestamp: Date()
+        )
+        history.removeAll { $0.requestFingerprint == entry.requestFingerprint }
+        history.insert(entry, at: 0)
+        if history.count > historyStore.maxEntries {
+            history.removeLast(history.count - historyStore.maxEntries)
+        }
+        persistHistory()
+    }
+
+    private func persistHistory() {
+        do {
+            try historyStore.save(history)
+        } catch {
+            Self.logger.error("Failed to persist compose history: \(error.localizedDescription)")
+        }
+    }
+
+    private func headerValue(named name: String, in headers: [EditableReplayHeader]) -> String? {
+        headers.first { $0.isEnabled && $0.name.caseInsensitiveCompare(name) == .orderedSame }?.value
+    }
+
+    private func appendHeader(_ rawHeader: String, to headers: inout [EditableReplayHeader]) {
+        guard let separator = rawHeader.firstIndex(of: ":") else {
+            return
+        }
+        let name = rawHeader[..<separator].trimmingCharacters(in: .whitespacesAndNewlines)
+        let value = rawHeader[rawHeader.index(after: separator)...].trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !name.isEmpty else {
+            return
+        }
+        headers.append(EditableReplayHeader(name: name, value: value))
+    }
+
+    private static func shellTokens(from command: String) -> [String] {
+        var tokens: [String] = []
+        var current = ""
+        var quote: Character?
+        var isEscaping = false
+
+        for character in command {
+            if isEscaping {
+                if character != "\n" {
+                    current.append(character)
+                }
+                isEscaping = false
+                continue
+            }
+
+            if character == "\\" {
+                isEscaping = true
+                continue
+            }
+
+            if let activeQuote = quote {
+                if character == activeQuote {
+                    quote = nil
+                } else {
+                    current.append(character)
+                }
+                continue
+            }
+
+            if character == "'" || character == "\"" {
+                quote = character
+            } else if character.isWhitespace {
+                if !current.isEmpty {
+                    tokens.append(current)
+                    current = ""
+                }
+            } else {
+                current.append(character)
+            }
+        }
+
+        if !current.isEmpty {
+            tokens.append(current)
+        }
+        return tokens
+    }
 }
 
 // MARK: - EditableReplayHeader
 
 /// Identifiable header pair for the compose window's editable header list.
-struct EditableReplayHeader: Identifiable {
-    let id = UUID()
+struct EditableReplayHeader: Codable, Equatable, Identifiable {
+    let id: UUID
     var name: String
     var value: String
+    var isEnabled = true
+
+    init(id: UUID = UUID(), name: String, value: String, isEnabled: Bool = true) {
+        self.id = id
+        self.name = name
+        self.value = value
+        self.isEnabled = isEnabled
+    }
+}
+
+// MARK: - NoRedirectSessionDelegate
+
+private final class NoRedirectSessionDelegate: NSObject, URLSessionTaskDelegate, @unchecked Sendable {
+    func urlSession(
+        _ session: URLSession,
+        task: URLSessionTask,
+        willPerformHTTPRedirection response: HTTPURLResponse,
+        newRequest request: URLRequest,
+        completionHandler: @escaping @Sendable (URLRequest?) -> Void
+    ) {
+        completionHandler(nil)
+    }
+}
+
+// MARK: - Collection Safe Subscript
+
+private extension Collection {
+    subscript(safe index: Index) -> Element? {
+        indices.contains(index) ? self[index] : nil
+    }
 }

--- a/Rockxy/Views/Breakpoint/AddBreakpointRuleSheet.swift
+++ b/Rockxy/Views/Breakpoint/AddBreakpointRuleSheet.swift
@@ -139,7 +139,10 @@ struct AddBreakpointRuleSheet: View {
             return (true, true)
         }()
 
-        let (displayPattern, matchType, includeSubpaths) = decodePattern(rawPattern)
+        let fallbackPattern = decodePattern(rawPattern)
+        let matchType = rule.matchCondition.matchType ?? fallbackPattern.matchType
+        let includeSubpaths = rule.matchCondition.includeSubpaths ?? fallbackPattern.includeSubpaths
+        let displayPattern = rule.matchCondition.matchType == .regex ? rawPattern : fallbackPattern.displayPattern
 
         return Decoded(
             displayPattern: displayPattern,
@@ -272,7 +275,11 @@ struct AddBreakpointRuleSheet: View {
     /// To preserve round-trip fidelity we stage each wildcard substitution into
     /// Unicode private-use-area placeholders before collapsing escapes, then
     /// restore the original user-facing wildcard characters at the end.
-    private static func decodePattern(_ pattern: String) -> (String, RuleMatchType, Bool) {
+    private static func decodePattern(
+        _ pattern: String
+    )
+        -> (displayPattern: String, matchType: RuleMatchType, includeSubpaths: Bool)
+    {
         var working = pattern
         var includeSubpaths = true
 

--- a/Rockxy/Views/Breakpoint/BreakpointRulesWindowView.swift
+++ b/Rockxy/Views/Breakpoint/BreakpointRulesWindowView.swift
@@ -505,6 +505,7 @@ struct BreakpointRulesWindowView: View {
             Button(String(localized: "Templates...")) {
                 openWindow(id: "breakpointTemplates")
             }
+            .keyboardShortcut("t", modifiers: .command)
 
             moreMenu
         }
@@ -534,7 +535,7 @@ struct BreakpointRulesWindowView: View {
                     openEditor(for: rule)
                 }
             }
-            .keyboardShortcut(.return, modifiers: .command)
+            .keyboardShortcut("e", modifiers: .command)
             .disabled(viewModel.selectedRuleID == nil)
 
             Button(String(localized: "Duplicate")) {
@@ -550,6 +551,15 @@ struct BreakpointRulesWindowView: View {
                     viewModel.toggleRule(id: id)
                 }
             }
+            .keyboardShortcut(.return, modifiers: [])
+            .disabled(viewModel.selectedRuleID == nil)
+
+            Button(enableDisableLabel) {
+                if let id = viewModel.selectedRuleID {
+                    viewModel.toggleRule(id: id)
+                }
+            }
+            .keyboardShortcut(.space, modifiers: [])
             .disabled(viewModel.selectedRuleID == nil)
 
             Divider()

--- a/Rockxy/Views/Breakpoint/BreakpointRulesWindowView.swift
+++ b/Rockxy/Views/Breakpoint/BreakpointRulesWindowView.swift
@@ -7,6 +7,12 @@ import SwiftUI
 
 @MainActor @Observable
 final class BreakpointRulesViewModel {
+    // MARK: Lifecycle
+
+    init(syncsChanges: Bool = !RockxyIdentity.isRunningTests) {
+        self.syncsChanges = syncsChanges
+    }
+
     // MARK: Internal
 
     var selectedRuleID: UUID?
@@ -58,6 +64,9 @@ final class BreakpointRulesViewModel {
     }
 
     func refreshFromEngine() async {
+        if await RuleEngine.shared.allRules.isEmpty {
+            await RuleSyncService.loadFromDisk()
+        }
         allRules = await RuleEngine.shared.allRules
     }
 
@@ -89,12 +98,17 @@ final class BreakpointRulesViewModel {
                     matchType: matchType,
                     includeSubpaths: includeSubpaths
                 ),
-                method: httpMethod.methodValue
+                method: httpMethod.methodValue,
+                matchType: matchType,
+                includeSubpaths: includeSubpaths
             ),
             action: .breakpoint(phase: Self.phase(request: phaseRequest, response: phaseResponse))
         )
         allRules.append(rule)
         selectedRuleID = rule.id
+        guard syncsChanges else {
+            return
+        }
         Task {
             let accepted = await RulePolicyGate.shared.addRule(rule)
             if !accepted {
@@ -129,12 +143,17 @@ final class BreakpointRulesViewModel {
             ),
             method: httpMethod.methodValue,
             headerName: rule.matchCondition.headerName,
-            headerValue: rule.matchCondition.headerValue
+            headerValue: rule.matchCondition.headerValue,
+            matchType: matchType,
+            includeSubpaths: includeSubpaths
         )
         rule.action = .breakpoint(phase: Self.phase(request: phaseRequest, response: phaseResponse))
         allRules[index] = rule
         selectedRuleID = rule.id
         let snapshot = rule
+        guard syncsChanges else {
+            return
+        }
         Task { await RulePolicyGate.shared.updateRule(snapshot) }
     }
 
@@ -144,6 +163,9 @@ final class BreakpointRulesViewModel {
         }
         allRules.removeAll { $0.id == id }
         selectedRuleID = nil
+        guard syncsChanges else {
+            return
+        }
         Task { await RulePolicyGate.shared.removeRule(id: id) }
     }
 
@@ -152,6 +174,9 @@ final class BreakpointRulesViewModel {
             return
         }
         allRules[index].isEnabled.toggle()
+        guard syncsChanges else {
+            return
+        }
         Task {
             let accepted = await RulePolicyGate.shared.toggleRule(id: id)
             if !accepted {
@@ -173,6 +198,9 @@ final class BreakpointRulesViewModel {
         )
         allRules.append(copy)
         selectedRuleID = copy.id
+        guard syncsChanges else {
+            return
+        }
         Task {
             let accepted = await RulePolicyGate.shared.addRule(copy)
             if !accepted {
@@ -223,6 +251,8 @@ final class BreakpointRulesViewModel {
     }
 
     // MARK: Private
+
+    private let syncsChanges: Bool
 
     private static func compilePattern(
         urlPattern: String,

--- a/Rockxy/Views/Breakpoint/BreakpointTemplateWindowView.swift
+++ b/Rockxy/Views/Breakpoint/BreakpointTemplateWindowView.swift
@@ -99,12 +99,21 @@ struct BreakpointTemplateWindowView: View {
                 Button(String(localized: "New Request Template")) {
                     store.addTemplate(kind: .request)
                 }
+                .keyboardShortcut(
+                    store.selectedKind == .request ? "n" : "n",
+                    modifiers: store.selectedKind == .request ? .command : [.command, .shift]
+                )
                 Button(String(localized: "New Response Template")) {
                     store.addTemplate(kind: .response)
                 }
+                .keyboardShortcut(
+                    store.selectedKind == .response ? "n" : "n",
+                    modifiers: store.selectedKind == .response ? .command : [.command, .shift]
+                )
                 Button(String(localized: "Duplicate")) {
                     store.duplicateSelectedTemplate()
                 }
+                .keyboardShortcut("d", modifiers: .command)
                 .disabled(store.selectedTemplate == nil)
                 Button(String(localized: "Reset Raw Message")) {
                     store.resetSelectedTemplate()
@@ -114,6 +123,7 @@ struct BreakpointTemplateWindowView: View {
                 Button(String(localized: "Delete"), role: .destructive) {
                     store.removeSelectedTemplate()
                 }
+                .keyboardShortcut(.delete, modifiers: .command)
                 .disabled(store.selectedTemplate == nil || store.templates.count <= 1)
             } label: {
                 HStack(spacing: 6) {

--- a/Rockxy/Views/Breakpoint/BreakpointWindowView.swift
+++ b/Rockxy/Views/Breakpoint/BreakpointWindowView.swift
@@ -49,11 +49,15 @@ struct BreakpointWindowView: View {
             actionBar
         }
         .frame(minWidth: 960, minHeight: 560)
+        .onExitCommand {
+            dismiss()
+        }
     }
 
     // MARK: Private
 
     @Environment(\.openWindow) private var openWindow
+    @Environment(\.dismiss) private var dismiss
     @AppStorage("breakpointQueueLayoutMode") private var layoutModeRaw = BreakpointQueueLayoutMode.horizontal.rawValue
 
     private let manager = BreakpointManager.shared
@@ -132,7 +136,6 @@ struct BreakpointWindowView: View {
             } label: {
                 Label(String(localized: "Continue"), systemImage: "play.fill")
             }
-            .keyboardShortcut(".", modifiers: .command)
             .disabled(!hasSelection)
 
             Button {
@@ -140,7 +143,7 @@ struct BreakpointWindowView: View {
             } label: {
                 Label(String(localized: "Abort"), systemImage: "xmark.octagon")
             }
-            .keyboardShortcut("\\", modifiers: .command)
+            .keyboardShortcut(".", modifiers: .command)
             .disabled(!hasSelection)
 
             Button {
@@ -157,7 +160,7 @@ struct BreakpointWindowView: View {
             } label: {
                 Label(String(localized: "Execute"), systemImage: "arrowshape.turn.up.right.fill")
             }
-            .keyboardShortcut(.defaultAction)
+            .keyboardShortcut(.return, modifiers: .command)
             .disabled(!hasSelection)
         }
         .padding(.horizontal, 12)
@@ -170,7 +173,7 @@ struct BreakpointWindowView: View {
             Button(String(localized: "Execute")) {
                 resolveSelected(.execute)
             }
-            .keyboardShortcut(.defaultAction)
+            .keyboardShortcut(.return, modifiers: .command)
             .disabled(!hasSelection)
 
             Button(String(localized: "Execute All")) {
@@ -184,7 +187,6 @@ struct BreakpointWindowView: View {
             Button(String(localized: "Continue")) {
                 resolveSelected(.cancel)
             }
-            .keyboardShortcut(".", modifiers: .command)
             .disabled(!hasSelection)
 
             Button(String(localized: "Continue All")) {
@@ -198,13 +200,27 @@ struct BreakpointWindowView: View {
             Button(String(localized: "Abort")) {
                 resolveSelected(.abort)
             }
-            .keyboardShortcut("\\", modifiers: .command)
+            .keyboardShortcut(".", modifiers: .command)
             .disabled(!hasSelection)
 
             Button(String(localized: "Abort All")) {
                 manager.resolveAll(decision: .abort)
             }
             .keyboardShortcut("\\", modifiers: [.command, .shift])
+            .disabled(!manager.hasPausedItems)
+
+            Divider()
+
+            Button(String(localized: "Previous Item")) {
+                manager.selectPreviousItem()
+            }
+            .keyboardShortcut("[", modifiers: .command)
+            .disabled(!manager.hasPausedItems)
+
+            Button(String(localized: "Next Item")) {
+                manager.selectNextItem()
+            }
+            .keyboardShortcut("]", modifiers: .command)
             .disabled(!manager.hasPausedItems)
 
             Divider()
@@ -223,7 +239,6 @@ struct BreakpointWindowView: View {
             Button(String(localized: "Add Rule")) {
                 openWindow(id: "breakpointRules")
             }
-            .keyboardShortcut("b", modifiers: .command)
         } label: {
             Label(String(localized: "More"), systemImage: "ellipsis.circle")
         }

--- a/Rockxy/Views/Compose/ComposeHistoryStore.swift
+++ b/Rockxy/Views/Compose/ComposeHistoryStore.swift
@@ -1,0 +1,140 @@
+import Foundation
+import os
+
+// Persists Compose history snapshots outside the active window lifecycle.
+
+// MARK: - ComposeHistoryStore
+
+/// Disk-backed storage for Compose history.
+///
+/// Request history can contain sensitive payloads. The live in-memory history keeps
+/// exact request headers so same-session restore is lossless, but persisted entries
+/// redact Authorization/Cookie-style headers before the JSON file is written.
+final class ComposeHistoryStore {
+    // MARK: Lifecycle
+
+    init(
+        fileURL: URL? = nil,
+        maxEntries: Int = ComposeHistoryStore.defaultMaxEntries,
+        bodySizeLimit: Int = ComposeHistoryStore.defaultBodySizeLimit,
+        fileManager: FileManager = .default
+    ) {
+        self.fileURL = fileURL ?? Self.defaultFileURL()
+        self.maxEntries = maxEntries
+        self.bodySizeLimit = bodySizeLimit
+        self.fileManager = fileManager
+    }
+
+    // MARK: Internal
+
+    static var live: ComposeHistoryStore {
+        ComposeHistoryStore()
+    }
+    static let defaultMaxEntries = 200
+    static let defaultBodySizeLimit = 256 * 1_024
+
+    let maxEntries: Int
+    let bodySizeLimit: Int
+
+    func load() -> [ComposeHistoryEntry] {
+        guard fileManager.fileExists(atPath: fileURL.path) else {
+            return []
+        }
+        do {
+            let data = try Data(contentsOf: fileURL)
+            return try decoder.decode([ComposeHistoryEntry].self, from: data)
+        } catch {
+            Self.logger.error("Failed to load compose history: \(error.localizedDescription)")
+            return []
+        }
+    }
+
+    func save(_ entries: [ComposeHistoryEntry]) throws {
+        let cappedEntries = Array(entries.prefix(maxEntries)).map(entryForPersistence)
+        let data = try encoder.encode(cappedEntries)
+        try fileManager.createDirectory(
+            at: fileURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try data.write(to: fileURL, options: .atomic)
+    }
+
+    // MARK: Private
+
+    private static let logger = Logger(subsystem: RockxyIdentity.current.logSubsystem, category: "ComposeHistoryStore")
+    private static let sensitiveHeaderNames: Set<String> = [
+        "authorization",
+        "cookie",
+        "proxy-authorization",
+        "set-cookie",
+    ]
+
+    private let fileURL: URL
+    private let fileManager: FileManager
+
+    private let encoder: JSONEncoder = {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        return encoder
+    }()
+
+    private let decoder = JSONDecoder()
+
+    private static func defaultFileURL() -> URL {
+        if RockxyIdentity.isRunningTests {
+            return RockxyIdentity.current.appSupportPath("compose-history-\(UUID().uuidString).json")
+        }
+        return RockxyIdentity.current.appSupportPath("compose-history.json")
+    }
+
+    private func entryForPersistence(_ entry: ComposeHistoryEntry) -> ComposeHistoryEntry {
+        let bodySnapshot = capped(entry.body)
+        let responseSnapshot = entry.responseBody.map(capped)
+        return ComposeHistoryEntry(
+            id: entry.id,
+            method: entry.method,
+            url: entry.url,
+            headers: redacted(entry.headers),
+            queryItems: entry.queryItems,
+            body: bodySnapshot.value,
+            bodyContentType: entry.bodyContentType,
+            statusCode: entry.statusCode,
+            responseHeaders: entry.responseHeaders.map(redacted),
+            responseBody: responseSnapshot?.value,
+            bodyTruncated: entry.bodyTruncated || bodySnapshot.truncated,
+            responseBodyTruncated: entry.responseBodyTruncated || (responseSnapshot?.truncated ?? false),
+            timestamp: entry.timestamp
+        )
+    }
+
+    private func redacted(_ headers: [EditableReplayHeader]) -> [EditableReplayHeader] {
+        headers.map { header in
+            guard Self.sensitiveHeaderNames.contains(header.name.lowercased()) else {
+                return header
+            }
+            return EditableReplayHeader(
+                id: header.id,
+                name: header.name,
+                value: String(localized: "<redacted before saving>"),
+                isEnabled: header.isEnabled
+            )
+        }
+    }
+
+    private func capped(_ text: String) -> (value: String, truncated: Bool) {
+        guard text.utf8.count > bodySizeLimit else {
+            return (text, false)
+        }
+        var result = ""
+        var byteCount = 0
+        for character in text {
+            let characterByteCount = String(character).utf8.count
+            guard byteCount + characterByteCount <= bodySizeLimit else {
+                break
+            }
+            result.append(character)
+            byteCount += characterByteCount
+        }
+        return (result, true)
+    }
+}

--- a/Rockxy/Views/Compose/ComposeRequestEditor.swift
+++ b/Rockxy/Views/Compose/ComposeRequestEditor.swift
@@ -9,19 +9,11 @@ struct ComposeRequestEditor: View {
     // MARK: Internal
 
     @Bindable var viewModel: ComposeViewModel
+    let onLoadFromFile: () -> Void
 
     var body: some View {
         VStack(spacing: 0) {
-            Picker("", selection: $selectedTab) {
-                ForEach(ComposeRequestTab.allCases) { tab in
-                    Text(tab.title).tag(tab)
-                }
-            }
-            .pickerStyle(.segmented)
-            .padding(.horizontal, 12)
-            .padding(.top, 8)
-            .padding(.bottom, 4)
-
+            headerBar
             Divider()
 
             Group {
@@ -44,15 +36,78 @@ struct ComposeRequestEditor: View {
 
     @State private var selectedTab: ComposeRequestTab = .headers
 
+    private var headerBar: some View {
+        HStack(spacing: 14) {
+            Text(String(localized: "Request"))
+                .font(.headline)
+                .fontWeight(.semibold)
+
+            ForEach(ComposeRequestTab.primaryTabs) { tab in
+                Button {
+                    selectedTab = tab
+                } label: {
+                    Text(tab.title)
+                        .foregroundStyle(selectedTab == tab ? Color.accentColor : .secondary)
+                }
+                .buttonStyle(.plain)
+            }
+
+            Divider()
+                .frame(height: 18)
+
+            Button {
+                selectedTab = .raw
+            } label: {
+                Text(String(localized: "Raw"))
+                    .foregroundStyle(selectedTab == .raw ? Color.accentColor : .secondary)
+            }
+            .buttonStyle(.plain)
+
+            Spacer()
+
+            requestMenu
+        }
+        .padding(.horizontal, 12)
+        .frame(height: 44)
+    }
+
+    private var requestMenu: some View {
+        Menu {
+            Button(String(localized: "Load from File...")) {
+                onLoadFromFile()
+                selectedTab = .body
+            }
+            Divider()
+            Button(String(localized: "JSON Prettier")) {
+                viewModel.prettifyJSONBody()
+                selectedTab = .body
+            }
+            Button(String(localized: "Prettify XML")) {
+                viewModel.prettifyXMLBody()
+                selectedTab = .body
+            }
+        } label: {
+            Image(systemName: "ellipsis.circle")
+                .imageScale(.large)
+        }
+        .menuStyle(.button)
+        .help(String(localized: "Request Body Options"))
+    }
+
     // MARK: - Headers Tab
 
     private var headersEditor: some View {
         ScrollView {
-            LazyVStack(spacing: 6) {
+            LazyVStack(spacing: 0) {
                 columnHeaders(name: "Name", value: "Value")
 
                 ForEach(viewModel.headers) { header in
                     HStack(spacing: 8) {
+                        Toggle("", isOn: headerEnabledBinding(for: header.id))
+                            .labelsHidden()
+                            .toggleStyle(.checkbox)
+                            .frame(width: 24)
+
                         TextField(
                             String(localized: "Header name"),
                             text: headerNameBinding(for: header.id)
@@ -71,6 +126,7 @@ struct ComposeRequestEditor: View {
                             viewModel.removeHeader(id: header.id)
                         }
                     }
+                    .padding(.vertical, 4)
                 }
 
                 addButton(String(localized: "Add Header")) {
@@ -86,11 +142,13 @@ struct ComposeRequestEditor: View {
 
     private var queryEditor: some View {
         ScrollView {
-            LazyVStack(spacing: 6) {
+            LazyVStack(spacing: 0) {
                 columnHeaders(name: "Name", value: "Value")
 
                 ForEach(viewModel.queryItems) { item in
                     HStack(spacing: 8) {
+                        Color.clear.frame(width: 24)
+
                         TextField(
                             String(localized: "Parameter name"),
                             text: queryNameBinding(for: item.id)
@@ -109,6 +167,7 @@ struct ComposeRequestEditor: View {
                             viewModel.removeQueryItem(id: item.id)
                         }
                     }
+                    .padding(.vertical, 4)
                 }
 
                 addButton(String(localized: "Add Parameter")) {
@@ -123,9 +182,21 @@ struct ComposeRequestEditor: View {
     // MARK: - Body Tab
 
     private var bodyEditor: some View {
-        TextEditor(text: $viewModel.body)
-            .font(.system(.body, design: .monospaced))
-            .padding(8)
+        VStack(spacing: 0) {
+            TextEditor(text: $viewModel.body)
+                .font(.system(.body, design: .monospaced))
+                .padding(8)
+
+            if let message = viewModel.lastFormattingError {
+                Divider()
+                Label(message, systemImage: "exclamationmark.triangle")
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 6)
+            }
+        }
     }
 
     // MARK: - Raw Tab
@@ -144,6 +215,7 @@ struct ComposeRequestEditor: View {
 
     private func columnHeaders(name: String, value: String) -> some View {
         HStack {
+            Color.clear.frame(width: 24)
             Text(String(localized: String.LocalizationValue(name)))
                 .font(.caption)
                 .fontWeight(.semibold)
@@ -180,6 +252,17 @@ struct ComposeRequestEditor: View {
     }
 
     // MARK: - Bindings
+
+    private func headerEnabledBinding(for id: UUID) -> Binding<Bool> {
+        Binding(
+            get: { viewModel.headers.first(where: { $0.id == id })?.isEnabled ?? true },
+            set: { newValue in
+                if let idx = viewModel.headers.firstIndex(where: { $0.id == id }) {
+                    viewModel.headers[idx].isEnabled = newValue
+                }
+            }
+        )
+    }
 
     private func headerNameBinding(for id: UUID) -> Binding<String> {
         Binding(
@@ -238,13 +321,15 @@ private enum ComposeRequestTab: String, CaseIterable, Identifiable {
 
     // MARK: Internal
 
+    static let primaryTabs: [ComposeRequestTab] = [.headers, .query, .body]
+
     var id: String {
         rawValue
     }
 
     var title: String {
         switch self {
-        case .headers: String(localized: "Headers")
+        case .headers: String(localized: "Header")
         case .query: String(localized: "Query")
         case .body: String(localized: "Body")
         case .raw: String(localized: "Raw")

--- a/Rockxy/Views/Compose/ComposeWindowView.swift
+++ b/Rockxy/Views/Compose/ComposeWindowView.swift
@@ -1,4 +1,6 @@
+import AppKit
 import SwiftUI
+import UniformTypeIdentifiers
 
 // Presents the compose window for the compose workflow.
 
@@ -12,21 +14,44 @@ struct ComposeWindowView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            composeBar
+            VStack(spacing: 0) {
+                composeBar
+                restoreConfirmationBanner
+            }
             Divider()
             HSplitView {
-                ComposeRequestEditor(viewModel: viewModel)
-                    .frame(minWidth: 300)
+                ComposeRequestEditor(
+                    viewModel: viewModel,
+                    onLoadFromFile: { isShowingBodyImporter = true }
+                )
+                .frame(minWidth: 430)
                 ComposeResponseViewer(viewModel: viewModel)
-                    .frame(minWidth: 300)
+                    .frame(minWidth: 360)
             }
+            Divider()
+            footerBar
         }
-        .frame(minWidth: 800, minHeight: 500)
+        .font(.system(.body))
+        .frame(minWidth: 900, minHeight: 600)
         .onAppear {
-            consumePendingTransaction()
+            consumeDraftRequest()
         }
         .onChange(of: ComposeStore.shared.draftVersion) {
-            consumePendingTransaction()
+            consumeDraftRequest()
+        }
+        .task(id: viewModel.restoreConfirmationID) {
+            guard viewModel.restoreConfirmationMessage != nil else {
+                return
+            }
+            try? await Task.sleep(for: .seconds(2))
+            viewModel.clearRestoreConfirmation()
+        }
+        .fileImporter(
+            isPresented: $isShowingBodyImporter,
+            allowedContentTypes: [.json, .xml, .plainText, .text, .data],
+            allowsMultipleSelection: false
+        ) { result in
+            importBodyFile(result)
         }
     }
 
@@ -35,29 +60,46 @@ struct ComposeWindowView: View {
     private static let httpMethods = ["GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS"]
 
     @State private var viewModel = ComposeViewModel()
+    @State private var isShowingBodyImporter = false
 
     private var composeBar: some View {
         HStack(spacing: 8) {
-            Picker("", selection: $viewModel.method) {
-                ForEach(Self.httpMethods, id: \.self) { method in
-                    Text(method).tag(method)
+            HStack(spacing: 8) {
+                Picker("", selection: $viewModel.method) {
+                    ForEach(Self.httpMethods, id: \.self) { method in
+                        Text(method).tag(method)
+                    }
                 }
-            }
-            .labelsHidden()
-            .frame(width: 100)
-
-            TextField(String(localized: "URL"), text: $viewModel.url)
-                .textFieldStyle(.roundedBorder)
-                .font(.system(.body, design: .monospaced))
-                .onSubmit {
-                    Task { await viewModel.send() }
-                }
-                .onChange(of: viewModel.url) {
-                    viewModel.syncURLToQuery()
-                }
+                .labelsHidden()
+                .pickerStyle(.menu)
+                .tint(.accentColor)
+                .frame(width: 86)
                 .onChange(of: viewModel.method) {
                     viewModel.syncUnsupportedState()
                 }
+
+                TextField(String(localized: "URL"), text: $viewModel.url)
+                    .textFieldStyle(.plain)
+                    .font(.system(.body, design: .monospaced))
+                    .onSubmit {
+                        Task { await viewModel.send() }
+                    }
+                    .onChange(of: viewModel.url) {
+                        viewModel.syncURLToQuery()
+                    }
+
+                Button {
+                    // Future raw-message expansion hook. Kept as a native toolbar-style affordance.
+                } label: {
+                    Image(systemName: "arrow.up.left.and.arrow.down.right")
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(.secondary)
+                .help(String(localized: "Expand Raw Message"))
+            }
+            .padding(.horizontal, 10)
+            .frame(height: 44)
+            .background(.quaternary.opacity(0.55), in: RoundedRectangle(cornerRadius: 16))
 
             sendButton
         }
@@ -75,16 +117,156 @@ struct ComposeWindowView: View {
                 Task { await viewModel.send() }
             }
             .buttonStyle(.borderedProminent)
+            .controlSize(.large)
             .keyboardShortcut(.return, modifiers: .command)
             .disabled(viewModel.url.isEmpty || viewModel.isUnsupportedForReplay)
         }
     }
 
-    private func consumePendingTransaction() {
-        guard let transaction = ComposeStore.shared.pendingTransaction else {
+    @ViewBuilder private var restoreConfirmationBanner: some View {
+        if let message = viewModel.restoreConfirmationMessage {
+            HStack(spacing: 6) {
+                Image(systemName: "clock.arrow.circlepath")
+                    .foregroundStyle(Color.accentColor)
+                Text(message)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Spacer()
+            }
+            .padding(.horizontal, 14)
+            .padding(.bottom, 6)
+            .transition(.opacity)
+        }
+    }
+
+    private var footerBar: some View {
+        HStack(spacing: 10) {
+            templateMenu
+            historyMenu
+            settingsMenu
+            Spacer()
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+    }
+
+    private var templateMenu: some View {
+        Menu {
+            Button(ComposeTemplate.empty.title) {
+                viewModel.applyTemplate(.empty)
+            }
+            Divider()
+            Button(ComposeTemplate.getWithQuery.title) {
+                viewModel.applyTemplate(.getWithQuery)
+            }
+            Divider()
+            Button(ComposeTemplate.postJSON.title) {
+                viewModel.applyTemplate(.postJSON)
+            }
+            Button(ComposeTemplate.postForm.title) {
+                viewModel.applyTemplate(.postForm)
+            }
+            Button(ComposeTemplate.postMultipart.title) {
+                viewModel.applyTemplate(.postMultipart)
+            }
+            Divider()
+            Button(String(localized: "Import from cURL...")) {
+                importCurlFromPasteboard()
+            }
+        } label: {
+            Label(String(localized: "Template"), systemImage: "doc.badge.plus")
+                .labelStyle(.titleAndIcon)
+        }
+        .menuStyle(.button)
+    }
+
+    private var historyMenu: some View {
+        Menu {
+            if viewModel.history.isEmpty {
+                Text(String(localized: "No History"))
+            } else {
+                ForEach(viewModel.history) { entry in
+                    Button(entry.menuTitle) {
+                        viewModel.restoreHistoryEntry(id: entry.id)
+                    }
+                }
+                Divider()
+                Text(String(localized: "Authorization and cookie headers are not stored on disk."))
+                    .font(.caption)
+                Button(String(localized: "Clear All..."), role: .destructive) {
+                    viewModel.clearHistory()
+                }
+            }
+        } label: {
+            Label(String(localized: "History"), systemImage: "clock.arrow.circlepath")
+                .labelStyle(.titleAndIcon)
+        }
+        .menuStyle(.button)
+    }
+
+    private var settingsMenu: some View {
+        Menu {
+            Menu(String(localized: "Request Timeout")) {
+                ForEach(ComposeRequestTimeout.allCases) { timeout in
+                    Button {
+                        viewModel.requestTimeout = timeout
+                    } label: {
+                        if viewModel.requestTimeout == timeout {
+                            Label(timeout.title, systemImage: "checkmark")
+                        } else {
+                            Text(timeout.title)
+                        }
+                    }
+                }
+            }
+            Divider()
+            Toggle(
+                String(localized: "Automatically Follow Redirects"),
+                isOn: $viewModel.followsRedirects
+            )
+        } label: {
+            Image(systemName: "ellipsis.circle")
+                .imageScale(.large)
+        }
+        .menuStyle(.button)
+        .help(String(localized: "Request Options"))
+    }
+
+    private func consumeDraftRequest() {
+        let store = ComposeStore.shared
+        if let transaction = store.pendingTransaction {
+            viewModel.prefill(from: transaction)
+            store.pendingTransaction = nil
+            store.shouldOpenBlankDraft = false
             return
         }
-        viewModel.prefill(from: transaction)
-        ComposeStore.shared.pendingTransaction = nil
+
+        guard store.shouldOpenBlankDraft else {
+            return
+        }
+        viewModel.resetDraft()
+        store.shouldOpenBlankDraft = false
+    }
+
+    private func importBodyFile(_ result: Result<[URL], Error>) {
+        guard case let .success(urls) = result, let url = urls.first else {
+            return
+        }
+        do {
+            try viewModel.loadBodyFromFile(url: url)
+        } catch {
+            // The body editor exposes formatter errors; file import failures remain non-destructive.
+        }
+    }
+
+    private func importCurlFromPasteboard() {
+        guard let command = NSPasteboard.general.string(forType: .string) else {
+            return
+        }
+        do {
+            try viewModel.importCurlCommand(command)
+        } catch {
+            // The body editor exposes formatter/import errors without replacing the current draft.
+        }
     }
 }

--- a/Rockxy/Views/Compose/ComposeWindowView.swift
+++ b/Rockxy/Views/Compose/ComposeWindowView.swift
@@ -35,6 +35,7 @@ struct ComposeWindowView: View {
         .frame(minWidth: 900, minHeight: 600)
         .onAppear {
             consumeDraftRequest()
+            isURLFocused = true
         }
         .onChange(of: ComposeStore.shared.draftVersion) {
             consumeDraftRequest()
@@ -53,6 +54,9 @@ struct ComposeWindowView: View {
         ) { result in
             importBodyFile(result)
         }
+        .onReceive(NotificationCenter.default.publisher(for: .focusComposeURLField)) { _ in
+            isURLFocused = true
+        }
     }
 
     // MARK: Private
@@ -61,6 +65,7 @@ struct ComposeWindowView: View {
 
     @State private var viewModel = ComposeViewModel()
     @State private var isShowingBodyImporter = false
+    @FocusState private var isURLFocused: Bool
 
     private var composeBar: some View {
         HStack(spacing: 8) {
@@ -81,6 +86,7 @@ struct ComposeWindowView: View {
                 TextField(String(localized: "URL"), text: $viewModel.url)
                     .textFieldStyle(.plain)
                     .font(.system(.body, design: .monospaced))
+                    .focused($isURLFocused)
                     .onSubmit {
                         Task { await viewModel.send() }
                     }
@@ -178,6 +184,7 @@ struct ComposeWindowView: View {
                 .labelStyle(.titleAndIcon)
         }
         .menuStyle(.button)
+        .keyboardShortcut("t", modifiers: .command)
     }
 
     private var historyMenu: some View {
@@ -202,10 +209,16 @@ struct ComposeWindowView: View {
                 .labelStyle(.titleAndIcon)
         }
         .menuStyle(.button)
+        .keyboardShortcut("y", modifiers: .command)
     }
 
     private var settingsMenu: some View {
         Menu {
+            Button(String(localized: "Focus URL Field")) {
+                isURLFocused = true
+            }
+            .keyboardShortcut("l", modifiers: .command)
+            Divider()
             Menu(String(localized: "Request Timeout")) {
                 ForEach(ComposeRequestTimeout.allCases) { timeout in
                     Button {
@@ -224,6 +237,12 @@ struct ComposeWindowView: View {
                 String(localized: "Automatically Follow Redirects"),
                 isOn: $viewModel.followsRedirects
             )
+            Divider()
+            Button(String(localized: "Reset to Fresh Request")) {
+                viewModel.resetDraft()
+                isURLFocused = true
+            }
+            .keyboardShortcut("0", modifiers: .command)
         } label: {
             Image(systemName: "ellipsis.circle")
                 .imageScale(.large)

--- a/Rockxy/Views/Help/KeyboardShortcutsView.swift
+++ b/Rockxy/Views/Help/KeyboardShortcutsView.swift
@@ -1,0 +1,114 @@
+import SwiftUI
+
+struct KeyboardShortcutsView: View {
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider()
+            shortcutList
+            Divider()
+            footer
+        }
+        .frame(minWidth: 640, idealWidth: 720, minHeight: 520, idealHeight: 620)
+    }
+
+    @State private var searchText = ""
+    @FocusState private var isSearchFocused: Bool
+
+    private var filteredSections: [KeyboardShortcutSection] {
+        KeyboardShortcutCatalog.filtered(by: searchText)
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text(String(localized: "Keyboard Shortcuts"))
+                .font(.title3.weight(.semibold))
+
+            HStack(spacing: 8) {
+                Image(systemName: "magnifyingglass")
+                    .foregroundStyle(.secondary)
+                TextField(String(localized: "Search shortcuts"), text: $searchText)
+                    .textFieldStyle(.plain)
+                    .focused($isSearchFocused)
+                if !searchText.isEmpty {
+                    Button {
+                        searchText = ""
+                    } label: {
+                        Image(systemName: "xmark.circle.fill")
+                    }
+                    .buttonStyle(.plain)
+                    .foregroundStyle(.secondary)
+                }
+            }
+            .padding(.horizontal, 10)
+            .frame(height: 32)
+            .background(Color(nsColor: .controlBackgroundColor), in: RoundedRectangle(cornerRadius: 8))
+        }
+        .padding(20)
+        .onAppear {
+            isSearchFocused = true
+        }
+    }
+
+    private var shortcutList: some View {
+        ScrollView {
+            LazyVStack(alignment: .leading, spacing: 18) {
+                ForEach(filteredSections) { section in
+                    shortcutSection(section)
+                }
+            }
+            .padding(20)
+        }
+    }
+
+    private func shortcutSection(_ section: KeyboardShortcutSection) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(section.title)
+                .font(.headline)
+
+            Grid(alignment: .leading, horizontalSpacing: 18, verticalSpacing: 7) {
+                ForEach(section.shortcuts) { shortcut in
+                    GridRow {
+                        shortcutKeys(shortcut.shortcut)
+                        Text(shortcut.action)
+                            .font(.system(size: 13))
+                        Text(shortcut.window)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                    if let note = shortcut.note {
+                        GridRow {
+                            Color.clear
+                            Text(note)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                                .gridCellColumns(2)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private func shortcutKeys(_ shortcut: String) -> some View {
+        Text(shortcut)
+            .font(.system(size: 12, weight: .semibold, design: .monospaced))
+            .foregroundStyle(.primary)
+            .padding(.horizontal, 7)
+            .frame(minWidth: 72, minHeight: 24)
+            .background(Color(nsColor: .quaternaryLabelColor).opacity(0.18), in: RoundedRectangle(cornerRadius: 6))
+            .overlay {
+                RoundedRectangle(cornerRadius: 6)
+                    .stroke(Color(nsColor: .separatorColor).opacity(0.7), lineWidth: 1)
+            }
+    }
+
+    private var footer: some View {
+        Text(String(localized: "Some shortcuts depend on focus — click the panel first."))
+            .font(.caption)
+            .foregroundStyle(.secondary)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 20)
+            .padding(.vertical, 10)
+    }
+}

--- a/Rockxy/Views/Main/Extensions/MainContentCoordinator+ContextMenu.swift
+++ b/Rockxy/Views/Main/Extensions/MainContentCoordinator+ContextMenu.swift
@@ -119,8 +119,7 @@ extension MainContentCoordinator {
     }
 
     func editAndReplayTransaction(_ transaction: HTTPTransaction) {
-        ComposeStore.shared.pendingTransaction = transaction
-        ComposeStore.shared.draftVersion &+= 1
+        ComposeStore.shared.requestDraft(from: transaction)
         NotificationCenter.default.post(name: .openComposeWindow, object: nil)
     }
 

--- a/Rockxy/Views/Main/Extensions/MainContentCoordinator+Selection.swift
+++ b/Rockxy/Views/Main/Extensions/MainContentCoordinator+Selection.swift
@@ -98,4 +98,20 @@ extension MainContentCoordinator {
         }
         deleteTransactions([selected])
     }
+
+    func selectFirstFilteredTransaction() {
+        guard let first = filteredTransactions.first else {
+            return
+        }
+        selectedTransactionIDs = [first.id]
+        selectTransaction(first)
+    }
+
+    func selectLastFilteredTransaction() {
+        guard let last = filteredTransactions.last else {
+            return
+        }
+        selectedTransactionIDs = [last.id]
+        selectTransaction(last)
+    }
 }

--- a/Rockxy/Views/Main/MainContentCommandActions.swift
+++ b/Rockxy/Views/Main/MainContentCommandActions.swift
@@ -94,6 +94,11 @@ struct MainContentCommandActions {
         coordinator.replaySelectedRequest()
     }
 
+    func composeFreshRequest() {
+        ComposeStore.shared.requestBlankDraft()
+        NotificationCenter.default.post(name: .openComposeWindow, object: nil)
+    }
+
     func editAndRepeat() {
         guard let transaction = coordinator.selectedTransaction else {
             return

--- a/Rockxy/Views/Main/MainContentCommandActions.swift
+++ b/Rockxy/Views/Main/MainContentCommandActions.swift
@@ -56,6 +56,16 @@ struct MainContentCommandActions {
         }
     }
 
+    func clearCaptureAndFilters() {
+        Task { @MainActor in
+            await coordinator.clearSession()
+            coordinator.filterCriteria = .empty
+            coordinator.filterCriteria.sidebarScope = .allTraffic
+            coordinator.filterRules = [FilterRule()]
+            coordinator.recomputeFilteredTransactions()
+        }
+    }
+
     func toggleRecording() {
         coordinator.toggleRecording()
     }
@@ -146,6 +156,11 @@ struct MainContentCommandActions {
         coordinator.recomputeFilteredTransactions()
     }
 
+    func focusSearchField() {
+        coordinator.filterCriteria.isSearchEnabled = true
+        NotificationCenter.default.post(name: .focusMainSearchField, object: nil)
+    }
+
     func toggleInspectorRight() {
         coordinator.toggleInspectorRight()
     }
@@ -168,6 +183,21 @@ struct MainContentCommandActions {
 
     func deleteSelected() {
         coordinator.deleteSelectedTransaction()
+    }
+
+    func selectFirstTransaction() {
+        coordinator.selectFirstFilteredTransaction()
+    }
+
+    func selectLastTransaction() {
+        coordinator.selectLastFilteredTransaction()
+    }
+
+    func addBreakpointRuleForSelection() {
+        guard let transaction = coordinator.selectedTransaction else {
+            return
+        }
+        coordinator.createBreakpointRule(for: transaction)
     }
 
     func compareSelected() {

--- a/Rockxy/Views/Rules/AllowListWindowView.swift
+++ b/Rockxy/Views/Rules/AllowListWindowView.swift
@@ -460,13 +460,21 @@ struct AllowListWindowView: View {
             Button(String(localized: "Edit…")) {
                 openEditorForSelection()
             }
-            .keyboardShortcut(.return, modifiers: .command)
+            .keyboardShortcut("e", modifiers: .command)
             .disabled(viewModel.selectedRuleID == nil)
 
             Button(String(localized: "Duplicate")) {
                 viewModel.duplicateSelected()
             }
             .keyboardShortcut("d", modifiers: .command)
+            .disabled(viewModel.selectedRuleID == nil)
+
+            Button(enableDisableLabel) {
+                if let id = viewModel.selectedRuleID {
+                    viewModel.toggleRule(id: id)
+                }
+            }
+            .keyboardShortcut(.return, modifiers: [])
             .disabled(viewModel.selectedRuleID == nil)
 
             Button(enableDisableLabel) {
@@ -525,13 +533,18 @@ struct AllowListWindowView: View {
         Button(String(localized: "Edit…")) {
             openEditorForRule(id)
         }
-        .keyboardShortcut(.return, modifiers: .command)
+        .keyboardShortcut("e", modifiers: .command)
 
         Button(String(localized: "Duplicate")) {
             viewModel.selectedRuleID = id
             viewModel.duplicateSelected()
         }
         .keyboardShortcut("d", modifiers: .command)
+
+        Button(enableDisableLabel(for: id)) {
+            viewModel.toggleRule(id: id)
+        }
+        .keyboardShortcut(.return, modifiers: [])
 
         Button(enableDisableLabel(for: id)) {
             viewModel.toggleRule(id: id)

--- a/Rockxy/Views/Rules/BlockListWindowView.swift
+++ b/Rockxy/Views/Rules/BlockListWindowView.swift
@@ -228,7 +228,9 @@ final class BlockListViewModel {
             name: displayName,
             matchCondition: RuleMatchCondition(
                 urlPattern: escapedPattern,
-                method: httpMethod.methodValue
+                method: httpMethod.methodValue,
+                matchType: matchType,
+                includeSubpaths: includeSubpaths
             ),
             action: .block(statusCode: blockAction.statusCode)
         )

--- a/Rockxy/Views/Rules/BlockListWindowView.swift
+++ b/Rockxy/Views/Rules/BlockListWindowView.swift
@@ -459,13 +459,21 @@ struct BlockListWindowView: View {
             Button(String(localized: "Edit…")) {
                 openEditorForSelection()
             }
-            .keyboardShortcut(.return, modifiers: .command)
+            .keyboardShortcut("e", modifiers: .command)
             .disabled(viewModel.selectedRuleID == nil)
 
             Button(String(localized: "Duplicate")) {
                 viewModel.duplicateSelected()
             }
             .keyboardShortcut("d", modifiers: .command)
+            .disabled(viewModel.selectedRuleID == nil)
+
+            Button(enableDisableLabel) {
+                if let id = viewModel.selectedRuleID {
+                    viewModel.toggleRule(id: id)
+                }
+            }
+            .keyboardShortcut(.return, modifiers: [])
             .disabled(viewModel.selectedRuleID == nil)
 
             Button(enableDisableLabel) {
@@ -517,13 +525,18 @@ struct BlockListWindowView: View {
         Button(String(localized: "Edit…")) {
             openEditorForRule(id)
         }
-        .keyboardShortcut(.return, modifiers: .command)
+        .keyboardShortcut("e", modifiers: .command)
 
         Button(String(localized: "Duplicate")) {
             viewModel.selectedRuleID = id
             viewModel.duplicateSelected()
         }
         .keyboardShortcut("d", modifiers: .command)
+
+        Button(enableDisableLabel(for: id)) {
+            viewModel.toggleRule(id: id)
+        }
+        .keyboardShortcut(.return, modifiers: [])
 
         Button(enableDisableLabel(for: id)) {
             viewModel.toggleRule(id: id)

--- a/Rockxy/Views/Rules/MapLocalWindowView.swift
+++ b/Rockxy/Views/Rules/MapLocalWindowView.swift
@@ -569,7 +569,7 @@ struct MapLocalWindowView: View {
             Button(String(localized: "New Folder")) {
                 viewModel.createNewFolderPlaceholder()
             }
-            .keyboardShortcut("n", modifiers: [.command, .option])
+            .keyboardShortcut("n", modifiers: [.command, .shift])
 
             Button {
                 viewModel.errorMessage = String(localized: "Map Local checks rules from top to bottom and returns the first matching local response.")
@@ -597,7 +597,7 @@ struct MapLocalWindowView: View {
                         openEditor(for: rule)
                     }
                 }
-                .keyboardShortcut(.return, modifiers: .command)
+                .keyboardShortcut("e", modifiers: .command)
                 .disabled(viewModel.selectedRule == nil)
                 Button(String(localized: "Duplicate")) { viewModel.duplicateSelectedRule() }
                     .keyboardShortcut("d", modifiers: .command)
@@ -608,6 +608,13 @@ struct MapLocalWindowView: View {
                     }
                 }
                 .keyboardShortcut(.return, modifiers: [])
+                .disabled(viewModel.selectedRule == nil)
+                Button(String(localized: "Toggle")) {
+                    if let id = viewModel.selectedRuleIDs.first {
+                        viewModel.toggleRule(id: id)
+                    }
+                }
+                .keyboardShortcut(.space, modifiers: [])
                 .disabled(viewModel.selectedRule == nil)
                 Divider()
                 Button(String(localized: "Delete"), role: .destructive) {

--- a/Rockxy/Views/Rules/MapRemoteWindowView.swift
+++ b/Rockxy/Views/Rules/MapRemoteWindowView.swift
@@ -457,7 +457,7 @@ struct MapRemoteWindowView: View {
                         openEditor(for: rule)
                     }
                 }
-                .keyboardShortcut(.return, modifiers: .command)
+                .keyboardShortcut("e", modifiers: .command)
                 .disabled(viewModel.selectedRule == nil)
                 Button(String(localized: "Duplicate")) { viewModel.duplicateSelectedRule() }
                     .keyboardShortcut("d", modifiers: .command)
@@ -468,6 +468,13 @@ struct MapRemoteWindowView: View {
                     }
                 }
                 .keyboardShortcut(.return, modifiers: [])
+                .disabled(viewModel.selectedRule == nil)
+                Button(String(localized: "Toggle")) {
+                    if let id = viewModel.selectedRuleIDs.first {
+                        viewModel.toggleRule(id: id)
+                    }
+                }
+                .keyboardShortcut(.space, modifiers: [])
                 .disabled(viewModel.selectedRule == nil)
                 Divider()
                 Button(String(localized: "Enable All")) { viewModel.enableAll() }

--- a/Rockxy/Views/Rules/ModifyHeaderWindowView.swift
+++ b/Rockxy/Views/Rules/ModifyHeaderWindowView.swift
@@ -335,6 +335,7 @@ struct ModifyHeaderWindowView: View {
                 Image(systemName: "plus")
             }
             .buttonStyle(.borderless)
+            .keyboardShortcut("n", modifiers: .command)
             .help(String(localized: "New Rule"))
 
             Button {
@@ -346,6 +347,7 @@ struct ModifyHeaderWindowView: View {
                 Image(systemName: "minus")
             }
             .buttonStyle(.borderless)
+            .keyboardShortcut(.delete, modifiers: .command)
             .disabled(viewModel.selectedRuleID == nil)
             .help(String(localized: "Delete Rule"))
 
@@ -370,7 +372,7 @@ struct ModifyHeaderWindowView: View {
         Button(String(localized: "Edit…")) {
             viewModel.presentEditorForSelection()
         }
-        .keyboardShortcut(.return, modifiers: .command)
+        .keyboardShortcut("e", modifiers: .command)
 
         Divider()
 

--- a/Rockxy/Views/Rules/NetworkConditionsWindowView.swift
+++ b/Rockxy/Views/Rules/NetworkConditionsWindowView.swift
@@ -630,7 +630,7 @@ struct NetworkConditionsWindowView: View {
                     .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
-            .keyboardShortcut("-", modifiers: [])
+            .keyboardShortcut(.delete, modifiers: .command)
             .disabled(viewModel.selectedRuleID == nil)
             .help(String(localized: "Delete Rule"))
         }
@@ -654,7 +654,7 @@ struct NetworkConditionsWindowView: View {
             Button(String(localized: "Edit…")) {
                 openEditorForSelection()
             }
-            .keyboardShortcut(.return, modifiers: .command)
+            .keyboardShortcut("e", modifiers: .command)
             .disabled(viewModel.selectedRule == nil)
 
             Button(String(localized: "Duplicate")) {
@@ -669,6 +669,13 @@ struct NetworkConditionsWindowView: View {
                 }
             }
             .keyboardShortcut(.return, modifiers: [])
+            .disabled(viewModel.selectedRule == nil)
+            Button(enableDisableLabel) {
+                if let id = viewModel.selectedRuleID {
+                    viewModel.toggleRule(id: id)
+                }
+            }
+            .keyboardShortcut(.space, modifiers: [])
             .disabled(viewModel.selectedRule == nil)
 
             Divider()

--- a/Rockxy/Views/Scripting/ScriptCodeEditor.swift
+++ b/Rockxy/Views/Scripting/ScriptCodeEditor.swift
@@ -71,10 +71,19 @@ struct ScriptCodeEditor: NSViewRepresentable {
     @Binding var text: String
 
     func makeNSView(context: Context) -> NSScrollView {
-        let scrollView = NSTextView.scrollableTextView()
-        guard let textView = scrollView.documentView as? NSTextView else {
-            return scrollView
-        }
+        let scrollView = NSScrollView()
+        let contentSize = scrollView.contentSize
+        let textStorage = NSTextStorage()
+        let layoutManager = NSLayoutManager()
+        let textContainer = NSTextContainer(containerSize: NSSize(
+            width: CGFloat.greatestFiniteMagnitude,
+            height: CGFloat.greatestFiniteMagnitude
+        ))
+        textContainer.widthTracksTextView = false
+        textStorage.addLayoutManager(layoutManager)
+        layoutManager.addTextContainer(textContainer)
+
+        let textView = ScriptCodeTextView(frame: NSRect(origin: .zero, size: contentSize), textContainer: textContainer)
         textView.isEditable = true
         textView.isSelectable = true
         textView.allowsUndo = true
@@ -106,8 +115,10 @@ struct ScriptCodeEditor: NSViewRepresentable {
         textView.delegate = context.coordinator
         scrollView.drawsBackground = true
         scrollView.backgroundColor = .textBackgroundColor
+        scrollView.hasVerticalScroller = true
         scrollView.hasHorizontalScroller = true
         scrollView.autohidesScrollers = true
+        scrollView.documentView = textView
 
         let ruler = ScriptCodeEditorRulerView(textView: textView)
         scrollView.verticalRulerView = ruler
@@ -132,6 +143,115 @@ struct ScriptCodeEditor: NSViewRepresentable {
 
     func makeCoordinator() -> Coordinator {
         Coordinator(text: $text)
+    }
+}
+
+// MARK: - ScriptCodeTextView
+
+final class ScriptCodeTextView: NSTextView {
+    override func performKeyEquivalent(with event: NSEvent) -> Bool {
+        let modifiers = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+        guard modifiers == .command,
+              let key = event.charactersIgnoringModifiers
+        else {
+            return super.performKeyEquivalent(with: event)
+        }
+
+        switch key {
+        case "/":
+            toggleLineComment()
+            return true
+        case "[":
+            outdentSelection()
+            return true
+        case "]":
+            indentSelection()
+            return true
+        default:
+            return super.performKeyEquivalent(with: event)
+        }
+    }
+
+    private func toggleLineComment() {
+        replaceSelectedLines { lines in
+            let codeLines = lines.filter { !$0.trimmingCharacters(in: .whitespaces).isEmpty }
+            let shouldUncomment = !codeLines.isEmpty && codeLines.allSatisfy {
+                $0.range(of: #"^[ \t]*//"#, options: .regularExpression) != nil
+            }
+
+            return lines.map { line in
+                guard !line.trimmingCharacters(in: .whitespaces).isEmpty else {
+                    return line
+                }
+                if shouldUncomment {
+                    return Self.uncommented(line)
+                }
+                return Self.commented(line)
+            }
+        }
+    }
+
+    private func indentSelection() {
+        replaceSelectedLines { lines in
+            lines.map { "  " + $0 }
+        }
+    }
+
+    private func outdentSelection() {
+        replaceSelectedLines { lines in
+            lines.map(Self.outdented)
+        }
+    }
+
+    private func replaceSelectedLines(_ transform: ([String]) -> [String]) {
+        let nsText = string as NSString
+        let selection = selectedRange()
+        let lineRange = nsText.lineRange(for: selection)
+        let original = nsText.substring(with: lineRange)
+        let hasTrailingNewline = original.hasSuffix("\n")
+        var lines = original.components(separatedBy: "\n")
+        if hasTrailingNewline {
+            lines.removeLast()
+        }
+
+        var replacement = transform(lines).joined(separator: "\n")
+        if hasTrailingNewline {
+            replacement += "\n"
+        }
+
+        guard shouldChangeText(in: lineRange, replacementString: replacement) else {
+            return
+        }
+        textStorage?.replaceCharacters(in: lineRange, with: replacement)
+        didChangeText()
+        setSelectedRange(NSRange(location: selection.location, length: 0))
+    }
+
+    private static func commented(_ line: String) -> String {
+        let prefix = line.prefix { $0 == " " || $0 == "\t" }
+        return String(prefix) + "// " + line.dropFirst(prefix.count)
+    }
+
+    private static func uncommented(_ line: String) -> String {
+        let prefix = line.prefix { $0 == " " || $0 == "\t" }
+        let remainder = line.dropFirst(prefix.count)
+        if remainder.hasPrefix("// ") {
+            return String(prefix) + remainder.dropFirst(3)
+        }
+        if remainder.hasPrefix("//") {
+            return String(prefix) + remainder.dropFirst(2)
+        }
+        return line
+    }
+
+    private static func outdented(_ line: String) -> String {
+        if line.hasPrefix("  ") {
+            return String(line.dropFirst(2))
+        }
+        if line.hasPrefix("\t") || line.hasPrefix(" ") {
+            return String(line.dropFirst())
+        }
+        return line
     }
 }
 

--- a/Rockxy/Views/Scripting/ScriptEditorWindowView.swift
+++ b/Rockxy/Views/Scripting/ScriptEditorWindowView.swift
@@ -214,10 +214,9 @@ struct ScriptEditorWindowView: View {
             Button {
                 viewModel.beautify()
             } label: {
-                Text("Beautify (⌘B)")
+                Text("Beautify")
             }
             .buttonStyle(.bordered)
-            .keyboardShortcut("b", modifiers: .command)
 
             Button {
                 // Snippet Code — deferred to v2. Insert a small header-mutation example for now.
@@ -228,6 +227,14 @@ struct ScriptEditorWindowView: View {
             .buttonStyle(.bordered)
 
             Spacer()
+
+            Button {
+                validateRule()
+            } label: {
+                Text("Validate")
+            }
+            .buttonStyle(.bordered)
+            .keyboardShortcut("r", modifiers: .command)
 
             Button {
                 Task { await viewModel.saveAndActivate() }
@@ -281,6 +288,7 @@ struct ScriptEditorWindowView: View {
             }
             .buttonStyle(.plain)
             .foregroundStyle(.secondary)
+            .keyboardShortcut("c", modifiers: [.command, .shift])
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 4)
@@ -293,6 +301,7 @@ struct ScriptEditorWindowView: View {
         }
         Divider()
         Button("Toggle Console Log Panel") { viewModel.toggleConsolePanel() }
+            .keyboardShortcut("c", modifiers: [.command, .shift])
         Divider()
         Button("Import JSON or Other File…") {} // deferred
         Divider()
@@ -332,5 +341,13 @@ struct ScriptEditorWindowView: View {
             Image(systemName: "chevron.down")
                 .font(.system(size: 9, weight: .semibold))
         }
+    }
+
+    private func validateRule() {
+        let sample = viewModel.sampleURL.trimmingCharacters(in: .whitespacesAndNewlines)
+        let effectiveSample = sample.isEmpty ? "https://api.example.com/path" : sample
+        viewModel.testRulePreview = viewModel.testRule(against: effectiveSample)
+            ? "Matches: \(effectiveSample)"
+            : "No match for: \(effectiveSample)"
     }
 }

--- a/Rockxy/Views/Scripting/ScriptingListWindowView.swift
+++ b/Rockxy/Views/Scripting/ScriptingListWindowView.swift
@@ -224,7 +224,7 @@ struct ScriptingListWindowView: View {
                 Text("New Folder")
             }
             .buttonStyle(.bordered)
-            .keyboardShortcut("n", modifiers: [.command, .option])
+            .keyboardShortcut("n", modifiers: [.command, .shift])
 
             Button {
                 // help button — opens docs in a future milestone; for now, no-op.
@@ -328,17 +328,24 @@ struct ScriptingListWindowView: View {
         }
         .keyboardShortcut("n", modifiers: .command)
         Button("New Folder") { viewModel.createNewFolder() }
-            .keyboardShortcut("n", modifiers: [.command, .option])
+            .keyboardShortcut("n", modifiers: [.command, .shift])
         Divider()
         Button("Edit") {
             viewModel.openEditorForSelection()
             openWindow(id: "scriptEditor")
         }
-        .keyboardShortcut(.return, modifiers: .command)
+        .keyboardShortcut("e", modifiers: .command)
         .disabled(!isScriptSelected)
         Button("Duplicate") { Task { await viewModel.duplicateSelection() } }
             .keyboardShortcut("d", modifiers: .command)
             .disabled(!isScriptSelected)
+        Button("Enable Rule") {
+            if case let .script(id) = viewModel.selectedRowID {
+                Task { await viewModel.toggleScript(id: id) }
+            }
+        }
+        .keyboardShortcut(.return, modifiers: [])
+        .disabled(!isScriptSelected)
         Button("Enable Rule") {
             if case let .script(id) = viewModel.selectedRowID {
                 Task { await viewModel.toggleScript(id: id) }
@@ -438,7 +445,7 @@ struct ScriptingListWindowView: View {
                 viewModel.selectedRowID = previousSelection
             }
         }
-        .keyboardShortcut(.return, modifiers: .command)
+        .keyboardShortcut("e", modifiers: .command)
         .disabled({
             if case .script = row {
                 return false

--- a/Rockxy/Views/Settings/SSLProxyingListView.swift
+++ b/Rockxy/Views/Settings/SSLProxyingListView.swift
@@ -355,7 +355,7 @@ struct SSLProxyingListView: View {
             Button(String(localized: "Edit…")) {
                 viewModel.presentEditorForSelection()
             }
-            .keyboardShortcut(.return, modifiers: .command)
+            .keyboardShortcut("e", modifiers: .command)
             .disabled(viewModel.selectedRuleID == nil)
 
             Divider()
@@ -365,6 +365,15 @@ struct SSLProxyingListView: View {
                     viewModel.toggleRule(id: id)
                 }
             }
+            .keyboardShortcut(.return, modifiers: [])
+            .disabled(viewModel.selectedRuleID == nil)
+
+            Button(viewModel.enableDisableLabel) {
+                if let id = viewModel.selectedRuleID {
+                    viewModel.toggleRule(id: id)
+                }
+            }
+            .keyboardShortcut(.space, modifiers: [])
             .disabled(viewModel.selectedRuleID == nil)
 
             Button(String(localized: "Delete"), role: .destructive) {

--- a/Rockxy/Views/Toolbar/SearchFilterBar.swift
+++ b/Rockxy/Views/Toolbar/SearchFilterBar.swift
@@ -25,6 +25,7 @@ struct SearchFilterBar: View {
 
             TextField(String(localized: "Search..."), text: $searchText)
                 .textFieldStyle(.roundedBorder)
+                .focused($isSearchFocused)
 
             if !searchText.isEmpty {
                 Button {
@@ -40,5 +41,11 @@ struct SearchFilterBar: View {
         .padding(.vertical, 4)
         .background(Color(nsColor: .windowBackgroundColor))
         .overlay(alignment: .bottom) { Divider() }
+        .onReceive(NotificationCenter.default.publisher(for: .focusMainSearchField)) { _ in
+            isEnabled = true
+            isSearchFocused = true
+        }
     }
+
+    @FocusState private var isSearchFocused: Bool
 }

--- a/RockxyTests/Breakpoint/BreakpointPhaseATests.swift
+++ b/RockxyTests/Breakpoint/BreakpointPhaseATests.swift
@@ -98,7 +98,7 @@ struct BreakpointPhaseATests {
     // BP_A4
     @Test("addButtonCommitsDraftToRuleList")
     func addButtonCommitsDraftToRuleList() {
-        let viewModel = BreakpointRulesViewModel()
+        let viewModel = BreakpointRulesViewModel(syncsChanges: false)
         viewModel.addBreakpointRule(
             ruleName: "Add Test",
             urlPattern: "httpbin.org/get",
@@ -130,6 +130,28 @@ struct BreakpointPhaseATests {
             #expect(loaded.matchCondition.method == "PATCH")
             #expect(loaded.matchCondition.urlPattern == rule.matchCondition.urlPattern)
             #expect(loaded.isEnabled == true)
+        }
+    }
+
+    @Test("breakpoint window refresh loads persisted rules after restart")
+    func breakpointWindowRefreshLoadsPersistedRulesAfterRestart() async throws {
+        try await BreakpointRuleTestIsolation.withSharedRuleState {
+            let rule = ProxyRule.breakpointTest(
+                name: "Persisted Breakpoint",
+                matchingRule: "httpbin.org/restart",
+                method: .get,
+                phases: .both,
+                includeSubpaths: true
+            )
+            try RuleStore().saveRules([rule])
+            await RuleEngine.shared.replaceAll([])
+
+            let viewModel = BreakpointRulesViewModel(syncsChanges: false)
+            await viewModel.refreshFromEngine()
+
+            #expect(viewModel.breakpointRules.count == 1)
+            #expect(viewModel.breakpointRules.first?.id == rule.id)
+            #expect(viewModel.breakpointRules.first?.name == "Persisted Breakpoint")
         }
     }
 
@@ -165,7 +187,7 @@ struct BreakpointPhaseATests {
     // BP_A8
     @Test("duplicateRuleCreatesIndependentCopy")
     func duplicateRuleCreatesIndependentCopy() {
-        let viewModel = BreakpointRulesViewModel()
+        let viewModel = BreakpointRulesViewModel(syncsChanges: false)
         viewModel.addBreakpointRule(
             ruleName: "Original",
             urlPattern: "httpbin.org/get",
@@ -203,7 +225,7 @@ struct BreakpointPhaseATests {
         phaseResponse: Bool = true,
         includeSubpaths: Bool = false
     ) -> ProxyRule {
-        let viewModel = BreakpointRulesViewModel()
+        let viewModel = BreakpointRulesViewModel(syncsChanges: false)
         viewModel.addBreakpointRule(
             ruleName: name,
             urlPattern: matchingRule,

--- a/RockxyTests/Breakpoint/BreakpointPhaseDTests.swift
+++ b/RockxyTests/Breakpoint/BreakpointPhaseDTests.swift
@@ -8,11 +8,13 @@ struct BreakpointPhaseDTests {
     // BP_D1
     @Test("upstreamReceivesEditedRequest")
     func upstreamReceivesEditedRequest() async throws {
+        let upstream = try await BreakpointLocalHTTPServer.start()
+        defer { Task { await upstream.stop() } }
         let harness = try await BreakpointTestHarness.start()
-        await harness.addRule(.breakpointTest(matchingRule: "httpbin.org/headers", phases: .request))
+        await harness.addRule(.breakpointTest(matchingRule: await upstream.matchingRule("headers"), phases: .request))
         let session = try await harness.client()
         async let response = BreakpointTestHarness.dataWithRetry(
-            from: TestEndpoints.httpbinHTTP("headers"),
+            from: await upstream.url("headers"),
             session: session
         )
 
@@ -32,11 +34,13 @@ struct BreakpointPhaseDTests {
     // BP_D2
     @Test("captureRowReflectsEditedValues")
     func captureRowReflectsEditedValues() async throws {
+        let upstream = try await BreakpointLocalHTTPServer.start()
+        defer { Task { await upstream.stop() } }
         let harness = try await BreakpointTestHarness.start()
-        await harness.addRule(.breakpointTest(matchingRule: "httpbin.org/headers", phases: .request))
+        await harness.addRule(.breakpointTest(matchingRule: await upstream.matchingRule("headers"), phases: .request))
         let session = try await harness.client()
         async let response = BreakpointTestHarness.dataWithRetry(
-            from: TestEndpoints.httpbinHTTP("headers"),
+            from: await upstream.url("headers"),
             session: session
         )
         let item = try await harness.awaitNextPause(timeout: 8)
@@ -44,7 +48,7 @@ struct BreakpointPhaseDTests {
         await harness.resolve(item.id, decision: .execute)
         _ = try await response
         let capture = try #require(await harness.lastCapturedRow())
-        #expect(capture.request.url.absoluteString.contains("httpbin.org/headers"))
+        #expect(capture.request.url.absoluteString.contains(await upstream.matchingRule("headers")))
         await harness.stop()
     }
 

--- a/RockxyTests/Breakpoint/BreakpointPhaseETests.swift
+++ b/RockxyTests/Breakpoint/BreakpointPhaseETests.swift
@@ -101,11 +101,13 @@ struct BreakpointPhaseETests {
     // BP_E6
     @Test("executeDeliversEditedResponseToClient")
     func executeDeliversEditedResponseToClient() async throws {
+        let upstream = try await BreakpointLocalHTTPServer.start()
+        defer { Task { await upstream.stop() } }
         let harness = try await BreakpointTestHarness.start()
-        await harness.addRule(.breakpointTest(matchingRule: "httpbin.org/status/401", phases: .response))
+        await harness.addRule(.breakpointTest(matchingRule: await upstream.matchingRule("status/401"), phases: .response))
         let session = try await harness.client()
         async let response = BreakpointTestHarness.dataWithRetry(
-            from: TestEndpoints.httpbinHTTP("status/401"),
+            from: await upstream.url("status/401"),
             session: session
         )
         let item = try await harness.awaitNextPause(timeout: 8)

--- a/RockxyTests/Breakpoint/BreakpointPhaseGTests.swift
+++ b/RockxyTests/Breakpoint/BreakpointPhaseGTests.swift
@@ -27,17 +27,19 @@ struct BreakpointPhaseGTests {
     // BP_G2
     @Test("nonMatchingRequestsFlowWhilePaused")
     func nonMatchingRequestsFlowWhilePaused() async throws {
+        let upstream = try await BreakpointLocalHTTPServer.start()
+        defer { Task { await upstream.stop() } }
         let harness = try await BreakpointTestHarness.start()
-        await harness.addRule(.breakpointTest(matchingRule: "httpbin.org/delay/1", phases: .request))
+        await harness.addRule(.breakpointTest(matchingRule: await upstream.matchingRule("delay/1"), phases: .request))
         let session = try await harness.client()
         async let paused = BreakpointTestHarness.dataWithRetry(
-            from: TestEndpoints.httpbinHTTP("delay/1"),
+            from: await upstream.url("delay/1"),
             session: session
         )
         let item = try await harness.awaitNextPause(timeout: 8)
 
         let (data, response) = try await BreakpointTestHarness.dataWithRetry(
-            from: TestEndpoints.httpbinHTTP("get"),
+            from: await upstream.url("get"),
             session: session
         )
         #expect((response as? HTTPURLResponse)?.statusCode == 200)
@@ -135,24 +137,19 @@ struct BreakpointPhaseGTests {
         _ = await task.value
     }
 
-    private func waitForQueueCount(_ count: Int, manager: BreakpointManager) async throws {
-        if manager.pausedItems.count >= count {
-            return
-        }
-        try await withThrowingTaskGroup(of: Void.self) { group in
-            group.addTask { @MainActor in
-                for await _ in NotificationCenter.default.notifications(named: .breakpointHit) {
-                    if manager.pausedItems.count >= count {
-                        return
-                    }
-                }
+    private func waitForQueueCount(
+        _ count: Int,
+        manager: BreakpointManager,
+        timeout seconds: TimeInterval = 2
+    ) async throws {
+        let deadline = Date().addingTimeInterval(seconds)
+        while Date() < deadline {
+            if manager.pausedItems.count >= count {
+                return
             }
-            group.addTask {
-                try await Task.sleep(nanoseconds: 2_000_000_000)
-                throw BreakpointHarnessError.timeout("Timed out waiting for \(count) queued breakpoint items.")
-            }
-            try await group.next()
-            group.cancelAll()
+            try await Task.sleep(nanoseconds: 10_000_000)
+            await Task.yield()
         }
+        throw BreakpointHarnessError.timeout("Timed out waiting for \(count) queued breakpoint items.")
     }
 }

--- a/RockxyTests/Breakpoint/BreakpointTestHarness.swift
+++ b/RockxyTests/Breakpoint/BreakpointTestHarness.swift
@@ -1,5 +1,8 @@
 import Darwin
 import Foundation
+import NIOCore
+import NIOHTTP1
+import NIOPosix
 @testable import Rockxy
 import Testing
 
@@ -213,6 +216,145 @@ actor BreakpointTestHarness {
             throw BreakpointHarnessError.socket("Unable to inspect test socket port.")
         }
         return Int(UInt16(bigEndian: addr.sin_port))
+    }
+}
+
+// MARK: - BreakpointLocalHTTPServer
+
+actor BreakpointLocalHTTPServer {
+    static func start() async throws -> BreakpointLocalHTTPServer {
+        let server = BreakpointLocalHTTPServer()
+        try await server.start()
+        return server
+    }
+
+    func url(_ path: String) -> URL {
+        var components = URLComponents()
+        components.scheme = "http"
+        components.host = host
+        components.port = port
+        components.path = "/\(path.trimmingCharacters(in: CharacterSet(charactersIn: "/")))"
+        guard let url = components.url else {
+            preconditionFailure("Breakpoint local test server produced an invalid URL.")
+        }
+        return url
+    }
+
+    func matchingRule(_ path: String) -> String {
+        "\(host):\(port)/\(path.trimmingCharacters(in: CharacterSet(charactersIn: "/")))"
+    }
+
+    func stop() async {
+        let channel = serverChannel
+        serverChannel = nil
+        if let channel {
+            try? await channel.close().get()
+        }
+        if let eventLoopGroup {
+            try? await eventLoopGroup.shutdownGracefully()
+        }
+        eventLoopGroup = nil
+        port = 0
+    }
+
+    private let host = "127.0.0.1"
+    private var port = 0
+    private var eventLoopGroup: MultiThreadedEventLoopGroup?
+    private var serverChannel: Channel?
+
+    private func start() async throws {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        eventLoopGroup = group
+
+        do {
+            let channel = try await ServerBootstrap(group: group)
+                .serverChannelOption(.backlog, value: 16)
+                .serverChannelOption(.socketOption(.so_reuseaddr), value: 1)
+                .childChannelInitializer { channel in
+                    channel.pipeline.configureHTTPServerPipeline().flatMap {
+                        channel.pipeline.addHandler(BreakpointLocalHTTPHandler())
+                    }
+                }
+                .childChannelOption(.socketOption(.so_reuseaddr), value: 1)
+                .bind(host: host, port: 0)
+                .get()
+
+            guard let boundPort = channel.localAddress?.port else {
+                try await channel.close().get()
+                throw BreakpointHarnessError.socket("Unable to inspect local test server port.")
+            }
+            serverChannel = channel
+            port = boundPort
+        } catch {
+            try? await group.shutdownGracefully()
+            eventLoopGroup = nil
+            throw error
+        }
+    }
+}
+
+private final class BreakpointLocalHTTPHandler: ChannelInboundHandler, @unchecked Sendable {
+    typealias InboundIn = HTTPServerRequestPart
+    typealias OutboundOut = HTTPServerResponsePart
+
+    func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+        switch unwrapInboundIn(data) {
+        case let .head(head):
+            requestHead = head
+        case .body:
+            break
+        case .end:
+            respond(context: context)
+            requestHead = nil
+        }
+    }
+
+    private var requestHead: HTTPRequestHead?
+
+    private func respond(context: ChannelHandlerContext) {
+        let head = requestHead
+        let path = URLComponents(string: head?.uri ?? "/")?.path ?? "/"
+        let response = response(for: path, requestHeaders: head?.headers ?? HTTPHeaders())
+        var headers = response.headers
+        headers.add(name: "Content-Length", value: "\(response.body.readableBytes)")
+        headers.add(name: "Connection", value: "close")
+
+        let responseHead = HTTPResponseHead(version: .http1_1, status: response.status, headers: headers)
+        context.write(wrapOutboundOut(.head(responseHead)), promise: nil)
+        context.write(wrapOutboundOut(.body(.byteBuffer(response.body))), promise: nil)
+        context.writeAndFlush(wrapOutboundOut(.end(nil))).whenComplete { _ in
+            context.close(promise: nil)
+        }
+    }
+
+    private func response(for path: String, requestHeaders: HTTPHeaders) -> (
+        status: HTTPResponseStatus,
+        headers: HTTPHeaders,
+        body: ByteBuffer
+    ) {
+        var buffer = ByteBufferAllocator().buffer(capacity: 256)
+        var headers = HTTPHeaders()
+
+        switch path {
+        case "/headers":
+            headers.add(name: "Content-Type", value: "application/json")
+            let echoedHeaders = Dictionary(requestHeaders.map { ($0.name, $0.value) }, uniquingKeysWith: { _, latest in latest })
+            let payload = (try? JSONSerialization.data(withJSONObject: ["headers": echoedHeaders])) ?? Data("{}".utf8)
+            buffer.writeBytes(payload)
+            return (.ok, headers, buffer)
+        case "/status/401":
+            headers.add(name: "Content-Type", value: "text/plain")
+            buffer.writeString("unauthorized")
+            return (.unauthorized, headers, buffer)
+        case "/delay/1", "/get":
+            headers.add(name: "Content-Type", value: "application/json")
+            buffer.writeString(#"{"ok":true}"#)
+            return (.ok, headers, buffer)
+        default:
+            headers.add(name: "Content-Type", value: "text/plain")
+            buffer.writeString("not found")
+            return (.notFound, headers, buffer)
+        }
     }
 }
 

--- a/RockxyTests/Breakpoint/BreakpointTestHarness.swift
+++ b/RockxyTests/Breakpoint/BreakpointTestHarness.swift
@@ -287,15 +287,7 @@ struct BreakpointRuleStateBackup {
 enum BreakpointRuleTestIsolation {
     private static let breakpointToolEnabledKey = "breakpointToolEnabled"
 
-    private static let rulesPath: URL = {
-        let appSupport = FileManager.default.urls(
-            for: .applicationSupportDirectory,
-            in: .userDomainMask
-        )[0]
-        return appSupport
-            .appendingPathComponent(TestIdentity.appSupportDirectoryName, isDirectory: true)
-            .appendingPathComponent(TestIdentity.rulesPathComponent)
-    }()
+    private static let rulesPath = RockxyIdentity.current.appSupportPath(TestIdentity.rulesPathComponent)
 
     static func withSharedRuleState(_ body: () async throws -> Void) async rethrows {
         await RuleTestLock.shared.acquire()

--- a/RockxyTests/Compose/ComposeHistoryTests.swift
+++ b/RockxyTests/Compose/ComposeHistoryTests.swift
@@ -1,0 +1,314 @@
+import Foundation
+@testable import Rockxy
+import Testing
+
+// Regression tests for Compose request-history snapshots and persistence.
+
+// MARK: - ComposeHistoryTests
+
+@MainActor
+struct ComposeHistoryTests {
+    // MARK: Internal
+
+    @Test("HIST_01 recordHistorySnapshotsFullRequest")
+    func recordHistorySnapshotsFullRequest() async throws {
+        let vm = ComposeViewModel(executor: successExecutor(), historyStore: makeStore())
+        vm.method = "POST"
+        vm.url = "https://api.example.com/orders?expectedTotal=42"
+        vm.syncURLToQuery(force: true)
+        vm.headers = [
+            EditableReplayHeader(name: "Content-Type", value: "application/json"),
+            EditableReplayHeader(name: "X-Debug", value: "on", isEnabled: false),
+        ]
+        vm.body = #"{"expectedTotal":42}"#
+
+        await vm.send()
+
+        let entry = try #require(vm.history.first)
+        #expect(entry.method == "POST")
+        #expect(entry.url == "https://api.example.com/orders?expectedTotal=42")
+        #expect(entry.headers == vm.headers)
+        #expect(entry.queryItems == vm.queryItems)
+        #expect(entry.body == #"{"expectedTotal":42}"#)
+        #expect(entry.bodyContentType == "application/json")
+        #expect(entry.statusCode == 200)
+    }
+
+    @Test("HIST_02 restoreEntryRestoresMethodUrl")
+    func restoreEntryRestoresMethodUrl() async throws {
+        let vm = ComposeViewModel(executor: successExecutor(), historyStore: makeStore())
+        vm.method = "PATCH"
+        vm.url = "https://api.example.com/items/1?expectedTotal=41"
+        vm.syncURLToQuery(force: true)
+        await vm.send()
+        let id = try #require(vm.history.first?.id)
+
+        vm.method = "GET"
+        vm.url = "https://api.example.com/other"
+        vm.restoreHistoryEntry(id: id)
+
+        #expect(vm.method == "PATCH")
+        #expect(vm.url == "https://api.example.com/items/1?expectedTotal=41")
+    }
+
+    @Test("HIST_03 restoreEntryRestoresHeaders")
+    func restoreEntryRestoresHeaders() async throws {
+        let vm = ComposeViewModel(executor: successExecutor(), historyStore: makeStore())
+        vm.url = "https://api.example.com/items"
+        vm.headers = [
+            EditableReplayHeader(name: "Content-Type", value: "application/json"),
+            EditableReplayHeader(name: "X-Expected-Total", value: "42"),
+        ]
+        await vm.send()
+        let id = try #require(vm.history.first?.id)
+
+        vm.headers = [EditableReplayHeader(name: "Accept", value: "text/plain")]
+        vm.restoreHistoryEntry(id: id)
+
+        #expect(vm.headers.map(\.name) == ["Content-Type", "X-Expected-Total"])
+        #expect(vm.headers.map(\.value) == ["application/json", "42"])
+    }
+
+    @Test("HIST_04 restoreEntryRestoresBody")
+    func restoreEntryRestoresBody() async throws {
+        let vm = ComposeViewModel(executor: successExecutor(), historyStore: makeStore())
+        vm.method = "POST"
+        vm.url = "https://api.example.com/items"
+        vm.body = #"{"expectedTotal":42}"#
+        await vm.send()
+        let id = try #require(vm.history.first?.id)
+
+        vm.body = #"{"expectedTotal":7}"#
+        vm.restoreHistoryEntry(id: id)
+
+        #expect(vm.body == #"{"expectedTotal":42}"#)
+    }
+
+    @Test("HIST_05 restoreEntryRestoresQueryItems")
+    func restoreEntryRestoresQueryItems() async throws {
+        let vm = ComposeViewModel(executor: successExecutor(), historyStore: makeStore())
+        vm.url = "https://api.example.com/search?expectedTotal=42&mode=strict"
+        vm.syncURLToQuery(force: true)
+        await vm.send()
+        let id = try #require(vm.history.first?.id)
+
+        vm.queryItems = [EditableQueryItem(name: "mode", value: "loose")]
+        vm.restoreHistoryEntry(id: id)
+
+        #expect(vm.queryItems.map(\.name) == ["expectedTotal", "mode"])
+        #expect(vm.queryItems.map(\.value) == ["42", "strict"])
+    }
+
+    @Test("HIST_06 restoreEntryRestoresResponsePanel")
+    func restoreEntryRestoresResponsePanel() async throws {
+        let vm = ComposeViewModel(
+            executor: successExecutor(body: #"{"ok":true}"#, headers: ["Content-Type": "application/json"]),
+            historyStore: makeStore()
+        )
+        vm.url = "https://api.example.com/items"
+        await vm.send()
+        let id = try #require(vm.history.first?.id)
+
+        vm.applyTemplate(.empty)
+        vm.restoreHistoryEntry(id: id)
+
+        if case let .success(response) = vm.responseState {
+            #expect(response.statusCode == 200)
+            #expect(response.bodyDisplayText == #"{"ok":true}"#)
+            #expect(response.headers.contains { $0.name == "Content-Type" && $0.value == "application/json" })
+        } else {
+            Issue.record("Expected restored response panel")
+        }
+    }
+
+    @Test("HIST_07 restoreEntryDoesNotPolluteFutureEdits")
+    func restoreEntryDoesNotPolluteFutureEdits() async throws {
+        let vm = ComposeViewModel(executor: successExecutor(), historyStore: makeStore())
+        vm.method = "POST"
+        vm.url = "https://api.example.com/items"
+        vm.headers = [EditableReplayHeader(name: "X-Expected-Total", value: "42")]
+        vm.body = #"{"expectedTotal":42}"#
+        await vm.send()
+        let id = try #require(vm.history.first?.id)
+
+        vm.restoreHistoryEntry(id: id)
+        vm.headers[0].value = "7"
+        vm.body = #"{"expectedTotal":7}"#
+
+        let entry = try #require(vm.history.first)
+        #expect(entry.headers[0].value == "42")
+        #expect(entry.body == #"{"expectedTotal":42}"#)
+    }
+
+    @Test("HIST_08 historyDedupeOnIdenticalConsecutiveSends")
+    func historyDedupeOnIdenticalConsecutiveSends() async {
+        let vm = ComposeViewModel(executor: successExecutor(), historyStore: makeStore())
+        vm.method = "POST"
+        vm.url = "https://api.example.com/items"
+        vm.body = #"{"expectedTotal":42}"#
+
+        await vm.send()
+        await vm.send()
+
+        #expect(vm.history.count == 1)
+    }
+
+    @Test("HIST_09 historyPersistsAcrossViewModelReset")
+    func historyPersistsAcrossViewModelReset() async throws {
+        let store = makeStore()
+        let firstVM = ComposeViewModel(executor: successExecutor(), historyStore: store)
+        firstVM.method = "POST"
+        firstVM.url = "https://api.example.com/items"
+        firstVM.body = #"{"expectedTotal":42}"#
+        await firstVM.send()
+
+        let secondVM = ComposeViewModel(executor: successExecutor(), historyStore: store)
+
+        let entry = try #require(secondVM.history.first)
+        #expect(entry.method == "POST")
+        #expect(entry.url == "https://api.example.com/items")
+        #expect(entry.body == #"{"expectedTotal":42}"#)
+    }
+
+    @Test("HIST_10 historyRedactsAuthorizationHeader")
+    func historyRedactsAuthorizationHeader() async throws {
+        let store = makeStore()
+        let firstVM = ComposeViewModel(executor: successExecutor(), historyStore: store)
+        firstVM.url = "https://api.example.com/private"
+        firstVM.headers = [
+            EditableReplayHeader(name: "Authorization", value: "Bearer secret"),
+            EditableReplayHeader(name: "Cookie", value: "session=secret"),
+            EditableReplayHeader(name: "X-Trace", value: "kept"),
+        ]
+        await firstVM.send()
+
+        #expect(firstVM.history[0].headers[0].value == "Bearer secret")
+
+        let secondVM = ComposeViewModel(executor: successExecutor(), historyStore: store)
+        let headers = try #require(secondVM.history.first?.headers)
+        #expect(headers.first { $0.name == "Authorization" }?.value == "<redacted before saving>")
+        #expect(headers.first { $0.name == "Cookie" }?.value == "<redacted before saving>")
+        #expect(headers.first { $0.name == "X-Trace" }?.value == "kept")
+    }
+
+    @Test("HIST_11 historyEnforcesSizeCap")
+    func historyEnforcesSizeCap() async {
+        let store = makeStore(maxEntries: 200)
+        let vm = ComposeViewModel(executor: successExecutor(), historyStore: store)
+
+        for index in 0 ..< 250 {
+            vm.url = "https://api.example.com/items/\(index)"
+            await vm.send()
+        }
+
+        #expect(vm.history.count == 200)
+        #expect(vm.history.first?.url == "https://api.example.com/items/249")
+        #expect(vm.history.last?.url == "https://api.example.com/items/50")
+    }
+
+    @Test("HIST_12 historyTruncatesLargeBodies")
+    func historyTruncatesLargeBodies() async throws {
+        let store = makeStore()
+        let largeBody = String(repeating: "x", count: 1_048_576)
+        let vm = ComposeViewModel(executor: successExecutor(body: largeBody), historyStore: store)
+        vm.method = "POST"
+        vm.url = "https://api.example.com/large"
+        vm.body = largeBody
+        await vm.send()
+
+        let reloadedVM = ComposeViewModel(executor: successExecutor(), historyStore: store)
+        let entry = try #require(reloadedVM.history.first)
+        #expect(entry.bodyTruncated == true)
+        #expect(entry.responseBodyTruncated == true)
+        #expect(Data(entry.body.utf8).count == ComposeHistoryStore.defaultBodySizeLimit)
+
+        reloadedVM.restoreHistoryEntry(id: entry.id)
+        #expect(reloadedVM.body == entry.body)
+    }
+
+    @Test("HIST_13 historyEntryWithDisabledHeaderRoundTrips")
+    func historyEntryWithDisabledHeaderRoundTrips() async throws {
+        let vm = ComposeViewModel(executor: successExecutor(), historyStore: makeStore())
+        vm.url = "https://api.example.com/items"
+        vm.headers = [
+            EditableReplayHeader(name: "X-Enabled", value: "yes"),
+            EditableReplayHeader(name: "X-Disabled", value: "no", isEnabled: false),
+        ]
+        await vm.send()
+        let id = try #require(vm.history.first?.id)
+
+        vm.headers = []
+        vm.restoreHistoryEntry(id: id)
+
+        #expect(vm.headers.count == 2)
+        #expect(vm.headers[0].isEnabled == true)
+        #expect(vm.headers[1].isEnabled == false)
+    }
+
+    @Test("HIST_14 webSocketSessionsExcludedFromHistory")
+    func webSocketSessionsExcludedFromHistory() async {
+        let transaction = TestFixtures.makeWebSocketTransaction()
+        let vm = ComposeViewModel(executor: successExecutor(), historyStore: makeStore())
+        vm.prefill(from: transaction)
+
+        await vm.send()
+
+        #expect(vm.history.isEmpty)
+    }
+
+    @Test("HIST_15 restoreEntryEmitsObservableChangeForBindings")
+    func restoreEntryEmitsObservableChangeForBindings() async throws {
+        let vm = ComposeViewModel(executor: successExecutor(), historyStore: makeStore())
+        vm.method = "POST"
+        vm.url = "https://api.example.com/items"
+        vm.headers = [EditableReplayHeader(name: "X-Expected-Total", value: "42")]
+        vm.body = #"{"expectedTotal":42}"#
+        await vm.send()
+        let id = try #require(vm.history.first?.id)
+        let previousConfirmationID = vm.restoreConfirmationID
+
+        vm.method = "GET"
+        vm.url = "https://api.example.com/other"
+        vm.headers = []
+        vm.body = ""
+        vm.restoreHistoryEntry(id: id)
+
+        #expect(vm.restoreConfirmationID != previousConfirmationID)
+        #expect(vm.restoreConfirmationMessage == "Restored from history")
+        #expect(vm.method == "POST")
+        #expect(vm.url == "https://api.example.com/items")
+        #expect(vm.headers.count == 1)
+        #expect(vm.body == #"{"expectedTotal":42}"#)
+    }
+
+    // MARK: Private
+
+    private func makeStore(
+        maxEntries: Int = ComposeHistoryStore.defaultMaxEntries,
+        bodySizeLimit: Int = ComposeHistoryStore.defaultBodySizeLimit
+    ) -> ComposeHistoryStore {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("rockxy-compose-history-\(UUID().uuidString)")
+            .appendingPathComponent("compose-history.json")
+        return ComposeHistoryStore(fileURL: url, maxEntries: maxEntries, bodySizeLimit: bodySizeLimit)
+    }
+
+    private func successExecutor(
+        statusCode: Int = 200,
+        body: String = "ok",
+        headers: [String: String] = [:]
+    ) -> MockComposeExecutor {
+        MockComposeExecutor { _, _ in
+            let url = try #require(URL(string: "https://api.example.com/response"))
+            let response = try #require(
+                HTTPURLResponse(
+                    url: url,
+                    statusCode: statusCode,
+                    httpVersion: nil,
+                    headerFields: headers
+                )
+            )
+            return (Data(body.utf8), response)
+        }
+    }
+}

--- a/RockxyTests/Compose/ComposeStoreTests.swift
+++ b/RockxyTests/Compose/ComposeStoreTests.swift
@@ -1,0 +1,49 @@
+import Foundation
+@testable import Rockxy
+import Testing
+
+// Regression tests for Compose menu/window handoff state.
+
+// MARK: - ComposeStoreTests
+
+@MainActor
+struct ComposeStoreTests {
+    // MARK: Internal
+
+    @Test("Fresh Compose request clears pending selected transaction")
+    func blankDraftRequestClearsPendingTransaction() {
+        let store = ComposeStore.shared
+        let transaction = TestFixtures.makeTransaction(method: "POST", url: "https://api.example.com/stale")
+        store.requestDraft(from: transaction)
+        let previousVersion = store.draftVersion
+
+        store.requestBlankDraft()
+
+        #expect(store.pendingTransaction == nil)
+        #expect(store.shouldOpenBlankDraft)
+        #expect(store.draftVersion == previousVersion &+ 1)
+        reset(store)
+    }
+
+    @Test("Edit and Repeat request targets the selected transaction")
+    func transactionDraftRequestClearsBlankFlag() {
+        let store = ComposeStore.shared
+        store.requestBlankDraft()
+        let previousVersion = store.draftVersion
+        let transaction = TestFixtures.makeTransaction(method: "PATCH", url: "https://api.example.com/selected")
+
+        store.requestDraft(from: transaction)
+
+        #expect(store.pendingTransaction === transaction)
+        #expect(store.shouldOpenBlankDraft == false)
+        #expect(store.draftVersion == previousVersion &+ 1)
+        reset(store)
+    }
+
+    // MARK: Private
+
+    private func reset(_ store: ComposeStore) {
+        store.pendingTransaction = nil
+        store.shouldOpenBlankDraft = false
+    }
+}

--- a/RockxyTests/Core/RuleEngine/RuleSyncServiceTests.swift
+++ b/RockxyTests/Core/RuleEngine/RuleSyncServiceTests.swift
@@ -144,6 +144,26 @@ struct RuleSyncServiceTests {
         }
     }
 
+    @Test("loadFromDisk does not overwrite persisted rules when decoding fails")
+    func loadFromDiskPreservesPersistedRulesOnDecodeFailure() async {
+        await withRuleTestLock { [self] in
+            let invalidData = Data(#"{"not":"a rule list"}"#.utf8)
+            try? FileManager.default.createDirectory(
+                at: Self.rulesPath.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            try? invalidData.write(to: Self.rulesPath, options: .atomic)
+            await RuleEngine.shared.replaceAll([])
+
+            await RuleSyncService.loadFromDisk()
+
+            let storedData = try? Data(contentsOf: Self.rulesPath)
+            let engineRules = await RuleEngine.shared.allRules
+            #expect(storedData == invalidData)
+            #expect(engineRules.isEmpty)
+        }
+    }
+
     @Test("setBreakpointToolEnabled persists UserDefaults and updates breakpoint matcher gate")
     func setBreakpointToolEnabledPersistsAndUpdatesGate() async {
         await withRuleTestLock { [self] in
@@ -190,15 +210,7 @@ struct RuleSyncServiceTests {
     private static let breakpointToolEnabledKey = "breakpointToolEnabled"
     private static let networkConditionsToolEnabledKey = "networkConditionsToolEnabled"
 
-    private static let rulesPath: URL = {
-        let appSupport = FileManager.default.urls(
-            for: .applicationSupportDirectory,
-            in: .userDomainMask
-        )[0]
-        return appSupport
-            .appendingPathComponent(TestIdentity.appSupportDirectoryName, isDirectory: true)
-            .appendingPathComponent(TestIdentity.rulesPathComponent)
-    }()
+    private static let rulesPath = RockxyIdentity.current.appSupportPath(TestIdentity.rulesPathComponent)
 
     private func backupRules() async -> RulesBackup {
         let diskData = try? Data(contentsOf: Self.rulesPath)

--- a/RockxyTests/Keyboard/KeyboardShortcutTests.swift
+++ b/RockxyTests/Keyboard/KeyboardShortcutTests.swift
@@ -1,0 +1,73 @@
+import Foundation
+@testable import Rockxy
+import Testing
+
+@Suite("Keyboard shortcuts")
+struct KeyboardShortcutTests {
+    @Test("KS convention row is documented", arguments: KeyboardShortcutCatalog.allShortcuts)
+    func conventionRowIsDocumented(shortcut: KeyboardShortcutReference) throws {
+        let reference = try Self.documentation(named: "keyboard-shortcuts.md")
+        #expect(Self.shortcutIsDocumented(shortcut.shortcut, in: reference))
+        #expect(reference.localizedCaseInsensitiveContains(shortcut.action))
+    }
+
+    @Test("KS_MENU_01 discoverable menu shortcuts are listed with menu locations")
+    func menuShortcutsHaveMenuLocation() {
+        let menuBacked = KeyboardShortcutCatalog.allShortcuts.filter { $0.menu != nil }
+        #expect(!menuBacked.isEmpty)
+        #expect(menuBacked.allSatisfy { $0.menu?.isEmpty == false })
+    }
+
+    @Test("KS_CONFLICT_01 no duplicate shortcut in the same documented context")
+    func noDuplicateShortcutInSameContext() {
+        let grouped = Dictionary(grouping: KeyboardShortcutCatalog.allShortcuts) { shortcut in
+            "\(shortcut.window)|\(shortcut.context)|\(shortcut.shortcut)"
+        }
+        let duplicates = grouped.filter { _, rows in rows.count > 1 }
+        #expect(duplicates.isEmpty)
+    }
+
+    @Test("KS_FOCUS_01 rules lists document immediate toggle focus")
+    func rulesListToggleFocusIsDocumented() throws {
+        let reference = try Self.documentation(named: "keyboard-shortcuts.md")
+        #expect(reference.contains("`↵` / `Space`"))
+        #expect(reference.localizedCaseInsensitiveContains("list has focus"))
+    }
+
+    @Test("KS_FOCUS_02 Compose documents URL autofocus and focus shortcut")
+    func composeURLFocusIsDocumented() throws {
+        let reference = try Self.documentation(named: "keyboard-shortcuts.md")
+        #expect(reference.contains("Focus the URL field"))
+        #expect(reference.contains("`⌘L`"))
+    }
+
+    @Test("KS_FOCUS_03 Breakpoint Queue documents execute without an extra click")
+    func breakpointQueueExecuteFocusIsDocumented() throws {
+        let reference = try Self.documentation(named: "keyboard-shortcuts.md")
+        #expect(reference.contains("Execute the selected paused item"))
+        #expect(reference.contains("`⌘↩`"))
+    }
+
+    @Test("Help sheet is backed by the same shortcut catalog")
+    func helpSheetUsesCatalog() {
+        let allRows = KeyboardShortcutCatalog.allShortcuts
+        #expect(allRows.count >= 40)
+        #expect(KeyboardShortcutCatalog.filtered(by: "compose").contains { $0.title == "Compose" })
+        #expect(KeyboardShortcutCatalog.filtered(by: "breakpoint").contains { $0.title == "Breakpoint Queue" })
+    }
+
+    private static func documentation(named name: String) throws -> String {
+        let testFile = URL(fileURLWithPath: #filePath)
+        let repoRoot = testFile
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let url = repoRoot.appendingPathComponent("docs").appendingPathComponent(name)
+        return try String(contentsOf: url, encoding: .utf8)
+    }
+
+    private static func shortcutIsDocumented(_ shortcut: String, in reference: String) -> Bool {
+        let parts = shortcut.components(separatedBy: " / ")
+        return parts.allSatisfy { reference.contains("`\($0)`") }
+    }
+}

--- a/RockxyTests/ViewModels/ComposeViewModelTests.swift
+++ b/RockxyTests/ViewModels/ComposeViewModelTests.swift
@@ -8,10 +8,10 @@ import Testing
 
 /// Mock executor for deterministic testing of ComposeViewModel.
 struct MockComposeExecutor: ComposeRequestExecutor {
-    let handler: @Sendable (URLRequest) async throws -> (Data, HTTPURLResponse)
+    let handler: @Sendable (URLRequest, Bool) async throws -> (Data, HTTPURLResponse)
 
-    func execute(_ request: URLRequest) async throws -> (Data, HTTPURLResponse) {
-        try await handler(request)
+    func execute(_ request: URLRequest, followsRedirects: Bool) async throws -> (Data, HTTPURLResponse) {
+        try await handler(request, followsRedirects)
     }
 }
 
@@ -55,7 +55,7 @@ struct ComposeViewModelTests {
     @Test("Prefill resets response state to empty")
     func prefillResetsResponse() async throws {
         let response = try makeResponse()
-        let executor = MockComposeExecutor { _ in
+        let executor = MockComposeExecutor { _, _ in
             (Data("ok".utf8), response)
         }
         let vm = ComposeViewModel(executor: executor)
@@ -83,7 +83,7 @@ struct ComposeViewModelTests {
             url: "https://api.example.com/test",
             headerFields: ["Content-Type": "application/json"]
         )
-        let executor = MockComposeExecutor { _ in
+        let executor = MockComposeExecutor { _, _ in
             (jsonBody, response)
         }
 
@@ -106,7 +106,7 @@ struct ComposeViewModelTests {
 
     @Test("Send failure updates error state")
     func sendFailure() async {
-        let executor = MockComposeExecutor { _ in
+        let executor = MockComposeExecutor { _, _ in
             throw URLError(.notConnectedToInternet)
         }
 
@@ -146,7 +146,7 @@ struct ComposeViewModelTests {
         let firstResponse = try makeResponse(statusCode: 200)
         let secondResponse = try makeResponse(statusCode: 201)
 
-        let executor = MockComposeExecutor { _ in
+        let executor = MockComposeExecutor { _, _ in
             let count = callCount.increment()
 
             if count == 1 {
@@ -194,7 +194,7 @@ struct ComposeViewModelTests {
     func binaryResponseFallback() async throws {
         let binaryData = Data([0x00, 0x01, 0xFF, 0xFE])
         let response = try makeResponse(headerFields: ["Content-Type": "application/octet-stream"])
-        let executor = MockComposeExecutor { _ in
+        let executor = MockComposeExecutor { _, _ in
             (binaryData, response)
         }
 
@@ -302,6 +302,351 @@ struct ComposeViewModelTests {
         #expect(raw.contains("{\"name\":\"test\"}"))
     }
 
+    @Test("Raw request text excludes disabled headers")
+    func rawRequestTextExcludesDisabledHeaders() {
+        let vm = ComposeViewModel()
+        vm.method = "GET"
+        vm.url = "https://api.example.com/users"
+        vm.headers = [
+            EditableReplayHeader(name: "X-Enabled", value: "yes"),
+            EditableReplayHeader(name: "X-Disabled", value: "no", isEnabled: false),
+        ]
+
+        let raw = vm.rawRequestText
+
+        #expect(raw.contains("X-Enabled: yes"))
+        #expect(!raw.contains("X-Disabled"))
+    }
+
+    // MARK: - Request Options
+
+    @Test("Send applies timeout, redirect policy, enabled headers, and body")
+    func sendAppliesRequestOptions() async throws {
+        let capture = RequestCapture()
+        let response = try makeResponse()
+        let executor = MockComposeExecutor { request, followsRedirects in
+            capture.record(request: request, followsRedirects: followsRedirects)
+            return (Data("ok".utf8), response)
+        }
+        let vm = ComposeViewModel(executor: executor)
+        vm.method = "POST"
+        vm.url = "https://api.example.com/create"
+        vm.body = "payload"
+        vm.requestTimeout = .sixty
+        vm.followsRedirects = false
+        vm.headers = [
+            EditableReplayHeader(name: "X-Enabled", value: "yes"),
+            EditableReplayHeader(name: "X-Disabled", value: "no", isEnabled: false),
+            EditableReplayHeader(name: "", value: "ignored"),
+        ]
+
+        await vm.send()
+
+        let captured = try #require(capture.request)
+        #expect(captured.httpMethod == "POST")
+        #expect(captured.timeoutInterval == 60)
+        #expect(captured.httpBody == Data("payload".utf8))
+        #expect(captured.value(forHTTPHeaderField: "X-Enabled") == "yes")
+        #expect(captured.value(forHTTPHeaderField: "X-Disabled") == nil)
+        #expect(capture.followsRedirects == false)
+    }
+
+    @Test("No timeout maps to a non-expiring request interval")
+    func noTimeoutUsesNonExpiringInterval() async throws {
+        let capture = RequestCapture()
+        let response = try makeResponse()
+        let executor = MockComposeExecutor { request, followsRedirects in
+            capture.record(request: request, followsRedirects: followsRedirects)
+            return (Data("ok".utf8), response)
+        }
+        let vm = ComposeViewModel(executor: executor)
+        vm.url = "https://api.example.com/no-timeout"
+        vm.requestTimeout = .none
+
+        await vm.send()
+
+        let captured = try #require(capture.request)
+        #expect(captured.timeoutInterval == TimeInterval.greatestFiniteMagnitude)
+        #expect(capture.followsRedirects == true)
+    }
+
+    // MARK: - Templates
+
+    @Test("Template menu applies empty request")
+    func templateEmptyRequestClearsDraft() {
+        let vm = ComposeViewModel()
+        vm.method = "POST"
+        vm.url = "https://api.example.com"
+        vm.headers = [EditableReplayHeader(name: "Content-Type", value: "application/json")]
+        vm.body = "{}"
+        vm.queryItems = [EditableQueryItem(name: "a", value: "b")]
+
+        vm.applyTemplate(.empty)
+
+        #expect(vm.method == "GET")
+        #expect(vm.url.isEmpty)
+        #expect(vm.headers.isEmpty)
+        #expect(vm.body.isEmpty)
+        #expect(vm.queryItems.isEmpty)
+    }
+
+    @Test("Template menu applies GET with Query")
+    func templateGetWithQuery() {
+        let vm = ComposeViewModel()
+
+        vm.applyTemplate(.getWithQuery)
+
+        #expect(vm.method == "GET")
+        #expect(vm.url.contains("?name=value"))
+        #expect(vm.queryItems.count == 1)
+        #expect(vm.queryItems[0].name == "name")
+        #expect(vm.queryItems[0].value == "value")
+        #expect(vm.headers.first?.name == "Accept")
+        #expect(vm.body.isEmpty)
+    }
+
+    @Test("Template menu applies POST JSON, form, and multipart defaults")
+    func templatePostDefaults() {
+        let vm = ComposeViewModel()
+
+        vm.applyTemplate(.postJSON)
+        #expect(vm.method == "POST")
+        #expect(vm.headers.contains { $0.name == "Content-Type" && $0.value == "application/json" })
+        #expect(vm.body.contains("\"key\""))
+
+        vm.applyTemplate(.postForm)
+        #expect(vm.headers.contains { $0.name == "Content-Type" && $0.value == "application/x-www-form-urlencoded" })
+        #expect(vm.body == "key=value")
+
+        vm.applyTemplate(.postMultipart)
+        #expect(vm.url == "https://example.com/upload")
+        #expect(vm.headers.contains { $0.value.contains("multipart/form-data") })
+        #expect(vm.body.contains("Content-Disposition: form-data"))
+    }
+
+    // MARK: - cURL Import
+
+    @Test("Import cURL parses Rockxy exported command")
+    func importCurlParsesRockxyExport() throws {
+        let transaction = TestFixtures.makeTransaction(method: "PATCH", url: "https://api.example.com/users?page=1")
+        transaction.request.headers = [
+            HTTPHeader(name: "Content-Type", value: "application/json"),
+            HTTPHeader(name: "Authorization", value: "Bearer token"),
+        ]
+        transaction.request.body = Data("{\"name\":\"rockxy\"}".utf8)
+        let curl = RequestCopyFormatter.curl(for: transaction)
+        let vm = ComposeViewModel()
+
+        try vm.importCurlCommand(curl)
+
+        #expect(vm.method == "PATCH")
+        #expect(vm.url == "https://api.example.com/users?page=1")
+        #expect(vm.headers.map(\.name) == ["Content-Type", "Authorization"])
+        #expect(vm.headers.map(\.value) == ["application/json", "Bearer token"])
+        #expect(vm.body == "{\"name\":\"rockxy\"}")
+        #expect(vm.queryItems.count == 1)
+        #expect(vm.queryItems[0].name == "page")
+        #expect(vm.queryItems[0].value == "1")
+    }
+
+    @Test("Import cURL supports common inline flags")
+    func importCurlSupportsInlineFlags() throws {
+        let vm = ComposeViewModel()
+
+        try vm.importCurlCommand(
+            #"curl --request=post "https://api.example.com/create" --header="Content-Type: application/json" --data='{"ok":true}'"#
+        )
+
+        #expect(vm.method == "POST")
+        #expect(vm.url == "https://api.example.com/create")
+        #expect(vm.headers.count == 1)
+        #expect(vm.headers[0].name == "Content-Type")
+        #expect(vm.headers[0].value == "application/json")
+        #expect(vm.body == #"{"ok":true}"#)
+    }
+
+    @Test("Import cURL rejects empty, non-cURL, and URL-less commands without clearing draft")
+    func importCurlRejectsInvalidCommands() {
+        let vm = ComposeViewModel()
+        vm.method = "POST"
+        vm.url = "https://api.example.com/keep"
+
+        #expect(throws: ComposeImportError.emptyCommand) {
+            try vm.importCurlCommand("")
+        }
+        #expect(vm.url == "https://api.example.com/keep")
+
+        #expect(throws: ComposeImportError.unsupportedCommand) {
+            try vm.importCurlCommand("wget https://api.example.com")
+        }
+        #expect(vm.url == "https://api.example.com/keep")
+
+        #expect(throws: ComposeImportError.missingURL) {
+            try vm.importCurlCommand("curl -H 'Accept: application/json'")
+        }
+        #expect(vm.url == "https://api.example.com/keep")
+    }
+
+    // MARK: - Body Loading And Formatting
+
+    @Test("Load body from file imports UTF-8 text")
+    func loadBodyFromFile() throws {
+        let vm = ComposeViewModel()
+        let fileURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("rockxy-compose-body-\(UUID().uuidString).txt")
+        try Data("from file".utf8).write(to: fileURL)
+        defer { try? FileManager.default.removeItem(at: fileURL) }
+
+        try vm.loadBodyFromFile(url: fileURL)
+
+        #expect(vm.body == "from file")
+        #expect(vm.lastFormattingError == nil)
+    }
+
+    @Test("JSON prettier formats valid JSON and preserves invalid body")
+    func jsonPrettier() {
+        let vm = ComposeViewModel()
+        vm.body = "{\"b\":2,\"a\":1}"
+
+        vm.prettifyJSONBody()
+
+        #expect(vm.lastFormattingError == nil)
+        #expect(vm.body.contains("\n"))
+        #expect(vm.body.contains("\"a\""))
+
+        let formatted = vm.body
+        vm.body = "{not json"
+        vm.prettifyJSONBody()
+
+        #expect(vm.body == "{not json")
+        #expect(vm.body != formatted)
+        #expect(vm.lastFormattingError?.contains("JSON") == true)
+    }
+
+    @Test("XML prettifier formats valid XML and preserves invalid body")
+    func xmlPrettifier() {
+        let vm = ComposeViewModel()
+        vm.body = "<root><child>value</child></root>"
+
+        vm.prettifyXMLBody()
+
+        #expect(vm.lastFormattingError == nil)
+        #expect(vm.body.contains("<root>"))
+        #expect(vm.body.contains("<child>value</child>"))
+
+        let formatted = vm.body
+        vm.body = "<root>"
+        vm.prettifyXMLBody()
+
+        #expect(vm.body == "<root>")
+        #expect(vm.body != formatted)
+        #expect(vm.lastFormattingError?.contains("XML") == true)
+    }
+
+    // MARK: - History
+
+    @Test("Successful and failed sends are recorded in history")
+    func sendsRecordHistory() async throws {
+        let callCount = ManagedAtomic(0)
+        let createdResponse = try makeResponse(statusCode: 201)
+        let executor = MockComposeExecutor { _, _ in
+            if callCount.increment() == 1 {
+                return (Data("ok".utf8), createdResponse)
+            }
+            throw URLError(.timedOut)
+        }
+        let vm = ComposeViewModel(executor: executor)
+        vm.method = "POST"
+        vm.url = "https://api.example.com/create"
+
+        await vm.send()
+        #expect(vm.history.count == 1)
+        #expect(vm.history[0].method == "POST")
+        #expect(vm.history[0].statusCode == 201)
+
+        vm.url = "https://api.example.com/fail"
+        await vm.send()
+        #expect(vm.history.count == 2)
+        #expect(vm.history[0].statusCode == nil)
+    }
+
+    @Test("History is deduped, capped, restorable, removable, and clearable")
+    func historyManagement() async throws {
+        let response = try makeResponse()
+        let executor = MockComposeExecutor { _, _ in
+            (Data("ok".utf8), response)
+        }
+        let vm = ComposeViewModel(executor: executor, historyStore: makeHistoryStore(maxEntries: 20))
+
+        for index in 0 ..< 22 {
+            vm.method = index.isMultiple(of: 2) ? "GET" : "POST"
+            vm.url = "https://api.example.com/\(index)"
+            await vm.send()
+        }
+
+        #expect(vm.history.count == 20)
+        #expect(vm.history.first?.url == "https://api.example.com/21")
+        #expect(vm.history.last?.url == "https://api.example.com/2")
+
+        vm.method = "GET"
+        vm.url = "https://api.example.com/21"
+        await vm.send()
+        #expect(vm.history.count == 20)
+        #expect(vm.history.first?.url == "https://api.example.com/21")
+
+        let restoreID = try #require(vm.history.first(where: { $0.url == "https://api.example.com/5" })?.id)
+        vm.restoreHistoryEntry(id: restoreID)
+        #expect(vm.url == "https://api.example.com/5")
+        #expect(vm.queryItems.isEmpty)
+
+        let removeID = try #require(vm.history.first?.id)
+        vm.removeHistoryEntry(id: removeID)
+        #expect(vm.history.count == 19)
+
+        vm.clearHistory()
+        #expect(vm.history.isEmpty)
+    }
+
+    private func makeHistoryStore(maxEntries: Int = ComposeHistoryStore.defaultMaxEntries) -> ComposeHistoryStore {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("rockxy-compose-view-model-tests-\(UUID().uuidString)", isDirectory: true)
+        return ComposeHistoryStore(
+            fileURL: directory.appendingPathComponent("compose-history.json"),
+            maxEntries: maxEntries
+        )
+    }
+
+    @Test("Fresh Compose reset clears stale selected-row draft")
+    func resetDraftClearsCapturedRequestState() async throws {
+        let response = try makeResponse(statusCode: 204)
+        let executor = MockComposeExecutor { _, _ in
+            (Data(), response)
+        }
+        let vm = ComposeViewModel(executor: executor, historyStore: makeHistoryStore())
+        vm.prefill(from: TestFixtures.makeTransaction(method: "POST", url: "https://api.example.com/checkout"))
+        vm.headers = [EditableReplayHeader(name: "Content-Type", value: "application/json", isEnabled: false)]
+        vm.body = #"{"expectedTotal":64.5}"#
+        vm.queryItems = [EditableQueryItem(name: "debug", value: "1")]
+        vm.requestTimeout = .sixty
+        vm.followsRedirects = false
+        await vm.send()
+
+        vm.resetDraft()
+
+        #expect(vm.method == "GET")
+        #expect(vm.url.isEmpty)
+        #expect(vm.headers.isEmpty)
+        #expect(vm.queryItems.isEmpty)
+        #expect(vm.body.isEmpty)
+        #expect(vm.sourceIsWebSocket == false)
+        #expect(vm.lastSyncedURL.isEmpty)
+        #expect(vm.requestTimeout == .sixty)
+        #expect(vm.followsRedirects == false)
+        if case .empty = vm.responseState {} else {
+            Issue.record("Expected fresh Compose reset to clear the response panel")
+        }
+    }
+
     // MARK: - Unsupported Request Types
 
     @Test("WebSocket prefill sets unsupported state")
@@ -333,7 +678,7 @@ struct ComposeViewModelTests {
     @Test("Send on unsupported draft does not invoke executor")
     func sendUnsupportedDoesNotCallExecutor() async {
         let callCount = ManagedAtomic(0)
-        let executor = MockComposeExecutor { _ in
+        let executor = MockComposeExecutor { _, _ in
             _ = callCount.increment()
             throw URLError(.badURL)
         }
@@ -422,7 +767,7 @@ struct ComposeViewModelTests {
     @Test("Changing method to CONNECT while response is success does not overwrite")
     func connectDoesNotOverwriteSuccess() async throws {
         let response = try makeResponse()
-        let executor = MockComposeExecutor { _ in
+        let executor = MockComposeExecutor { _, _ in
             (Data("ok".utf8), response)
         }
         let vm = ComposeViewModel(executor: executor)
@@ -492,5 +837,36 @@ private final class ManagedAtomic: @unchecked Sendable {
     // MARK: Private
 
     private var value: Int
+    private let lock = NSLock()
+}
+
+// MARK: - RequestCapture
+
+private final class RequestCapture: @unchecked Sendable {
+    // MARK: Internal
+
+    var request: URLRequest? {
+        lock.lock()
+        defer { lock.unlock() }
+        return capturedRequest
+    }
+
+    var followsRedirects: Bool? {
+        lock.lock()
+        defer { lock.unlock() }
+        return capturedFollowsRedirects
+    }
+
+    func record(request: URLRequest, followsRedirects: Bool) {
+        lock.lock()
+        defer { lock.unlock() }
+        capturedRequest = request
+        capturedFollowsRedirects = followsRedirects
+    }
+
+    // MARK: Private
+
+    private var capturedRequest: URLRequest?
+    private var capturedFollowsRedirects: Bool?
     private let lock = NSLock()
 }

--- a/Shared/RockxyIdentity.swift
+++ b/Shared/RockxyIdentity.swift
@@ -93,9 +93,14 @@ struct RockxyIdentity {
     static let current = RockxyIdentity(bundle: .main)
 
     static var isRunningTests: Bool {
-        NSClassFromString("XCTestCase") != nil
-            || !(ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] ?? "").isEmpty
+        let environment = ProcessInfo.processInfo.environment
+        let arguments = ProcessInfo.processInfo.arguments
+        return NSClassFromString("XCTestCase") != nil
+            || NSClassFromString("XCTest.XCTestCase") != nil
             || NSClassFromString("Testing.Test") != nil
+            || !(environment["XCTestConfigurationFilePath"] ?? "").isEmpty
+            || environment.keys.contains { $0.hasPrefix("XCTest") }
+            || arguments.contains { $0.contains(".xctest") || $0.contains("XCTest") }
     }
 
     let displayName: String

--- a/docs/keyboard-shortcuts.md
+++ b/docs/keyboard-shortcuts.md
@@ -1,0 +1,116 @@
+# Keyboard Shortcuts
+
+Rockxy follows the same shortcut pattern across the main capture window, rule editors, breakpoint tools, Compose, and script editing. Shortcuts that act on a selection require the relevant table or editor to be focused.
+
+## Universal
+
+| Shortcut | Action |
+|---|---|
+| `⌘N` | New rule, template, script, or item in the active window |
+| `⇧⌘N` | New Folder where folders are supported |
+| `⌘↩` | Primary action: Add, Save, Send, or Execute |
+| `Esc` | Cancel sheets and modal editors; close the Breakpoint Queue without resolving the selected item |
+| `⌘⌫` | Delete the selected item |
+| `⌘D` | Duplicate the selected item |
+| `↵` / `Space` | Toggle the enabled state of the selected rule or script when the list has focus |
+| `⌘F` | Focus the filter or search field |
+| `⌘W` | Close the current window |
+| `⌘,` | Settings |
+| `⌘C` / `⌘V` / `⌘X` / `⌘A` | Copy, Paste, Cut, and Select All in text fields and standard editable controls |
+
+## Main Capture
+
+| Shortcut | Action |
+|---|---|
+| `⌘K` | Clear capture |
+| `⇧⌘K` | Clear capture and filters |
+| `⌘P` | Pause or resume capture |
+| `⌘L` | Focus the search bar |
+| `⌘↑` / `⌘↓` | Jump to the first or last captured row |
+| `↑` / `↓` | Move row selection |
+| `⌘E` | Edit and Repeat the selected request |
+| `⌘R` | Replay the selected request |
+| `⌘B` | Add a Breakpoint rule for the selected request URL |
+| `⇧⌘[` / `⇧⌘]` | Switch workspace tabs |
+
+## Compose
+
+| Shortcut | Action |
+|---|---|
+| `⌘↩` | Send |
+| `⌘L` | Focus the URL field |
+| `⌘T` | Open Template menu |
+| `⌘Y` | Open History menu |
+| `⌘0` | Reset to a fresh request |
+
+`⌘H` remains reserved for the macOS Hide App command, so Compose uses `⌘Y` for History.
+
+## Breakpoint Queue
+
+| Shortcut | Action |
+|---|---|
+| `⌘↩` | Execute the selected paused item |
+| `⌘.` | Abort the selected paused item |
+| `Esc` | Close the queue window; queued items remain paused |
+| `⌘[` / `⌘]` | Move to the previous or next queued item |
+
+## Rules Windows
+
+Applies to Map Local, Map Remote, Block List, Allow List, Modify Headers, Network Conditions, Scripting, and Breakpoint Rules where the action exists.
+
+| Shortcut | Action |
+|---|---|
+| `⌘N` | New rule |
+| `⇧⌘N` | New folder |
+| `⌘E` | Edit selected rule |
+| `⌘D` | Duplicate selected rule |
+| `⌘⌫` | Delete selected rule |
+| `↵` / `Space` | Toggle selected rule enabled state |
+| `⌘F` | Filter rules |
+| `⌘T` | Open Breakpoint Templates from Breakpoint Rules |
+
+## Settings
+
+Applies to the SSL Proxying rule list in Settings.
+
+| Shortcut | Action |
+|---|---|
+| `⌘N` | Add app rule |
+| `⇧⌘N` | Add domain rule |
+| `⌘E` | Edit selected SSL proxying rule |
+| `⌘⌫` | Delete selected SSL proxying rule |
+| `↵` / `Space` | Toggle selected SSL proxying rule |
+| `⌘F` | Filter SSL proxying rules |
+
+## Script Editor
+
+| Shortcut | Action |
+|---|---|
+| `⌘S` | Save and activate script |
+| `⌘R` | Validate the matching rule against the sample URL |
+| `⇧⌘C` | Toggle Console panel |
+| `⌘/` | Toggle line comment in the code editor |
+| `⌘[` / `⌘]` | Outdent or indent the selection in the code editor |
+
+## Templates
+
+| Shortcut | Action |
+|---|---|
+| `⌘N` | New template of the selected kind |
+| `⇧⌘N` | New template of the opposite kind |
+| `⌘D` | Duplicate selected template |
+| `⌘⌫` | Delete selected template |
+
+## Help
+
+| Shortcut | Action |
+|---|---|
+| `⌘?` | Open Help → Keyboard Shortcuts |
+
+## Conflict Resolutions
+
+| Conflict | Resolution |
+|---|---|
+| Compose History wanted `⌘H`, but macOS reserves `⌘H` for Hide App. | Compose uses `⌘Y`, matching the common History shortcut family without overriding Hide App. |
+| Main capture previously used `⌘↩` for replay and `⌘⌥↩` for Edit and Repeat. | Main capture now uses `⌘R` for Replay and `⌘E` for Edit and Repeat so `⌘↩` stays reserved for primary actions inside Compose and Breakpoint Queue. |
+| New Folder previously used `⌘⌥N` in some rules windows. | New Folder now uses `⇧⌘N` everywhere it exists, matching Finder and common macOS creation patterns. |


### PR DESCRIPTION
## Summary
- Standardize keyboard shortcuts across Capture, Compose, Breakpoint, Rules, Scripting, and SSL Proxying settings flows.
- Add a searchable Help → Keyboard Shortcuts sheet backed by the shared shortcut reference.
- Add regression coverage for the documented shortcut convention, menu discoverability, focus expectations, and duplicate shortcut conflicts.

## Validation
- `xcodebuild -project Rockxy.xcodeproj -scheme Rockxy -destination 'platform=macOS' -only-testing:RockxyTests/KeyboardShortcutTests test`
- `swiftlint lint --strict`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Searchable keyboard shortcuts reference with organized sections
  * Compose request history with persistence and restoration
  * Compose request timeout and redirect control options
  * Import request bodies from files and cURL commands
  * Compose request templates
  * Previous/next navigation for breakpoint queue items
  * Extensive keyboard shortcuts throughout the application

* **Bug Fixes**
  * Rule loading now explicitly handles and logs errors

* **Documentation**
  * Added comprehensive keyboard shortcuts reference guide

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RockxyApp/Rockxy/pull/107?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->