### PR TITLE
feat: add advanced traffic filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Added a compact advanced filter builder with expanded request/response fields, AND/OR row connectors, saved presets, and inspector match highlighting for security/debugging workflows.
 - Added Upstream Proxy core support for routing outbound traffic through HTTP/HTTPS proxies, with Community caps for SOCKS5, authentication, and bypass-list size enforced by app policy.
 - Added WebSocket Protobuf heuristic decoding infrastructure for inspecting binary frame payloads without requiring schema uploads.
 - Added Tools menu windows for External Proxy Settings, SOCKS Proxy Settings, Protobuf mapping rules, and Protobuf schema list management.
 - Added an on-demand Protobuf view to the WebSocket frame inspector for heuristic field-tree rendering.
 
 ### Fixed
+
+- Improved sidebar grouping cleanup when selected domain/app groups disappear, keeping active filters and sidebar state aligned.
 
 ### Changed
 

--- a/Rockxy/Models/UI/FilterCriteria.swift
+++ b/Rockxy/Models/UI/FilterCriteria.swift
@@ -50,6 +50,12 @@ struct FilterCriteria {
         if !statusCodes.isEmpty {
             count += 1
         }
+        if !contentTypes.isEmpty {
+            count += 1
+        }
+        if !domains.isEmpty {
+            count += 1
+        }
         if !activeProtocolFilters.isEmpty {
             count += 1
         }

--- a/Rockxy/Models/UI/FilterField.swift
+++ b/Rockxy/Models/UI/FilterField.swift
@@ -1,16 +1,22 @@
 import Foundation
 
 /// The request property that a search filter targets in the traffic list toolbar.
-enum FilterField: String, CaseIterable {
+enum FilterField: String, CaseIterable, Codable, Hashable {
     case url
     case contains
     case host
+    case domain
     case path
     case method
     case statusCode
     case requestHeader
     case responseHeader
+    case requestBody
+    case responseBody
     case queryString
+    case cookies
+    case clientApp
+    case contentType
     case comment
     case color
 
@@ -21,12 +27,18 @@ enum FilterField: String, CaseIterable {
         case .url: "URL"
         case .contains: "Contains"
         case .host: "Host"
+        case .domain: "Domain"
         case .path: "Path"
         case .method: "Method"
         case .statusCode: "Status Code"
         case .requestHeader: "Request Header"
         case .responseHeader: "Response Header"
+        case .requestBody: "Request Body"
+        case .responseBody: "Response Body"
         case .queryString: "Query String"
+        case .cookies: "Cookies"
+        case .clientApp: "Client/App"
+        case .contentType: "Content Type"
         case .comment: "Comment"
         case .color: "Color"
         }

--- a/Rockxy/Models/UI/FilterOperator.swift
+++ b/Rockxy/Models/UI/FilterOperator.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// String comparison operators used by `FilterRule` in the advanced filter builder.
 /// All comparisons are case-insensitive.
-enum FilterOperator: String, CaseIterable {
+enum FilterOperator: String, CaseIterable, Codable, Hashable {
     case contains
     case `is`
     case startsWith
@@ -26,6 +26,9 @@ enum FilterOperator: String, CaseIterable {
     }
 
     func matches(_ fieldValue: String, against text: String) -> Bool {
+        guard !text.isEmpty else {
+            return true
+        }
         let lowerField = fieldValue.lowercased()
         let lowerText = text.lowercased()
         switch self {
@@ -41,6 +44,20 @@ enum FilterOperator: String, CaseIterable {
             }
             let range = NSRange(fieldValue.startIndex..., in: fieldValue)
             return pattern.firstMatch(in: fieldValue, range: range) != nil
+        }
+    }
+
+    var contributesHighlight: Bool {
+        switch self {
+        case .doesNotContain,
+             .notEqual:
+            false
+        case .contains,
+             .is,
+             .startsWith,
+             .endsWith,
+             .regex:
+            true
         }
     }
 }

--- a/Rockxy/Models/UI/FilterPreset.swift
+++ b/Rockxy/Models/UI/FilterPreset.swift
@@ -1,0 +1,85 @@
+import Foundation
+
+struct FilterPreset: Identifiable, Codable, Hashable {
+    var id = UUID()
+    var name: String
+    var rules: [FilterRule]
+    var createdAt = Date()
+    var updatedAt = Date()
+}
+
+@MainActor @Observable
+final class FilterPresetStore {
+    init(
+        userDefaults: UserDefaults = .standard,
+        storageKey: String = RockxyIdentity.current.defaultsKey("advancedFilterPresets")
+    ) {
+        self.userDefaults = userDefaults
+        self.storageKey = storageKey
+        presets = Self.loadPresets(from: userDefaults, key: storageKey)
+    }
+
+    var presets: [FilterPreset] = []
+
+    @discardableResult
+    func savePreset(name: String, rules: [FilterRule]) -> FilterPreset? {
+        let trimmedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        let enabledRules = FilterRuleEvaluator.activeRules(in: rules, isFilterBarVisible: true)
+        guard !trimmedName.isEmpty, !enabledRules.isEmpty else {
+            return nil
+        }
+
+        var preset = FilterPreset(name: trimmedName, rules: enabledRules)
+        if let index = presets.firstIndex(where: { $0.name.caseInsensitiveCompare(trimmedName) == .orderedSame }) {
+            preset.id = presets[index].id
+            preset.createdAt = presets[index].createdAt
+            preset.updatedAt = Date()
+            presets[index] = preset
+        } else {
+            presets.append(preset)
+        }
+        persist()
+        return preset
+    }
+
+    @discardableResult
+    func saveGeneratedPreset(rules: [FilterRule]) -> FilterPreset? {
+        savePreset(name: generatedPresetName(for: rules), rules: rules)
+    }
+
+    func deletePreset(id: UUID) {
+        presets.removeAll { $0.id == id }
+        persist()
+    }
+
+    private let userDefaults: UserDefaults
+    private let storageKey: String
+
+    private func generatedPresetName(for rules: [FilterRule]) -> String {
+        let activeRules = FilterRuleEvaluator.activeRules(in: rules, isFilterBarVisible: true)
+        guard let first = activeRules.first else {
+            return String(localized: "Advanced Filter")
+        }
+        let base = "\(first.field.displayName): \(first.value)"
+        if activeRules.count == 1 {
+            return base
+        }
+        return "\(base) + \(activeRules.count - 1)"
+    }
+
+    private func persist() {
+        guard let data = try? JSONEncoder().encode(presets) else {
+            return
+        }
+        userDefaults.set(data, forKey: storageKey)
+    }
+
+    private static func loadPresets(from userDefaults: UserDefaults, key: String) -> [FilterPreset] {
+        guard let data = userDefaults.data(forKey: key),
+              let decoded = try? JSONDecoder().decode([FilterPreset].self, from: data) else
+        {
+            return []
+        }
+        return decoded
+    }
+}

--- a/Rockxy/Models/UI/FilterRule.swift
+++ b/Rockxy/Models/UI/FilterRule.swift
@@ -1,10 +1,23 @@
 import Foundation
 
+enum FilterLogicConnector: String, CaseIterable, Codable, Hashable {
+    case and
+    case or
+
+    var displayName: String {
+        switch self {
+        case .and: "AND"
+        case .or: "OR"
+        }
+    }
+}
+
 /// A single row in the advanced filter builder. Combines a target field, comparison operator,
 /// and match value into a toggleable predicate applied to the traffic list.
-struct FilterRule: Identifiable {
-    let id = UUID()
+struct FilterRule: Identifiable, Codable, Hashable {
+    var id = UUID()
     var isEnabled: Bool = true
+    var connector: FilterLogicConnector = .and
     var field: FilterField = .url
     var filterOperator: FilterOperator = .contains
     var value: String = ""

--- a/Rockxy/Models/UI/FilterRuleEvaluator.swift
+++ b/Rockxy/Models/UI/FilterRuleEvaluator.swift
@@ -1,0 +1,107 @@
+import Foundation
+
+enum FilterRuleEvaluator {
+    static let maxTextScanBytes = 1_000_000
+
+    static func activeRules(in rules: [FilterRule], isFilterBarVisible: Bool) -> [FilterRule] {
+        guard isFilterBarVisible else {
+            return []
+        }
+        return rules.filter { $0.isEnabled && !$0.value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
+    }
+
+    static func matches(_ transaction: HTTPTransaction, rules: [FilterRule]) -> Bool {
+        guard let first = rules.first else {
+            return true
+        }
+        var result = matches(transaction, rule: first)
+        for rule in rules.dropFirst() {
+            let ruleMatches = matches(transaction, rule: rule)
+            switch rule.connector {
+            case .and:
+                result = result && ruleMatches
+            case .or:
+                result = result || ruleMatches
+            }
+        }
+        return result
+    }
+
+    static func matches(_ transaction: HTTPTransaction, rule: FilterRule) -> Bool {
+        let value = fieldValue(for: rule.field, in: transaction)
+        return rule.filterOperator.matches(value, against: rule.value)
+    }
+
+    static func fieldValue(for field: FilterField, in transaction: HTTPTransaction) -> String {
+        switch field {
+        case .url,
+             .contains:
+            transaction.request.url.absoluteString
+        case .host,
+             .domain:
+            transaction.request.host
+        case .path:
+            transaction.request.path
+        case .method:
+            transaction.request.method
+        case .statusCode:
+            transaction.response.map { String($0.statusCode) } ?? ""
+        case .requestHeader:
+            joinedHeaders(transaction.request.headers)
+        case .responseHeader:
+            joinedHeaders(transaction.response?.headers ?? [])
+        case .requestBody:
+            bodyText(transaction.request.body)
+        case .responseBody:
+            bodyText(transaction.response?.body)
+        case .queryString:
+            transaction.request.url.query ?? ""
+        case .cookies:
+            cookieText(for: transaction)
+        case .clientApp:
+            transaction.clientApp ?? ""
+        case .contentType:
+            contentTypeText(for: transaction)
+        case .comment:
+            transaction.comment ?? ""
+        case .color:
+            transaction.highlightColor?.rawValue ?? ""
+        }
+    }
+
+    private static func joinedHeaders(_ headers: [HTTPHeader]) -> String {
+        headers.map { "\($0.name): \($0.value)" }.joined(separator: "\n")
+    }
+
+    private static func bodyText(_ body: Data?) -> String {
+        guard let body, !body.isEmpty else {
+            return ""
+        }
+        return String(bytes: body.prefix(maxTextScanBytes), encoding: .utf8) ?? ""
+    }
+
+    private static func cookieText(for transaction: HTTPTransaction) -> String {
+        let requestCookies = transaction.request.cookies
+            .map { "\($0.name)=\($0.value); domain=\($0.domain); path=\($0.path)" }
+        let responseCookies = (transaction.response?.setCookies ?? [])
+            .map { "\($0.name)=\($0.value); domain=\($0.domain); path=\($0.path)" }
+        return (requestCookies + responseCookies).joined(separator: "\n")
+    }
+
+    private static func contentTypeText(for transaction: HTTPTransaction) -> String {
+        var values: [String] = []
+        if let requestType = transaction.request.contentType {
+            values.append(requestType.rawValue)
+        }
+        if let responseType = transaction.response?.contentType {
+            values.append(responseType.rawValue)
+        }
+        values.append(contentsOf: transaction.request.headers
+            .filter { $0.name.caseInsensitiveCompare("Content-Type") == .orderedSame }
+            .map(\.value))
+        values.append(contentsOf: (transaction.response?.headers ?? [])
+            .filter { $0.name.caseInsensitiveCompare("Content-Type") == .orderedSame }
+            .map(\.value))
+        return values.joined(separator: "\n")
+    }
+}

--- a/Rockxy/Models/UI/InspectorHighlightContext.swift
+++ b/Rockxy/Models/UI/InspectorHighlightContext.swift
@@ -1,0 +1,77 @@
+import Foundation
+
+struct InspectorHighlightContext: Equatable, Sendable {
+    static let empty = InspectorHighlightContext()
+
+    var literalTerms: [String] = []
+    var regexPatterns: [String] = []
+
+    var isEmpty: Bool {
+        literalTerms.isEmpty && regexPatterns.isEmpty
+    }
+
+    var identity: String {
+        (literalTerms + regexPatterns.map { "regex:\($0)" }).joined(separator: "|")
+    }
+
+    func containsMatch(in text: String) -> Bool {
+        !matchRanges(in: text).isEmpty
+    }
+
+    func matchRanges(in text: String, limit: Int = 250) -> [NSRange] {
+        guard !text.isEmpty, !isEmpty else {
+            return []
+        }
+        let nsText = text as NSString
+        let fullRange = NSRange(location: 0, length: nsText.length)
+        var ranges: [NSRange] = []
+
+        for term in literalTerms where !term.isEmpty {
+            var searchRange = fullRange
+            while searchRange.length > 0, ranges.count < limit {
+                let found = nsText.range(of: term, options: [.caseInsensitive], range: searchRange)
+                guard found.location != NSNotFound else {
+                    break
+                }
+                ranges.append(found)
+                let nextLocation = found.location + max(found.length, 1)
+                let remaining = max(0, nsText.length - nextLocation)
+                searchRange = NSRange(location: nextLocation, length: remaining)
+            }
+        }
+
+        for pattern in regexPatterns where ranges.count < limit {
+            guard let regex = try? NSRegularExpression(pattern: pattern, options: .caseInsensitive) else {
+                continue
+            }
+            regex.enumerateMatches(in: text, range: fullRange) { match, _, stop in
+                guard let match else {
+                    return
+                }
+                ranges.append(match.range)
+                if ranges.count >= limit {
+                    stop.pointee = true
+                }
+            }
+        }
+
+        return normalized(ranges).prefix(limit).map { $0 }
+    }
+
+    private func normalized(_ ranges: [NSRange]) -> [NSRange] {
+        ranges
+            .filter { $0.length > 0 }
+            .sorted { lhs, rhs in
+                lhs.location == rhs.location ? lhs.length > rhs.length : lhs.location < rhs.location
+            }
+            .reduce(into: [NSRange]()) { result, range in
+                guard let last = result.last else {
+                    result.append(range)
+                    return
+                }
+                if range.location >= last.location + last.length {
+                    result.append(range)
+                }
+            }
+    }
+}

--- a/Rockxy/Theme/Theme.swift
+++ b/Rockxy/Theme/Theme.swift
@@ -129,6 +129,11 @@ enum Theme {
         static let urlBarBackground = Color(nsColor: .controlBackgroundColor)
         static let tabActive = Color.primary
         static let tabInactive = Color.secondary
+        static let matchHighlight = Color(nsColor: matchHighlightNS)
+        static let matchHighlightText = Color(nsColor: matchHighlightTextNS)
+
+        static let matchHighlightNS = NSColor.systemYellow.withAlphaComponent(0.36)
+        static let matchHighlightTextNS = NSColor.labelColor
     }
 
     // MARK: - Plugin

--- a/Rockxy/Views/Inspector/AuthInspectorView.swift
+++ b/Rockxy/Views/Inspector/AuthInspectorView.swift
@@ -6,6 +6,7 @@ struct AuthInspectorView: View {
     // MARK: Internal
 
     let transaction: HTTPTransaction
+    var highlightContext: InspectorHighlightContext = .empty
 
     var body: some View {
         if let authHeader = findAuthHeader() {
@@ -54,7 +55,7 @@ struct AuthInspectorView: View {
             Text(label)
                 .font(.caption)
                 .foregroundStyle(.secondary)
-            Text(value)
+            HighlightedInspectorText(text: value, highlightContext: highlightContext)
                 .font(.system(.caption, design: .monospaced))
                 .textSelection(.enabled)
         }

--- a/Rockxy/Views/Inspector/BodyInspectorView.swift
+++ b/Rockxy/Views/Inspector/BodyInspectorView.swift
@@ -4,12 +4,14 @@ import SwiftUI
 /// the byte count for binary payloads that cannot be decoded as text.
 struct BodyInspectorView: View {
     let transaction: HTTPTransaction
+    var highlightContext: InspectorHighlightContext = .empty
 
     var body: some View {
         if let body = transaction.response?.body {
             AsyncInspectorTextEditor(
                 renderID: "\(transaction.id.uuidString)-legacy-body-\(body.count)",
-                fontSize: 12
+                fontSize: 12,
+                highlightContext: highlightContext
             ) {
                 InspectorPayloadFormatter.requestBodyText(body)
             }

--- a/Rockxy/Views/Inspector/CookiesInspectorView.swift
+++ b/Rockxy/Views/Inspector/CookiesInspectorView.swift
@@ -6,6 +6,7 @@ struct CookiesInspectorView: View {
     // MARK: Internal
 
     let transaction: HTTPTransaction
+    var highlightContext: InspectorHighlightContext = .empty
 
     var body: some View {
         ScrollView {
@@ -47,28 +48,28 @@ struct CookiesInspectorView: View {
                 Text("Name")
                     .font(.system(.caption, design: .monospaced))
                     .fontWeight(.semibold)
-                Text(cookie.name)
+                HighlightedInspectorText(text: cookie.name, highlightContext: highlightContext)
                     .font(.system(.caption, design: .monospaced))
                     .textSelection(.enabled)
 
                 Text("Value")
                     .font(.system(.caption, design: .monospaced))
                     .fontWeight(.semibold)
-                Text(cookie.value)
+                HighlightedInspectorText(text: cookie.value, highlightContext: highlightContext)
                     .font(.system(.caption, design: .monospaced))
                     .textSelection(.enabled)
 
                 Text("Domain")
                     .font(.system(.caption, design: .monospaced))
                     .fontWeight(.semibold)
-                Text(cookie.domain)
+                HighlightedInspectorText(text: cookie.domain, highlightContext: highlightContext)
                     .font(.system(.caption, design: .monospaced))
                     .textSelection(.enabled)
 
                 Text("Path")
                     .font(.system(.caption, design: .monospaced))
                     .fontWeight(.semibold)
-                Text(cookie.path)
+                HighlightedInspectorText(text: cookie.path, highlightContext: highlightContext)
                     .font(.system(.caption, design: .monospaced))
                     .textSelection(.enabled)
 

--- a/Rockxy/Views/Inspector/HeaderKeyValueTable.swift
+++ b/Rockxy/Views/Inspector/HeaderKeyValueTable.swift
@@ -5,6 +5,7 @@ import SwiftUI
 /// Keeps the column names visible so header values read like a native key/value grid.
 struct HeaderKeyValueTable: View {
     let headers: [HTTPHeader]
+    var highlightContext: InspectorHighlightContext = .empty
 
     var body: some View {
         VStack(spacing: 0) {
@@ -47,7 +48,7 @@ struct HeaderKeyValueTable: View {
 
     private func row(_ header: HTTPHeader) -> some View {
         HStack(spacing: 0) {
-            Text(header.name)
+            HighlightedInspectorText(text: header.name, highlightContext: highlightContext)
                 .font(.system(.caption, design: .monospaced))
                 .fontWeight(.semibold)
                 .foregroundStyle(.primary)
@@ -57,13 +58,125 @@ struct HeaderKeyValueTable: View {
                 .padding(.horizontal, 10)
                 .padding(.vertical, 6)
             Divider()
-            Text(header.value)
-                .font(.system(.caption, design: .monospaced))
-                .foregroundStyle(.primary)
-                .textSelection(.enabled)
-                .frame(maxWidth: .infinity, alignment: .topLeading)
-                .padding(.horizontal, 10)
-                .padding(.vertical, 6)
+            HStack(alignment: .top, spacing: 6) {
+                HighlightedInspectorText(text: header.value, highlightContext: highlightContext)
+                    .font(.system(.caption, design: .monospaced))
+                    .foregroundStyle(.primary)
+                    .textSelection(.enabled)
+                    .frame(maxWidth: .infinity, alignment: .topLeading)
+                if let badge = HeaderDebugBadge.classify(header.name) {
+                    Text(badge.title)
+                        .font(.caption2.weight(.semibold))
+                        .foregroundStyle(badge.foreground)
+                        .padding(.horizontal, 5)
+                        .padding(.vertical, 2)
+                        .background(badge.background, in: RoundedRectangle(cornerRadius: 4))
+                        .help(badge.help)
+                }
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
+        }
+    }
+}
+
+private extension Text {
+    init(_ text: String, highlightContext: InspectorHighlightContext) {
+        guard !highlightContext.isEmpty else {
+            self.init(text)
+            return
+        }
+        var attributed = AttributedString(text)
+        let ranges = highlightContext.matchRanges(in: text, limit: 50)
+        for range in ranges {
+            guard let attributedRange = Range(range, in: text),
+                  let lower = AttributedString.Index(attributedRange.lowerBound, within: attributed),
+                  let upper = AttributedString.Index(attributedRange.upperBound, within: attributed) else
+            {
+                continue
+            }
+            attributed[lower ..< upper].backgroundColor = Theme.Inspector.matchHighlight
+            attributed[lower ..< upper].foregroundColor = Theme.Inspector.matchHighlightText
+        }
+        self.init(attributed)
+    }
+}
+
+struct HighlightedInspectorText: View {
+    let text: String
+    var highlightContext: InspectorHighlightContext = .empty
+
+    var body: some View {
+        Text(text, highlightContext: highlightContext)
+    }
+}
+
+private struct HeaderDebugBadge {
+    let title: String
+    let help: String
+    let foreground: Color
+    let background: Color
+
+    static func classify(_ headerName: String) -> HeaderDebugBadge? {
+        switch headerName.lowercased() {
+        case "content-security-policy":
+            HeaderDebugBadge(
+                title: "CSP",
+                help: String(localized: "Content Security Policy header"),
+                foreground: .red,
+                background: .red.opacity(0.12)
+            )
+        case "access-control-allow-origin",
+             "access-control-allow-headers",
+             "access-control-allow-methods",
+             "access-control-allow-credentials":
+            HeaderDebugBadge(
+                title: "CORS",
+                help: String(localized: "Cross-Origin Resource Sharing header"),
+                foreground: .blue,
+                background: .blue.opacity(0.12)
+            )
+        case "set-cookie",
+             "cookie":
+            HeaderDebugBadge(
+                title: "Cookie",
+                help: String(localized: "Cookie header"),
+                foreground: .orange,
+                background: .orange.opacity(0.12)
+            )
+        case "cache-control",
+             "etag",
+             "expires",
+             "last-modified":
+            HeaderDebugBadge(
+                title: "Cache",
+                help: String(localized: "Cache debugging header"),
+                foreground: .indigo,
+                background: .indigo.opacity(0.12)
+            )
+        case "authorization",
+             "proxy-authorization",
+             "www-authenticate":
+            HeaderDebugBadge(
+                title: "Auth",
+                help: String(localized: "Authentication header"),
+                foreground: .purple,
+                background: .purple.opacity(0.12)
+            )
+        case "x-forwarded-for",
+             "x-forwarded-host",
+             "x-forwarded-proto",
+             "x-real-ip",
+             "via",
+             "forwarded":
+            HeaderDebugBadge(
+                title: "Proxy",
+                help: String(localized: "Proxy or gateway header"),
+                foreground: .teal,
+                background: .teal.opacity(0.12)
+            )
+        default:
+            nil
         }
     }
 }

--- a/Rockxy/Views/Inspector/InspectorBodyTextEditor.swift
+++ b/Rockxy/Views/Inspector/InspectorBodyTextEditor.swift
@@ -7,6 +7,7 @@ import SwiftUI
 struct InspectorBodyTextEditor: NSViewRepresentable {
     let text: String
     var fontSize: CGFloat = 12
+    var highlightContext: InspectorHighlightContext = .empty
 
     func makeCoordinator() -> Coordinator {
         Coordinator()
@@ -27,6 +28,13 @@ struct InspectorBodyTextEditor: NSViewRepresentable {
             let selectedRange = textView.selectedRange()
             apply(text, to: nsView, coordinator: context.coordinator)
             textView.setSelectedRange(clamped(range: selectedRange, length: (text as NSString).length))
+        } else if context.coordinator.lastHighlightIdentity != highlightContext.identity {
+            context.coordinator.scheduleHighlight(
+                text: text,
+                fontSize: fontSize,
+                highlightContext: highlightContext,
+                in: nsView
+            )
         }
     }
 
@@ -34,6 +42,7 @@ struct InspectorBodyTextEditor: NSViewRepresentable {
 
     final class Coordinator {
         var highlightTask: Task<Void, Never>?
+        var lastHighlightIdentity = ""
         private var previewPopover: NSPopover?
 
         deinit {
@@ -52,13 +61,20 @@ struct InspectorBodyTextEditor: NSViewRepresentable {
         }
 
         @MainActor
-        func scheduleHighlight(text: String, fontSize: CGFloat, in scrollView: NSScrollView) {
+        func scheduleHighlight(
+            text: String,
+            fontSize: CGFloat,
+            highlightContext: InspectorHighlightContext,
+            in scrollView: NSScrollView
+        ) {
             highlightTask?.cancel()
+            lastHighlightIdentity = highlightContext.identity
 
             highlightTask = Task { [weak scrollView] in
                 let spans = await Task.detached(priority: .utility) {
                     Self.highlightSpans(for: text)
                 }.value
+                let matchRanges = highlightContext.matchRanges(in: text, limit: 500)
 
                 guard !Task.isCancelled,
                       let scrollView,
@@ -72,6 +88,10 @@ struct InspectorBodyTextEditor: NSViewRepresentable {
                 let attributed = Self.baseAttributedString(text, fontSize: fontSize)
                 for span in spans where NSMaxRange(span.range) <= attributed.length {
                     attributed.addAttribute(.foregroundColor, value: span.role.color, range: span.range)
+                }
+                for range in matchRanges where NSMaxRange(range) <= attributed.length {
+                    attributed.addAttribute(.backgroundColor, value: Theme.Inspector.matchHighlightNS, range: range)
+                    attributed.addAttribute(.foregroundColor, value: Theme.Inspector.matchHighlightTextNS, range: range)
                 }
                 textView.textStorage?.setAttributedString(attributed)
                 textView.setSelectedRange(clamped(range: selectedRange, length: attributed.length))
@@ -224,7 +244,12 @@ struct InspectorBodyTextEditor: NSViewRepresentable {
         ]
 
         if let coordinator {
-            coordinator.scheduleHighlight(text: text, fontSize: fontSize, in: scrollView)
+            coordinator.scheduleHighlight(
+                text: text,
+                fontSize: fontSize,
+                highlightContext: highlightContext,
+                in: scrollView
+            )
         }
         (scrollView.verticalRulerView as? ScriptCodeEditorRulerView)?.invalidateLineNumbers()
     }
@@ -329,6 +354,7 @@ final class InspectorSelectableTextView: NSTextView {
 struct AsyncInspectorTextEditor: View {
     let renderID: String
     var fontSize: CGFloat = 12
+    var highlightContext: InspectorHighlightContext = .empty
     let render: @Sendable () -> InspectorTextRenderResult
 
     var body: some View {
@@ -351,7 +377,7 @@ struct AsyncInspectorTextEditor: View {
     private func loadedContent(_ result: InspectorTextRenderResult) -> some View {
         switch result {
         case let .text(text):
-            InspectorBodyTextEditor(text: text, fontSize: fontSize)
+            InspectorBodyTextEditor(text: text, fontSize: fontSize, highlightContext: highlightContext)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
         case let .unavailable(title, systemImage, description):
             InspectorEmptyStateView(title, systemImage: systemImage, description: description)

--- a/Rockxy/Views/Inspector/InspectorPanelView.swift
+++ b/Rockxy/Views/Inspector/InspectorPanelView.swift
@@ -8,18 +8,21 @@ struct InspectorPanelView: View {
     var body: some View {
         VStack(spacing: 0) {
             if let transaction = coordinator.selectedTransaction {
-                InspectorURLBar(transaction: transaction)
+                let highlightContext = coordinator.activeInspectorHighlightContext()
+                InspectorURLBar(transaction: transaction, highlightContext: highlightContext)
                 Divider()
                 HSplitView {
                     RequestInspectorView(
                         transaction: transaction,
-                        previewTabStore: coordinator.previewTabStore
+                        previewTabStore: coordinator.previewTabStore,
+                        highlightContext: highlightContext
                     )
                     .frame(minWidth: 250, maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
                     ResponseInspectorView(
                         transaction: transaction,
                         coordinator: coordinator,
-                        previewTabStore: coordinator.previewTabStore
+                        previewTabStore: coordinator.previewTabStore,
+                        highlightContext: highlightContext
                     )
                     .frame(minWidth: 250, maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
                 }

--- a/Rockxy/Views/Inspector/InspectorURLBar.swift
+++ b/Rockxy/Views/Inspector/InspectorURLBar.swift
@@ -6,6 +6,7 @@ struct InspectorURLBar: View {
     // MARK: Internal
 
     let transaction: HTTPTransaction
+    var highlightContext: InspectorHighlightContext = .empty
 
     var body: some View {
         HStack(spacing: 8) {
@@ -75,7 +76,17 @@ struct InspectorURLBar: View {
         let urlString = transaction.request.url.absoluteString
         let host = transaction.request.host
 
-        return HStack(spacing: 0) {
+        if !highlightContext.isEmpty {
+            return AnyView(
+                HighlightedInspectorText(text: urlString, highlightContext: highlightContext)
+                    .font(.system(size: 11, design: .monospaced))
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                    .textSelection(.enabled)
+            )
+        }
+
+        return AnyView(HStack(spacing: 0) {
             if let hostRange = urlString.range(of: host), !host.isEmpty {
                 Text(urlString[urlString.startIndex ..< hostRange.lowerBound])
                     .font(.system(size: 11, design: .monospaced))
@@ -89,8 +100,8 @@ struct InspectorURLBar: View {
                     .font(.system(size: 11, design: .monospaced))
             }
         }
-        .lineLimit(1)
-        .truncationMode(.middle)
-        .textSelection(.enabled)
+            .lineLimit(1)
+            .truncationMode(.middle)
+            .textSelection(.enabled))
     }
 }

--- a/Rockxy/Views/Inspector/QueryInspectorView.swift
+++ b/Rockxy/Views/Inspector/QueryInspectorView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 /// Parses and displays URL query parameters from the request URL in a name/value grid.
 struct QueryInspectorView: View {
     let transaction: HTTPTransaction
+    var highlightContext: InspectorHighlightContext = .empty
 
     var body: some View {
         let components = URLComponents(url: transaction.request.url, resolvingAgainstBaseURL: false)
@@ -30,10 +31,10 @@ struct QueryInspectorView: View {
                             .foregroundStyle(.secondary)
 
                         ForEach(Array(queryItems.enumerated()), id: \.offset) { _, item in
-                            Text(item.name)
+                            HighlightedInspectorText(text: item.name, highlightContext: highlightContext)
                                 .font(.system(.caption, design: .monospaced))
                                 .fontWeight(.semibold)
-                            Text(item.value ?? "")
+                            HighlightedInspectorText(text: item.value ?? "", highlightContext: highlightContext)
                                 .font(.system(.caption, design: .monospaced))
                                 .textSelection(.enabled)
                         }

--- a/Rockxy/Views/Inspector/RawInspectorView.swift
+++ b/Rockxy/Views/Inspector/RawInspectorView.swift
@@ -6,12 +6,14 @@ struct RawInspectorView: View {
     // MARK: Internal
 
     let transaction: HTTPTransaction
+    var highlightContext: InspectorHighlightContext = .empty
 
     var body: some View {
         let snapshot = InspectorTransactionSnapshot(transaction: transaction)
         AsyncInspectorTextEditor(
             renderID: "\(snapshot.id.uuidString)-full-raw-\(snapshot.response?.body?.count ?? 0)",
-            fontSize: 12
+            fontSize: 12,
+            highlightContext: highlightContext
         ) {
             var text = InspectorPayloadFormatter.rawRequest(snapshot.request)
             if let rawResponse = InspectorPayloadFormatter.rawResponse(snapshot.response) {

--- a/Rockxy/Views/Inspector/RequestInspectorView.swift
+++ b/Rockxy/Views/Inspector/RequestInspectorView.swift
@@ -8,6 +8,7 @@ struct RequestInspectorView: View {
 
     let transaction: HTTPTransaction
     var previewTabStore: PreviewTabStore
+    var highlightContext: InspectorHighlightContext = .empty
 
     var body: some View {
         VStack(spacing: 0) {
@@ -106,11 +107,11 @@ struct RequestInspectorView: View {
         case .headers:
             requestHeadersView
         case .query:
-            QueryInspectorView(transaction: transaction)
+            QueryInspectorView(transaction: transaction, highlightContext: highlightContext)
         case .body:
             requestBodyView
         case .cookies:
-            CookiesInspectorView(transaction: transaction)
+            CookiesInspectorView(transaction: transaction, highlightContext: highlightContext)
         case .raw:
             requestRawView
         case .synopsis:
@@ -128,7 +129,7 @@ struct RequestInspectorView: View {
             )
         } else {
             ScrollView {
-                HeaderKeyValueTable(headers: transaction.request.headers)
+                HeaderKeyValueTable(headers: transaction.request.headers, highlightContext: highlightContext)
                     .padding()
             }
         }
@@ -138,7 +139,8 @@ struct RequestInspectorView: View {
         if let body = transaction.request.body {
             AsyncInspectorTextEditor(
                 renderID: "\(transaction.id.uuidString)-request-body-\(body.count)",
-                fontSize: 12
+                fontSize: 12,
+                highlightContext: highlightContext
             ) {
                 InspectorPayloadFormatter.requestBodyText(body)
             }
@@ -155,7 +157,8 @@ struct RequestInspectorView: View {
         let snapshot = InspectorTransactionSnapshot(transaction: transaction)
         return AsyncInspectorTextEditor(
             renderID: "\(snapshot.id.uuidString)-request-raw-\(snapshot.request.body?.count ?? 0)",
-            fontSize: 12
+            fontSize: 12,
+            highlightContext: highlightContext
         ) {
             .text(InspectorPayloadFormatter.rawRequest(snapshot.request))
         }

--- a/Rockxy/Views/Inspector/ResponseInspectorView.swift
+++ b/Rockxy/Views/Inspector/ResponseInspectorView.swift
@@ -16,6 +16,7 @@ struct ResponseInspectorView: View {
     let transaction: HTTPTransaction
     let coordinator: MainContentCoordinator
     var previewTabStore: PreviewTabStore
+    var highlightContext: InspectorHighlightContext = .empty
 
     var body: some View {
         VStack(spacing: 0) {
@@ -324,9 +325,9 @@ struct ResponseInspectorView: View {
             case .body:
                 responseBodyView(response: response)
             case .setCookie:
-                SetCookieInspectorView(transaction: transaction)
+                SetCookieInspectorView(transaction: transaction, highlightContext: highlightContext)
             case .auth:
-                AuthInspectorView(transaction: transaction)
+                AuthInspectorView(transaction: transaction, highlightContext: highlightContext)
             case .timeline:
                 TimingInspectorView(transaction: transaction)
             }
@@ -348,7 +349,7 @@ struct ResponseInspectorView: View {
             )
         } else {
             ScrollView {
-                HeaderKeyValueTable(headers: response.headers)
+                HeaderKeyValueTable(headers: response.headers, highlightContext: highlightContext)
                     .padding()
             }
         }
@@ -394,7 +395,8 @@ struct ResponseInspectorView: View {
         let snapshot = InspectorTransactionSnapshot(transaction: transaction)
         AsyncInspectorTextEditor(
             renderID: "\(snapshot.id.uuidString)-response-raw-\(snapshot.response?.body?.count ?? 0)",
-            fontSize: bodyFontSize
+            fontSize: bodyFontSize,
+            highlightContext: highlightContext
         ) {
             if let text = InspectorPayloadFormatter.rawResponse(snapshot.response) {
                 return .text(text)
@@ -412,7 +414,8 @@ struct ResponseInspectorView: View {
         let sortedKeys = sortJSONKeys
         AsyncInspectorTextEditor(
             renderID: "\(transaction.id.uuidString)-response-json-\(sortedKeys)-\(body.count)",
-            fontSize: bodyFontSize
+            fontSize: bodyFontSize,
+            highlightContext: highlightContext
         ) {
             if let text = InspectorPayloadFormatter.responseDisplayText(body: body, sortedKeys: sortedKeys) {
                 return .text(text)

--- a/Rockxy/Views/Inspector/SetCookieInspectorView.swift
+++ b/Rockxy/Views/Inspector/SetCookieInspectorView.swift
@@ -6,6 +6,7 @@ struct SetCookieInspectorView: View {
     // MARK: Internal
 
     let transaction: HTTPTransaction
+    var highlightContext: InspectorHighlightContext = .empty
 
     var body: some View {
         if let response = transaction.response {
@@ -38,10 +39,10 @@ struct SetCookieInspectorView: View {
 
     private func cookieRow(_ cookie: HTTPCookie) -> some View {
         VStack(alignment: .leading, spacing: 4) {
-            Text(cookie.name)
+            HighlightedInspectorText(text: cookie.name, highlightContext: highlightContext)
                 .font(.system(.caption, design: .monospaced))
                 .fontWeight(.bold)
-            Text(cookie.value)
+            HighlightedInspectorText(text: cookie.value, highlightContext: highlightContext)
                 .font(.system(.caption, design: .monospaced))
                 .textSelection(.enabled)
                 .foregroundStyle(.secondary)
@@ -70,7 +71,7 @@ struct SetCookieInspectorView: View {
             Text(label + ":")
                 .font(.caption2)
                 .foregroundStyle(.secondary)
-            Text(value)
+            HighlightedInspectorText(text: value, highlightContext: highlightContext)
                 .font(.system(.caption2, design: .monospaced))
         }
     }

--- a/Rockxy/Views/Main/Extensions/MainContentCoordinator+Filtering.swift
+++ b/Rockxy/Views/Main/Extensions/MainContentCoordinator+Filtering.swift
@@ -61,8 +61,8 @@ extension MainContentCoordinator {
     // MARK: - Filtered Transactions
 
     func appendFilteredTransactions(_ batch: [HTTPTransaction]) {
-        let hasActiveRules = isFilterBarVisible && filterRules.contains { $0.isEnabled && !$0.value.isEmpty }
-        if filterCriteria.sidebarScope == .allTraffic, filterCriteria.isEmpty, !hasActiveRules,
+        let activeRules = FilterRuleEvaluator.activeRules(in: filterRules, isFilterBarVisible: isFilterBarVisible)
+        if filterCriteria.sidebarScope == .allTraffic, filterCriteria.isEmpty, activeRules.isEmpty,
            activeSortDescriptors.isEmpty
         {
             filteredTransactions.append(contentsOf: batch.filter { !$0.isTLSFailure })
@@ -85,8 +85,8 @@ extension MainContentCoordinator {
             transactions
         }
 
-        let hasActiveRules = isFilterBarVisible && filterRules.contains { $0.isEnabled && !$0.value.isEmpty }
-        guard !filterCriteria.isEmpty || hasActiveRules else {
+        let activeRules = FilterRuleEvaluator.activeRules(in: filterRules, isFilterBarVisible: isFilterBarVisible)
+        guard !filterCriteria.isEmpty || !activeRules.isEmpty else {
             filteredTransactions = baseList.filter { !$0.isTLSFailure }
             deriveFilteredRows()
             return
@@ -127,6 +127,22 @@ extension MainContentCoordinator {
                     return false
                 }
             }
+            if !filterCriteria.contentTypes.isEmpty {
+                let requestType = transaction.request.contentType
+                let responseType = transaction.response?.contentType
+                guard requestType.map(filterCriteria.contentTypes.contains) == true
+                    || responseType.map(filterCriteria.contentTypes.contains) == true else
+                {
+                    return false
+                }
+            }
+            if !filterCriteria.domains.isEmpty {
+                guard filterCriteria.domains.contains(where: {
+                    DomainGrouping.host(transaction.request.host, matchesDomain: $0)
+                }) else {
+                    return false
+                }
+            }
             if !filterCriteria.activeProtocolFilters.isEmpty {
                 let contentFilters = filterCriteria.activeProtocolFilters.filter { !$0.isStatusFilter }
                 let statusFilters = filterCriteria.activeProtocolFilters.filter(\.isStatusFilter)
@@ -142,13 +158,8 @@ extension MainContentCoordinator {
                     }
                 }
             }
-            if hasActiveRules {
-                for rule in filterRules where rule.isEnabled && !rule.value.isEmpty {
-                    let fieldValue = fieldValue(for: rule.field, in: transaction)
-                    guard rule.filterOperator.matches(fieldValue, against: rule.value) else {
-                        return false
-                    }
-                }
+            if !activeRules.isEmpty, !FilterRuleEvaluator.matches(transaction, rules: activeRules) {
+                return false
             }
             return true
         }
@@ -156,29 +167,55 @@ extension MainContentCoordinator {
     }
 
     func fieldValue(for field: FilterField, in transaction: HTTPTransaction) -> String {
-        switch field {
-        case .url,
-             .contains: transaction.request.url.absoluteString
-        case .host: transaction.request.host
-        case .path: transaction.request.path
-        case .method: transaction.request.method
-        case .statusCode: transaction.response.map { String($0.statusCode) } ?? ""
-        case .requestHeader: transaction.request.headers.map { "\($0.name): \($0.value)" }.joined(separator: "\n")
-        case .responseHeader:
-            (transaction.response?.headers ?? []).map { "\($0.name): \($0.value)" }.joined(separator: "\n")
-        case .queryString: transaction.request.url.query ?? ""
-        case .comment: transaction.comment ?? ""
-        case .color: transaction.highlightColor?.rawValue ?? ""
+        FilterRuleEvaluator.fieldValue(for: field, in: transaction)
+    }
+
+    func activeInspectorHighlightContext() -> InspectorHighlightContext {
+        var literalTerms: [String] = []
+        var regexPatterns: [String] = []
+
+        func appendLiteral(_ value: String) {
+            let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty,
+                  !literalTerms.contains(where: { $0.caseInsensitiveCompare(trimmed) == .orderedSame }) else
+            {
+                return
+            }
+            literalTerms.append(trimmed)
         }
+
+        if filterCriteria.isSearchEnabled {
+            appendLiteral(filterCriteria.searchText)
+        }
+
+        let activeRules = FilterRuleEvaluator.activeRules(in: filterRules, isFilterBarVisible: isFilterBarVisible)
+        for rule in activeRules where rule.filterOperator.contributesHighlight {
+            let trimmed = rule.value.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else {
+                continue
+            }
+            if rule.filterOperator == .regex {
+                regexPatterns.append(trimmed)
+            } else {
+                appendLiteral(trimmed)
+            }
+        }
+
+        return InspectorHighlightContext(
+            literalTerms: Array(literalTerms.prefix(20)),
+            regexPatterns: Array(regexPatterns.prefix(10))
+        )
     }
 
     // MARK: - Per-Workspace Filtering
 
     func appendFilteredTransactions(_ batch: [HTTPTransaction], to workspace: WorkspaceState) {
-        let hasActiveRules = workspace.isFilterBarVisible
-            && workspace.filterRules.contains { $0.isEnabled && !$0.value.isEmpty }
+        let activeRules = FilterRuleEvaluator.activeRules(
+            in: workspace.filterRules,
+            isFilterBarVisible: workspace.isFilterBarVisible
+        )
         if workspace.filterCriteria.sidebarScope == .allTraffic,
-           workspace.filterCriteria.isEmpty, !hasActiveRules, workspace.activeSortDescriptors.isEmpty
+           workspace.filterCriteria.isEmpty, activeRules.isEmpty, workspace.activeSortDescriptors.isEmpty
         {
             workspace.filteredTransactions.append(contentsOf: batch.filter { !$0.isTLSFailure })
             workspace.lastDeriveWasAppendOnly = true
@@ -200,9 +237,11 @@ extension MainContentCoordinator {
             transactions
         }
 
-        let hasActiveRules = workspace.isFilterBarVisible
-            && workspace.filterRules.contains { $0.isEnabled && !$0.value.isEmpty }
-        guard !workspace.filterCriteria.isEmpty || hasActiveRules else {
+        let activeRules = FilterRuleEvaluator.activeRules(
+            in: workspace.filterRules,
+            isFilterBarVisible: workspace.isFilterBarVisible
+        )
+        guard !workspace.filterCriteria.isEmpty || !activeRules.isEmpty else {
             workspace.filteredTransactions = baseList.filter { !$0.isTLSFailure }
             deriveFilteredRows(for: workspace)
             return
@@ -243,6 +282,22 @@ extension MainContentCoordinator {
                     return false
                 }
             }
+            if !workspace.filterCriteria.contentTypes.isEmpty {
+                let requestType = transaction.request.contentType
+                let responseType = transaction.response?.contentType
+                guard requestType.map(workspace.filterCriteria.contentTypes.contains) == true
+                    || responseType.map(workspace.filterCriteria.contentTypes.contains) == true else
+                {
+                    return false
+                }
+            }
+            if !workspace.filterCriteria.domains.isEmpty {
+                guard workspace.filterCriteria.domains.contains(where: {
+                    DomainGrouping.host(transaction.request.host, matchesDomain: $0)
+                }) else {
+                    return false
+                }
+            }
             if !workspace.filterCriteria.activeProtocolFilters.isEmpty {
                 let contentFilters = workspace.filterCriteria.activeProtocolFilters.filter { !$0.isStatusFilter }
                 let statusFilters = workspace.filterCriteria.activeProtocolFilters.filter(\.isStatusFilter)
@@ -258,13 +313,8 @@ extension MainContentCoordinator {
                     }
                 }
             }
-            if hasActiveRules {
-                for rule in workspace.filterRules where rule.isEnabled && !rule.value.isEmpty {
-                    let fv = fieldValue(for: rule.field, in: transaction)
-                    guard rule.filterOperator.matches(fv, against: rule.value) else {
-                        return false
-                    }
-                }
+            if !activeRules.isEmpty, !FilterRuleEvaluator.matches(transaction, rules: activeRules) {
+                return false
             }
             return true
         }

--- a/Rockxy/Views/Main/Extensions/MainContentCoordinator+SidebarMenu.swift
+++ b/Rockxy/Views/Main/Extensions/MainContentCoordinator+SidebarMenu.swift
@@ -455,9 +455,15 @@ extension MainContentCoordinator {
         switch sidebarSelection {
         case let .domainNode(selectedDomain) where selectedDomain == domain && pathPrefix == nil:
             sidebarSelection = nil
+            filterCriteria.sidebarDomain = nil
+            filterCriteria.sidebarPathPrefix = nil
+            filterCriteria.sidebarScope = .allTraffic
         case let .domainPath(selectedDomain, selectedPath)
             where selectedDomain == domain && selectedPath == pathPrefix:
             sidebarSelection = nil
+            filterCriteria.sidebarDomain = nil
+            filterCriteria.sidebarPathPrefix = nil
+            filterCriteria.sidebarScope = .allTraffic
         default:
             break
         }
@@ -484,6 +490,8 @@ extension MainContentCoordinator {
         // Clear selection if it was this app
         if case .app(appName, _) = sidebarSelection {
             sidebarSelection = nil
+            filterCriteria.sidebarApp = nil
+            filterCriteria.sidebarScope = .allTraffic
         }
 
         recomputeFilteredTransactions()

--- a/Rockxy/Views/Main/Extensions/MainContentCoordinator+Workspaces.swift
+++ b/Rockxy/Views/Main/Extensions/MainContentCoordinator+Workspaces.swift
@@ -100,7 +100,53 @@ extension MainContentCoordinator {
             updateAppNodes(for: transaction, in: workspace)
         }
         refreshDomainTree(for: workspace)
+        pruneSidebarSelectionIfNeeded(in: workspace)
         TrafficDomainSnapshot.shared.update(appNodes: appNodes, domainTree: domainTree)
+    }
+
+    func pruneSidebarSelectionIfNeeded(in workspace: WorkspaceState) {
+        guard let selection = workspace.sidebarSelection else {
+            return
+        }
+
+        let isValid: Bool = switch selection {
+        case let .domainNode(domain):
+            workspace.domainTree.contains { $0.selectionDomain == domain }
+        case let .domainPath(domain, pathPrefix):
+            workspace.domainTree.contains { nodeContainsPath($0, domain: domain, pathPrefix: pathPrefix) }
+        case let .app(name, _):
+            workspace.appNodeIndexMap[name] != nil
+        case let .pinnedTransaction(id):
+            allPinnedTransactions.contains { $0.id == id }
+        case let .savedTransaction(id):
+            allSavedTransactions.contains { $0.id == id }
+        case .allApps,
+             .allDomains,
+             .allPinned,
+             .allSaved:
+            true
+        case .filter,
+             .ruleGroup,
+             .savedSession,
+             .logStream:
+            true
+        }
+
+        guard !isValid else {
+            return
+        }
+        workspace.sidebarSelection = nil
+        workspace.filterCriteria.sidebarDomain = nil
+        workspace.filterCriteria.sidebarPathPrefix = nil
+        workspace.filterCriteria.sidebarApp = nil
+        workspace.filterCriteria.sidebarScope = .allTraffic
+    }
+
+    private func nodeContainsPath(_ node: DomainNode, domain: String, pathPrefix: String) -> Bool {
+        if node.selectionDomain == domain, node.pathPrefix == pathPrefix {
+            return true
+        }
+        return node.children.contains { nodeContainsPath($0, domain: domain, pathPrefix: pathPrefix) }
     }
 
     // MARK: - Eviction Across Workspaces

--- a/Rockxy/Views/Main/MainContentCoordinator.swift
+++ b/Rockxy/Views/Main/MainContentCoordinator.swift
@@ -141,6 +141,7 @@ final class MainContentCoordinator {
     var workspaceStore: WorkspaceStore
     var previewTabStore = PreviewTabStore()
     var headerColumnStore = HeaderColumnStore()
+    var filterPresetStore = FilterPresetStore()
 
     // MARK: - UI State — Import/Export
 

--- a/Rockxy/Views/RequestList/CenterContentView.swift
+++ b/Rockxy/Views/RequestList/CenterContentView.swift
@@ -57,7 +57,8 @@ struct CenterContentView: View {
                             coordinator.filterRules = $0
                             coordinator.recomputeFilteredTransactions()
                         }
-                    )
+                    ),
+                    presetStore: coordinator.filterPresetStore
                 )
             }
 
@@ -79,7 +80,7 @@ struct CenterContentView: View {
                 isNoCachingActive: isNoCachingEnabled,
                 isAutoSelectEnabled: coordinator.isAutoSelectEnabled,
                 isFilterBarVisible: coordinator.isFilterBarVisible,
-                activeFilterCount: coordinator.filterCriteria.activeFilterCount,
+                activeFilterCount: activeFilterCount,
                 errorCount: coordinator.errorCount,
                 proxyStartedAt: coordinator.proxyStartedAt,
                 selectedRequestInfo: coordinator.selectedTransaction.map {
@@ -168,6 +169,14 @@ struct CenterContentView: View {
     private static let minimumRightPaneWidth: CGFloat = 300
     private static let minimumBottomTableHeight: CGFloat = 200
     private static let minimumBottomInspectorHeight: CGFloat = 200
+
+    private var activeFilterCount: Int {
+        coordinator.filterCriteria.activeFilterCount
+            + FilterRuleEvaluator.activeRules(
+                in: coordinator.filterRules,
+                isFilterBarVisible: coordinator.isFilterBarVisible
+            ).count
+    }
 
     private var tableContent: some View {
         RequestTableView(

--- a/Rockxy/Views/Toolbar/AdvancedFilterBar.swift
+++ b/Rockxy/Views/Toolbar/AdvancedFilterBar.swift
@@ -12,6 +12,7 @@ struct AdvancedFilterBar: View {
 
     @Binding var rules: [FilterRule]
 
+    var presetStore: FilterPresetStore
     var onSave: () -> Void = {}
 
     var body: some View {
@@ -44,17 +45,34 @@ struct AdvancedFilterBar: View {
     }
 
     private func filterRow(at index: Int, isFirst: Bool) -> some View {
-        HStack(spacing: 8) {
+        HStack(spacing: 10) {
             Toggle("", isOn: $rules[index].isEnabled)
                 .toggleStyle(.checkbox)
                 .labelsHidden()
+                .frame(width: Self.enableToggleWidth, alignment: .center)
+
+            if isFirst {
+                Text("Where")
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(.secondary)
+                    .frame(width: Self.connectorWidth, alignment: .leading)
+            } else {
+                Picker("", selection: $rules[index].connector) {
+                    ForEach(FilterLogicConnector.allCases, id: \.self) { connector in
+                        Text(connector.displayName).tag(connector)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .controlSize(.small)
+                .frame(width: Self.connectorWidth)
+            }
 
             Picker("", selection: $rules[index].field) {
-                ForEach(FilterField.allCases.filter { $0 != .contains }, id: \.self) { field in
+                ForEach(Self.advancedFields, id: \.self) { field in
                     Text(field.displayName).tag(field)
                 }
             }
-            .frame(width: 120)
+            .frame(width: 138)
 
             Picker("", selection: $rules[index].filterOperator) {
                 ForEach(FilterOperator.allCases, id: \.self) { op in
@@ -86,14 +104,13 @@ struct AdvancedFilterBar: View {
             .controlSize(.small)
 
             if isFirst {
-                Button(String(localized: "Save"), action: onSave)
-                    .buttonStyle(.bordered)
-                    .controlSize(.small)
+                presetMenu
             }
         }
         .padding(.horizontal, 12)
         .padding(.top, index == 0 ? 8 : 4)
         .padding(.bottom, 0)
+        .frame(minHeight: 30)
         .opacity(rules[index].isEnabled ? 1.0 : 0.5)
     }
 
@@ -107,5 +124,53 @@ struct AdvancedFilterBar: View {
             return
         }
         rules.remove(at: index)
+    }
+
+    private static let advancedFields: [FilterField] = [
+        .url, .method, .statusCode, .requestHeader, .responseHeader, .requestBody,
+        .responseBody, .clientApp, .domain, .contentType, .queryString, .cookies,
+        .comment, .color,
+    ]
+
+    private static let enableToggleWidth: CGFloat = 22
+    private static let connectorWidth: CGFloat = 76
+
+    private var presetMenu: some View {
+        Menu {
+            Button {
+                _ = presetStore.saveGeneratedPreset(rules: rules)
+                onSave()
+            } label: {
+                Label(String(localized: "Save Current Filter"), systemImage: "square.and.arrow.down")
+            }
+            .disabled(FilterRuleEvaluator.activeRules(in: rules, isFilterBarVisible: true).isEmpty)
+
+            if !presetStore.presets.isEmpty {
+                Divider()
+                ForEach(presetStore.presets) { preset in
+                    Button {
+                        rules = preset.rules.isEmpty ? [FilterRule()] : preset.rules
+                    } label: {
+                        Label(preset.name, systemImage: "line.3.horizontal.decrease.circle")
+                    }
+                }
+
+                Divider()
+                Menu(String(localized: "Delete Preset")) {
+                    ForEach(presetStore.presets) { preset in
+                        Button(role: .destructive) {
+                            presetStore.deletePreset(id: preset.id)
+                        } label: {
+                            Text(preset.name)
+                        }
+                    }
+                }
+            }
+        } label: {
+            Label(String(localized: "Presets"), systemImage: "chevron.down")
+                .labelStyle(.titleAndIcon)
+        }
+        .menuStyle(.borderlessButton)
+        .controlSize(.small)
     }
 }

--- a/RockxyTests/Models/UI/FilterPresetStoreTests.swift
+++ b/RockxyTests/Models/UI/FilterPresetStoreTests.swift
@@ -1,0 +1,51 @@
+import Foundation
+@testable import Rockxy
+import Testing
+
+@MainActor
+struct FilterPresetStoreTests {
+    @Test("Saved presets persist rules and connectors")
+    func savedPresetsPersistRulesAndConnectors() throws {
+        let suiteName = "FilterPresetStoreTests-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let key = "filter-presets"
+
+        let store = FilterPresetStore(userDefaults: defaults, storageKey: key)
+        let rules = [
+            FilterRule(isEnabled: true, field: .requestHeader, filterOperator: .contains, value: "Host"),
+            FilterRule(
+                isEnabled: true,
+                connector: .or,
+                field: .responseHeader,
+                filterOperator: .contains,
+                value: "unsafe-inline"
+            ),
+        ]
+
+        let preset = try #require(store.savePreset(name: "CSP Debug", rules: rules))
+        let reloaded = FilterPresetStore(userDefaults: defaults, storageKey: key)
+
+        #expect(reloaded.presets.count == 1)
+        #expect(reloaded.presets.first?.id == preset.id)
+        #expect(reloaded.presets.first?.rules.count == 2)
+        #expect(reloaded.presets.first?.rules[1].connector == .or)
+    }
+
+    @Test("Preset save ignores disabled and empty rules")
+    func presetSaveIgnoresInactiveRules() throws {
+        let suiteName = "FilterPresetStoreTests-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let store = FilterPresetStore(userDefaults: defaults, storageKey: "filter-presets")
+        let preset = try #require(store.savePreset(name: "Active Only", rules: [
+            FilterRule(isEnabled: false, field: .url, filterOperator: .contains, value: "hidden"),
+            FilterRule(isEnabled: true, field: .url, filterOperator: .contains, value: ""),
+            FilterRule(isEnabled: true, field: .url, filterOperator: .contains, value: "api"),
+        ]))
+
+        #expect(preset.rules.count == 1)
+        #expect(preset.rules.first?.value == "api")
+    }
+}

--- a/RockxyTests/Models/UI/InspectorHighlightContextTests.swift
+++ b/RockxyTests/Models/UI/InspectorHighlightContextTests.swift
@@ -1,0 +1,81 @@
+import AppKit
+import Foundation
+@testable import Rockxy
+import Testing
+
+struct InspectorHighlightContextTests {
+    @Test("Literal highlights are case insensitive")
+    func literalHighlightsCaseInsensitive() {
+        let context = InspectorHighlightContext(literalTerms: ["unsafe-inline"])
+        let ranges = context.matchRanges(in: "script-src 'UNSAFE-INLINE'")
+        #expect(ranges.count == 1)
+    }
+
+    @Test("Negative filter values are not represented in highlight context")
+    @MainActor
+    func negativeRulesDoNotHighlight() {
+        let coordinator = MainContentCoordinator()
+        coordinator.isFilterBarVisible = true
+        coordinator.filterRules = [
+            FilterRule(isEnabled: true, field: .url, filterOperator: .doesNotContain, value: "secret"),
+            FilterRule(isEnabled: true, field: .responseHeader, filterOperator: .contains, value: "unsafe-inline"),
+        ]
+        let context = coordinator.activeInspectorHighlightContext()
+
+        #expect(!context.literalTerms.contains("secret"))
+        #expect(context.literalTerms.contains("unsafe-inline"))
+    }
+
+    @Test("Highlight ranges are capped for large payloads")
+    func highlightRangesAreCapped() {
+        let context = InspectorHighlightContext(literalTerms: ["a"])
+        let ranges = context.matchRanges(in: String(repeating: "a", count: 2_000), limit: 20)
+        #expect(ranges.count == 20)
+    }
+
+    @Test("Long header values highlight matches near the end")
+    func longHeaderHighlightingFindsLateMatches() {
+        let context = InspectorHighlightContext(literalTerms: ["unsafe-inline"])
+        let headerValue = String(repeating: "default-src 'self'; ", count: 80) + "script-src 'unsafe-inline'"
+
+        let ranges = context.matchRanges(in: headerValue, limit: 5)
+
+        #expect(ranges.count == 1)
+    }
+
+@Test("Highlight theme colors remain visible in light and dark appearances")
+func highlightThemeColorsReadable() {
+    let appearances: [NSAppearance.Name] = [.aqua, .darkAqua]
+
+    for appearanceName in appearances {
+        guard let appearance = NSAppearance(named: appearanceName) else {
+            continue
+        }
+
+        appearance.performAsCurrentDrawingAppearance {
+            let backgroundAlpha = Theme.Inspector.matchHighlightNS.alphaComponent
+            let foregroundAlpha = Theme.Inspector.matchHighlightTextNS.alphaComponent
+
+            #expect(backgroundAlpha > 0.2)
+            #expect(foregroundAlpha > 0.9)
+        }
+    }
+}
+
+    @Test("Rapid filter updates produce a fresh highlight identity")
+    @MainActor
+    func rapidFilterUpdatesProduceFreshHighlightContext() {
+        let coordinator = MainContentCoordinator()
+        coordinator.isFilterBarVisible = true
+        coordinator.filterRules = [
+            FilterRule(isEnabled: true, field: .url, filterOperator: .contains, value: "first"),
+        ]
+        let firstContext = coordinator.activeInspectorHighlightContext()
+
+        coordinator.filterRules[0].value = "second"
+        let secondContext = coordinator.activeInspectorHighlightContext()
+
+        #expect(firstContext.identity != secondContext.identity)
+        #expect(secondContext.literalTerms == ["second"])
+    }
+}

--- a/RockxyTests/Views/Main/FilteringTests.swift
+++ b/RockxyTests/Views/Main/FilteringTests.swift
@@ -233,6 +233,30 @@ struct FilteringTests {
         #expect(coordinator.filteredTransactions[0].id == match.id)
     }
 
+    @Test("Filter rules support OR connectors")
+    func filterRulesORCombined() {
+        let coordinator = MainContentCoordinator()
+        let getUsers = TestFixtures.makeTransaction(method: "GET", url: "https://api.example.com/users")
+        let postOrders = TestFixtures.makeTransaction(method: "POST", url: "https://api.example.com/orders")
+        let deleteOther = TestFixtures.makeTransaction(method: "DELETE", url: "https://api.example.com/admin")
+        coordinator.transactions = [getUsers, postOrders, deleteOther]
+        coordinator.isFilterBarVisible = true
+        coordinator.filterRules = [
+            FilterRule(isEnabled: true, field: .method, filterOperator: .is, value: "GET"),
+            FilterRule(
+                isEnabled: true,
+                connector: .or,
+                field: .method,
+                filterOperator: .is,
+                value: "POST"
+            ),
+        ]
+
+        coordinator.recomputeFilteredTransactions()
+
+        #expect(coordinator.filteredTransactions.map(\.id) == [getUsers.id, postOrders.id])
+    }
+
     @Test("Disabled rules are ignored")
     func disabledRulesIgnored() {
         let coordinator = makeCoordinator()
@@ -242,6 +266,87 @@ struct FilteringTests {
         ]
         coordinator.recomputeFilteredTransactions()
         #expect(coordinator.filteredTransactions.count == coordinator.transactions.count)
+    }
+
+    @Test("Request body filter matches decoded text")
+    func requestBodyRule() {
+        let coordinator = MainContentCoordinator()
+        let match = TestFixtures.makeTransaction(method: "POST")
+        match.request.body = Data("{\"token\":\"needle\"}".utf8)
+        let noMatch = TestFixtures.makeTransaction(method: "POST")
+        noMatch.request.body = Data("{\"token\":\"other\"}".utf8)
+        coordinator.transactions = [match, noMatch]
+        coordinator.isFilterBarVisible = true
+        coordinator.filterRules = [
+            FilterRule(isEnabled: true, field: .requestBody, filterOperator: .contains, value: "needle"),
+        ]
+
+        coordinator.recomputeFilteredTransactions()
+
+        #expect(coordinator.filteredTransactions.map(\.id) == [match.id])
+    }
+
+    @Test("Response body filter matches decoded text")
+    func responseBodyRule() {
+        let coordinator = MainContentCoordinator()
+        let match = TestFixtures.makeTransaction(statusCode: 200)
+        match.response = TestFixtures.makeResponse(body: Data("unsafe-inline".utf8))
+        let noMatch = TestFixtures.makeTransaction(statusCode: 200)
+        noMatch.response = TestFixtures.makeResponse(body: Data("safe".utf8))
+        coordinator.transactions = [match, noMatch]
+        coordinator.isFilterBarVisible = true
+        coordinator.filterRules = [
+            FilterRule(isEnabled: true, field: .responseBody, filterOperator: .contains, value: "unsafe-inline"),
+        ]
+
+        coordinator.recomputeFilteredTransactions()
+
+        #expect(coordinator.filteredTransactions.map(\.id) == [match.id])
+    }
+
+    @Test("No-result state keeps filtered rows empty")
+    func noResultStateForUnmatchedFilter() {
+        let coordinator = MainContentCoordinator()
+        coordinator.transactions = [
+            TestFixtures.makeTransaction(url: "https://api.example.com/users"),
+            TestFixtures.makeTransaction(url: "https://api.example.com/orders"),
+        ]
+        coordinator.isFilterBarVisible = true
+        coordinator.filterRules = [
+            FilterRule(isEnabled: true, field: .url, filterOperator: .contains, value: "missing-value"),
+        ]
+
+        coordinator.recomputeFilteredTransactions()
+
+        #expect(coordinator.filteredTransactions.isEmpty)
+        #expect(coordinator.filteredRows.isEmpty)
+    }
+
+    @Test("Client app, domain, content type, and cookie fields match")
+    func expandedDebugFields() {
+        let coordinator = MainContentCoordinator()
+        let match = TestFixtures.makeTransaction(url: "https://api.example.com/users")
+        match.clientApp = "Google Chrome"
+        match.request.contentType = .json
+        match.request.headers = [
+            HTTPHeader(name: "Content-Type", value: "application/json"),
+            HTTPHeader(name: "Cookie", value: "session=abc123"),
+        ]
+        let noMatch = TestFixtures.makeTransaction(url: "https://other.test/users")
+        noMatch.clientApp = "Safari"
+        noMatch.request.contentType = .text
+        coordinator.transactions = [match, noMatch]
+        coordinator.isFilterBarVisible = true
+        coordinator.filterRules = [
+            FilterRule(isEnabled: true, field: .clientApp, filterOperator: .contains, value: "Chrome"),
+            FilterRule(isEnabled: true, field: .domain, filterOperator: .contains, value: "example.com"),
+            FilterRule(isEnabled: true, field: .contentType, filterOperator: .contains, value: "json"),
+            FilterRule(isEnabled: true, field: .cookies, filterOperator: .contains, value: "abc123"),
+        ]
+
+        coordinator.recomputeFilteredTransactions()
+
+        #expect(coordinator.filteredTransactions.map(\.id) == [match.id])
     }
 
     @Test("Rules only apply when filter bar is visible")
@@ -272,6 +377,18 @@ struct FilteringTests {
         let value = coordinator.fieldValue(for: .requestHeader, in: transaction)
         #expect(value.contains("Content-Type"))
         #expect(value.contains("application/json"))
+    }
+
+    @Test("fieldValue for responseHeader returns joined headers")
+    func fieldValueResponseHeader() {
+        let coordinator = MainContentCoordinator()
+        let transaction = TestFixtures.makeTransaction()
+        transaction.response = TestFixtures.makeResponse(headers: [
+            HTTPHeader(name: "Content-Security-Policy", value: "script-src 'unsafe-inline'"),
+        ])
+        let value = coordinator.fieldValue(for: .responseHeader, in: transaction)
+        #expect(value.contains("Content-Security-Policy"))
+        #expect(value.contains("unsafe-inline"))
     }
 
     @Test("fieldValue for queryString returns query")
@@ -362,6 +479,24 @@ struct FilteringTests {
         #expect(coordinator.filteredTransactions.allSatisfy {
             $0.request.url.absoluteString.contains("users")
         })
+    }
+
+    @Test("Large traffic sessions keep filtered counts correct")
+    func largeTrafficSessionFiltering() {
+        let coordinator = MainContentCoordinator()
+        coordinator.transactions = (0 ..< 5_000).map { index in
+            let method = index.isMultiple(of: 2) ? "GET" : "POST"
+            return TestFixtures.makeTransaction(method: method, url: "https://api.example.com/items/\(index)")
+        }
+        coordinator.isFilterBarVisible = true
+        coordinator.filterRules = [
+            FilterRule(isEnabled: true, field: .method, filterOperator: .is, value: "POST"),
+        ]
+
+        coordinator.recomputeFilteredTransactions()
+
+        #expect(coordinator.filteredTransactions.count == 2_500)
+        #expect(coordinator.filteredRows.count == 2_500)
     }
 
     // MARK: - Sidebar Scope

--- a/RockxyTests/Views/RequestList/RequestTableRefreshTests.swift
+++ b/RockxyTests/Views/RequestList/RequestTableRefreshTests.swift
@@ -452,6 +452,22 @@ struct RequestTableRefreshTests {
         #expect(coordinator.domainTree.first?.domain == "other.com")
     }
 
+    @Test("Deleting selected sidebar domain clears stale sidebar filter")
+    func deleteSelectedSidebarDomainClearsFilter() {
+        let coordinator = MainContentCoordinator()
+        let transaction = TestFixtures.makeTransaction(url: "https://api.example.com/test")
+        coordinator.transactions = [transaction]
+        coordinator.rebuildSidebarIndexes()
+        coordinator.selectSidebarItem(.domainNode(domain: "example.com"))
+
+        coordinator.removeDomainFromSidebar("example.com")
+
+        #expect(coordinator.sidebarSelection == nil)
+        #expect(coordinator.filterCriteria.sidebarDomain == nil)
+        #expect(coordinator.filterCriteria.sidebarPathPrefix == nil)
+        #expect(coordinator.filterCriteria.sidebarScope == .allTraffic)
+    }
+
     @Test("Delete updates sidebar app state")
     func deleteUpdatessSidebarApp() {
         let coordinator = MainContentCoordinator()
@@ -471,6 +487,22 @@ struct RequestTableRefreshTests {
         // Sidebar rebuilt after delete — only Chrome remains
         #expect(coordinator.appNodes.count == 1)
         #expect(coordinator.appNodes.first?.name == "Chrome")
+    }
+
+    @Test("Deleting selected sidebar app clears stale app filter")
+    func deleteSelectedSidebarAppClearsFilter() {
+        let coordinator = MainContentCoordinator()
+        let transaction = TestFixtures.makeTransaction()
+        transaction.clientApp = "Chrome"
+        coordinator.transactions = [transaction]
+        coordinator.rebuildSidebarIndexes()
+        coordinator.selectSidebarItem(.app(name: "Chrome", bundleId: nil))
+
+        coordinator.removeAppFromSidebar("Chrome")
+
+        #expect(coordinator.sidebarSelection == nil)
+        #expect(coordinator.filterCriteria.sidebarApp == nil)
+        #expect(coordinator.filterCriteria.sidebarScope == .allTraffic)
     }
 
     @Test("selectedTransactionIDs is pruned after delete")


### PR DESCRIPTION
## Summary
- Add a compact advanced filter builder with enabled rows, AND/OR connectors, expanded request/response fields, and saved presets.
- Reuse shared filter evaluation across active and workspace filtering, including URL, method, status, headers, bodies, client/app, domain, content type, query, cookies, comments, and color.
- Highlight matched search/filter values inside request and response inspector surfaces, including URL, headers, cookies, auth, body, and raw views.
- Improve sidebar grouping cleanup when selected domain/app groups disappear so active filters stay aligned with visible traffic.

## Validation
- xcodebuild -project Rockxy.xcodeproj -scheme Rockxy -destination 'platform=macOS' -only-testing:RockxyTests/Views/Main/FilteringTests -only-testing:RockxyTests/Models/UI/FilterPresetStoreTests -only-testing:RockxyTests/Models/UI/InspectorHighlightContextTests -only-testing:RockxyTests/Views/RequestList/RequestTableRefreshTests test
- swiftlint lint --strict
- xcodebuild -project Rockxy.xcodeproj -scheme Rockxy -configuration Debug build

## Notes
- Existing Debug build warnings remain for the Info.plist copy phase and duplicate TrafficDomainSnapshot.swift compile source entry; this change does not touch those project settings.