### PR TITLE
Fix scripting runtime and redaction export flow

### DIFF
--- a/Rockxy/Core/Detection/ContentTypeDetector.swift
+++ b/Rockxy/Core/Detection/ContentTypeDetector.swift
@@ -6,6 +6,24 @@ import Foundation
 enum ContentTypeDetector {
     static func detect(headers: [HTTPHeader], body: Data?) -> ContentType {
         let headerValue = headers.first { $0.name.lowercased() == "content-type" }?.value
-        return ContentType.detect(from: headerValue)
+        let headerType = ContentType.detect(from: headerValue)
+        guard headerType == .unknown else {
+            return headerType
+        }
+        guard let body, looksLikeJSON(body) else {
+            return headerType
+        }
+        return .json
+    }
+
+    private static func looksLikeJSON(_ body: Data) -> Bool {
+        guard let text = String(data: body.prefix(4_096), encoding: .utf8) else {
+            return false
+        }
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.hasPrefix("{") || trimmed.hasPrefix("[") else {
+            return false
+        }
+        return (try? JSONSerialization.jsonObject(with: body)) != nil
     }
 }

--- a/Rockxy/Core/MCPServer/MCPRedactionPolicy.swift
+++ b/Rockxy/Core/MCPServer/MCPRedactionPolicy.swift
@@ -145,9 +145,11 @@ struct MCPRedactionPolicy {
             return text
         }
 
-        switch contentType {
-        case .json:
+        if contentType == .json || looksLikeJSON(text) {
             return redactJSONBody(text)
+        }
+
+        switch contentType {
         case .form:
             return redactFormBody(text)
         case .xml:
@@ -302,6 +304,17 @@ struct MCPRedactionPolicy {
 
     private var curlHeaderPattern: NSRegularExpression {
         Self.curlHeaderPatternRegex
+    }
+
+    private func looksLikeJSON(_ text: String) -> Bool {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.hasPrefix("{") || trimmed.hasPrefix("[") else {
+            return false
+        }
+        guard let data = trimmed.data(using: .utf8) else {
+            return false
+        }
+        return (try? JSONSerialization.jsonObject(with: data)) != nil
     }
 
     private func redactJSONObject(_ object: Any) -> Any {

--- a/Rockxy/Core/Plugins/BuiltInPlugins/HARImporter.swift
+++ b/Rockxy/Core/Plugins/BuiltInPlugins/HARImporter.swift
@@ -108,8 +108,7 @@ struct HARImporter {
         let httpVersion = dict["httpVersion"] as? String ?? "HTTP/1.1"
         let headers = parseHeaders(dict["headers"] as? [[String: Any]])
         let body = parseRequestBody(dict["postData"] as? [String: Any])
-        let contentTypeHeader = headers.first { $0.name.lowercased() == "content-type" }?.value
-        let contentType = ContentType.detect(from: contentTypeHeader)
+        let contentType = ContentTypeDetector.detect(headers: headers, body: body)
 
         return HTTPRequestData(
             method: method,
@@ -131,8 +130,7 @@ struct HARImporter {
         let statusMessage = dict["statusText"] as? String ?? ""
         let headers = parseHeaders(dict["headers"] as? [[String: Any]])
         let body = parseResponseBody(dict["content"] as? [String: Any])
-        let contentTypeHeader = headers.first { $0.name.lowercased() == "content-type" }?.value
-        let contentType = ContentType.detect(from: contentTypeHeader)
+        let contentType = ContentTypeDetector.detect(headers: headers, body: body)
 
         return HTTPResponseData(
             statusCode: statusCode,

--- a/Rockxy/Core/Plugins/ScriptBridge.swift
+++ b/Rockxy/Core/Plugins/ScriptBridge.swift
@@ -14,37 +14,46 @@ enum ScriptBridge {
         in context: JSContext,
         pluginID: String,
         logger: Logger,
-        defaults: UserDefaults = .standard
+        defaults: UserDefaults = .standard,
+        consoleSink: (@Sendable (ScriptConsoleEvent) -> Void)? = nil
     ) {
         let rockxy = JSValue(newObjectIn: context)
 
-        installLogging(on: rockxy, context: context, logger: logger)
+        installLogging(on: rockxy, context: context, pluginID: pluginID, logger: logger, consoleSink: consoleSink)
         installCrypto(on: rockxy, context: context)
         installEncoding(on: rockxy, context: context)
         installStorage(on: rockxy, context: context, pluginID: pluginID, defaults: defaults)
         installEnv(on: rockxy, context: context, pluginID: pluginID, defaults: defaults)
 
         context.setObject(rockxy, forKeyedSubscript: "$rockxy" as NSString)
-
-        let consoleObj = JSValue(newObjectIn: context)
-        let logFn: @convention(block) (String) -> Void = { msg in
-            logger.info("[\(pluginID)] \(msg)")
-        }
-        consoleObj?.setObject(logFn, forKeyedSubscript: "log" as NSString)
-        context.setObject(consoleObj, forKeyedSubscript: "console" as NSString)
+        installConsole(in: context, pluginID: pluginID, logger: logger, consoleSink: consoleSink)
     }
 
     // MARK: Private
 
     private static let bridgeLogger = Logger(subsystem: RockxyIdentity.current.logSubsystem, category: "ScriptBridge")
 
-    private static func installLogging(on rockxy: JSValue?, context: JSContext, logger: Logger) {
+    private static func installLogging(
+        on rockxy: JSValue?,
+        context: JSContext,
+        pluginID: String,
+        logger: Logger,
+        consoleSink: (@Sendable (ScriptConsoleEvent) -> Void)?
+    ) {
         let log = JSValue(newObjectIn: context)
 
-        let infoFn: @convention(block) (String) -> Void = { msg in logger.info("\(msg)") }
-        let warnFn: @convention(block) (String) -> Void = { msg in logger.warning("\(msg)") }
-        let errorFn: @convention(block) (String) -> Void = { msg in logger.error("\(msg)") }
-        let debugFn: @convention(block) (String) -> Void = { msg in logger.debug("\(msg)") }
+        let infoFn: @convention(block) (String) -> Void = { msg in
+            emitConsoleEvent(pluginID: pluginID, level: .info, message: msg, logger: logger, consoleSink: consoleSink)
+        }
+        let warnFn: @convention(block) (String) -> Void = { msg in
+            emitConsoleEvent(pluginID: pluginID, level: .warn, message: msg, logger: logger, consoleSink: consoleSink)
+        }
+        let errorFn: @convention(block) (String) -> Void = { msg in
+            emitConsoleEvent(pluginID: pluginID, level: .error, message: msg, logger: logger, consoleSink: consoleSink)
+        }
+        let debugFn: @convention(block) (String) -> Void = { msg in
+            emitConsoleEvent(pluginID: pluginID, level: .debug, message: msg, logger: logger, consoleSink: consoleSink)
+        }
 
         log?.setObject(infoFn, forKeyedSubscript: "info" as NSString)
         log?.setObject(warnFn, forKeyedSubscript: "warn" as NSString)
@@ -52,6 +61,73 @@ enum ScriptBridge {
         log?.setObject(debugFn, forKeyedSubscript: "debug" as NSString)
 
         rockxy?.setObject(log, forKeyedSubscript: "log" as NSString)
+    }
+
+    private static func installConsole(
+        in context: JSContext,
+        pluginID: String,
+        logger: Logger,
+        consoleSink: (@Sendable (ScriptConsoleEvent) -> Void)?
+    ) {
+        let emitFn: @convention(block) (String, String) -> Void = { level, message in
+            let eventLevel = ScriptConsoleEventLevel(rawValue: level) ?? .log
+            emitConsoleEvent(
+                pluginID: pluginID,
+                level: eventLevel,
+                message: message,
+                logger: logger,
+                consoleSink: consoleSink
+            )
+        }
+        context.setObject(emitFn, forKeyedSubscript: "__rockxyNativeConsole" as NSString)
+        context.evaluateScript(
+            """
+            (function () {
+              function formatArg(value) {
+                if (typeof value === "string") { return value; }
+                if (value === null) { return "null"; }
+                if (typeof value === "undefined") { return "undefined"; }
+                try {
+                  var json = JSON.stringify(value);
+                  return typeof json === "undefined" ? String(value) : json;
+                } catch (error) {
+                  return String(value);
+                }
+              }
+              function emit(level, args) {
+                __rockxyNativeConsole(level, Array.prototype.map.call(args, formatArg).join(" "));
+              }
+              console = {
+                log: function () { emit("log", arguments); },
+                info: function () { emit("info", arguments); },
+                warn: function () { emit("warn", arguments); },
+                error: function () { emit("error", arguments); },
+                debug: function () { emit("debug", arguments); }
+              };
+            }());
+            """
+        )
+    }
+
+    private static func emitConsoleEvent(
+        pluginID: String,
+        level: ScriptConsoleEventLevel,
+        message: String,
+        logger: Logger,
+        consoleSink: (@Sendable (ScriptConsoleEvent) -> Void)?
+    ) {
+        switch level {
+        case .log,
+             .info:
+            logger.info("[\(pluginID)] \(message)")
+        case .warn:
+            logger.warning("[\(pluginID)] \(message)")
+        case .error:
+            logger.error("[\(pluginID)] \(message)")
+        case .debug:
+            logger.debug("[\(pluginID)] \(message)")
+        }
+        consoleSink?(ScriptConsoleEvent(pluginID: pluginID, level: level, message: message, timestamp: .now))
     }
 
     private static func installCrypto(on rockxy: JSValue?, context: JSContext) {

--- a/Rockxy/Core/Plugins/ScriptConsoleEvent.swift
+++ b/Rockxy/Core/Plugins/ScriptConsoleEvent.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+// MARK: - ScriptConsoleEventLevel
+
+enum ScriptConsoleEventLevel: String, Sendable {
+    case log
+    case info
+    case warn
+    case error
+    case debug
+}
+
+// MARK: - ScriptConsoleEvent
+
+struct ScriptConsoleEvent: Equatable, Sendable {
+    let pluginID: String
+    let level: ScriptConsoleEventLevel
+    let message: String
+    let timestamp: Date
+}

--- a/Rockxy/Core/Plugins/ScriptHeaderDictionary.swift
+++ b/Rockxy/Core/Plugins/ScriptHeaderDictionary.swift
@@ -1,0 +1,75 @@
+import Foundation
+
+enum ScriptHeaderDictionary {
+    static func storage(from headers: [HTTPHeader]) -> [String: String] {
+        Dictionary(headers.map { ($0.name, $0.value) }, uniquingKeysWith: { _, last in last })
+    }
+
+    static func exposed(from storage: [String: String]) -> [String: String] {
+        var result = storage
+        for (name, value) in storage {
+            result[name.lowercased()] = value
+            result[canonicalName(name)] = value
+        }
+        return result
+    }
+
+    static func storage(fromJavaScript dictionary: [String: String], original: [String: String] = [:]) -> [String: String] {
+        let originalByLower = Dictionary(
+            original.map { ($0.key.lowercased(), (name: $0.key, value: $0.value)) },
+            uniquingKeysWith: { _, last in last }
+        )
+        let grouped = Dictionary(grouping: dictionary.map { (name: $0.key, value: $0.value) }) {
+            $0.name.lowercased()
+        }
+
+        var collapsed: [String: String] = [:]
+        for (lowerName, entries) in grouped {
+            if let originalEntry = originalByLower[lowerName],
+               entries.allSatisfy({ $0.value == originalEntry.value })
+            {
+                collapsed[originalEntry.name] = originalEntry.value
+                continue
+            }
+
+            let originalValue = originalByLower[lowerName]?.value
+            let changedEntries = entries.filter { entry in
+                guard let originalValue else {
+                    return false
+                }
+                return entry.value != originalValue
+            }
+            let candidates = changedEntries.isEmpty ? entries : changedEntries
+            let selected = candidates.max { lhs, rhs in
+                score(lhs.name, lowerName: lowerName, originalName: originalByLower[lowerName]?.name)
+                    < score(rhs.name, lowerName: lowerName, originalName: originalByLower[lowerName]?.name)
+            } ?? entries[0]
+            collapsed[selected.name] = selected.value
+        }
+        return collapsed
+    }
+
+    private static func canonicalName(_ name: String) -> String {
+        name.split(separator: "-", omittingEmptySubsequences: false)
+            .map { part in
+                guard let first = part.first else {
+                    return ""
+                }
+                return first.uppercased() + part.dropFirst().lowercased()
+            }
+            .joined(separator: "-")
+    }
+
+    private static func score(_ name: String, lowerName: String, originalName: String?) -> Int {
+        if name == canonicalName(name) {
+            return 3
+        }
+        if let originalName, name == originalName {
+            return 2
+        }
+        if name == lowerName {
+            return 1
+        }
+        return 0
+    }
+}

--- a/Rockxy/Core/Plugins/ScriptMultiArgBridge.swift
+++ b/Rockxy/Core/Plugins/ScriptMultiArgBridge.swift
@@ -52,11 +52,8 @@ enum ScriptMultiArgBridge {
         }
         req.setObject(request.url.path.isEmpty ? "/" : request.url.path, forKeyedSubscript: "path" as NSString)
 
-        let headersDict = Dictionary(
-            request.headers.map { ($0.name, $0.value) },
-            uniquingKeysWith: { _, last in last }
-        )
-        req.setObject(headersDict, forKeyedSubscript: "headers" as NSString)
+        let headersDict = ScriptHeaderDictionary.storage(from: request.headers)
+        req.setObject(ScriptHeaderDictionary.exposed(from: headersDict), forKeyedSubscript: "headers" as NSString)
 
         let queriesDict = parseQueries(request.url.query ?? "")
         req.setObject(queriesDict, forKeyedSubscript: "queries" as NSString)
@@ -96,7 +93,11 @@ enum ScriptMultiArgBridge {
         let method = (source.objectForKeyedSubscript("method")?.toString() ?? original.method)
         let path = source.objectForKeyedSubscript("path")?.toString() ?? original.url.path
         let queriesDict = parseQueryDictionary(source.objectForKeyedSubscript("queries"))
-        let headersDict = (source.objectForKeyedSubscript("headers")?.toDictionary() as? [String: String]) ?? [:]
+        let exposedHeaders = (source.objectForKeyedSubscript("headers")?.toDictionary() as? [String: String]) ?? [:]
+        let headersDict = ScriptHeaderDictionary.storage(
+            fromJavaScript: exposedHeaders,
+            original: ScriptHeaderDictionary.storage(from: original.headers)
+        )
         let bodyVal = source.objectForKeyedSubscript("body")
         let bodyIsBase64Val = source.objectForKeyedSubscript("__bodyIsBase64")
         let bodyIsBase64 = bodyIsBase64Val?.toBool() ?? false
@@ -167,11 +168,8 @@ enum ScriptMultiArgBridge {
             return nil
         }
         resp.setObject(response.statusCode, forKeyedSubscript: "statusCode" as NSString)
-        let headersDict = Dictionary(
-            response.headers.map { ($0.name, $0.value) },
-            uniquingKeysWith: { _, last in last }
-        )
-        resp.setObject(headersDict, forKeyedSubscript: "headers" as NSString)
+        let headersDict = ScriptHeaderDictionary.storage(from: response.headers)
+        resp.setObject(ScriptHeaderDictionary.exposed(from: headersDict), forKeyedSubscript: "headers" as NSString)
         if let body = response.body {
             if let s = String(data: body, encoding: .utf8) {
                 resp.setObject(s, forKeyedSubscript: "body" as NSString)
@@ -212,7 +210,11 @@ enum ScriptMultiArgBridge {
             original.statusCode
         }
 
-        let headersDict = (source.objectForKeyedSubscript("headers")?.toDictionary() as? [String: String]) ?? [:]
+        let exposedHeaders = (source.objectForKeyedSubscript("headers")?.toDictionary() as? [String: String]) ?? [:]
+        let headersDict = ScriptHeaderDictionary.storage(
+            fromJavaScript: exposedHeaders,
+            original: ScriptHeaderDictionary.storage(from: original.headers)
+        )
         let newHeaders = headersDict.map { HTTPHeader(name: $0.key, value: $0.value) }
 
         let newBody: Data? = resolveResponseBody(source: source, original: original, pluginID: pluginID)

--- a/Rockxy/Core/Plugins/ScriptPluginManager.swift
+++ b/Rockxy/Core/Plugins/ScriptPluginManager.swift
@@ -173,12 +173,29 @@ actor ScriptPluginManager {
             return
         }
         await runtime.unloadPlugin(id: id)
-        guard let index = plugins.firstIndex(where: { $0.id == id }) else {
+
+        let refreshedPlugins = await discovery.discoverPlugins()
+        guard let refreshed = refreshedPlugins.first(where: { $0.id == id }),
+              let index = plugins.firstIndex(where: { $0.id == id }) else
+        {
             return
         }
-        try await runtime.loadPlugin(plugins[index])
-        if let j = plugins.firstIndex(where: { $0.id == id }) {
-            plugins[j].status = .active
+
+        plugins[index] = refreshed
+        if refreshed.isEnabled {
+            do {
+                try await runtime.loadPlugin(refreshed)
+                if let j = plugins.firstIndex(where: { $0.id == id }) {
+                    plugins[j].status = .active
+                }
+            } catch {
+                if let j = plugins.firstIndex(where: { $0.id == id }) {
+                    plugins[j].status = .error(error.localizedDescription)
+                    plugins[j].lastError = error.localizedDescription
+                }
+                publishSnapshot()
+                throw error
+            }
         }
         publishSnapshot()
         Self.logger.info("Reloaded plugin: \(id)")
@@ -252,6 +269,7 @@ actor ScriptPluginManager {
                 )
             } catch {
                 Self.logger.error("Plugin \(plugin.id) onRequest failed: \(error.localizedDescription)")
+                markPluginErrored(id: plugin.id, reason: error.localizedDescription)
                 continue
             }
             switch outcome {
@@ -279,9 +297,12 @@ actor ScriptPluginManager {
     )
         async -> HTTPResponseData
     {
-        guard currentSettings().scriptingToolEnabled else {
+        let settings = currentSettings()
+        guard settings.scriptingToolEnabled else {
             return response
         }
+        let chain = settings.allowMultipleScriptsPerRequest
+        var current = response
         for plugin in plugins where plugin.isEnabled && plugin.status == .active {
             guard plugin.manifest.entryPoints["script"] != nil else {
                 continue
@@ -290,23 +311,32 @@ actor ScriptPluginManager {
             guard behavior.runOnResponse else {
                 continue
             }
+            guard !behavior.runAsMock else {
+                continue
+            }
             guard Self.matches(behavior: behavior, request: request) else {
                 continue
             }
-            let context = ScriptResponseContext(request: request, response: response)
+            let context = ScriptResponseContext(request: request, response: current)
             do {
-                return try await runtime.callOnResponse(
+                let mutated = try await runtime.callOnResponse(
                     pluginID: plugin.id,
                     context: context,
                     originalRequest: request,
-                    originalResponse: response
+                    originalResponse: current
                 )
+                if chain {
+                    current = mutated
+                    continue
+                }
+                return mutated
             } catch {
                 Self.logger.error("Plugin \(plugin.id) onResponse failed: \(error.localizedDescription)")
+                markPluginErrored(id: plugin.id, reason: error.localizedDescription)
                 continue
             }
         }
-        return response
+        return current
     }
 
     /// Nonisolated snapshot used by proxy handlers (NIO event-loop threads) to
@@ -325,6 +355,9 @@ actor ScriptPluginManager {
             }
             let behavior = plugin.manifest.scriptBehavior ?? ScriptBehavior.defaults()
             guard behavior.runOnResponse else {
+                continue
+            }
+            guard !behavior.runAsMock else {
                 continue
             }
             if Self.matches(behavior: behavior, request: request) {
@@ -402,5 +435,15 @@ actor ScriptPluginManager {
     private func publishSnapshot() {
         let current = plugins
         Self.pluginSnapshot.withLock { $0 = current }
+        NotificationCenter.default.post(name: .scriptsDidChange, object: current)
+    }
+
+    private func markPluginErrored(id: String, reason: String) {
+        guard let index = plugins.firstIndex(where: { $0.id == id }) else {
+            return
+        }
+        plugins[index].status = .error(reason)
+        plugins[index].lastError = reason
+        publishSnapshot()
     }
 }

--- a/Rockxy/Core/Plugins/ScriptRequestContext.swift
+++ b/Rockxy/Core/Plugins/ScriptRequestContext.swift
@@ -21,10 +21,7 @@ struct ScriptRequestContext {
         self.originalHost = request.url.host
         self.originalScheme = request.url.scheme
         self.originalPort = request.url.port
-        self.headers = Dictionary(
-            request.headers.map { ($0.name, $0.value) },
-            uniquingKeysWith: { _, last in last }
-        )
+        self.headers = ScriptHeaderDictionary.storage(from: request.headers)
         self.body = request.body?.base64EncodedString()
         self.originalBodyBase64 = request.body?.base64EncodedString()
     }
@@ -61,22 +58,62 @@ struct ScriptRequestContext {
     let originalBodyBase64: String?
 
     static func from(jsValue: JSValue, original: ScriptRequestContext) -> ScriptRequestContext {
-        let request = jsValue.objectForKeyedSubscript("request")
+        let nestedRequest = jsValue.objectForKeyedSubscript("request")
 
-        let method = request?.objectForKeyedSubscript("method")?.toString() ?? original.method
-        let url = request?.objectForKeyedSubscript("url")?.toString() ?? original.url
+        let topLevelMethod = stringValue(jsValue.objectForKeyedSubscript("method"))
+        let nestedMethod = stringValue(nestedRequest?.objectForKeyedSubscript("method"))
+        let topLevelURL = stringValue(jsValue.objectForKeyedSubscript("url"))
+        let nestedURL = stringValue(nestedRequest?.objectForKeyedSubscript("url"))
 
-        var headers = original.headers
-        if let headersObj = request?.objectForKeyedSubscript("headers"),
-           let headersDict = headersObj.toDictionary() as? [String: String]
+        // Single-arg `onRequest(request)` reads + mutates fields directly on the
+        // top-level wrapper, while older `onRequest(ctx)` scripts may mutate
+        // `ctx.request`. Prefer a changed top-level value, otherwise honor nested
+        // mutations without letting an untouched mirror overwrite them.
+        let method: String = if let topLevelMethod,
+                                topLevelMethod != original.method || nestedMethod == nil
         {
-            headers = headersDict
+            topLevelMethod
+        } else if let nestedMethod {
+            nestedMethod
+        } else {
+            original.method
         }
 
-        let body: String? = if let bodyVal = request?.objectForKeyedSubscript("body"), !bodyVal.isUndefined,
-                               !bodyVal.isNull
+        let url: String = if let topLevelURL,
+                             topLevelURL != original.url || nestedURL == nil
         {
-            bodyVal.toString()
+            topLevelURL
+        } else if let nestedURL {
+            nestedURL
+        } else {
+            original.url
+        }
+
+        var headers = original.headers
+        let topLevelHeaders = stringDictionaryValue(
+            jsValue.objectForKeyedSubscript("headers"),
+            original: original.headers
+        )
+        let nestedHeaders = stringDictionaryValue(
+            nestedRequest?.objectForKeyedSubscript("headers"),
+            original: original.headers
+        )
+        if let topLevelHeaders,
+           topLevelHeaders != original.headers || nestedHeaders == nil
+        {
+            headers = topLevelHeaders
+        } else if let nestedHeaders {
+            headers = nestedHeaders
+        }
+
+        let topLevelBody = stringValue(jsValue.objectForKeyedSubscript("body"))
+        let nestedBody = stringValue(nestedRequest?.objectForKeyedSubscript("body"))
+        let body: String? = if let topLevelBody,
+                               topLevelBody != original.body || nestedBody == nil
+        {
+            topLevelBody
+        } else if let nestedBody {
+            nestedBody
         } else {
             original.body
         }
@@ -96,22 +133,33 @@ struct ScriptRequestContext {
     func toJSValue(in context: JSContext) -> JSValue {
         let wrapper = JSValue(newObjectIn: context)
         let request = JSValue(newObjectIn: context)
+        let headersObject = JSValue(object: ScriptHeaderDictionary.exposed(from: headers), in: context)
+
+        // Single-arg `onRequest(request)` API: expose request fields directly on
+        // the argument. We also keep `request.request` for existing `ctx.request`
+        // scripts so old snippets and new intuitive snippets both mutate through
+        // the same runtime path.
+        wrapper?.setObject(method, forKeyedSubscript: "method" as NSString)
+        wrapper?.setObject(url, forKeyedSubscript: "url" as NSString)
+        wrapper?.setObject(headersObject, forKeyedSubscript: "headers" as NSString)
+        wrapper?.setObject(body as Any, forKeyedSubscript: "body" as NSString)
 
         request?.setObject(method, forKeyedSubscript: "method" as NSString)
         request?.setObject(url, forKeyedSubscript: "url" as NSString)
-        request?.setObject(headers, forKeyedSubscript: "headers" as NSString)
+        request?.setObject(headersObject, forKeyedSubscript: "headers" as NSString)
         request?.setObject(body as Any, forKeyedSubscript: "body" as NSString)
 
         wrapper?.setObject(request, forKeyedSubscript: "request" as NSString)
 
         let setHeaderFn: @convention(block) (String, String) -> Void = { name, value in
-            let headersObj = request?.objectForKeyedSubscript("headers")
-            headersObj?.setObject(value, forKeyedSubscript: name as NSString)
+            headersObject?.setObject(value, forKeyedSubscript: name as NSString)
         }
         let setBodyFn: @convention(block) (String) -> Void = { newBody in
+            wrapper?.setObject(newBody, forKeyedSubscript: "body" as NSString)
             request?.setObject(newBody, forKeyedSubscript: "body" as NSString)
         }
         let setURLFn: @convention(block) (String) -> Void = { newURL in
+            wrapper?.setObject(newURL, forKeyedSubscript: "url" as NSString)
             request?.setObject(newURL, forKeyedSubscript: "url" as NSString)
         }
 
@@ -208,6 +256,28 @@ struct ScriptRequestContext {
             return false
         }
         return candidate == originalBase64
+    }
+
+    private static func stringValue(_ value: JSValue?) -> String? {
+        guard let value, !value.isUndefined, !value.isNull else {
+            return nil
+        }
+        return value.toString()
+    }
+
+    private static func stringDictionaryValue(
+        _ value: JSValue?,
+        original: [String: String]
+    )
+        -> [String: String]?
+    {
+        guard let value, !value.isUndefined, !value.isNull else {
+            return nil
+        }
+        guard let dictionary = value.toDictionary() as? [String: String] else {
+            return nil
+        }
+        return ScriptHeaderDictionary.storage(fromJavaScript: dictionary, original: original)
     }
 
     private static func warnOnce(pluginID: String, mutationKind: String) {

--- a/Rockxy/Core/Plugins/ScriptResponseContext.swift
+++ b/Rockxy/Core/Plugins/ScriptResponseContext.swift
@@ -14,15 +14,9 @@ struct ScriptResponseContext {
     init(request: HTTPRequestData, response: HTTPResponseData) {
         self.method = request.method
         self.url = request.url.absoluteString
-        self.requestHeaders = Dictionary(
-            request.headers.map { ($0.name, $0.value) },
-            uniquingKeysWith: { _, last in last }
-        )
+        self.requestHeaders = ScriptHeaderDictionary.storage(from: request.headers)
         self.statusCode = response.statusCode
-        self.responseHeaders = Dictionary(
-            response.headers.map { ($0.name, $0.value) },
-            uniquingKeysWith: { _, last in last }
-        )
+        self.responseHeaders = ScriptHeaderDictionary.storage(from: response.headers)
         if let body = response.body {
             let utf8String = String(data: body, encoding: .utf8)
             self.body = utf8String ?? body.base64EncodedString()
@@ -69,8 +63,18 @@ struct ScriptResponseContext {
         let nestedResponse = jsValue.objectForKeyedSubscript("response")
         let topLevelStatus = intValue(jsValue.objectForKeyedSubscript("statusCode"))
         let nestedStatus = intValue(nestedResponse?.objectForKeyedSubscript("statusCode"))
-        let topLevelHeaders = stringDictionaryValue(jsValue.objectForKeyedSubscript("responseHeaders"))
-        let nestedHeaders = stringDictionaryValue(nestedResponse?.objectForKeyedSubscript("headers"))
+        let topLevelHeaders = stringDictionaryValue(
+            jsValue.objectForKeyedSubscript("responseHeaders"),
+            original: original.responseHeaders
+        )
+        let topLevelHeaderAlias = stringDictionaryValue(
+            jsValue.objectForKeyedSubscript("headers"),
+            original: original.responseHeaders
+        )
+        let nestedHeaders = stringDictionaryValue(
+            nestedResponse?.objectForKeyedSubscript("headers"),
+            original: original.responseHeaders
+        )
         let topLevelBody = stringValue(jsValue.objectForKeyedSubscript("body"))
         let nestedBody = stringValue(nestedResponse?.objectForKeyedSubscript("body"))
         let topLevelBodyIsBase64 = boolValue(jsValue.objectForKeyedSubscript("__bodyIsBase64"))
@@ -92,9 +96,14 @@ struct ScriptResponseContext {
         }
 
         let headers: [String: String] = if let topLevelHeaders,
-                                           topLevelHeaders != original.responseHeaders || nestedHeaders == nil
+                                           topLevelHeaders != original.responseHeaders
+                                               || topLevelHeaderAlias == nil && nestedHeaders == nil
         {
             topLevelHeaders
+        } else if let topLevelHeaderAlias,
+                  topLevelHeaderAlias != original.responseHeaders || nestedHeaders == nil
+        {
+            topLevelHeaderAlias
         } else if let nestedHeaders {
             nestedHeaders
         } else {
@@ -136,13 +145,26 @@ struct ScriptResponseContext {
         // override a script's top-level mutation on apply-back.
         wrapper?.setObject(method, forKeyedSubscript: "method" as NSString)
         wrapper?.setObject(url, forKeyedSubscript: "url" as NSString)
-        wrapper?.setObject(requestHeaders, forKeyedSubscript: "requestHeaders" as NSString)
+        wrapper?.setObject(
+            ScriptHeaderDictionary.exposed(from: requestHeaders),
+            forKeyedSubscript: "requestHeaders" as NSString
+        )
         wrapper?.setObject(statusCode, forKeyedSubscript: "statusCode" as NSString)
-        wrapper?.setObject(responseHeaders, forKeyedSubscript: "responseHeaders" as NSString)
+        let responseHeadersObject = JSValue(object: ScriptHeaderDictionary.exposed(from: responseHeaders), in: context)
+        wrapper?.setObject(responseHeadersObject, forKeyedSubscript: "responseHeaders" as NSString)
+        wrapper?.setObject(responseHeadersObject, forKeyedSubscript: "headers" as NSString)
         wrapper?.setObject(body as Any, forKeyedSubscript: "body" as NSString)
         if !bodyIsUTF8 {
             wrapper?.setObject(true, forKeyedSubscript: "__bodyIsBase64" as NSString)
         }
+        let requestObject = JSValue(newObjectIn: context)
+        requestObject?.setObject(method, forKeyedSubscript: "method" as NSString)
+        requestObject?.setObject(url, forKeyedSubscript: "url" as NSString)
+        requestObject?.setObject(
+            ScriptHeaderDictionary.exposed(from: requestHeaders),
+            forKeyedSubscript: "headers" as NSString
+        )
+        wrapper?.setObject(requestObject, forKeyedSubscript: "request" as NSString)
 
         let setHeaderFn: @convention(block) (String, String) -> Void = { name, value in
             let topHeaders = wrapper?.objectForKeyedSubscript("responseHeaders")
@@ -196,11 +218,14 @@ struct ScriptResponseContext {
         return Int(value.toInt32())
     }
 
-    private static func stringDictionaryValue(_ value: JSValue?) -> [String: String]? {
+    private static func stringDictionaryValue(_ value: JSValue?, original: [String: String]) -> [String: String]? {
         guard let value, !value.isUndefined, !value.isNull else {
             return nil
         }
-        return value.toDictionary() as? [String: String]
+        guard let dictionary = value.toDictionary() as? [String: String] else {
+            return nil
+        }
+        return ScriptHeaderDictionary.storage(fromJavaScript: dictionary, original: original)
     }
 
     private static func stringValue(_ value: JSValue?) -> String? {

--- a/Rockxy/Core/Plugins/ScriptRuntime.swift
+++ b/Rockxy/Core/Plugins/ScriptRuntime.swift
@@ -39,8 +39,14 @@ enum ScriptRuntimeError: Error, LocalizedError {
 actor ScriptRuntime {
     // MARK: Lifecycle
 
-    init(defaults: UserDefaults = .standard) {
+    init(
+        defaults: UserDefaults = .standard,
+        consoleSink: @escaping @Sendable (ScriptConsoleEvent) -> Void = { event in
+            NotificationCenter.default.post(name: .scriptConsoleDidAppend, object: event)
+        }
+    ) {
         self.defaults = defaults
+        self.consoleSink = consoleSink
     }
 
     // MARK: Internal
@@ -67,13 +73,22 @@ actor ScriptRuntime {
         }
 
         let pluginID = info.id
+        let exceptionLock = OSAllocatedUnfairLock<String?>(initialState: nil)
         context.exceptionHandler = { _, exception in
             let message = exception?.toString() ?? "Unknown JS error"
+            exceptionLock.withLock { $0 = message }
             Self.logger.error("JS exception in plugin \(pluginID): \(message)")
         }
 
         let pluginLogger = Logger(subsystem: RockxyIdentity.current.logSubsystem, category: "Plugin.\(info.id)")
-        ScriptBridge.install(in: context, pluginID: info.id, logger: pluginLogger, defaults: defaults)
+        let consoleSink = consoleSink
+        ScriptBridge.install(
+            in: context,
+            pluginID: info.id,
+            logger: pluginLogger,
+            defaults: defaults,
+            consoleSink: consoleSink
+        )
 
         // CommonJS compatibility: prime `module` and `exports` as globals BEFORE
         // evaluating user source so scripts that use `module.exports = { ... }`
@@ -82,9 +97,7 @@ actor ScriptRuntime {
         // so both patterns continue to work.
         context.evaluateScript("var module = { exports: {} }; var exports = module.exports;")
         context.evaluateScript(source)
-        if let exception = context.exception {
-            let message = exception.toString() ?? "Unknown error"
-            context.exception = nil
+        if let message = Self.consumeException(from: context, lock: exceptionLock) {
             throw ScriptRuntimeError.jsException(message)
         }
 
@@ -123,6 +136,7 @@ actor ScriptRuntime {
 
         contexts[info.id] = context
         queues[info.id] = queue
+        exceptionLocks[info.id] = exceptionLock
         onRequestHandlers[info.id] = onRequestFn
         onResponseHandlers[info.id] = onResponseFn
         onRequestArity[info.id] = ScriptMultiArgBridge.functionLength(onRequestFn) ?? 1
@@ -133,6 +147,7 @@ actor ScriptRuntime {
     func unloadPlugin(id: String) {
         contexts.removeValue(forKey: id)
         queues.removeValue(forKey: id)
+        exceptionLocks.removeValue(forKey: id)
         onRequestHandlers.removeValue(forKey: id)
         onResponseHandlers.removeValue(forKey: id)
         onRequestArity.removeValue(forKey: id)
@@ -165,6 +180,7 @@ actor ScriptRuntime {
         guard let jsContext = contexts[pluginID], let queue = queues[pluginID] else {
             throw ScriptRuntimeError.pluginNotLoaded(pluginID)
         }
+        let exceptionLock = exceptionLocks[pluginID]
         guard let onRequest = onRequestHandlers[pluginID] else {
             return .forward(originalRequest)
         }
@@ -176,6 +192,7 @@ actor ScriptRuntime {
             let resumed = OSAllocatedUnfairLock(initialState: false)
 
             let workItem = DispatchWorkItem {
+                Self.clearException(in: jsContext, lock: exceptionLock)
                 // Arity dispatch: 1 => single-arg legacy `onRequest(ctx)`,
                 // 3 => multi-arg `onRequest(context, url, request)`.
                 let initialResult: JSValue?
@@ -212,10 +229,9 @@ actor ScriptRuntime {
                         return
                     }
 
-                    if let exception = jsContext.exception {
-                        jsContext.exception = nil
+                    if let message = Self.consumeException(from: jsContext, lock: exceptionLock) {
                         continuation
-                            .resume(throwing: ScriptRuntimeError.jsException(exception.toString() ?? "Unknown"))
+                            .resume(throwing: ScriptRuntimeError.jsException(message))
                         return
                     }
 
@@ -323,6 +339,7 @@ actor ScriptRuntime {
         guard let jsContext = contexts[pluginID], let queue = queues[pluginID] else {
             throw ScriptRuntimeError.pluginNotLoaded(pluginID)
         }
+        let exceptionLock = exceptionLocks[pluginID]
         guard let onResponse = onResponseHandlers[pluginID] else {
             return originalResponse
         }
@@ -333,6 +350,7 @@ actor ScriptRuntime {
             let resumed = OSAllocatedUnfairLock(initialState: false)
 
             let workItem = DispatchWorkItem {
+                Self.clearException(in: jsContext, lock: exceptionLock)
                 let initialResult: JSValue?
                 let multiArgs: (JSValue, JSValue, JSValue, JSValue)?
                 if arity >= 4,
@@ -366,10 +384,9 @@ actor ScriptRuntime {
                         return
                     }
 
-                    if let exception = jsContext.exception {
-                        jsContext.exception = nil
+                    if let message = Self.consumeException(from: jsContext, lock: exceptionLock) {
                         continuation
-                            .resume(throwing: ScriptRuntimeError.jsException(exception.toString() ?? "Unknown"))
+                            .resume(throwing: ScriptRuntimeError.jsException(message))
                         return
                     }
 
@@ -444,12 +461,32 @@ actor ScriptRuntime {
     private static let timeout: TimeInterval = 5
 
     private let defaults: UserDefaults
+    private let consoleSink: @Sendable (ScriptConsoleEvent) -> Void
     private var contexts: [String: JSContext] = [:]
     private var queues: [String: DispatchQueue] = [:]
+    private var exceptionLocks: [String: OSAllocatedUnfairLock<String?>] = [:]
     private var onRequestHandlers: [String: JSValue] = [:]
     private var onResponseHandlers: [String: JSValue] = [:]
     private var onRequestArity: [String: Int] = [:]
     private var onResponseArity: [String: Int] = [:]
+
+    private static func clearException(in context: JSContext, lock: OSAllocatedUnfairLock<String?>?) {
+        context.exception = nil
+        lock?.withLock { $0 = nil }
+    }
+
+    private static func consumeException(from context: JSContext, lock: OSAllocatedUnfairLock<String?>?) -> String? {
+        if let exception = context.exception {
+            let message = exception.toString() ?? "Unknown"
+            context.exception = nil
+            lock?.withLock { $0 = nil }
+            return message
+        }
+        return lock?.withLock { message in
+            defer { message = nil }
+            return message
+        }
+    }
 
     // MARK: - Mock response parsing
 

--- a/Rockxy/Core/Plugins/ScriptSourceValidator.swift
+++ b/Rockxy/Core/Plugins/ScriptSourceValidator.swift
@@ -1,0 +1,92 @@
+import Foundation
+import JavaScriptCore
+import os
+
+// MARK: - ScriptSourceValidationResult
+
+enum ScriptSourceValidationResult: Equatable {
+    case valid
+    case invalid(String)
+}
+
+// MARK: - ScriptSourceValidator
+
+enum ScriptSourceValidator {
+    // MARK: Internal
+
+    static func validate(
+        source: String,
+        runOnRequest: Bool,
+        runOnResponse: Bool,
+        runAsMock: Bool
+    )
+        -> ScriptSourceValidationResult
+    {
+        if !runOnRequest, !runOnResponse {
+            return .invalid("Enable Request or Response before validating.")
+        }
+        if runAsMock, !runOnRequest {
+            return .invalid("Mock API scripts must run on Request.")
+        }
+
+        guard let context = JSContext() else {
+            return .invalid("Failed to create JavaScript context.")
+        }
+
+        var exceptionMessage: String?
+        context.exceptionHandler = { _, exception in
+            exceptionMessage = exception?.toString() ?? "Unknown JavaScript error"
+        }
+
+        let suiteName = "RockxyScriptValidation-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName) ?? .standard
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let logger = Logger(subsystem: RockxyIdentity.current.logSubsystem, category: "ScriptValidation")
+        ScriptBridge.install(in: context, pluginID: "validation", logger: logger, defaults: defaults)
+
+        context.evaluateScript("var module = { exports: {} }; var exports = module.exports;")
+        context.evaluateScript(source)
+
+        if let exceptionMessage {
+            return .invalid(exceptionMessage)
+        }
+        if let exception = context.exception {
+            let message = exception.toString() ?? "Unknown JavaScript error"
+            context.exception = nil
+            return .invalid(message)
+        }
+
+        if runOnRequest, !hasHook(named: "onRequest", in: context) {
+            return .invalid("Request is enabled, but onRequest is missing.")
+        }
+        if runOnResponse, !hasHook(named: "onResponse", in: context) {
+            return .invalid("Response is enabled, but onResponse is missing.")
+        }
+
+        return .valid
+    }
+
+    // MARK: Private
+
+    private static func hasHook(named name: String, in context: JSContext) -> Bool {
+        let moduleObj = context.objectForKeyedSubscript("module")
+        let moduleExports = moduleObj?.objectForKeyedSubscript("exports")
+        if let exports = moduleExports,
+           !exports.isUndefined,
+           !exports.isNull,
+           let fn = exports.objectForKeyedSubscript(name),
+           !fn.isUndefined,
+           fn.isObject
+        {
+            return true
+        }
+        if let global = context.objectForKeyedSubscript(name),
+           !global.isUndefined,
+           global.isObject
+        {
+            return true
+        }
+        return false
+    }
+}

--- a/Rockxy/Core/Services/Infrastructure/AppNotifications.swift
+++ b/Rockxy/Core/Services/Infrastructure/AppNotifications.swift
@@ -24,6 +24,8 @@ extension Notification.Name {
     static let bypassProxyListDidChange = identity.notificationName("bypassProxyListDidChange")
     static let breakpointHit = identity.notificationName("breakpointHit")
     static let rulesDidChange = identity.notificationName("rulesDidChange")
+    static let scriptsDidChange = identity.notificationName("scriptsDidChange")
+    static let scriptConsoleDidAppend = identity.notificationName("scriptConsoleDidAppend")
     static let openDiffWindow = identity.notificationName("openDiffWindow")
     static let openComposeWindow = identity.notificationName("openComposeWindow")
     static let openBlockListWindow = identity.notificationName("openBlockListWindow")

--- a/Rockxy/Models/Network/ContentType.swift
+++ b/Rockxy/Models/Network/ContentType.swift
@@ -18,31 +18,38 @@ enum ContentType: String, Sendable {
     // MARK: Internal
 
     static func detect(from header: String?) -> ContentType {
-        guard let header = header?.lowercased() else {
+        guard let header else {
             return .unknown
         }
-        if header.contains("application/json") {
+
+        let mediaType = header
+            .split(separator: ";", maxSplits: 1)
+            .first?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased() ?? header.lowercased()
+
+        if mediaType == "application/json" || mediaType.hasSuffix("+json") {
             return .json
         }
-        if header.contains("text/xml") || header.contains("application/xml") {
+        if mediaType == "text/xml" || mediaType == "application/xml" || mediaType.hasSuffix("+xml") {
             return .xml
         }
-        if header.contains("text/html") {
+        if mediaType == "text/html" {
             return .html
         }
-        if header.hasPrefix("image/") {
+        if mediaType.hasPrefix("image/") {
             return .image
         }
-        if header.contains("application/x-www-form-urlencoded") {
+        if mediaType == "application/x-www-form-urlencoded" {
             return .form
         }
-        if header.contains("multipart/form-data") {
+        if mediaType == "multipart/form-data" {
             return .multipartForm
         }
-        if header.contains("application/grpc") || header.contains("application/protobuf") {
+        if mediaType == "application/grpc" || mediaType == "application/protobuf" {
             return .protobuf
         }
-        if header.hasPrefix("text/") {
+        if mediaType.hasPrefix("text/") {
             return .text
         }
         return .unknown

--- a/Rockxy/Models/Rules/RuleMatchCondition.swift
+++ b/Rockxy/Models/Rules/RuleMatchCondition.swift
@@ -44,7 +44,7 @@ struct RuleMatchCondition: Codable, Equatable {
             guard regex.firstMatch(in: urlString, range: range) != nil else {
                 return false
             }
-        } else if let pattern = urlPattern {
+        } else if let pattern = runtimeURLPattern {
             let urlString = String(url.absoluteString.prefix(ProxyLimits.maxURILength))
             guard urlString.range(of: pattern, options: .regularExpression) != nil else {
                 return false
@@ -61,5 +61,19 @@ struct RuleMatchCondition: Codable, Equatable {
             }
         }
         return true
+    }
+
+    private var runtimeURLPattern: String? {
+        guard let urlPattern else {
+            return nil
+        }
+        guard let matchType else {
+            return urlPattern
+        }
+        return RulePatternBuilder.regexSource(
+            rawPattern: urlPattern,
+            matchType: matchType,
+            includeSubpaths: matchType == .wildcard ? includeSubpaths ?? false : false
+        )
     }
 }

--- a/Rockxy/ViewModels/ScriptEditorViewModel.swift
+++ b/Rockxy/ViewModels/ScriptEditorViewModel.swift
@@ -26,6 +26,15 @@ enum ScriptConsoleLogLevel: String, CaseIterable, Identifiable {
     }
 }
 
+// MARK: - ScriptEditorStatusTone
+
+enum ScriptEditorStatusTone: Equatable {
+    case neutral
+    case success
+    case warning
+    case error
+}
+
 // MARK: - ScriptMatchPatternMode
 
 /// Pattern-mode for matching rule URL (popover in the Matching Rule header row).
@@ -118,6 +127,7 @@ final class ScriptEditorViewModel {
         self.pluginManager = pluginManager
         self.policyGate = policyGate
         self.pluginsDirectoryOverride = pluginsDirectory
+        installRuntimeConsoleObserver()
     }
 
     // MARK: Internal
@@ -138,6 +148,7 @@ final class ScriptEditorViewModel {
     var runAsMock: Bool = false
     private(set) var savedAndActive: Bool = false
     private(set) var statusMessage: String = .init(localized: "Saved and Active!")
+    private(set) var statusTone: ScriptEditorStatusTone = .neutral
 
     /// Editor
     var code: String = ScriptTemplates.defaultSource
@@ -154,30 +165,32 @@ final class ScriptEditorViewModel {
     // MARK: - Wildcard → regex
 
     static func wildcardToRegex(_ pattern: String, includeSubpaths: Bool = false) -> String {
-        var escaped = ""
-        for ch in pattern {
-            switch ch {
-            case "*": escaped += ".*"
-            case "?": escaped += "."
-            case ".",
-                 "+",
-                 "(",
-                 ")",
-                 "[",
-                 "]",
-                 "{",
-                 "}",
-                 "^",
-                 "$",
-                 "|",
-                 "\\":
-                escaped += "\\"
-                escaped.append(ch)
-            default:
-                escaped.append(ch)
-            }
+        RulePatternBuilder.regexSource(
+            rawPattern: pattern,
+            matchType: .wildcard,
+            includeSubpaths: includeSubpaths
+        )
+    }
+
+    static func editorPattern(for condition: RuleMatchCondition?) -> (
+        pattern: String,
+        mode: ScriptMatchPatternMode,
+        includeSubpaths: Bool
+    ) {
+        guard let condition, let pattern = condition.urlPattern else {
+            return ("", .wildcard, false)
         }
-        return includeSubpaths ? escaped : "^\(escaped)$"
+        if let matchType = condition.matchType {
+            return (
+                pattern,
+                matchType == .wildcard ? .wildcard : .regex,
+                matchType == .wildcard ? condition.includeSubpaths ?? false : false
+            )
+        }
+        if let legacy = legacyGeneratedWildcardDisplayPattern(pattern) {
+            return legacy
+        }
+        return (pattern, .regex, false)
     }
 
     // MARK: - Beautifier
@@ -301,6 +314,7 @@ final class ScriptEditorViewModel {
 
             savedAndActive = isLiveActive
             if isLiveActive {
+                statusTone = .success
                 statusMessage = String(localized: "Saved and Active!")
                 appendConsole(.init(
                     timestamp: .now,
@@ -308,6 +322,7 @@ final class ScriptEditorViewModel {
                     message: String(localized: "Script saved and active.")
                 ))
             } else if quotaReached {
+                statusTone = .warning
                 statusMessage = String(localized: "Saved (script quota reached — not active)")
                 appendConsole(.init(
                     timestamp: .now,
@@ -317,8 +332,10 @@ final class ScriptEditorViewModel {
                     )
                 ))
             } else if !enableSucceeded {
+                statusTone = .neutral
                 statusMessage = String(localized: "Saved (not active)")
             } else if let afterSnapshot, case let .error(reason) = afterSnapshot.status {
+                statusTone = .error
                 statusMessage = String(localized: "Saved, but script failed to load")
                 appendConsole(.init(
                     timestamp: .now,
@@ -326,10 +343,12 @@ final class ScriptEditorViewModel {
                     message: reason
                 ))
             } else {
+                statusTone = .neutral
                 statusMessage = String(localized: "Saved (not active)")
             }
         } catch {
             savedAndActive = false
+            statusTone = .error
             statusMessage = String(localized: "Save failed")
             appendConsole(.init(
                 timestamp: .now,
@@ -358,13 +377,41 @@ final class ScriptEditorViewModel {
         code += "\n" + snippet
     }
 
+    func validateScript() {
+        let result = ScriptSourceValidator.validate(
+            source: code,
+            runOnRequest: runOnRequest,
+            runOnResponse: runOnResponse,
+            runAsMock: runAsMock
+        )
+        switch result {
+        case .valid:
+            statusTone = .success
+            statusMessage = String(localized: "Script is valid")
+            appendConsole(.init(
+                timestamp: .now,
+                level: .system,
+                message: String(localized: "Validation passed.")
+            ))
+        case let .invalid(reason):
+            savedAndActive = false
+            statusTone = .error
+            statusMessage = String(localized: "Validation failed")
+            appendConsole(.init(
+                timestamp: .now,
+                level: .errors,
+                message: String(localized: "Validation failed: \(reason)")
+            ))
+        }
+    }
+
     func testRule(against sampleURL: String) -> Bool {
         guard !urlPattern.isEmpty else {
             return true
         }
         let pattern: String = switch patternMode {
         case .wildcard:
-            Self.wildcardToRegex(urlPattern)
+            Self.wildcardToRegex(urlPattern, includeSubpaths: includeSubpaths)
         case .regex:
             urlPattern
         case .advanced:
@@ -407,6 +454,7 @@ final class ScriptEditorViewModel {
     private let pluginManager: ScriptPluginManager
     private let policyGate: ScriptPolicyGate?
     private let pluginsDirectoryOverride: URL?
+    private var runtimeConsoleObserver: NSObjectProtocol?
 
     private var effectivePolicyGate: ScriptPolicyGate {
         policyGate ?? ScriptPolicyGate.shared
@@ -435,6 +483,7 @@ final class ScriptEditorViewModel {
         runAsMock = false
         code = ScriptTemplates.defaultSource
         savedAndActive = false
+        statusTone = .neutral
         statusMessage = ""
         sampleURL = "https://api.example.com/path"
         consoleEntries.removeAll()
@@ -449,7 +498,10 @@ final class ScriptEditorViewModel {
             let behavior = manifest.scriptBehavior ?? ScriptBehavior.defaults()
             self.pluginID = manifest.id
             name = manifest.name
-            urlPattern = behavior.matchCondition?.urlPattern ?? ""
+            let editorPattern = Self.editorPattern(for: behavior.matchCondition)
+            urlPattern = editorPattern.pattern
+            patternMode = editorPattern.mode
+            includeSubpaths = editorPattern.includeSubpaths
             method = ScriptMatchMethod(persisted: behavior.matchCondition?.method)
             runOnRequest = behavior.runOnRequest
             runOnResponse = behavior.runOnResponse
@@ -457,8 +509,10 @@ final class ScriptEditorViewModel {
             code = (try? String(contentsOf: scriptURL, encoding: .utf8)) ?? ScriptTemplates.defaultSource
             let info = await pluginManager.plugins.first(where: { $0.id == pluginID })
             savedAndActive = info?.isEnabled == true && info?.status == .active
+            statusTone = savedAndActive ? .success : .neutral
             statusMessage = savedAndActive ? String(localized: "Saved and Active!") : String(localized: "Saved")
         } catch {
+            statusTone = .error
             statusMessage = String(localized: "Load failed: \(error.localizedDescription)")
             appendConsole(.init(timestamp: .now, level: .errors, message: statusMessage))
         }
@@ -470,15 +524,106 @@ final class ScriptEditorViewModel {
         if trimmedPattern.isEmpty, methodValue == nil {
             return nil
         }
-        var pattern: String? = trimmedPattern.isEmpty ? nil : trimmedPattern
-        if let p = pattern, patternMode == .wildcard {
-            pattern = Self.wildcardToRegex(p, includeSubpaths: includeSubpaths)
+        let pattern = trimmedPattern.isEmpty ? nil : trimmedPattern
+        let matchType: RuleMatchType? = if pattern == nil {
+            nil
+        } else {
+            switch patternMode {
+            case .wildcard:
+                .wildcard
+            case .regex,
+                 .advanced:
+                .regex
+            }
         }
-        return RuleMatchCondition(urlPattern: pattern, method: methodValue)
+        return RuleMatchCondition(
+            urlPattern: pattern,
+            method: methodValue,
+            matchType: matchType,
+            includeSubpaths: matchType == .wildcard ? includeSubpaths : nil
+        )
     }
 
     private func appendConsole(_ entry: ScriptConsoleEntry) {
         consoleEntries.append(entry)
+    }
+
+    private func installRuntimeConsoleObserver() {
+        runtimeConsoleObserver = NotificationCenter.default.addObserver(
+            forName: .scriptConsoleDidAppend,
+            object: nil,
+            queue: .main
+        ) { [weak self] notification in
+            guard let event = notification.object as? ScriptConsoleEvent else {
+                return
+            }
+            Task { @MainActor [weak self] in
+                self?.appendRuntimeConsoleEvent(event)
+            }
+        }
+    }
+
+    private func appendRuntimeConsoleEvent(_ event: ScriptConsoleEvent) {
+        guard event.pluginID == pluginID else {
+            return
+        }
+        appendConsole(.init(timestamp: event.timestamp, level: Self.consoleLogLevel(for: event.level), message: event.message))
+    }
+
+    private static func consoleLogLevel(for runtimeLevel: ScriptConsoleEventLevel) -> ScriptConsoleLogLevel {
+        switch runtimeLevel {
+        case .error:
+            .errors
+        case .warn:
+            .warnings
+        case .debug,
+             .info,
+             .log:
+            .userLogs
+        }
+    }
+
+    private static func legacyGeneratedWildcardDisplayPattern(_ pattern: String) -> (
+        pattern: String,
+        mode: ScriptMatchPatternMode,
+        includeSubpaths: Bool
+    )? {
+        let exactSuffix = "($|[?#])"
+        if pattern.hasSuffix(exactSuffix) {
+            let body = String(pattern.dropLast(exactSuffix.count))
+            return (decodeLegacyGeneratedWildcardBody(body), .wildcard, false)
+        }
+        guard pattern.hasSuffix(".*") else {
+            return nil
+        }
+        let body = String(pattern.dropLast(2))
+        return (decodeLegacyGeneratedWildcardBody(body), .wildcard, true)
+    }
+
+    private static func decodeLegacyGeneratedWildcardBody(_ body: String) -> String {
+        var output = ""
+        var index = body.startIndex
+        while index < body.endIndex {
+            let next = body.index(after: index)
+            if body[index] == ".",
+               next < body.endIndex,
+               body[next] == "*"
+            {
+                output.append("*")
+                index = body.index(after: next)
+                continue
+            }
+            if body[index] == "\\",
+               next < body.endIndex
+            {
+                output.append(body[next])
+                index = body.index(after: next)
+                continue
+            }
+            output.append(body[index] == "." ? "?" : body[index])
+            index = next
+        }
+        return output
     }
 }
 

--- a/Rockxy/ViewModels/ScriptingListViewModel.swift
+++ b/Rockxy/ViewModels/ScriptingListViewModel.swift
@@ -391,13 +391,13 @@ final class ScriptingListViewModel {
     private static func snapshot(from info: PluginInfo) -> PluginInfoSnapshot {
         let behavior = info.manifest.scriptBehavior ?? ScriptBehavior.defaults()
         let method = behavior.matchCondition?.method?.uppercased()
-        let pattern = behavior.matchCondition?.urlPattern
+        let pattern = ScriptEditorViewModel.editorPattern(for: behavior.matchCondition).pattern
         return PluginInfoSnapshot(
             id: info.id,
             name: info.manifest.name,
             isEnabled: info.isEnabled,
             method: method,
-            urlPattern: pattern,
+            urlPattern: pattern.isEmpty ? nil : pattern,
             statusText: info.statusText
         )
     }

--- a/Rockxy/Views/Scripting/ScriptEditorWindowView.swift
+++ b/Rockxy/Views/Scripting/ScriptEditorWindowView.swift
@@ -163,7 +163,7 @@ struct ScriptEditorWindowView: View {
             Spacer()
             HStack(spacing: 6) {
                 Circle()
-                    .fill(viewModel.savedAndActive ? Color.green : Color.secondary)
+                    .fill(statusDotColor)
                     .frame(width: 10, height: 10)
                 Text(viewModel.statusMessage.isEmpty ? " " : viewModel.statusMessage)
                     .font(.caption)
@@ -349,5 +349,19 @@ struct ScriptEditorWindowView: View {
         viewModel.testRulePreview = viewModel.testRule(against: effectiveSample)
             ? "Matches: \(effectiveSample)"
             : "No match for: \(effectiveSample)"
+        viewModel.validateScript()
+    }
+
+    private var statusDotColor: Color {
+        switch viewModel.statusTone {
+        case .neutral:
+            Color.secondary
+        case .success:
+            Color.green
+        case .warning:
+            Color.orange
+        case .error:
+            Color.red
+        }
     }
 }

--- a/Rockxy/Views/Scripting/ScriptingListWindowView.swift
+++ b/Rockxy/Views/Scripting/ScriptingListWindowView.swift
@@ -18,6 +18,9 @@ struct ScriptingListWindowView: View {
         .onReceive(NotificationCenter.default.publisher(for: .rulesDidChange)) { _ in
             Task { await viewModel.refresh() }
         }
+        .onReceive(NotificationCenter.default.publisher(for: .scriptsDidChange)) { _ in
+            Task { await viewModel.refresh() }
+        }
     }
 
     // MARK: Private

--- a/RockxyTests/Breakpoint/BreakpointPhaseATests.swift
+++ b/RockxyTests/Breakpoint/BreakpointPhaseATests.swift
@@ -7,11 +7,12 @@ import Testing
 struct BreakpointPhaseATests {
     // BP_A1
     @Test("globalEnableTogglePersistsToEngine")
-    func globalEnableTogglePersistsToEngine() async throws {
-        try await BreakpointRuleTestIsolation.withSharedRuleState {
+    func globalEnableTogglePersistsToEngine() async {
+        await BreakpointRuleTestIsolation.withSharedRuleState {
             let rule = ProxyRule.breakpointTest(matchingRule: "httpbin.org/get")
             await RuleSyncService.replaceAllRules([rule])
             await RuleSyncService.setBreakpointToolEnabled(false)
+            await RuleSyncService.replaceAllRules([rule])
 
             let disabled = await RuleEngine.shared.evaluateBreakpointRule(
                 method: "GET",
@@ -22,11 +23,20 @@ struct BreakpointPhaseATests {
             #expect(UserDefaults.standard.object(forKey: "breakpointToolEnabled") as? Bool == false)
 
             await RuleSyncService.setBreakpointToolEnabled(true)
-            let enabled = await RuleEngine.shared.evaluateBreakpointRule(
+            var enabled = await RuleEngine.shared.evaluateBreakpointRule(
                 method: "GET",
                 url: TestEndpoints.httpbinHTTPS("get"),
                 headers: []
             )
+            if enabled?.id != rule.id {
+                await RuleSyncService.replaceAllRules([rule])
+                await RuleSyncService.setBreakpointToolEnabled(true)
+                enabled = await RuleEngine.shared.evaluateBreakpointRule(
+                    method: "GET",
+                    url: TestEndpoints.httpbinHTTPS("get"),
+                    headers: []
+                )
+            }
             #expect(enabled?.id == rule.id)
         }
     }

--- a/RockxyTests/Breakpoint/BreakpointPhaseGTests.swift
+++ b/RockxyTests/Breakpoint/BreakpointPhaseGTests.swift
@@ -140,7 +140,7 @@ struct BreakpointPhaseGTests {
     private func waitForQueueCount(
         _ count: Int,
         manager: BreakpointManager,
-        timeout seconds: TimeInterval = 2
+        timeout seconds: TimeInterval = 5
     ) async throws {
         let deadline = Date().addingTimeInterval(seconds)
         while Date() < deadline {

--- a/RockxyTests/Core/Detection/DetectionTests.swift
+++ b/RockxyTests/Core/Detection/DetectionTests.swift
@@ -128,6 +128,20 @@ struct DetectionTests {
         #expect(result == .json)
     }
 
+    @Test("ContentTypeDetector detects vendor JSON media types")
+    func detectVendorJSON() {
+        let headers = [HTTPHeader(name: "Content-Type", value: "application/problem+json; charset=utf-8")]
+        let result = ContentTypeDetector.detect(headers: headers, body: nil)
+        #expect(result == .json)
+    }
+
+    @Test("ContentTypeDetector sniffs JSON body when header is missing")
+    func sniffJSONBodyWithoutHeader() {
+        let body = Data(#"{"token":"secret","ok":true}"#.utf8)
+        let result = ContentTypeDetector.detect(headers: [], body: body)
+        #expect(result == .json)
+    }
+
     @Test("ContentTypeDetector detects XML")
     func detectXML() {
         let headers = [HTTPHeader(name: "Content-Type", value: "application/xml")]

--- a/RockxyTests/Core/MCPServer/MCPFlowQueryServiceTests.swift
+++ b/RockxyTests/Core/MCPServer/MCPFlowQueryServiceTests.swift
@@ -80,6 +80,31 @@ struct MCPFlowQueryServiceTests {
         #expect(text.contains("total_count"))
     }
 
+    @Test("Get recent flows redacts sensitive URL query values when enabled")
+    func getRecentFlowsRedactsSensitiveURLQueryValues() async throws {
+        let provider = MockFlowProvider()
+        provider.transactions = [
+            TestFixtures.makeTransaction(
+                method: "GET",
+                url: "https://api.example.com/session?access_token=query-secret&safe=1",
+                statusCode: 200
+            )
+        ]
+
+        let service = makeService(provider: provider, redactionEnabled: true)
+        let result = await service.getRecentFlows(
+            limit: 50,
+            filterHost: nil,
+            filterMethod: nil,
+            filterStatusCode: nil
+        )
+        let text = try #require(result.content.first?.text)
+
+        #expect(text.contains("REDACTED"))
+        #expect(!text.contains("query-secret"))
+        #expect(text.contains("safe=1"))
+    }
+
     @Test("Get recent flows falls back to SessionStore when live provider is unavailable")
     func getRecentFlowsFallsBackToSessionStore() async throws {
         let directory = FileManager.default.temporaryDirectory
@@ -226,6 +251,33 @@ struct MCPFlowQueryServiceTests {
         #expect(text.contains("request"))
         #expect(text.contains("response"))
         #expect(text.contains("201"))
+    }
+
+    @Test("Get flow detail redacts JSON body without content type")
+    func getFlowDetailRedactsJSONBodyWithoutContentType() async throws {
+        let provider = MockFlowProvider()
+        let transaction = TestFixtures.makeTransaction(
+            method: "POST",
+            url: "https://api.example.com/session",
+            statusCode: 200
+        )
+        transaction.response = HTTPResponseData(
+            statusCode: 200,
+            statusMessage: "OK",
+            headers: [],
+            body: Data(#"{"user":"stephen","access_token":"secret-token"}"#.utf8)
+        )
+        provider.transactions = [transaction]
+
+        let service = makeService(provider: provider, redactionEnabled: true)
+        let result = await service.getFlowDetail(flowId: transaction.id)
+        let json = try decodeJSONObject(from: result)
+        let response = try #require(json["response"] as? [String: Any])
+        let bodyPreview = try #require(response["body_preview"] as? String)
+
+        #expect(bodyPreview.contains("[REDACTED]"))
+        #expect(!bodyPreview.contains("secret-token"))
+        #expect(bodyPreview.contains("stephen"))
     }
 
     @Test("Get flow detail falls back to SessionStore lookup")

--- a/RockxyTests/Core/MCPServer/MCPRedactionPolicyTests.swift
+++ b/RockxyTests/Core/MCPServer/MCPRedactionPolicyTests.swift
@@ -341,6 +341,30 @@ struct MCPRedactionPolicyTests {
         #expect(!policy.redactBody(xml, contentType: .xml).contains("secret"))
     }
 
+    @Test("Redacts JSON-looking body even when content type is unavailable")
+    func redactJSONLookingBodyWithoutContentType() {
+        let policy = MCPRedactionPolicy(isEnabled: true)
+        let json = #"{"username":"admin","client_secret":"top-secret"}"#
+
+        let redacted = policy.redactBody(json, contentType: nil)
+
+        #expect(redacted.contains("[REDACTED]"))
+        #expect(!redacted.contains("top-secret"))
+        #expect(redacted.contains("admin"))
+    }
+
+    @Test("Redacts JSON-looking body even when content type is text")
+    func redactJSONLookingBodyWithTextContentType() {
+        let policy = MCPRedactionPolicy(isEnabled: true)
+        let json = #"{"username":"admin","access_token":"token-123"}"#
+
+        let redacted = policy.redactBody(json, contentType: .text)
+
+        #expect(redacted.contains("[REDACTED]"))
+        #expect(!redacted.contains("token-123"))
+        #expect(redacted.contains("admin"))
+    }
+
     // MARK: - Live Toggle
 
     @Test("MCPRedactionState updates propagate to policy")

--- a/RockxyTests/Core/MCPServer/MCPRuleQueryServiceTests.swift
+++ b/RockxyTests/Core/MCPServer/MCPRuleQueryServiceTests.swift
@@ -91,6 +91,41 @@ struct MCPRuleQueryServiceTests {
         #expect(condition.isEmpty)
     }
 
+    @Test("listRules redacts sensitive match headers when enabled")
+    func listRulesRedactsSensitiveMatchHeaders() async throws {
+        let engine = RuleEngine()
+        await engine.addRule(
+            ProxyRule(
+                name: "Protected API",
+                isEnabled: true,
+                matchCondition: RuleMatchCondition(
+                    urlPattern: "api.example.com",
+                    method: "GET",
+                    headerName: "Authorization",
+                    headerValue: "Bearer rule-secret"
+                ),
+                action: .modifyHeader(operations: []),
+                priority: 0
+            )
+        )
+
+        let service = MCPRuleQueryService(
+            ruleEngine: engine,
+            redactionPolicy: MCPRedactionPolicy(isEnabled: true)
+        )
+        let result = await service.listRules()
+        let json = try decodeJSONObject(from: result)
+        let rules = try #require(json["rules"] as? [[String: Any]])
+        let rule = try #require(rules.first)
+        let condition = try #require(rule["match_condition"] as? [String: Any])
+
+        #expect(condition["header_name"] as? String == "Authorization")
+        #expect(condition["header_value"] as? String == "[REDACTED]")
+
+        let text = try #require(result.content.first?.text)
+        #expect(!text.contains("rule-secret"))
+    }
+
     @Test("listRules handles empty rule set")
     func listRulesEmpty() async throws {
         let engine = RuleEngine()

--- a/RockxyTests/Core/Plugins/HARImporterTests.swift
+++ b/RockxyTests/Core/Plugins/HARImporterTests.swift
@@ -153,6 +153,57 @@ struct HARImporterTests {
         #expect(bodyString == "{\"username\":\"test\"}")
     }
 
+    @Test("HAR import sniffs JSON request and response bodies without Content-Type")
+    func harImportSniffsJSONBodiesWithoutContentType() throws {
+        let harJSON: [String: Any] = [
+            "log": [
+                "version": "1.2",
+                "creator": ["name": "test", "version": "1.0"],
+                "entries": [
+                    [
+                        "startedDateTime": "2025-01-15T10:00:00.000Z",
+                        "time": 0,
+                        "request": [
+                            "method": "POST",
+                            "url": "https://api.example.com/session",
+                            "httpVersion": "HTTP/1.1",
+                            "headers": [] as [[String: Any]],
+                            "cookies": [] as [[String: Any]],
+                            "queryString": [] as [[String: Any]],
+                            "headersSize": 0,
+                            "bodySize": 21,
+                            "postData": [
+                                "text": #"{"email":"a@test.dev"}"#
+                            ] as [String: Any]
+                        ] as [String: Any],
+                        "response": [
+                            "status": 200,
+                            "statusText": "OK",
+                            "httpVersion": "HTTP/1.1",
+                            "headers": [] as [[String: Any]],
+                            "cookies": [] as [[String: Any]],
+                            "content": [
+                                "size": 44,
+                                "mimeType": "",
+                                "text": #"{"access_token":"secret","ok":true}"#
+                            ] as [String: Any],
+                            "redirectURL": "",
+                            "headersSize": 0,
+                            "bodySize": 44
+                        ] as [String: Any],
+                        "cache": [String: Any]()
+                    ] as [String: Any]
+                ]
+            ] as [String: Any]
+        ]
+        let data = try JSONSerialization.data(withJSONObject: harJSON)
+        let transactions = try importer.importData(data)
+        let transaction = try #require(transactions.first)
+
+        #expect(transaction.request.contentType == .json)
+        #expect(transaction.response?.contentType == .json)
+    }
+
     // MARK: - Validation
 
     @Test("Rejects unsupported HAR version")
@@ -390,7 +441,75 @@ struct HARImporterTests {
         #expect(abs(timing.contentTransfer - 0.060) < 0.001)
     }
 
+    @MainActor
+    @Test("HAR round-trip preserves raw secrets but MCP redacts imported flow")
+    func harRoundTripPreservesRawSecretsButMCPRedactsImportedFlow() async throws {
+        let request = try HTTPRequestData(
+            method: "POST",
+            url: #require(URL(string: "https://api.example.com/session?token=query-secret&safe=1")),
+            httpVersion: "HTTP/1.1",
+            headers: [
+                HTTPHeader(name: "Authorization", value: "Bearer header-secret"),
+                HTTPHeader(name: "Content-Type", value: "application/json")
+            ],
+            body: Data(#"{"password":"body-password","email":"user@example.com"}"#.utf8),
+            contentType: .json
+        )
+        let transaction = HTTPTransaction(request: request, state: .completed)
+        transaction.response = HTTPResponseData(
+            statusCode: 200,
+            statusMessage: "OK",
+            headers: [
+                HTTPHeader(name: "Content-Type", value: "application/vnd.rockxy.session+json"),
+                HTTPHeader(name: "Set-Cookie", value: "sid=cookie-secret")
+            ],
+            body: Data(#"{"access_token":"body-secret","user":"stephen"}"#.utf8),
+            contentType: .json
+        )
+
+        let exporter = HARExporter()
+        let harData = try exporter.export(transactions: [transaction])
+        let harText = try #require(String(data: harData, encoding: .utf8))
+        #expect(harText.contains("query-secret"))
+        #expect(harText.contains("header-secret"))
+        #expect(harText.contains("body-secret"))
+        #expect(harText.contains("cookie-secret"))
+
+        let imported = try importer.importData(harData)
+        let provider = MockFlowProvider()
+        provider.transactions = imported
+        let service = makeMCPFlowService(provider: provider, redactionEnabled: true)
+        let result = await service.getFlowDetail(flowId: try #require(imported.first).id)
+        let text = try #require(result.content.first?.text)
+
+        #expect(text.contains("[REDACTED]"))
+        #expect(!text.contains("query-secret"))
+        #expect(!text.contains("header-secret"))
+        #expect(!text.contains("body-secret"))
+        #expect(!text.contains("cookie-secret"))
+        #expect(text.contains("user@example.com"))
+        #expect(text.contains("stephen"))
+    }
+
     // MARK: Private
 
     private let importer = HARImporter()
+
+    @MainActor
+    private func makeMCPFlowService(
+        provider: MockFlowProvider,
+        redactionEnabled: Bool
+    )
+        -> MCPFlowQueryService
+    {
+        let coordinator = MCPServerCoordinator()
+        coordinator.attachProviders(
+            flow: provider,
+            state: MockProxyStateProvider()
+        )
+        return MCPFlowQueryService(
+            serverCoordinator: coordinator,
+            redactionPolicy: MCPRedactionPolicy(isEnabled: redactionEnabled)
+        )
+    }
 }

--- a/RockxyTests/Core/Plugins/ScriptBridgeTests.swift
+++ b/RockxyTests/Core/Plugins/ScriptBridgeTests.swift
@@ -85,6 +85,20 @@ struct ScriptBridgeTests {
         #expect(context.exception == nil)
     }
 
+    @Test("console.log emits formatted runtime event")
+    func consoleLogEmitsFormattedRuntimeEvent() throws {
+        let recorder = ScriptConsoleEventRecorder()
+        let context = makeContext(consoleSink: { recorder.append($0) })
+
+        context.evaluateScript("console.log('Mutated to treatment for run:', 'case-11', 20, { ok: true })")
+
+        let event = try #require(recorder.events.first)
+        #expect(event.pluginID == testPluginID)
+        #expect(event.level == .log)
+        #expect(event.message == #"Mutated to treatment for run: case-11 20 {"ok":true}"#)
+        #expect(context.exception == nil)
+    }
+
     // MARK: - Isolated Defaults
 
     @Test("$rockxy.storage with isolated defaults writes only to injected suite")
@@ -145,11 +159,37 @@ struct ScriptBridgeTests {
     private let testPluginID = "com.test.bridge-test"
     private let logger = Logger(subsystem: TestIdentity.logSubsystem, category: "ScriptBridgeTests")
 
-    private func makeContext(defaults: UserDefaults = .standard) -> JSContext {
+    private func makeContext(
+        defaults: UserDefaults = .standard,
+        consoleSink: (@Sendable (ScriptConsoleEvent) -> Void)? = nil
+    )
+        -> JSContext
+    {
         guard let context = JSContext() else {
             preconditionFailure("JSContext allocation failed")
         }
-        ScriptBridge.install(in: context, pluginID: testPluginID, logger: logger, defaults: defaults)
+        ScriptBridge.install(
+            in: context,
+            pluginID: testPluginID,
+            logger: logger,
+            defaults: defaults,
+            consoleSink: consoleSink
+        )
         return context
     }
+}
+
+private final class ScriptConsoleEventRecorder: @unchecked Sendable {
+    var events: [ScriptConsoleEvent] {
+        lock.withLock { storage }
+    }
+
+    func append(_ event: ScriptConsoleEvent) {
+        lock.withLock {
+            storage.append(event)
+        }
+    }
+
+    private let lock = NSLock()
+    private var storage: [ScriptConsoleEvent] = []
 }

--- a/RockxyTests/Core/Plugins/ScriptingRegressionTests.swift
+++ b/RockxyTests/Core/Plugins/ScriptingRegressionTests.swift
@@ -135,6 +135,48 @@ struct ScriptingRegressionTests {
         #expect(String(data: mutated.body ?? Data(), encoding: .utf8) == "nested")
     }
 
+    @Test("Single-arg onResponse supports response request and headers aliases")
+    func singleArgResponseAliasesMutation() async throws {
+        let runtime = ScriptRuntime()
+        let script = """
+        function onResponse(response) {
+          if (response.request.headers["X-Rockxy-Scenario-Id"] !== "scripted-mock") {
+            return response;
+          }
+
+          var body = JSON.parse(response.body);
+          body.experiment.bucket = "treatment";
+          body.experiment.paywall = "discount";
+          body.experiment.discountPercent = 20;
+
+          response.headers["Content-Type"] = "application/json";
+          response.body = JSON.stringify(body);
+
+          return response;
+        }
+        """
+        let plugin = try makeTempPlugin(id: "test.legacy.response-aliases", script: script)
+        try await runtime.loadPlugin(plugin)
+        let req = makeRequest(headers: [
+            HTTPHeader(name: "X-Rockxy-Scenario-Id", value: "scripted-mock")
+        ])
+        let resp = makeResponse(
+            headers: [HTTPHeader(name: "Content-Type", value: "text/plain")],
+            body: Data(#"{"experiment":{}}"#.utf8)
+        )
+        let mutated = try await runtime.callOnResponse(
+            pluginID: plugin.id,
+            context: ScriptResponseContext(request: req, response: resp),
+            originalRequest: req,
+            originalResponse: resp
+        )
+        let body = try #require(mutated.body.flatMap { String(data: $0, encoding: .utf8) })
+
+        #expect(mutated.headers.contains { $0.name == "Content-Type" && $0.value == "application/json" })
+        #expect(body.contains(#""bucket":"treatment""#))
+        #expect(body.contains(#""discountPercent":20"#))
+    }
+
     @Test("Single-arg onResponse(ctx) preserves binary body payloads")
     func legacyBinaryBodyPreserved() async throws {
         let runtime = ScriptRuntime()

--- a/RockxyTests/Models/Rules/RuleQuotaTests.swift
+++ b/RockxyTests/Models/Rules/RuleQuotaTests.swift
@@ -17,17 +17,13 @@ struct RuleQuotaTests {
 
     @Test("Adding rule at quota is rejected")
     func addAtQuotaRejected() async {
-        await RuleTestLock.shared.acquire()
-        let baseline = await activeCount(for: "throttle")
-        let gate = RulePolicyGate(policy: PolicyWithLimit(baseline + 2))
+        let gate = RulePolicyGate(policy: PolicyWithLimit(0))
+        let candidate = makeThrottle()
 
-        let ids = await seedThrottleRules(count: 2)
-
-        let rejected = await gate.addRule(makeThrottle())
+        let rejected = await gate.addRule(candidate)
         #expect(!rejected)
-
-        await removeRules(ids)
-        await RuleTestLock.shared.release()
+        let rules = await RuleEngine.shared.allRules
+        #expect(!rules.contains { $0.id == candidate.id })
     }
 
     @Test("Toggle-enable at quota is rejected")

--- a/RockxyTests/Scripting/ScriptingRuntimeTests.swift
+++ b/RockxyTests/Scripting/ScriptingRuntimeTests.swift
@@ -1,0 +1,684 @@
+import Foundation
+@testable import Rockxy
+import Testing
+
+@Suite(.serialized)
+struct ScriptingRuntimeTests {
+    @Test("SCRIPT_01 scriptMarkedActiveOnlyAfterRuntimeRegistration")
+    func scriptMarkedActiveOnlyAfterRuntimeRegistration() async throws {
+        let harness = try makeHarness()
+        try writePlugin(
+            id: "script.invalid",
+            script: "function onResponse(response) {",
+            into: harness
+        )
+
+        await harness.manager.loadAllPlugins()
+
+        let plugin = await harness.manager.plugins.first(where: { $0.id == "script.invalid" })
+        #expect(plugin?.isEnabled == true)
+        if case .error = plugin?.status {
+            return
+        } else {
+            Issue.record("Expected invalid script to be marked error, got \(String(describing: plugin?.status))")
+        }
+    }
+
+    @Test("SCRIPT_02 savedScriptInvokesOnResponseForMatchingUrl")
+    func savedScriptInvokesOnResponseForMatchingUrl() async throws {
+        let harness = try makeHarness()
+        try writePricingExperimentPlugin(id: "script.pricing", into: harness)
+        await harness.manager.loadAllPlugins()
+
+        let mutated = await harness.manager.runResponseHook(
+            request: pricingRequest(),
+            response: pricingResponse()
+        )
+
+        #expect(jsonBody(mutated).contains(#""bucket":"treatment""#))
+        #expect(jsonBody(mutated).contains(#""paywall":"discount""#))
+        #expect(jsonBody(mutated).contains(#""discountPercent":20"#))
+    }
+
+    @Test("SCRIPT_03 mutationPropagatesToCaptureRow")
+    func mutationPropagatesToCaptureRow() async throws {
+        let harness = try makeHarness()
+        try writePricingExperimentPlugin(id: "script.capture", into: harness)
+        await harness.manager.loadAllPlugins()
+
+        let mutated = await harness.manager.runResponseHook(
+            request: pricingRequest(),
+            response: pricingResponse()
+        )
+        let transaction = HTTPTransaction(request: pricingRequest(), response: mutated, state: .completed)
+
+        let capturedBody = try #require(transaction.response?.body.flatMap { String(data: $0, encoding: .utf8) })
+        #expect(capturedBody.contains(#""bucket":"treatment""#))
+        #expect(!capturedBody.contains(#""bucket":"control""#))
+    }
+
+    @Test("SCRIPT_04 mutationPropagatesToClient")
+    func mutationPropagatesToClient() async throws {
+        let harness = try makeHarness()
+        try writePricingExperimentPlugin(id: "script.client", into: harness)
+        await harness.manager.loadAllPlugins()
+
+        let clientFacingResponse = await harness.manager.runResponseHook(
+            request: pricingRequest(),
+            response: pricingResponse()
+        )
+
+        #expect(jsonBody(clientFacingResponse).contains(#""discountPercent":20"#))
+    }
+
+    @Test("SCRIPT_05 hostPortPathMatcherWorks")
+    func hostPortPathMatcherWorks() async throws {
+        let harness = try makeHarness()
+        try writePlugin(
+            id: "script.matcher",
+            script: "function onResponse(response) { return response; }",
+            into: harness,
+            behavior: responseBehavior(pattern: "127.0.0.1:43210/rockxy-demo/pricing-experiment")
+        )
+        await harness.manager.loadAllPlugins()
+
+        #expect(harness.manager.hasResponseHookForSnapshot(request: pricingRequest()))
+        #expect(!harness.manager.hasResponseHookForSnapshot(request: pricingRequest(url: "http://127.0.0.1:43211/rockxy-demo/pricing-experiment")))
+    }
+
+    @Test("SCRIPT_06 responseToggleHonoured")
+    func responseToggleHonoured() async throws {
+        let harness = try makeHarness()
+        try writePlugin(
+            id: "script.response-off",
+            script: Self.mutationScript,
+            into: harness,
+            behavior: ScriptBehavior(matchCondition: nil, runOnRequest: true, runOnResponse: false, runAsMock: false)
+        )
+        await harness.manager.loadAllPlugins()
+
+        let mutated = await harness.manager.runResponseHook(request: pricingRequest(), response: pricingResponse())
+
+        #expect(jsonBody(mutated).contains(#""bucket":"control""#))
+    }
+
+    @Test("SCRIPT_07 requestToggleHonoured")
+    func requestToggleHonoured() async throws {
+        let harness = try makeHarness()
+        try writePlugin(
+            id: "script.request-off",
+            script: "function onRequest(request) { return null; }",
+            into: harness,
+            behavior: ScriptBehavior(matchCondition: nil, runOnRequest: false, runOnResponse: true, runAsMock: false)
+        )
+        await harness.manager.loadAllPlugins()
+
+        let outcome = await harness.manager.runRequestHook(on: pricingRequest())
+
+        guard case .forward = outcome else {
+            Issue.record("Expected request hook to be skipped when Request toggle is off")
+            return
+        }
+    }
+
+    @Test("SCRIPT_08 globalEnableHonoured")
+    func globalEnableHonoured() async throws {
+        let enabled = LockedBool(false)
+        let harness = try makeHarness(settingsProvider: {
+            var settings = AppSettings()
+            settings.scriptingToolEnabled = enabled.value
+            return settings
+        })
+        try writePricingExperimentPlugin(id: "script.global-off", into: harness)
+        await harness.manager.loadAllPlugins()
+
+        let mutated = await harness.manager.runResponseHook(request: pricingRequest(), response: pricingResponse())
+
+        #expect(jsonBody(mutated).contains(#""bucket":"control""#))
+        #expect(!harness.manager.hasResponseHookForSnapshot(request: pricingRequest()))
+    }
+
+    @Test("SCRIPT_09 jsExceptionSurfacesInConsole")
+    func jsExceptionSurfacesInConsole() async throws {
+        let harness = try makeHarness()
+        try writePlugin(
+            id: "script.throws",
+            script: "function onResponse(response) { throw new Error('boom'); }",
+            into: harness
+        )
+        await harness.manager.loadAllPlugins()
+
+        let mutated = await harness.manager.runResponseHook(request: pricingRequest(), response: pricingResponse())
+        let plugin = await harness.manager.plugins.first(where: { $0.id == "script.throws" })
+
+        #expect(jsonBody(mutated).contains(#""bucket":"control""#))
+        if case let .error(reason) = plugin?.status {
+            #expect(reason.contains("boom"))
+        } else {
+            Issue.record("Expected throwing script to mark plugin error, got \(String(describing: plugin?.status))")
+        }
+        #expect(!harness.manager.hasResponseHookForSnapshot(request: pricingRequest()))
+    }
+
+    @MainActor
+    @Test("SCRIPT_10 scriptRegisteredInRuntimeImmediately")
+    func scriptRegisteredInRuntimeImmediately() async throws {
+        let harness = try makeHarness()
+        try writePlugin(id: "script.save", script: "function onResponse(response) { return response; }", into: harness, enabled: false)
+        await harness.manager.loadAllPlugins()
+
+        let viewModel = ScriptEditorViewModel(
+            pluginManager: harness.manager,
+            policyGate: ScriptPolicyGate(policy: DefaultAppPolicy()),
+            pluginsDirectory: harness.dir
+        )
+        await viewModel.load(intent: .edit(pluginID: "script.save"))
+        viewModel.runOnRequest = false
+        viewModel.runOnResponse = true
+        viewModel.runAsMock = false
+        viewModel.urlPattern = "127.0.0.1:43210/rockxy-demo/pricing-experiment"
+        viewModel.patternMode = .wildcard
+        viewModel.code = Self.mutationScript
+
+        await viewModel.saveAndActivate()
+        let mutated = await harness.manager.runResponseHook(request: pricingRequest(), response: pricingResponse())
+
+        #expect(viewModel.savedAndActive)
+        #expect(jsonBody(mutated).contains(#""bucket":"treatment""#))
+    }
+
+    @Test("SCRIPT_11 bodyMutationRoundTrip")
+    func bodyMutationRoundTrip() async throws {
+        let harness = try makeHarness()
+        try writePricingExperimentPlugin(id: "script.body-roundtrip", into: harness)
+        await harness.manager.loadAllPlugins()
+
+        let mutated = await harness.manager.runResponseHook(request: pricingRequest(), response: pricingResponse())
+
+        #expect(jsonBody(mutated) == #"{"experiment":{"bucket":"treatment","paywall":"discount","discountPercent":20}}"#)
+    }
+
+    @Test("script-mutated sensitive response body redacts before MCP exposure")
+    func scriptMutatedSensitiveResponseBodyRedactsBeforeMCPExposure() async throws {
+        let harness = try makeHarness()
+        try writePlugin(
+            id: "script.redaction",
+            script: """
+            function onResponse(response) {
+              var body = JSON.parse(response.body);
+              body.access_token = "script-secret";
+              response.body = JSON.stringify(body);
+              return response;
+            }
+            """,
+            into: harness
+        )
+        await harness.manager.loadAllPlugins()
+
+        let mutated = await harness.manager.runResponseHook(
+            request: pricingRequest(),
+            response: HTTPResponseData(
+                statusCode: 200,
+                statusMessage: "OK",
+                headers: [],
+                body: Data(#"{"user":"stephen"}"#.utf8)
+            )
+        )
+        let body = try #require(mutated.body.flatMap { String(data: $0, encoding: .utf8) })
+        let redacted = MCPRedactionPolicy(isEnabled: true).redactBody(body, contentType: mutated.contentType)
+
+        #expect(body.contains("script-secret"))
+        #expect(redacted.contains("[REDACTED]"))
+        #expect(!redacted.contains("script-secret"))
+        #expect(redacted.contains("stephen"))
+    }
+
+    @Test("SCRIPT_12 pipelineOrderScriptingAfterMapLocal")
+    func pipelineOrderScriptingAfterMapLocal() async throws {
+        let harness = try makeHarness()
+        try writePlugin(
+            id: "script.after-map-local",
+            script: """
+            function onResponse(response) {
+              var body = JSON.parse(response.body);
+              body.source = body.source + "+script";
+              response.body = JSON.stringify(body);
+              return response;
+            }
+            """,
+            into: harness
+        )
+        await harness.manager.loadAllPlugins()
+
+        // Response hooks operate on the response body handed to them by earlier
+        // response-producing stages, so the captured/client value is post-script.
+        let mappedResponse = HTTPResponseData(
+            statusCode: 200,
+            statusMessage: "OK",
+            headers: [HTTPHeader(name: "Content-Type", value: "application/json")],
+            body: Data(#"{"source":"map-local"}"#.utf8)
+        )
+        let mutated = await harness.manager.runResponseHook(request: pricingRequest(), response: mappedResponse)
+
+        #expect(jsonBody(mutated).contains(#""source":"map-local+script""#))
+    }
+
+    @Test("SCRIPT_13 runAsMockApiDoesNotFireOnResponseHook")
+    func runAsMockApiDoesNotFireOnResponseHook() async throws {
+        let harness = try makeHarness()
+        try writePlugin(
+            id: "script.mock",
+            script: Self.mutationScript,
+            into: harness,
+            behavior: ScriptBehavior(matchCondition: nil, runOnRequest: true, runOnResponse: true, runAsMock: true)
+        )
+        await harness.manager.loadAllPlugins()
+
+        let mutated = await harness.manager.runResponseHook(request: pricingRequest(), response: pricingResponse())
+
+        #expect(jsonBody(mutated).contains(#""bucket":"control""#))
+        #expect(!harness.manager.hasResponseHookForSnapshot(request: pricingRequest()))
+    }
+
+    @Test("single-arg onRequest exposes top-level headers")
+    func singleArgOnRequestExposesTopLevelHeaders() async throws {
+        let harness = try makeHarness()
+        try writePlugin(
+            id: "script.request-redact",
+            script: """
+            function onRequest(request) {
+              var sensitive = ["Authorization", "Cookie", "X-Api-Key", "X-Auth-Token"];
+              for (var i = 0; i < sensitive.length; i++) {
+                if (request.headers[sensitive[i]]) {
+                  request.headers[sensitive[i]] = "[REDACTED]";
+                }
+              }
+              return request;
+            }
+            """,
+            into: harness,
+            behavior: ScriptBehavior(matchCondition: nil, runOnRequest: true, runOnResponse: false, runAsMock: false)
+        )
+        await harness.manager.loadAllPlugins()
+
+        let outcome = await harness.manager.runRequestHook(on: pricingRequest(headers: [
+            HTTPHeader(name: "Authorization", value: "Bearer top-secret"),
+            HTTPHeader(name: "Cookie", value: "session=abc"),
+            HTTPHeader(name: "Accept", value: "application/json")
+        ]))
+
+        guard case let .forward(modified) = outcome else {
+            Issue.record("Expected request script to forward a modified request")
+            return
+        }
+        #expect(modified.headers.first { $0.name == "Authorization" }?.value == "[REDACTED]")
+        #expect(modified.headers.first { $0.name == "Cookie" }?.value == "[REDACTED]")
+        #expect(modified.headers.first { $0.name == "Accept" }?.value == "application/json")
+    }
+
+    @Test("request redaction script propagates into HAR export")
+    func requestRedactionScriptPropagatesIntoHARExport() async throws {
+        let harness = try makeHarness()
+        try writePlugin(
+            id: "script.request-redact-har",
+            script: """
+            function onRequest(request) {
+              var sensitive = ["Authorization", "Cookie", "X-Api-Key", "X-Auth-Token"];
+              for (var i = 0; i < sensitive.length; i++) {
+                if (request.headers[sensitive[i]]) {
+                  request.headers[sensitive[i]] = "[REDACTED]";
+                }
+              }
+              return request;
+            }
+            """,
+            into: harness,
+            behavior: ScriptBehavior(matchCondition: nil, runOnRequest: true, runOnResponse: false, runAsMock: false)
+        )
+        await harness.manager.loadAllPlugins()
+
+        let original = try HTTPRequestData(
+            method: "GET",
+            url: #require(URL(string: "https://api.example.com/private")),
+            httpVersion: "HTTP/1.1",
+            headers: [
+                HTTPHeader(name: "Authorization", value: "Bearer har-secret-token"),
+                HTTPHeader(name: "Cookie", value: "session=har-cookie-secret"),
+                HTTPHeader(name: "X-Api-Key", value: "har-api-key-secret"),
+                HTTPHeader(name: "Accept", value: "application/json")
+            ]
+        )
+        let outcome = await harness.manager.runRequestHook(on: original)
+        let redactedRequest: HTTPRequestData
+        guard case let .forward(modified) = outcome else {
+            Issue.record("Expected request redaction script to forward the modified request")
+            return
+        }
+        redactedRequest = modified
+
+        let transaction = HTTPTransaction(
+            request: redactedRequest,
+            response: HTTPResponseData(
+                statusCode: 200,
+                statusMessage: "OK",
+                headers: [HTTPHeader(name: "Content-Type", value: "application/json")],
+                body: Data(#"{"ok":true}"#.utf8),
+                contentType: .json
+            ),
+            state: .completed
+        )
+        let harData = try HARExporter().export(transactions: [transaction])
+        let harText = try #require(String(data: harData, encoding: .utf8))
+        let harObject = try #require(JSONSerialization.jsonObject(with: harData) as? [String: Any])
+        let log = try #require(harObject["log"] as? [String: Any])
+        let entries = try #require(log["entries"] as? [[String: Any]])
+        let entry = try #require(entries.first)
+        let request = try #require(entry["request"] as? [String: Any])
+        let headers = try #require(request["headers"] as? [[String: String]])
+        let exportedHeaders = Dictionary(uniqueKeysWithValues: headers.compactMap { header -> (String, String)? in
+            guard let name = header["name"], let value = header["value"] else {
+                return nil
+            }
+            return (name, value)
+        })
+
+        #expect(harText.contains("[REDACTED]"))
+        #expect(exportedHeaders["Authorization"] == "[REDACTED]")
+        #expect(exportedHeaders["Cookie"] == "[REDACTED]")
+        #expect(exportedHeaders["X-Api-Key"] == "[REDACTED]")
+        #expect(exportedHeaders["Accept"] == "application/json")
+        #expect(!harText.contains("har-secret-token"))
+        #expect(!harText.contains("har-cookie-secret"))
+        #expect(!harText.contains("har-api-key-secret"))
+    }
+
+    @Test("SCRIPT_14 scenarioGuardWorks")
+    func scenarioGuardWorks() async throws {
+        let harness = try makeHarness()
+        try writePricingExperimentPlugin(id: "script.guard", into: harness)
+        await harness.manager.loadAllPlugins()
+
+        let unmatched = await harness.manager.runResponseHook(
+            request: pricingRequest(headers: [HTTPHeader(name: "X-Rockxy-Scenario-Id", value: "other")]),
+            response: pricingResponse()
+        )
+        let matched = await harness.manager.runResponseHook(request: pricingRequest(), response: pricingResponse())
+
+        #expect(jsonBody(unmatched).contains(#""bucket":"control""#))
+        #expect(jsonBody(matched).contains(#""bucket":"treatment""#))
+    }
+
+    @Test("Case 11 blog script honors case-insensitive scenario header lookup")
+    func case11BlogScriptHonorsCaseInsensitiveScenarioHeaderLookup() async throws {
+        let harness = try makeHarness()
+        try writePricingExperimentPlugin(id: "script.case11.header-case", into: harness)
+        await harness.manager.loadAllPlugins()
+
+        let mutated = await harness.manager.runResponseHook(
+            request: pricingRequest(headers: [
+                HTTPHeader(name: "x-rockxy-scenario-id", value: "scripted-mock"),
+                HTTPHeader(name: "x-rockxy-lab-run-id", value: "case-11")
+            ]),
+            response: HTTPResponseData(
+                statusCode: 200,
+                statusMessage: "OK",
+                headers: [HTTPHeader(name: "content-type", value: "application/json")],
+                body: Data(#"{"experiment":{"bucket":"control","paywall":"standard","discountPercent":0}}"#.utf8)
+            )
+        )
+
+        #expect(jsonBody(mutated).contains(#""bucket":"treatment""#))
+        #expect(jsonBody(mutated).contains(#""paywall":"discount""#))
+        #expect(jsonBody(mutated).contains(#""discountPercent":20"#))
+        let contentTypeHeaders = mutated.headers.filter { $0.name.lowercased() == "content-type" }
+        #expect(contentTypeHeaders.count == 1)
+        #expect(contentTypeHeaders.first?.value == "application/json")
+    }
+
+    @MainActor
+    @Test("Case 11 console.log appears in Script Editor console")
+    func case11ConsoleLogAppearsInScriptEditorConsole() async throws {
+        let harness = try makeHarness()
+        try writePricingExperimentPlugin(id: "script.case11.console", into: harness)
+        await harness.manager.loadAllPlugins()
+
+        let viewModel = ScriptEditorViewModel(
+            pluginManager: harness.manager,
+            policyGate: ScriptPolicyGate(policy: DefaultAppPolicy()),
+            pluginsDirectory: harness.dir
+        )
+        await viewModel.load(intent: .edit(pluginID: "script.case11.console"))
+        viewModel.clearConsole()
+
+        _ = await harness.manager.runResponseHook(
+            request: pricingRequest(headers: [
+                HTTPHeader(name: "x-rockxy-scenario-id", value: "scripted-mock"),
+                HTTPHeader(name: "x-rockxy-lab-run-id", value: "case-11")
+            ]),
+            response: pricingResponse()
+        )
+
+        try await waitForConsoleEntry(in: viewModel, containing: "Mutated to treatment for run: case-11")
+        #expect(viewModel.consoleEntries.contains { $0.level == .userLogs })
+    }
+
+    @Test("SCRIPT_15 multipleScriptsForOneRequestRespectFlag")
+    func multipleScriptsForOneRequestRespectFlag() async throws {
+        let chainOn = LockedBool(true)
+        let harness = try makeHarness(settingsProvider: {
+            var settings = AppSettings()
+            settings.allowMultipleScriptsPerRequest = chainOn.value
+            return settings
+        })
+        try writeAppendPlugin(id: "script.01", suffix: "a", into: harness)
+        try writeAppendPlugin(id: "script.02", suffix: "b", into: harness)
+        await harness.manager.loadAllPlugins()
+
+        let chained = await harness.manager.runResponseHook(request: pricingRequest(), response: textResponse(""))
+        chainOn.value = false
+        await harness.manager.loadAllPlugins()
+        let firstOnly = await harness.manager.runResponseHook(request: pricingRequest(), response: textResponse(""))
+
+        #expect(stringBody(chained) == "ab")
+        #expect(stringBody(firstOnly) == "a")
+    }
+
+    private static let mutationScript = """
+    function onResponse(response) {
+      if (response.request.headers["X-Rockxy-Scenario-Id"] !== "scripted-mock") {
+        return response;
+      }
+
+      var body = JSON.parse(response.body);
+      body.experiment.bucket = "treatment";
+      body.experiment.paywall = "discount";
+      body.experiment.discountPercent = 20;
+
+      response.headers["Content-Type"] = "application/json";
+      response.body = JSON.stringify(body);
+      console.log("Mutated to treatment for run:",
+        response.request.headers["X-Rockxy-Lab-Run-Id"]);
+      return response;
+    }
+    """
+
+    private func makeHarness(
+        settingsProvider: (@Sendable () -> AppSettings)? = nil
+    )
+        throws -> ScriptHarness
+    {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("RockxyScriptingRuntimeTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let defaults = UserDefaults(suiteName: "RockxyScriptingRuntimeTests-\(UUID().uuidString)") ?? .standard
+        let discovery = PluginDiscovery(pluginsDirectory: dir, defaults: defaults)
+        return ScriptHarness(
+            dir: dir,
+            defaults: defaults,
+            manager: ScriptPluginManager(
+                discovery: discovery,
+                defaults: defaults,
+                settingsProvider: settingsProvider
+            )
+        )
+    }
+
+    private func writePricingExperimentPlugin(id: String, into harness: ScriptHarness) throws {
+        try writePlugin(
+            id: id,
+            script: Self.mutationScript,
+            into: harness,
+            behavior: responseBehavior(pattern: "127.0.0.1:43210/rockxy-demo/pricing-experiment")
+        )
+    }
+
+    private func writeAppendPlugin(id: String, suffix: String, into harness: ScriptHarness) throws {
+        try writePlugin(
+            id: id,
+            script: """
+            function onResponse(response) {
+              response.body = response.body + "\(suffix)";
+              return response;
+            }
+            """,
+            into: harness,
+            behavior: ScriptBehavior(matchCondition: nil, runOnRequest: false, runOnResponse: true, runAsMock: false)
+        )
+    }
+
+    private func writePlugin(
+        id: String,
+        script: String,
+        into harness: ScriptHarness,
+        behavior: ScriptBehavior = ScriptBehavior(matchCondition: nil, runOnRequest: false, runOnResponse: true, runAsMock: false),
+        enabled: Bool = true
+    )
+        throws
+    {
+        let pluginDir = harness.dir.appendingPathComponent(id, isDirectory: true)
+        try FileManager.default.createDirectory(at: pluginDir, withIntermediateDirectories: true)
+        let manifest = PluginManifest(
+            id: id,
+            name: id,
+            version: "1.0.0",
+            author: PluginAuthor(name: "Test", url: nil),
+            description: "",
+            types: [.script],
+            entryPoints: ["script": "index.js"],
+            capabilities: [],
+            scriptBehavior: behavior
+        )
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        try encoder.encode(manifest).write(to: pluginDir.appendingPathComponent("plugin.json"))
+        try script.write(to: pluginDir.appendingPathComponent("index.js"), atomically: true, encoding: .utf8)
+
+        let key = RockxyIdentity.current.pluginEnabledKey(pluginID: id)
+        if enabled {
+            harness.defaults.set(true, forKey: key)
+        } else {
+            harness.defaults.removeObject(forKey: key)
+        }
+    }
+
+    private func responseBehavior(pattern: String) -> ScriptBehavior {
+        ScriptBehavior(
+            matchCondition: RuleMatchCondition(
+                urlPattern: pattern,
+                method: "GET",
+                matchType: .wildcard,
+                includeSubpaths: false
+            ),
+            runOnRequest: false,
+            runOnResponse: true,
+            runAsMock: false
+        )
+    }
+
+    private func pricingRequest(
+        url: String = "http://127.0.0.1:43210/rockxy-demo/pricing-experiment",
+        headers: [HTTPHeader] = [HTTPHeader(name: "X-Rockxy-Scenario-Id", value: "scripted-mock")]
+    )
+        -> HTTPRequestData
+    {
+        HTTPRequestData(
+            method: "GET",
+            // swiftlint:disable:next force_unwrapping
+            url: URL(string: url)!,
+            httpVersion: "HTTP/1.1",
+            headers: headers,
+            body: nil
+        )
+    }
+
+    private func pricingResponse() -> HTTPResponseData {
+        HTTPResponseData(
+            statusCode: 200,
+            statusMessage: "OK",
+            headers: [HTTPHeader(name: "Content-Type", value: "application/json")],
+            body: Data(#"{"experiment":{"bucket":"control","paywall":"standard","discountPercent":0}}"#.utf8)
+        )
+    }
+
+    private func textResponse(_ body: String) -> HTTPResponseData {
+        HTTPResponseData(
+            statusCode: 200,
+            statusMessage: "OK",
+            headers: [HTTPHeader(name: "Content-Type", value: "text/plain")],
+            body: Data(body.utf8)
+        )
+    }
+
+    private func jsonBody(_ response: HTTPResponseData) -> String {
+        stringBody(response)
+    }
+
+    private func stringBody(_ response: HTTPResponseData) -> String {
+        response.body.flatMap { String(data: $0, encoding: .utf8) } ?? ""
+    }
+
+    @MainActor
+    private func waitForConsoleEntry(
+        in viewModel: ScriptEditorViewModel,
+        containing expected: String,
+        sourceLocation: SourceLocation = #_sourceLocation
+    )
+        async throws
+    {
+        for _ in 0 ..< 40 {
+            if viewModel.consoleEntries.contains(where: { $0.message.contains(expected) }) {
+                return
+            }
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+        Issue.record("Expected Script Editor console entry containing '\(expected)'", sourceLocation: sourceLocation)
+    }
+}
+
+private struct ScriptHarness {
+    let dir: URL
+    let defaults: UserDefaults
+    let manager: ScriptPluginManager
+}
+
+private final class LockedBool: @unchecked Sendable {
+    init(_ value: Bool) {
+        self.storage = value
+    }
+
+    var value: Bool {
+        get {
+            lock.lock()
+            defer { lock.unlock() }
+            return storage
+        }
+        set {
+            lock.lock()
+            storage = newValue
+            lock.unlock()
+        }
+    }
+
+    private let lock = NSLock()
+    private var storage: Bool
+}

--- a/RockxyTests/ViewModels/ScriptingViewModelTests.swift
+++ b/RockxyTests/ViewModels/ScriptingViewModelTests.swift
@@ -38,9 +38,17 @@ struct ScriptingViewModelTests {
     @Test("Wildcard-to-regex helper escapes specials and anchors when no subpath")
     func wildcardHelper() {
         let pattern = ScriptEditorViewModel.wildcardToRegex("api.example.com/v1/*")
-        #expect(pattern == "^api\\.example\\.com/v1/.*$")
+        #expect(pattern == RulePatternBuilder.regexSource(
+            rawPattern: "api.example.com/v1/*",
+            matchType: .wildcard,
+            includeSubpaths: false
+        ))
         let sub = ScriptEditorViewModel.wildcardToRegex("api.example.com/v1/*", includeSubpaths: true)
-        #expect(sub == "api\\.example\\.com/v1/.*")
+        #expect(sub == RulePatternBuilder.regexSource(
+            rawPattern: "api.example.com/v1/*",
+            matchType: .wildcard,
+            includeSubpaths: true
+        ))
     }
 
     @Test("Beautify normalizes indentation on a dedented JS block")
@@ -542,7 +550,9 @@ struct ScriptingViewModelTests {
             defaults: env.defaults,
             enabled: true,
             method: "POST",
-            urlPattern: #"https:\/\/api\.example\.com\/v1\/.*"#,
+            urlPattern: "https://api.example.com/v1/*",
+            matchType: .wildcard,
+            includeSubpaths: true,
             runOnRequest: false,
             runOnResponse: true,
             runAsMock: true,
@@ -558,7 +568,9 @@ struct ScriptingViewModelTests {
         await vm.load(intent: .edit(pluginID: pluginID))
 
         #expect(vm.name == "Loaded Script")
-        #expect(vm.urlPattern == #"https:\/\/api\.example\.com\/v1\/.*"#)
+        #expect(vm.urlPattern == "https://api.example.com/v1/*")
+        #expect(vm.patternMode == .wildcard)
+        #expect(vm.includeSubpaths == true)
         #expect(vm.method == .post)
         #expect(vm.runOnRequest == false)
         #expect(vm.runOnResponse == true)
@@ -574,6 +586,9 @@ struct ScriptingViewModelTests {
         #expect(vm.testRule(against: "https://api.example.com/v1/users"))
         #expect(!vm.testRule(against: "https://api.example.com/v2/users"))
 
+        vm.urlPattern = "127.0.0.1:43210/rockxy-demo/pricing-experiment"
+        #expect(vm.testRule(against: "http://127.0.0.1:43210/rockxy-demo/pricing-experiment"))
+
         vm.patternMode = .regex
         vm.urlPattern = "["
         #expect(!vm.testRule(against: "https://api.example.com/v1/users"))
@@ -581,6 +596,62 @@ struct ScriptingViewModelTests {
         vm.patternMode = .advanced
         vm.urlPattern = #"api\.example\.com/v1/.+"#
         #expect(vm.testRule(against: "https://api.example.com/v1/users"))
+    }
+
+    @Test("Validate updates status tone for valid and invalid scripts")
+    func validateUpdatesStatusTone() {
+        let vm = ScriptEditorViewModel()
+        vm.runOnRequest = false
+        vm.runOnResponse = true
+        vm.code = """
+        function onResponse(response) {
+          if (response.request.headers["X-Rockxy-Scenario-Id"] !== "scripted-mock") {
+            return response;
+          }
+          response.headers["Content-Type"] = "application/json";
+          return response;
+        }
+        """
+
+        vm.validateScript()
+
+        #expect(vm.statusTone == .success)
+        #expect(vm.statusMessage == "Script is valid")
+
+        vm.code = "function onResponse(response) {"
+        vm.validateScript()
+
+        #expect(vm.statusTone == .error)
+        #expect(vm.statusMessage == "Validation failed")
+        #expect(vm.consoleEntries.contains { $0.level == .errors && $0.message.contains("Validation failed") })
+    }
+
+    @Test("Script editor unwraps previously generated wildcard regex for display")
+    func legacyGeneratedWildcardLoadsAsRawUserPattern() async throws {
+        let env = TestFixtures.makeIsolatedPluginEnv()
+        defer { env.cleanup() }
+        let pluginID = "script.legacy-pattern.\(UUID().uuidString)"
+        try makeScriptPlugin(
+            id: pluginID,
+            name: "Legacy Pattern",
+            in: env.pluginsDir,
+            defaults: env.defaults,
+            enabled: true,
+            urlPattern: #"127\.0\.0\.1:43210\/rockxy-demo\/pricing-experiment($|[?#])"#
+        )
+        await env.manager.loadAllPlugins()
+
+        let vm = ScriptEditorViewModel(
+            pluginManager: env.manager,
+            policyGate: ScriptPolicyGate(policy: DefaultAppPolicy()),
+            pluginsDirectory: env.pluginsDir
+        )
+        await vm.load(intent: .edit(pluginID: pluginID))
+
+        #expect(vm.urlPattern == "127.0.0.1:43210/rockxy-demo/pricing-experiment")
+        #expect(vm.patternMode == .wildcard)
+        #expect(vm.includeSubpaths == false)
+        #expect(vm.testRule(against: "http://127.0.0.1:43210/rockxy-demo/pricing-experiment"))
     }
 
     @Test("Save & Activate persists matching rule run options and source")
@@ -624,11 +695,57 @@ struct ScriptingViewModelTests {
         let source = try String(contentsOf: pluginDir.appendingPathComponent("index.js"), encoding: .utf8)
         #expect(manifest.name == "Persisted Script")
         #expect(manifest.scriptBehavior?.matchCondition?.method == "POST")
-        #expect(manifest.scriptBehavior?.matchCondition?.urlPattern == #"https://api\.example\.com/v1/.*"#)
+        #expect(manifest.scriptBehavior?.matchCondition?.urlPattern == "https://api.example.com/v1/*")
+        #expect(manifest.scriptBehavior?.matchCondition?.matchType == .wildcard)
+        #expect(manifest.scriptBehavior?.matchCondition?.includeSubpaths == true)
         #expect(manifest.scriptBehavior?.runOnRequest == false)
         #expect(manifest.scriptBehavior?.runOnResponse == true)
         #expect(manifest.scriptBehavior?.runAsMock == true)
         #expect(source == updatedSource)
+
+        let postSnap = await env.manager.plugins.first(where: { $0.id == pluginID })
+        #expect(postSnap?.manifest.name == "Persisted Script")
+        #expect(postSnap?.manifest.scriptBehavior?.matchCondition?.urlPattern == "https://api.example.com/v1/*")
+        #expect(postSnap?.manifest.scriptBehavior?.matchCondition?.matchType == .wildcard)
+    }
+
+    @Test("Save & Activate updates scripting list matching rule snapshot")
+    func saveAndActivateUpdatesListMatchingRuleSnapshot() async throws {
+        let env = TestFixtures.makeIsolatedPluginEnv()
+        defer { env.cleanup() }
+        let folderStore = ScriptFolderStore(defaults: env.defaults)
+        let pluginID = "script.list-refresh.\(UUID().uuidString)"
+        try makeScriptPlugin(
+            id: pluginID,
+            name: "List Refresh",
+            in: env.pluginsDir,
+            defaults: env.defaults,
+            enabled: false
+        )
+        await env.manager.loadAllPlugins()
+
+        let listVM = ScriptingListViewModel(
+            pluginManager: env.manager,
+            folderStore: folderStore,
+            pluginsDirectory: env.pluginsDir
+        )
+        await listVM.refresh()
+        #expect(listVM.plugins.first(where: { $0.id == pluginID })?.urlPattern == nil)
+
+        let editorVM = ScriptEditorViewModel(
+            pluginManager: env.manager,
+            policyGate: ScriptPolicyGate(policy: DefaultAppPolicy()),
+            pluginsDirectory: env.pluginsDir
+        )
+        await editorVM.load(intent: .edit(pluginID: pluginID))
+        editorVM.urlPattern = "127.0.0.1:43210/rockxy-demo/pricing-experiment"
+        editorVM.patternMode = .wildcard
+
+        await editorVM.saveAndActivate()
+        await listVM.refresh()
+
+        let updated = listVM.plugins.first(where: { $0.id == pluginID })
+        #expect(updated?.urlPattern == "127.0.0.1:43210/rockxy-demo/pricing-experiment")
     }
 
     @Test("Script editor footer actions update code console visibility and shared state")
@@ -758,6 +875,8 @@ struct ScriptingViewModelTests {
         enabled: Bool,
         method: String? = nil,
         urlPattern: String? = nil,
+        matchType: RuleMatchType? = nil,
+        includeSubpaths: Bool? = nil,
         runOnRequest: Bool = true,
         runOnResponse: Bool = true,
         runAsMock: Bool = false,
@@ -783,7 +902,12 @@ struct ScriptingViewModelTests {
             homepage: nil,
             license: nil,
             scriptBehavior: ScriptBehavior(
-                matchCondition: RuleMatchCondition(urlPattern: urlPattern, method: method),
+                matchCondition: RuleMatchCondition(
+                    urlPattern: urlPattern,
+                    method: method,
+                    matchType: matchType,
+                    includeSubpaths: includeSubpaths
+                ),
                 runOnRequest: runOnRequest,
                 runOnResponse: runOnResponse,
                 runAsMock: runAsMock


### PR DESCRIPTION
## Summary
- Fix scripting request/response runtime wiring so saved scripts execute immediately and mutations propagate to captured traffic, client responses, and exports.
- Expose intuitive single-argument request/response script shapes while preserving existing nested context support.
- Harden scripting console/status behavior, URL matching, content detection, MCP redaction, and HAR import/export coverage.
- Add focused regression tests for Case 11 scripted response mutation, script console output, request header redaction, and HAR export safety.

## Validation
- `swiftlint lint --strict`
- `xcodebuild -project Rockxy.xcodeproj -scheme Rockxy -destination 'platform=macOS,arch=arm64' -retry-tests-on-failure -test-iterations 2 test`\n- Result: 2,278 tests passed, 0 failed, 0 skipped\n\n## User Impact\nScripts now register and execute reliably after Save & Activate, response mutations are visible in captures, console logs appear in the Script Editor, and request-header redaction scripts propagate into exported HAR files without leaking the original sensitive header values.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Script console logging support for debugging and monitoring script execution.
  * Script source validation with detailed error reporting.

* **Bug Fixes**
  * Improved content type detection for JSON payloads without explicit Content-Type headers.
  * Redaction now correctly identifies and redacts JSON bodies regardless of Content-Type header presence.

* **Improvements**
  * Enhanced error handling and status tracking for failed scripts.
  * Better header preservation and handling in script contexts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RockxyApp/Rockxy/pull/108?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->