### PR TITLE
Improve workspace tabs and status chrome

### DIFF
--- a/Rockxy/Models/UI/WorkspaceState.swift
+++ b/Rockxy/Models/UI/WorkspaceState.swift
@@ -36,6 +36,7 @@ final class WorkspaceState: Identifiable {
     // Selection
     var selectedTransaction: HTTPTransaction?
     var selectedLogEntry: LogEntry?
+    var selectedTransactionIDs: Set<UUID> = []
 
     // Filtering
     var filterCriteria: FilterCriteria = .empty
@@ -69,6 +70,7 @@ final class WorkspaceState: Identifiable {
         // activeSortDescriptors intentionally preserved — sort is a user preference
         selectedTransaction = nil
         selectedLogEntry = nil
+        selectedTransactionIDs.removeAll()
         domainTree.removeAll()
         domainIndexMap.removeAll()
         domainGroupingIndex.removeAll()

--- a/Rockxy/Views/Main/Extensions/MainContentCoordinator+ContextMenu.swift
+++ b/Rockxy/Views/Main/Extensions/MainContentCoordinator+ContextMenu.swift
@@ -502,15 +502,10 @@ extension MainContentCoordinator {
         rebuildObservedDomainsByApp()
         persistedFavorites.removeAll { ids.contains($0.id) }
 
-        // Prune selection state
-        selectedTransactionIDs.subtract(ids)
-        if let selected = selectedTransaction, ids.contains(selected.id) {
-            selectedTransaction = nil
-        }
-
         // Update all workspaces (same consistency as eviction)
         for workspace in workspaceStore.workspaces {
             workspace.filteredTransactions.removeAll { ids.contains($0.id) }
+            workspace.selectedTransactionIDs.subtract(ids)
             if workspace.selectedTransaction.map({ ids.contains($0.id) }) == true {
                 workspace.selectedTransaction = nil
             }

--- a/Rockxy/Views/Main/Extensions/MainContentCoordinator+ProxyControl.swift
+++ b/Rockxy/Views/Main/Extensions/MainContentCoordinator+ProxyControl.swift
@@ -263,7 +263,6 @@ extension MainContentCoordinator {
 
         transactions.removeAll()
         rebuildObservedDomainsByApp()
-        selectedTransactionIDs.removeAll()
         logEntries.removeAll()
         errorCount = 0
         sessionProvenance = nil

--- a/Rockxy/Views/Main/Extensions/MainContentCoordinator+Workspaces.swift
+++ b/Rockxy/Views/Main/Extensions/MainContentCoordinator+Workspaces.swift
@@ -154,6 +154,7 @@ extension MainContentCoordinator {
     func evictFromAllWorkspaces(removedIDs: Set<UUID>) {
         for workspace in workspaceStore.workspaces {
             workspace.filteredTransactions.removeAll { removedIDs.contains($0.id) }
+            workspace.selectedTransactionIDs.subtract(removedIDs)
             if workspace.selectedTransaction.map({ removedIDs.contains($0.id) }) == true {
                 workspace.selectedTransaction = nil
             }

--- a/Rockxy/Views/Main/MainContentCoordinator.swift
+++ b/Rockxy/Views/Main/MainContentCoordinator.swift
@@ -80,10 +80,6 @@ final class MainContentCoordinator {
 
     var cachedSessionStore: SessionStore?
 
-    // MARK: - UI State — Selection
-
-    var selectedTransactionIDs: Set<UUID> = []
-
     // MARK: - Sequence Numbering (request-list ordering metadata)
 
     var nextSequenceNumber: Int = 0
@@ -195,6 +191,11 @@ final class MainContentCoordinator {
     var selectedTransaction: HTTPTransaction? {
         get { activeWorkspace.selectedTransaction }
         set { activeWorkspace.selectedTransaction = newValue }
+    }
+
+    var selectedTransactionIDs: Set<UUID> {
+        get { activeWorkspace.selectedTransactionIDs }
+        set { activeWorkspace.selectedTransactionIDs = newValue }
     }
 
     var filterCriteria: FilterCriteria {

--- a/Rockxy/Views/Main/WorkspaceWindowManager.swift
+++ b/Rockxy/Views/Main/WorkspaceWindowManager.swift
@@ -822,7 +822,9 @@ private final class WorkspaceTabBarView: NSView, NSTextFieldDelegate {
     }
 
     private func drawTabBackground(in frame: NSRect, isActive: Bool, isHovered: Bool) {
-        let rect = frame.insetBy(dx: 0.5, dy: 0)
+        let leadingOverlap: CGFloat = frame.minX <= WorkspaceTabBarMetrics.leftInset + 0.5 ? 8 : 0
+        let rect = NSRect(x: frame.minX - leadingOverlap, y: frame.minY, width: frame.width + leadingOverlap, height: frame.height)
+            .insetBy(dx: 0.5, dy: 0)
         let path = NSBezierPath(roundedRect: rect, xRadius: 14, yRadius: 14)
         if isActive {
             NSGraphicsContext.saveGraphicsState()

--- a/Rockxy/Views/Main/WorkspaceWindowManager.swift
+++ b/Rockxy/Views/Main/WorkspaceWindowManager.swift
@@ -34,6 +34,18 @@ final class RockxyWorkspaceWindowManager: NSObject {
         }
     }
 
+    static func workspaceTabWidth(availableWidth: CGFloat, tabCount: Int) -> CGFloat {
+        guard tabCount > 0 else {
+            return 0
+        }
+
+        let distributedWidth = availableWidth / CGFloat(tabCount)
+        guard distributedWidth < WorkspaceTabBarMetrics.preferredMinimumTabWidth else {
+            return distributedWidth
+        }
+        return max(WorkspaceTabBarMetrics.minimumTabWidth, distributedWidth)
+    }
+
     func registerPrimaryWindow(_ window: NSWindow, coordinator: MainContentCoordinator) {
         self.coordinator = coordinator
         primaryWindow = window
@@ -311,6 +323,16 @@ final class RockxyWorkspaceWindowManager: NSObject {
     }
 }
 
+// MARK: - WorkspaceTabBarMetrics
+
+private enum WorkspaceTabBarMetrics {
+    static let barHeight: CGFloat = 36, leftInset: CGFloat = 74, rightInset: CGFloat = 12
+    static let minimumTabWidth: CGFloat = 56, preferredMinimumTabWidth: CGFloat = 82
+    static let addButtonSize: CGFloat = 28, dragThreshold: CGFloat = 4
+    static let reorderAnimationDuration: TimeInterval = 0.22
+    static let tabAnimationFrameInterval: TimeInterval = 1 / 120
+}
+
 // MARK: - WorkspaceTabBarAccessoryController
 
 @MainActor
@@ -356,7 +378,7 @@ private final class WorkspaceTabBarView: NSView, NSTextFieldDelegate {
 
     init(manager: RockxyWorkspaceWindowManager) {
         self.manager = manager
-        super.init(frame: NSRect(x: 0, y: 0, width: 900, height: Self.barHeight))
+        super.init(frame: NSRect(x: 0, y: 0, width: 900, height: WorkspaceTabBarMetrics.barHeight))
         autoresizingMask = [.width]
         wantsLayer = false
     }
@@ -377,7 +399,7 @@ private final class WorkspaceTabBarView: NSView, NSTextFieldDelegate {
     }
 
     override var intrinsicContentSize: NSSize {
-        NSSize(width: NSView.noIntrinsicMetric, height: Self.barHeight)
+        NSSize(width: NSView.noIntrinsicMetric, height: WorkspaceTabBarMetrics.barHeight)
     }
 
     override func updateTrackingAreas() {
@@ -469,7 +491,7 @@ private final class WorkspaceTabBarView: NSView, NSTextFieldDelegate {
 
         let point = convert(event.locationInWindow, from: nil)
         if draggingWorkspaceID == nil,
-           distance(from: mouseDownPoint, to: point) >= Self.dragThreshold {
+           distance(from: mouseDownPoint, to: point) >= WorkspaceTabBarMetrics.dragThreshold {
             draggingWorkspaceID = mouseDownWorkspaceID
             dragGrabOffsetX = dragGrabOffset(for: mouseDownWorkspaceID, at: mouseDownPoint)
         }
@@ -643,16 +665,6 @@ private final class WorkspaceTabBarView: NSView, NSTextFieldDelegate {
 
     // MARK: Private
 
-    private static let barHeight: CGFloat = 36
-    private static let leftInset: CGFloat = 74
-    private static let rightInset: CGFloat = 12
-    private static let minimumTabWidth: CGFloat = 82
-    private static let maximumTabWidth: CGFloat = 220
-    private static let addButtonSize: CGFloat = 28
-    private static let dragThreshold: CGFloat = 4
-    private static let reorderAnimationDuration: TimeInterval = 0.22
-    private static let tabAnimationFrameInterval: TimeInterval = 1 / 120
-
     private weak var manager: RockxyWorkspaceWindowManager!
     private weak var coordinator: MainContentCoordinator?
     private var trackingArea: NSTrackingArea?
@@ -687,21 +699,24 @@ private final class WorkspaceTabBarView: NSView, NSTextFieldDelegate {
         }
 
         let workspaces = coordinator.workspaceStore.workspaces
-        let addX = max(Self.leftInset, bounds.maxX - Self.rightInset - Self.addButtonSize - 8)
+        let addX = max(
+            WorkspaceTabBarMetrics.leftInset,
+            bounds.maxX - WorkspaceTabBarMetrics.rightInset - WorkspaceTabBarMetrics.addButtonSize - 8
+        )
         addButtonFrame = NSRect(
             x: addX,
             y: 4,
-            width: Self.addButtonSize,
-            height: Self.addButtonSize
+            width: WorkspaceTabBarMetrics.addButtonSize,
+            height: WorkspaceTabBarMetrics.addButtonSize
         )
 
         let availableWidth = max(
-            Self.minimumTabWidth,
-            addButtonFrame.minX - Self.leftInset - 6
+            WorkspaceTabBarMetrics.minimumTabWidth,
+            addButtonFrame.minX - WorkspaceTabBarMetrics.leftInset - 6
         )
-        let tabWidth = min(
-            Self.maximumTabWidth,
-            max(Self.minimumTabWidth, availableWidth / CGFloat(max(workspaces.count, 1)))
+        let tabWidth = RockxyWorkspaceWindowManager.workspaceTabWidth(
+            availableWidth: availableWidth,
+            tabCount: max(workspaces.count, 1)
         )
 
         tabFrames.removeAll(keepingCapacity: true)
@@ -709,10 +724,10 @@ private final class WorkspaceTabBarView: NSView, NSTextFieldDelegate {
 
         for (index, workspace) in workspaces.enumerated() {
             let frame = NSRect(
-                x: Self.leftInset + CGFloat(index) * tabWidth,
+                x: WorkspaceTabBarMetrics.leftInset + CGFloat(index) * tabWidth,
                 y: 4,
                 width: tabWidth,
-                height: Self.barHeight - 8
+                height: WorkspaceTabBarMetrics.barHeight - 8
             )
             tabFrames[workspace.id] = frame
             if workspace.isClosable {
@@ -730,13 +745,13 @@ private final class WorkspaceTabBarView: NSView, NSTextFieldDelegate {
         NSColor.clear.setFill()
         bounds.fill()
 
-        let stripWidth = max(0, addButtonFrame.minX - Self.leftInset - 4)
+        let stripWidth = max(0, addButtonFrame.minX - WorkspaceTabBarMetrics.leftInset - 4)
         guard stripWidth > 0 else {
             return
         }
 
         let stripRect = NSRect(
-            x: Self.leftInset - 8,
+            x: WorkspaceTabBarMetrics.leftInset - 8,
             y: 4,
             width: stripWidth + 8,
             height: 28
@@ -919,7 +934,10 @@ private final class WorkspaceTabBarView: NSView, NSTextFieldDelegate {
         let width = sourceFrame.width
         let grabOffset = dragGrabOffsetX ?? width / 2
         let rect = NSRect(
-            x: min(max(Self.leftInset, point.x - grabOffset), bounds.maxX - Self.rightInset - Self.addButtonSize - width - 10),
+            x: min(
+                max(WorkspaceTabBarMetrics.leftInset, point.x - grabOffset),
+                bounds.maxX - WorkspaceTabBarMetrics.rightInset - WorkspaceTabBarMetrics.addButtonSize - width - 10
+            ),
             y: sourceFrame.minY,
             width: width,
             height: sourceFrame.height
@@ -944,7 +962,7 @@ private final class WorkspaceTabBarView: NSView, NSTextFieldDelegate {
         guard let markerX = insertionMarkerX(for: insertionIndex) else {
             return
         }
-        let markerRect = NSRect(x: markerX - 1, y: 8, width: 2, height: Self.barHeight - 16)
+        let markerRect = NSRect(x: markerX - 1, y: 8, width: 2, height: WorkspaceTabBarMetrics.barHeight - 16)
         let path = NSBezierPath(roundedRect: markerRect, xRadius: 1, yRadius: 1)
         NSColor.controlAccentColor.withAlphaComponent(0.9).setFill()
         path.fill()
@@ -1201,7 +1219,7 @@ private final class WorkspaceTabBarView: NSView, NSTextFieldDelegate {
         presentedTabFrames = tabAnimationStartFrames
 
         let timer = Timer(
-            timeInterval: Self.tabAnimationFrameInterval,
+            timeInterval: WorkspaceTabBarMetrics.tabAnimationFrameInterval,
             target: self,
             selector: #selector(advanceTabFrameAnimation(_:)),
             userInfo: nil,
@@ -1214,7 +1232,7 @@ private final class WorkspaceTabBarView: NSView, NSTextFieldDelegate {
 
     @objc private func advanceTabFrameAnimation(_ timer: Timer) {
         let elapsed = Date().timeIntervalSince(tabAnimationStartDate)
-        let progress = min(1, elapsed / Self.reorderAnimationDuration)
+        let progress = min(1, elapsed / WorkspaceTabBarMetrics.reorderAnimationDuration)
         let easedProgress = easeOutCubic(progress)
 
         presentedTabFrames = Dictionary(uniqueKeysWithValues: tabAnimationTargetFrames.map { workspaceID, targetFrame in

--- a/Rockxy/Views/Main/WorkspaceWindowManager.swift
+++ b/Rockxy/Views/Main/WorkspaceWindowManager.swift
@@ -823,8 +823,8 @@ private final class WorkspaceTabBarView: NSView, NSTextFieldDelegate {
 
     private func drawTabBackground(in frame: NSRect, isActive: Bool, isHovered: Bool) {
         let leadingOverlap: CGFloat = frame.minX <= WorkspaceTabBarMetrics.leftInset + 0.5 ? 8 : 0
-        let rect = NSRect(x: frame.minX - leadingOverlap, y: frame.minY, width: frame.width + leadingOverlap, height: frame.height)
-            .insetBy(dx: 0.5, dy: 0)
+        let trailingOverlap: CGFloat = { let gap = addButtonFrame.minX - 4 - frame.maxX; return gap > 0 && gap <= 2.5 ? gap : 0 }()
+        let rect = NSRect(x: frame.minX - leadingOverlap, y: frame.minY, width: frame.width + leadingOverlap + trailingOverlap, height: frame.height).insetBy(dx: 0.5, dy: 0)
         let path = NSBezierPath(roundedRect: rect, xRadius: 14, yRadius: 14)
         if isActive {
             NSGraphicsContext.saveGraphicsState()

--- a/Rockxy/Views/RequestList/CenterContentView.swift
+++ b/Rockxy/Views/RequestList/CenterContentView.swift
@@ -114,6 +114,9 @@ struct CenterContentView: View {
                 }
             }
         }
+        .onChange(of: coordinator.activeWorkspace.id) {
+            selectedIDs = coordinator.selectedTransactionIDs
+        }
     }
 
     // MARK: Private
@@ -180,6 +183,7 @@ struct CenterContentView: View {
 
     private var tableContent: some View {
         RequestTableView(
+            workspaceID: coordinator.activeWorkspace.id,
             rows: coordinator.filteredRows,
             refreshToken: coordinator.refreshToken,
             isAppendOnly: coordinator.activeWorkspace.lastDeriveWasAppendOnly,

--- a/Rockxy/Views/RequestList/RequestTableView.swift
+++ b/Rockxy/Views/RequestList/RequestTableView.swift
@@ -15,6 +15,7 @@ import SwiftUI
 struct RequestTableView: NSViewRepresentable {
     // MARK: Internal
 
+    let workspaceID: UUID
     let rows: [RequestListRow]
     let refreshToken: Int
     let isAppendOnly: Bool
@@ -108,15 +109,19 @@ struct RequestTableView: NSViewRepresentable {
         let coordinator = context.coordinator
         let oldToken = coordinator.lastRefreshToken
         let newToken = refreshToken
+        let oldWorkspaceID = coordinator.lastWorkspaceID
+        let workspaceChanged = oldWorkspaceID != workspaceID
 
         coordinator.parent = self
         coordinator.rows = rows
         coordinator.mainCoordinator = mainCoordinator
         coordinator.lastRefreshToken = newToken
+        coordinator.lastWorkspaceID = workspaceID
 
-        if newToken != oldToken {
+        if workspaceChanged || newToken != oldToken {
             let newCount = rows.count
-            if isAppendOnly,
+            if !workspaceChanged,
+               isAppendOnly,
                newCount > coordinator.previousRowCount,
                coordinator.previousRowCount > 0
             {
@@ -248,6 +253,7 @@ extension RequestTableView {
         var mainCoordinator: MainContentCoordinator?
         weak var tableView: NSTableView?
         var hasAutoSizedColumns = false
+        var lastWorkspaceID: UUID?
         var lastClickedColumn: String?
         var lastRefreshToken: Int = 0
         var previousRowCount: Int = 0

--- a/Rockxy/Views/Toolbar/ProxyStatusIndicator.swift
+++ b/Rockxy/Views/Toolbar/ProxyStatusIndicator.swift
@@ -39,29 +39,22 @@ struct ProxyStatusIndicator: View {
                             .foregroundStyle(Color(nsColor: .tertiaryLabelColor))
                     }
                 }
-                .padding(.leading, 12)
-                .padding(.trailing, updateStatusSummary == nil ? 12 : 7)
-                .padding(.vertical, 6)
-                .contentShape(Rectangle())
+                .padding(.leading, ProxyStatusChromeMetrics.horizontalPadding)
+                .padding(.trailing, updateStatusSummary == nil ? ProxyStatusChromeMetrics.horizontalPadding : 7)
+                .frame(height: ProxyStatusChromeMetrics.outerHeight)
+                .contentShape(Capsule(style: .continuous))
             }
             .buttonStyle(.plain)
             .help(statusHelpText)
 
             if let updateStatusSummary {
                 updateStatus(updateStatusSummary)
-                    .padding(.trailing, 12)
-                    .padding(.vertical, 6)
+                    .padding(.trailing, ProxyStatusChromeMetrics.horizontalPadding)
+                    .frame(height: ProxyStatusChromeMetrics.outerHeight)
             }
         }
-        .background(
-            Color(nsColor: .windowBackgroundColor)
-                .opacity(0.55)
-        )
-        .clipShape(Capsule())
-        .overlay(
-            Capsule()
-                .stroke(Color.primary.opacity(0.08), lineWidth: 1)
-        )
+        .frame(height: ProxyStatusChromeMetrics.outerHeight)
+        .contentShape(Rectangle())
         .popover(isPresented: $showPopover) {
             ProxyStatusPopover(
                 listenAddress: listenAddress,
@@ -74,10 +67,18 @@ struct ProxyStatusIndicator: View {
 
     // MARK: Private
 
+    private enum ProxyStatusChromeMetrics {
+        static let outerHeight: CGFloat = 32
+        static let updateBadgeHeight: CGFloat = 24
+        static let horizontalPadding: CGFloat = 14
+        static let statusDotSize: CGFloat = 10
+        static let strokeWidth: CGFloat = 0.75
+    }
+
     private var statusDot: some View {
         Circle()
             .fill(statusColor)
-            .frame(width: 9, height: 9)
+            .frame(width: ProxyStatusChromeMetrics.statusDotSize, height: ProxyStatusChromeMetrics.statusDotSize)
             .shadow(
                 color: statusShadowColor,
                 radius: 4,
@@ -149,22 +150,25 @@ struct ProxyStatusIndicator: View {
 
     private func updateBadge(_ title: String) -> some View {
         Text(title)
-            .font(.caption.weight(.semibold))
+            .font(.system(size: 13, weight: .semibold))
             .foregroundStyle(.white)
             .lineLimit(1)
             .padding(.horizontal, 9)
-            .padding(.vertical, 3)
-            .background(
-                Capsule()
-                    .fill(updateBadgeBackground)
-            )
-            .overlay(
-                Capsule()
-                    .stroke(Color.primary.opacity(colorScheme == .dark ? 0.08 : 0.05), lineWidth: 1)
-            )
+            .frame(height: ProxyStatusChromeMetrics.updateBadgeHeight)
+            .background {
+                Capsule(style: .continuous).fill(updateBadgeBackground)
+            }
+            .overlay {
+                Capsule(style: .continuous).strokeBorder(updateBadgeStroke, lineWidth: ProxyStatusChromeMetrics.strokeWidth)
+            }
+            .contentShape(Capsule(style: .continuous))
     }
 
     private var updateBadgeBackground: Color {
         Color(nsColor: .systemGray).opacity(colorScheme == .dark ? 0.62 : 0.82)
+    }
+
+    private var updateBadgeStroke: Color {
+        Color.primary.opacity(colorScheme == .dark ? 0.10 : 0.06)
     }
 }

--- a/RockxyTests/Core/Services/ReadinessCoordinatorTests.swift
+++ b/RockxyTests/Core/Services/ReadinessCoordinatorTests.swift
@@ -365,9 +365,14 @@ struct ReadinessCoordinatorTests {
         let coordinator = MainContentCoordinator()
         coordinator.selectedTransactionIDs.insert(UUID())
         coordinator.selectedTransactionIDs.insert(UUID())
-        #expect(coordinator.selectedTransactionIDs.count == 2)
+        let workspace = coordinator.workspaceStore.createWorkspace(title: "Other")
+        coordinator.selectedTransactionIDs.insert(UUID())
+        #expect(coordinator.workspaceStore.workspaces[0].selectedTransactionIDs.count == 2)
+        #expect(coordinator.selectedTransactionIDs.count == 1)
         await coordinator.clearSession()
         #expect(coordinator.selectedTransactionIDs.isEmpty)
+        #expect(coordinator.workspaceStore.workspaces[0].selectedTransactionIDs.isEmpty)
+        #expect(workspace.selectedTransactionIDs.isEmpty)
     }
 }
 

--- a/RockxyTests/Models/UI/WorkspaceStateTests.swift
+++ b/RockxyTests/Models/UI/WorkspaceStateTests.swift
@@ -17,6 +17,7 @@ struct WorkspaceStateTests {
         #expect(workspace.inspectorLayout == .hidden)
         #expect(workspace.selectedTransaction == nil)
         #expect(workspace.selectedLogEntry == nil)
+        #expect(workspace.selectedTransactionIDs.isEmpty)
         #expect(workspace.filterCriteria.isEmpty)
         #expect(workspace.filterRules.count == 1)
         #expect(workspace.isFilterBarVisible == false)
@@ -60,7 +61,9 @@ struct WorkspaceStateTests {
         // Mutate state
         workspace.activeMainTab = .logs
         workspace.filteredTransactions = [TestFixtures.makeTransaction()]
-        workspace.selectedTransaction = TestFixtures.makeTransaction()
+        let selected = TestFixtures.makeTransaction()
+        workspace.selectedTransaction = selected
+        workspace.selectedTransactionIDs = [selected.id]
         workspace.domainTree = [DomainNode(id: "test", domain: "test.com", requestCount: 1, children: [])]
 
         workspace.reset()
@@ -70,6 +73,7 @@ struct WorkspaceStateTests {
         #expect(workspace.filteredTransactions.isEmpty)
         #expect(workspace.selectedTransaction == nil)
         #expect(workspace.selectedLogEntry == nil)
+        #expect(workspace.selectedTransactionIDs.isEmpty)
         #expect(workspace.domainTree.isEmpty)
         #expect(workspace.appNodes.isEmpty)
         // activeMainTab is NOT reset (navigation state preserved)

--- a/RockxyTests/Views/Main/WorkspaceWindowPlacementTests.swift
+++ b/RockxyTests/Views/Main/WorkspaceWindowPlacementTests.swift
@@ -5,6 +5,19 @@ import Testing
 @MainActor
 @Suite("Workspace window placement")
 struct WorkspaceWindowPlacementTests {
+    @Test("Workspace tabs distribute available width before shrinking")
+    func workspaceTabsDistributeAvailableWidth() {
+        #expect(RockxyWorkspaceWindowManager.workspaceTabWidth(availableWidth: 1_200, tabCount: 2) == 600)
+        #expect(RockxyWorkspaceWindowManager.workspaceTabWidth(availableWidth: 1_200, tabCount: 4) == 300)
+        #expect(RockxyWorkspaceWindowManager.workspaceTabWidth(availableWidth: 640, tabCount: 8) == 80)
+    }
+
+    @Test("Workspace tab width handles empty and narrow inputs")
+    func workspaceTabWidthHandlesEdgeInputs() {
+        #expect(RockxyWorkspaceWindowManager.workspaceTabWidth(availableWidth: 1_200, tabCount: 0) == 0)
+        #expect(RockxyWorkspaceWindowManager.workspaceTabWidth(availableWidth: 320, tabCount: 8) == 56)
+    }
+
     @Test("Auxiliary windows are centered over the primary workspace window")
     func auxiliaryWindowsAreCenteredOverPrimaryWorkspaceWindow() {
         let windowFrame = NSRect(x: 0, y: 0, width: 760, height: 500)

--- a/RockxyTests/Views/RequestList/RequestTableRefreshTests.swift
+++ b/RockxyTests/Views/RequestList/RequestTableRefreshTests.swift
@@ -538,6 +538,52 @@ struct RequestTableRefreshTests {
         #expect(resolved.count == 2)
     }
 
+    @Test("Selected transaction IDs are scoped to the active workspace")
+    func selectedIDsScopedToActiveWorkspace() {
+        let coordinator = MainContentCoordinator()
+        let t1 = TestFixtures.makeTransaction(url: "https://alpha.example.com/a")
+        let t2 = TestFixtures.makeTransaction(url: "https://beta.example.com/b")
+        coordinator.transactions = [t1, t2]
+        coordinator.recomputeFilteredTransactions()
+
+        let firstWorkspaceID = coordinator.workspaceStore.activeWorkspaceID
+        coordinator.selectedTransactionIDs = [t1.id]
+
+        let secondWorkspace = coordinator.workspaceStore.createWorkspace(title: "Beta")
+        coordinator.recomputeFilteredTransactions(for: secondWorkspace)
+        coordinator.selectedTransactionIDs = [t2.id]
+
+        #expect(secondWorkspace.selectedTransactionIDs == [t2.id])
+        coordinator.workspaceStore.selectWorkspace(id: firstWorkspaceID)
+        #expect(coordinator.selectedTransactionIDs == [t1.id])
+        #expect(coordinator.resolveSelectedTransactions().map(\.id) == [t1.id])
+    }
+
+    @Test("Export scope uses selected rows from active workspace")
+    func exportScopeUsesActiveWorkspaceSelection() {
+        let coordinator = MainContentCoordinator()
+        let t1 = TestFixtures.makeTransaction(url: "https://alpha.example.com/a")
+        let t2 = TestFixtures.makeTransaction(url: "https://beta.example.com/b")
+        coordinator.transactions = [t1, t2]
+        coordinator.recomputeFilteredTransactions()
+
+        let firstWorkspaceID = coordinator.workspaceStore.activeWorkspaceID
+        coordinator.selectedTransactionIDs = [t1.id]
+
+        let secondWorkspace = coordinator.workspaceStore.createWorkspace(title: "Beta")
+        coordinator.recomputeFilteredTransactions(for: secondWorkspace)
+        coordinator.selectedTransactionIDs = []
+
+        coordinator.presentExport(format: .har)
+        #expect(coordinator.exportScopeContext?.selectedCount == 0)
+        #expect(coordinator.exportScopeContext?.initialScope != .selected)
+
+        coordinator.workspaceStore.selectWorkspace(id: firstWorkspaceID)
+        coordinator.presentExport(format: .har)
+        #expect(coordinator.exportScopeContext?.selectedCount == 1)
+        #expect(coordinator.exportScopeContext?.initialScope == .selected)
+    }
+
     // MARK: - Persisted Delete Durability
 
     @Test("Persisted delete is durable across SessionStore reload")

--- a/RockxyTests/Views/RequestList/RequestTableSelectionScrollTests.swift
+++ b/RockxyTests/Views/RequestList/RequestTableSelectionScrollTests.swift
@@ -9,6 +9,7 @@ struct RequestTableSelectionScrollTests {
     func unchangedSelectionReplayPreservesScrollPosition() {
         var selectedIDs = Set<UUID>()
         let parent = RequestTableView(
+            workspaceID: UUID(),
             rows: [],
             refreshToken: 0,
             isAppendOnly: false,


### PR DESCRIPTION
## Summary
- Expand workspace tabs across available titlebar width before shrinking as tab count grows.
- Preserve per-workspace view state for filters, sort, selection, selected transaction, and export selected count when switching tabs.
- Refresh request table state reliably when the active workspace changes.
- Refine workspace tab and proxy status indicator chrome for a more native macOS toolbar appearance.

## Validation
- `swiftlint lint --strict`
- `xcodebuild -project Rockxy.xcodeproj -scheme Rockxy -configuration Debug build`
- `xcodebuild -project Rockxy.xcodeproj -scheme Rockxy -destination 'platform=macOS' test` was run; one full-suite pass reported transient failures in unrelated inspector/JSONPath tests.\n- Focused rerun passed: `InspectorHighlightContextTests.highlightThemeColorsReadable`, `JSONPathEvaluatorTests.supportsAdvancedFilters`, `JSONPathEvaluatorTests.supportsFunctionsAndTruncation`.\n