### PR TITLE
Improve certificate UX and launch capture startup

### DIFF
--- a/Rockxy/ContentView.swift
+++ b/Rockxy/ContentView.swift
@@ -85,6 +85,7 @@ struct ContentView: View {
             coordinator.setupSSLProxyingObserver()
             coordinator.loadInitialRules()
             coordinator.refreshProxyOverrideStatus()
+            coordinator.startProxyOnLaunchIfNeeded()
         }
         .modifier(ConditionalScriptingWindowOpeners(isEnabled: managesLifecycle, openWindow: openWindow))
         .alert(

--- a/Rockxy/Core/Certificate/CertificateStore.swift
+++ b/Rockxy/Core/Certificate/CertificateStore.swift
@@ -41,6 +41,10 @@ nonisolated enum CertificateStore {
         }
     }
 
+    static var rootCACertificateURL: URL {
+        storageDirectory.appendingPathComponent(rootCACertFilename)
+    }
+
     static func saveRootCACertificate(_ certificate: Certificate) throws {
         try ensureDirectoryExists()
 
@@ -51,7 +55,7 @@ nonisolated enum CertificateStore {
         let pemDocument = PEMDocument(type: "CERTIFICATE", derBytes: derBytes)
         let pemString = pemDocument.pemString
 
-        let filePath = storageDirectory.appendingPathComponent(rootCACertFilename)
+        let filePath = rootCACertificateURL
         try Data(pemString.utf8).write(to: filePath)
         try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: filePath.path)
         logger.info("Saved root CA certificate to disk")
@@ -86,7 +90,7 @@ nonisolated enum CertificateStore {
     }
 
     static func loadRootCACertificate() throws -> Certificate? {
-        let filePath = storageDirectory.appendingPathComponent(rootCACertFilename)
+        let filePath = rootCACertificateURL
 
         guard FileManager.default.fileExists(atPath: filePath.path) else {
             return nil

--- a/Rockxy/Core/Certificate/CustomCertificateManager.swift
+++ b/Rockxy/Core/Certificate/CustomCertificateManager.swift
@@ -1,6 +1,7 @@
 import Crypto
 import Foundation
 import NIOSSL
+import Security
 import SwiftASN1
 import X509
 
@@ -45,6 +46,189 @@ struct CustomTLSIdentity: Sendable {
         get throws {
             try .privateKey(NIOSSLPrivateKey(bytes: Array(privateKeyPEM.utf8), format: .pem))
         }
+    }
+}
+
+// MARK: - CustomCertificateImportIdentity
+
+struct CustomCertificateImportIdentity: Equatable {
+    let displayName: String
+    let certificatePEM: String
+    let privateKeyPEM: String
+
+    static func fromCertificateAndPrivateKey(
+        certificateData: Data,
+        privateKeyData: Data,
+        displayName: String
+    ) throws -> Self {
+        let certificate = try certificatePEM(from: certificateData)
+        let privateKeyPEM = try privateKeyPEM(from: privateKeyData)
+        return Self(displayName: displayName, certificatePEM: certificate, privateKeyPEM: privateKeyPEM)
+    }
+
+    static func fromPKCS12(data: Data, displayName: String, passphrase: String) throws -> Self {
+        do {
+            return try fromNIOSSLPKCS12(data: data, displayName: displayName, passphrase: passphrase)
+        } catch let error as CustomCertificateImportError {
+            throw error
+        } catch {
+            return try fromSecurityPKCS12(data: data, displayName: displayName, passphrase: passphrase)
+        }
+    }
+
+    private static func fromNIOSSLPKCS12(data: Data, displayName: String, passphrase: String) throws -> Self {
+        let bundle = try pkcs12Bundle(data: data, passphrase: passphrase)
+        guard let leafCertificate = bundle.certificateChain.first else {
+            throw CustomCertificateImportError.missingCertificate
+        }
+
+        let certificateDER = try leafCertificate.toDERBytes()
+        let certificate = try Certificate(derEncoded: certificateDER)
+
+        return Self(
+            displayName: displayName,
+            certificatePEM: try pem(certificate),
+            privateKeyPEM: try privateKeyPEM(from: Data(try bundle.privateKey.derBytes))
+        )
+    }
+
+    private static func fromSecurityPKCS12(data: Data, displayName: String, passphrase: String) throws -> Self {
+        let identity = try secItemImportIdentity(data: data, passphrase: passphrase)
+        let certificate = try certificate(from: identity.certificate)
+        let privateKey: Certificate.PrivateKey
+        do {
+            privateKey = try Certificate.PrivateKey(identity.privateKey)
+        } catch {
+            throw CustomCertificateImportError.invalidPrivateKey
+        }
+
+        return Self(
+            displayName: displayName,
+            certificatePEM: try pem(certificate),
+            privateKeyPEM: try privateKey.serializeAsPEM().pemString
+        )
+    }
+
+    private static func pkcs12Bundle(data: Data, passphrase: String) throws -> NIOSSLPKCS12Bundle {
+        let bytes = Array(data)
+        if passphrase.isEmpty {
+            do {
+                return try NIOSSLPKCS12Bundle(buffer: bytes)
+            } catch {
+                return try NIOSSLPKCS12Bundle(buffer: bytes, passphrase: [UInt8]())
+            }
+        }
+        return try NIOSSLPKCS12Bundle(buffer: bytes, passphrase: Array(passphrase.utf8))
+    }
+
+    private static func secItemImportIdentity(data: Data, passphrase: String) throws -> (certificate: SecCertificate, privateKey: SecKey) {
+        var format = SecExternalFormat.formatPKCS12
+        var itemType = SecExternalItemType.itemTypeAggregate
+        let importPassphrase = passphrase as NSString
+        let keyAttributes = [kSecAttrIsExtractable] as NSArray
+        var keyParams = SecItemImportExportKeyParameters()
+        keyParams.version = UInt32(SEC_KEY_IMPORT_EXPORT_PARAMS_VERSION)
+        keyParams.passphrase = Unmanaged.passUnretained(importPassphrase)
+        keyParams.keyAttributes = Unmanaged.passUnretained(keyAttributes)
+        var importedItems: CFArray?
+        let status = SecItemImport(
+            data as CFData,
+            "p12" as CFString,
+            &format,
+            &itemType,
+            SecItemImportExportFlags(),
+            &keyParams,
+            nil,
+            &importedItems
+        )
+        guard status == errSecSuccess, let importedItems else {
+            return try secPKCS12Identity(data: data, passphrase: passphrase)
+        }
+        return try identity(from: importedItems)
+    }
+
+    private static func secPKCS12Identity(data: Data, passphrase: String) throws -> (certificate: SecCertificate, privateKey: SecKey) {
+        var importedItems: CFArray?
+        let options = [kSecImportExportPassphrase as String: passphrase] as CFDictionary
+        let status = SecPKCS12Import(data as CFData, options, &importedItems)
+        guard status == errSecSuccess, let importedItems else {
+            throw CustomCertificateImportError.invalidPKCS12
+        }
+        return try identity(from: importedItems)
+    }
+
+    private static func identity(from importedItems: CFArray) throws -> (certificate: SecCertificate, privateKey: SecKey) {
+        let items = importedItems as NSArray
+        let rawIdentity = items.compactMap { item -> Any? in
+            if CFGetTypeID(item as AnyObject) == SecIdentityGetTypeID() {
+                return item
+            }
+            return (item as? [String: Any])?[kSecImportItemIdentity as String]
+        }.first
+        guard let rawIdentity else {
+            throw CustomCertificateImportError.invalidPKCS12
+        }
+
+        let identityObject = rawIdentity as AnyObject
+        guard CFGetTypeID(identityObject) == SecIdentityGetTypeID() else {
+            throw CustomCertificateImportError.invalidPKCS12
+        }
+        let identity = unsafeBitCast(identityObject, to: SecIdentity.self)
+
+        var certificate: SecCertificate?
+        guard SecIdentityCopyCertificate(identity, &certificate) == errSecSuccess,
+              let certificate else {
+            throw CustomCertificateImportError.missingCertificate
+        }
+
+        var privateKey: SecKey?
+        guard SecIdentityCopyPrivateKey(identity, &privateKey) == errSecSuccess,
+              let privateKey else {
+            throw CustomCertificateImportError.invalidPrivateKey
+        }
+
+        return (certificate, privateKey)
+    }
+
+    private static func certificate(from secCertificate: SecCertificate) throws -> Certificate {
+        try Certificate(derEncoded: Array(SecCertificateCopyData(secCertificate) as Data))
+    }
+
+    private static func certificatePEM(from data: Data) throws -> String {
+        if let pemString = String(data: data, encoding: .utf8),
+           let certificate = try? Certificate(pemEncoded: pemString)
+        {
+            return try pem(certificate)
+        }
+
+        do {
+            let certificate = try Certificate(derEncoded: Array(data))
+            return try pem(certificate)
+        } catch {
+            throw CustomCertificateImportError.invalidCertificate
+        }
+    }
+
+    private static func privateKeyPEM(from data: Data) throws -> String {
+        if let pemString = String(data: data, encoding: .utf8),
+           let privateKey = try? Certificate.PrivateKey(pemEncoded: pemString)
+        {
+            return try privateKey.serializeAsPEM().pemString
+        }
+
+        for discriminator in ["PRIVATE KEY", "EC PRIVATE KEY", "RSA PRIVATE KEY"] {
+            let pemDocument = PEMDocument(type: discriminator, derBytes: Array(data))
+            if let privateKey = try? Certificate.PrivateKey(pemDocument: pemDocument) {
+                return try privateKey.serializeAsPEM().pemString
+            }
+        }
+        throw CustomCertificateImportError.invalidPrivateKey
+    }
+
+    private static func pem(_ certificate: Certificate) throws -> String {
+        var serializer = DER.Serializer()
+        try certificate.serialize(into: &serializer)
+        return PEMDocument(type: "CERTIFICATE", derBytes: serializer.serializedBytes).pemString
     }
 }
 
@@ -290,6 +474,28 @@ enum CustomCertificateError: LocalizedError, Equatable {
             String(localized: "The certificate and private key do not belong to the same identity.")
         case .missingPrivateKey:
             String(localized: "The private key for this certificate could not be found in Keychain.")
+        }
+    }
+}
+
+// MARK: - CustomCertificateImportError
+
+enum CustomCertificateImportError: LocalizedError, Equatable {
+    case invalidCertificate
+    case invalidPrivateKey
+    case invalidPKCS12
+    case missingCertificate
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidCertificate:
+            String(localized: "The selected certificate must be a valid PEM or DER X.509 certificate.")
+        case .invalidPrivateKey:
+            String(localized: "The selected private key must be a valid PEM or DER private key.")
+        case .invalidPKCS12:
+            String(localized: "The selected P12 file could not be imported. Check that the file contains a certificate and private key, then try the correct password.")
+        case .missingCertificate:
+            String(localized: "The selected P12 file does not contain a certificate.")
         }
     }
 }

--- a/Rockxy/RockxyApp.swift
+++ b/Rockxy/RockxyApp.swift
@@ -53,7 +53,7 @@ struct RockxyApp: App {
             MacCertificateSetupGuideView()
         }
         .commandsRemoved()
-        .defaultSize(width: 940, height: 620)
+        .defaultSize(width: 860, height: 540)
         .defaultPosition(.center)
         .windowToolbarStyle(.unifiedCompact)
 

--- a/Rockxy/Views/Certificate/CustomCertificatesView.swift
+++ b/Rockxy/Views/Certificate/CustomCertificatesView.swift
@@ -1,6 +1,10 @@
 import AppKit
+import Security
+import SecurityInterface
+import SwiftASN1
 import SwiftUI
 import UniformTypeIdentifiers
+import X509
 
 // MARK: - CustomCertificatesView
 
@@ -9,6 +13,9 @@ struct CustomCertificatesView: View {
     @State private var rootEntries: [CustomCertificateMetadata] = []
     @State private var serverEntries: [CustomCertificateMetadata] = []
     @State private var clientEntries: [CustomCertificateMetadata] = []
+    @State private var defaultRootCertificate: CertificatePreviewItem?
+    @State private var defaultRootSnapshot: RootCAStatusSnapshot?
+    @State private var isLoadingDefaultRoot = false
     @State private var errorMessage: String?
 
     var body: some View {
@@ -32,7 +39,10 @@ struct CustomCertificatesView: View {
             bottomBar
         }
         .frame(minWidth: 900, minHeight: 540)
-        .onAppear(perform: reload)
+        .task {
+            reload()
+            await refreshDefaultRootCertificate()
+        }
         .alert(String(localized: "Custom Certificate Failed"), isPresented: Binding(
             get: { errorMessage != nil },
             set: { if !$0 { errorMessage = nil } }
@@ -60,7 +70,12 @@ struct CustomCertificatesView: View {
     private var content: some View {
         switch selectedTab {
         case .root:
-            RootCertificateTab(entries: rootEntries)
+            RootCertificateTab(
+                entries: rootEntries,
+                defaultRootCertificate: defaultRootCertificate,
+                defaultRootSnapshot: defaultRootSnapshot,
+                isLoadingDefaultRoot: isLoadingDefaultRoot
+            )
         case .server:
             CertificateListTab(
                 title: String(localized: "Config Server Certificates used when establishing SSL connections to clients"),
@@ -89,7 +104,7 @@ struct CustomCertificatesView: View {
                 .disabled(currentEntries.isEmpty)
 
             Button(String(localized: "How to generate self-signed certificates")) {
-                if let helpURL = URL(string: "https://github.com/RockxyApp/Rockxy/wiki") {
+                if let helpURL = URL(string: "https://docs.rockxy.io/features/custom-certificates") {
                     NSWorkspace.shared.open(helpURL)
                 }
             }
@@ -97,26 +112,33 @@ struct CustomCertificatesView: View {
 
             Spacer()
 
-            if let helpURL = URL(string: "https://github.com/RockxyApp/Rockxy/wiki") {
+            if let helpURL = URL(string: "https://docs.rockxy.io/features/custom-certificates") {
                 HelpLink(destination: helpURL)
             }
 
-            Button(String(localized: "Preview")) {}
+            Button(String(localized: "Preview")) {
+                previewCurrentCertificate()
+            }
                 .buttonStyle(.bordered)
-                .disabled(true)
+                .disabled(currentPreviewItem == nil)
 
             Menu {
-                Button(String(localized: "Root Certificate…")) {
-                    importCertificate(kind: .root)
-                }
-                Button(String(localized: "Server Certificate…")) {
-                    importCertificate(kind: .server)
-                }
-                Button(String(localized: "Client Certificate…")) {
-                    importCertificate(kind: .client)
+                switch selectedTab {
+                case .root:
+                    Button(String(localized: "Import P12...")) {
+                        importPKCS12Certificate(kind: .root)
+                    }
+                case .server, .client:
+                    Button(String(localized: "Import PEM / DER...")) {
+                        importPEMOrDERCertificate(kind: selectedTab.kind)
+                    }
+                    Divider()
+                    Button(String(localized: "Import P12...")) {
+                        importPKCS12Certificate(kind: selectedTab.kind)
+                    }
                 }
             } label: {
-                Label(String(localized: "Import"), systemImage: "chevron.down")
+                Text(String(localized: "Import"))
             }
             .menuStyle(.button)
         }
@@ -135,6 +157,20 @@ struct CustomCertificatesView: View {
         }
     }
 
+    private var currentPreviewItem: CertificatePreviewItem? {
+        switch selectedTab {
+        case .root:
+            if let customRoot = rootEntries.last.flatMap({ try? CertificatePreviewItem(metadata: $0) }) {
+                return customRoot
+            }
+            return defaultRootCertificate
+        case .server:
+            return serverEntries.last.flatMap { try? CertificatePreviewItem(metadata: $0) }
+        case .client:
+            return clientEntries.last.flatMap { try? CertificatePreviewItem(metadata: $0) }
+        }
+    }
+
     private func reload() {
         rootEntries = CustomCertificateManager.shared.metadata(kind: .root)
         serverEntries = CustomCertificateManager.shared.metadata(kind: .server)
@@ -145,72 +181,155 @@ struct CustomCertificatesView: View {
         do {
             try CustomCertificateManager.shared.deleteAll(kind: selectedTab.kind)
             reload()
+            Task { await refreshDefaultRootCertificate() }
         } catch {
             errorMessage = error.localizedDescription
         }
     }
 
-    private func importCertificate(kind: CustomCertificateKind) {
+    private func importPEMOrDERCertificate(kind: CustomCertificateKind) {
         do {
-            guard let certificateURL = chooseFile(title: String(localized: "Choose Certificate PEM")),
-                  let privateKeyURL = chooseFile(title: String(localized: "Choose Private Key PEM")) else {
+            guard let certificateURL = chooseFile(
+                title: String(localized: "Choose Certificate PEM or DER"),
+                allowedContentTypes: CertificateImportFileType.certificateTypes
+            ),
+                let privateKeyURL = chooseFile(
+                    title: String(localized: "Choose Private Key PEM or DER"),
+                    allowedContentTypes: CertificateImportFileType.privateKeyTypes
+                ) else {
                 return
             }
-            let certificatePEM = try String(contentsOf: certificateURL, encoding: .utf8)
-            let privateKeyPEM = try String(contentsOf: privateKeyURL, encoding: .utf8)
-            let displayName = certificateURL.deletingPathExtension().lastPathComponent
-
-            switch kind {
-            case .root:
-                try CustomCertificateManager.shared.importRoot(
-                    displayName: displayName,
-                    certificatePEM: certificatePEM,
-                    privateKeyPEM: privateKeyPEM
-                )
-                selectedTab = .root
-            case .server:
-                guard let hostPattern = promptHostPattern(
-                    title: String(localized: "Server Certificate Host"),
-                    message: String(localized: "Enter the host or wildcard pattern this server certificate should match.")
-                ) else {
-                    return
-                }
-                try CustomCertificateManager.shared.importServerIdentity(
-                    hostPattern: hostPattern,
-                    displayName: displayName,
-                    certificatePEM: certificatePEM,
-                    privateKeyPEM: privateKeyPEM
-                )
-                selectedTab = .server
-            case .client:
-                guard let hostPattern = promptHostPattern(
-                    title: String(localized: "Client Certificate Host"),
-                    message: String(localized: "Enter the upstream host or wildcard pattern that should receive this client identity.")
-                ) else {
-                    return
-                }
-                try CustomCertificateManager.shared.importClientIdentity(
-                    hostPattern: hostPattern,
-                    displayName: displayName,
-                    certificatePEM: certificatePEM,
-                    privateKeyPEM: privateKeyPEM
-                )
-                selectedTab = .client
-            }
-            reload()
+            let identity = try CustomCertificateImportIdentity.fromCertificateAndPrivateKey(
+                certificateData: Data(contentsOf: certificateURL),
+                privateKeyData: Data(contentsOf: privateKeyURL),
+                displayName: certificateURL.deletingPathExtension().lastPathComponent
+            )
+            try importIdentity(identity, kind: kind)
         } catch {
             errorMessage = error.localizedDescription
         }
     }
 
-    private func chooseFile(title: String) -> URL? {
+    private func importPKCS12Certificate(kind: CustomCertificateKind) {
+        do {
+            guard let pkcs12URL = chooseFile(
+                title: String(localized: "Choose P12 Certificate"),
+                allowedContentTypes: CertificateImportFileType.pkcs12Types
+            ),
+                let passphrase = promptPKCS12Passphrase() else {
+                return
+            }
+            let identity = try CustomCertificateImportIdentity.fromPKCS12(
+                data: Data(contentsOf: pkcs12URL),
+                displayName: pkcs12URL.deletingPathExtension().lastPathComponent,
+                passphrase: passphrase
+            )
+            try importIdentity(identity, kind: kind)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    private func importIdentity(_ identity: CustomCertificateImportIdentity, kind: CustomCertificateKind) throws {
+        switch kind {
+        case .root:
+            try CustomCertificateManager.shared.importRoot(
+                displayName: identity.displayName,
+                certificatePEM: identity.certificatePEM,
+                privateKeyPEM: identity.privateKeyPEM
+            )
+            selectedTab = .root
+        case .server:
+            guard let hostPattern = promptHostPattern(
+                title: String(localized: "Server Certificate Host"),
+                message: String(localized: "Enter the host or wildcard pattern this server certificate should match.")
+            ) else {
+                return
+            }
+            try CustomCertificateManager.shared.importServerIdentity(
+                hostPattern: hostPattern,
+                displayName: identity.displayName,
+                certificatePEM: identity.certificatePEM,
+                privateKeyPEM: identity.privateKeyPEM
+            )
+            selectedTab = .server
+        case .client:
+            guard let hostPattern = promptHostPattern(
+                title: String(localized: "Client Certificate Host"),
+                message: String(localized: "Enter the upstream host or wildcard pattern that should receive this client identity.")
+            ) else {
+                return
+            }
+            try CustomCertificateManager.shared.importClientIdentity(
+                hostPattern: hostPattern,
+                displayName: identity.displayName,
+                certificatePEM: identity.certificatePEM,
+                privateKeyPEM: identity.privateKeyPEM
+            )
+            selectedTab = .client
+        }
+
+        reload()
+        Task { await refreshDefaultRootCertificate() }
+    }
+
+    private func refreshDefaultRootCertificate() async {
+        isLoadingDefaultRoot = true
+        defer { isLoadingDefaultRoot = false }
+
+        do {
+            try await CertificateManager.shared.ensureRootCA()
+            defaultRootSnapshot = await CertificateManager.shared.rootCAStatusSnapshot(performValidation: false)
+            let material = try await CertificateManager.shared.exportMaterial()
+            guard let certificate = material.certificate else {
+                defaultRootCertificate = nil
+                return
+            }
+            defaultRootCertificate = try CertificatePreviewItem(
+                certificate: certificate,
+                displayName: String(localized: "Rockxy Default Root Certificate"),
+                fingerprintSHA256: defaultRootSnapshot?.fingerprintSHA256
+            )
+        } catch {
+            defaultRootSnapshot = await CertificateManager.shared.rootCAStatusSnapshot(performValidation: false)
+            defaultRootCertificate = nil
+        }
+    }
+
+    private func previewCurrentCertificate() {
+        guard let item = currentPreviewItem else {
+            return
+        }
+
+        let panel = SFCertificatePanel.shared()
+        panel?.runModal(for: item.secTrust, showGroup: true)
+    }
+
+    private func chooseFile(title: String, allowedContentTypes: [UTType]) -> URL? {
         let panel = NSOpenPanel()
         panel.title = title
         panel.canChooseFiles = true
         panel.canChooseDirectories = false
         panel.allowsMultipleSelection = false
-        panel.allowedContentTypes = [.init(filenameExtension: "pem") ?? .data]
+        panel.allowedContentTypes = allowedContentTypes
         return panel.runModal() == .OK ? panel.url : nil
+    }
+
+    private func promptPKCS12Passphrase() -> String? {
+        let alert = NSAlert()
+        alert.messageText = String(localized: "P12 Password")
+        alert.informativeText = String(localized: "Enter the password for this P12 file. Leave it empty if the file has no password.")
+        alert.addButton(withTitle: String(localized: "Import"))
+        alert.addButton(withTitle: String(localized: "Cancel"))
+
+        let field = NSSecureTextField(frame: NSRect(x: 0, y: 0, width: 320, height: 24))
+        field.placeholderString = String(localized: "Password")
+        alert.accessoryView = field
+
+        guard alert.runModal() == .alertFirstButtonReturn else {
+            return nil
+        }
+        return field.stringValue
     }
 
     private func promptHostPattern(title: String, message: String) -> String? {
@@ -262,10 +381,25 @@ struct CustomCertificatesView: View {
     }
 }
 
+// MARK: - CertificateImportFileType
+
+private enum CertificateImportFileType {
+    static let certificateTypes = extensions(["pem", "der", "cer", "crt"])
+    static let privateKeyTypes = extensions(["pem", "key", "der"])
+    static let pkcs12Types = extensions(["p12", "pfx"])
+
+    private static func extensions(_ values: [String]) -> [UTType] {
+        values.map { UTType(filenameExtension: $0) ?? .data }
+    }
+}
+
 // MARK: - RootCertificateTab
 
 private struct RootCertificateTab: View {
     let entries: [CustomCertificateMetadata]
+    let defaultRootCertificate: CertificatePreviewItem?
+    let defaultRootSnapshot: RootCAStatusSnapshot?
+    let isLoadingDefaultRoot: Bool
 
     var body: some View {
         VStack(alignment: .leading, spacing: 18) {
@@ -282,18 +416,39 @@ private struct RootCertificateTab: View {
                     .foregroundStyle(.yellow)
                     .symbolRenderingMode(.hierarchical)
 
-                VStack(alignment: .leading, spacing: 6) {
-                    Text(entries.last?.displayName ?? String(localized: "Rockxy Default Root Certificate"))
-                        .font(.headline)
-                    if let entry = entries.last {
-                        Text(validityText(for: entry))
-                            .foregroundStyle(.secondary)
-                        Label(String(localized: "Custom Root Active"), systemImage: "checkmark.circle.fill")
-                            .foregroundStyle(.green)
-                    } else {
-                        Text(String(localized: "No custom root has been imported. Rockxy will use its default root CA."))
-                            .foregroundStyle(.secondary)
-                        Label(String(localized: "Default Root Active"), systemImage: "checkmark.circle.fill")
+                if isLoadingDefaultRoot, entries.isEmpty {
+                    ProgressView()
+                        .controlSize(.small)
+                    Text(String(localized: "Loading certificate details..."))
+                        .foregroundStyle(.secondary)
+                } else {
+                    VStack(alignment: .leading, spacing: 5) {
+                        Text(activeTitle)
+                            .font(.headline)
+
+                        if let certificate = activeCertificate {
+                            Text(validityLine(prefix: String(localized: "Not Valid Before:"), date: certificate.notValidBefore))
+                                .font(.callout)
+                                .foregroundStyle(.secondary)
+                            Text(validityLine(prefix: String(localized: "Not Valid After:"), date: certificate.notValidAfter))
+                                .font(.callout)
+                                .foregroundStyle(.secondary)
+                            if let fingerprint = certificate.fingerprintSHA256 {
+                                Text(String(localized: "SHA-256: \(fingerprint)"))
+                                    .font(.caption.monospaced())
+                                    .foregroundStyle(.secondary)
+                                    .lineLimit(1)
+                                    .truncationMode(.middle)
+                                    .textSelection(.enabled)
+                            }
+                        } else {
+                            Text(String(localized: "No generated root certificate details are available yet."))
+                                .font(.callout)
+                                .foregroundStyle(.secondary)
+                        }
+
+                        Label(statusText, systemImage: "checkmark.circle.fill")
+                            .font(.callout)
                             .foregroundStyle(.green)
                     }
                 }
@@ -301,8 +456,59 @@ private struct RootCertificateTab: View {
             }
             .padding(18)
             .background(.quaternary, in: RoundedRectangle(cornerRadius: 10, style: .continuous))
+
+            if let certificate = activeCertificate {
+                certificateSummary(certificate)
+            }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var activeCertificate: CertificatePreviewItem? {
+        if let entry = entries.last {
+            return try? CertificatePreviewItem(metadata: entry)
+        }
+        return defaultRootCertificate
+    }
+
+    private var activeTitle: String {
+        activeCertificate?.displayName ?? String(localized: "Rockxy Default Root Certificate")
+    }
+
+    private var statusText: String {
+        if !entries.isEmpty {
+            return String(localized: "Custom Root Active")
+        }
+        if defaultRootSnapshot?.isInstalledInKeychain == true,
+           defaultRootSnapshot?.isSystemTrustValidated == true
+        {
+            return String(localized: "Installed & Trusted")
+        }
+        return String(localized: "Default Root Active")
+    }
+
+    private func certificateSummary(_ certificate: CertificatePreviewItem) -> some View {
+        Grid(alignment: .leading, horizontalSpacing: 14, verticalSpacing: 5) {
+            if let commonName = certificate.commonName {
+                summaryRow(label: String(localized: "Common Name"), value: commonName)
+            }
+            summaryRow(label: String(localized: "Subject"), value: certificate.subjectSummary)
+            summaryRow(label: String(localized: "Issuer"), value: certificate.issuerSummary)
+        }
+        .font(.caption)
+        .padding(.horizontal, 6)
+    }
+
+    private func summaryRow(label: String, value: String) -> some View {
+        GridRow {
+            Text(label)
+                .foregroundStyle(.secondary)
+                .gridColumnAlignment(.trailing)
+            Text(value)
+                .foregroundStyle(.primary)
+                .lineLimit(2)
+                .textSelection(.enabled)
+        }
     }
 
     private var rootTitle: String {
@@ -313,10 +519,9 @@ private struct RootCertificateTab: View {
         }
     }
 
-    private func validityText(for entry: CustomCertificateMetadata) -> String {
-        let before = entry.notValidBefore?.formatted(date: .abbreviated, time: .shortened) ?? String(localized: "Unknown")
-        let after = entry.notValidAfter?.formatted(date: .abbreviated, time: .shortened) ?? String(localized: "Unknown")
-        return String(localized: "Valid from \(before) to \(after)")
+    private func validityLine(prefix: String, date: Date?) -> String {
+        let value = date?.formatted(date: .complete, time: .shortened) ?? String(localized: "Unknown")
+        return "\(prefix) \(value)"
     }
 }
 
@@ -352,6 +557,131 @@ private struct CertificateListTab: View {
                 }
             }
             .frame(minHeight: 280)
+        }
+    }
+}
+
+// MARK: - CertificatePreviewItem
+
+struct CertificatePreviewItem {
+    let displayName: String
+    let notValidBefore: Date?
+    let notValidAfter: Date?
+    let fingerprintSHA256: String?
+    let commonName: String?
+    let subjectSummary: String
+    let issuerSummary: String
+    let secCertificate: SecCertificate
+    let secTrust: SecTrust
+
+    init(metadata: CustomCertificateMetadata) throws {
+        try self.init(
+            certificate: Certificate(pemEncoded: metadata.certificatePEM),
+            displayName: metadata.displayName,
+            fingerprintSHA256: metadata.fingerprintSHA256
+        )
+    }
+
+    init(
+        certificate: Certificate,
+        displayName: String?,
+        fingerprintSHA256: String?
+    ) throws {
+        self.displayName = displayName ?? Self.commonName(from: certificate.subject) ?? String(localized: "Certificate")
+        notValidBefore = certificate.notValidBefore
+        notValidAfter = certificate.notValidAfter
+        self.fingerprintSHA256 = fingerprintSHA256 ?? Self.fingerprint(certificate)
+        commonName = Self.commonName(from: certificate.subject)
+        subjectSummary = Self.summary(from: certificate.subject)
+        issuerSummary = Self.summary(from: certificate.issuer)
+        secCertificate = try Self.secCertificate(from: certificate)
+        secTrust = try Self.secTrust(for: secCertificate)
+    }
+
+    private static func secCertificate(from certificate: Certificate) throws -> SecCertificate {
+        var serializer = DER.Serializer()
+        try certificate.serialize(into: &serializer)
+        let data = Data(serializer.serializedBytes)
+        guard let secCertificate = SecCertificateCreateWithData(nil, data as CFData) else {
+            throw CustomCertificatePreviewError.invalidCertificate
+        }
+        return secCertificate
+    }
+
+    private static func secTrust(for certificate: SecCertificate) throws -> SecTrust {
+        let policy = SecPolicyCreateBasicX509()
+        var trust: SecTrust?
+        let status = SecTrustCreateWithCertificates(certificate, policy, &trust)
+        guard status == errSecSuccess, let trust else {
+            throw CustomCertificatePreviewError.invalidCertificate
+        }
+        return trust
+    }
+
+    private static func fingerprint(_ certificate: Certificate) -> String? {
+        var serializer = DER.Serializer()
+        guard (try? certificate.serialize(into: &serializer)) != nil else {
+            return nil
+        }
+        return KeychainHelper.computeFingerprintSHA256(Data(serializer.serializedBytes))
+    }
+
+    private static func commonName(from name: DistinguishedName) -> String? {
+        for relativeDistinguishedName in name {
+            for attribute in relativeDistinguishedName where attribute.type == ASN1ObjectIdentifier.NameAttributes.commonName {
+                return String(describing: attribute.value)
+            }
+        }
+        return nil
+    }
+
+    private static func summary(from name: DistinguishedName) -> String {
+        let values = rows(from: name).map(\.value)
+        return values.isEmpty ? String(describing: name) : values.joined(separator: ", ")
+    }
+
+    private static func rows(from name: DistinguishedName) -> [CertificateNameRow] {
+        name.flatMap { relativeDistinguishedName in
+            relativeDistinguishedName.map { attribute in
+                CertificateNameRow(label: label(for: attribute.type), value: String(describing: attribute.value))
+            }
+        }
+    }
+
+    private static func label(for oid: ASN1ObjectIdentifier) -> String {
+        switch oid {
+        case ASN1ObjectIdentifier.NameAttributes.commonName:
+            String(localized: "Common Name")
+        case ASN1ObjectIdentifier.NameAttributes.countryName:
+            String(localized: "Country or Region")
+        case ASN1ObjectIdentifier.NameAttributes.localityName:
+            String(localized: "Locality")
+        case ASN1ObjectIdentifier.NameAttributes.organizationName:
+            String(localized: "Organization")
+        case ASN1ObjectIdentifier.NameAttributes.organizationalUnitName:
+            String(localized: "Organizational Unit")
+        case ASN1ObjectIdentifier.NameAttributes.stateOrProvinceName:
+            String(localized: "State/Province")
+        default:
+            String(describing: oid)
+        }
+    }
+}
+
+private struct CertificateNameRow: Identifiable {
+    let label: String
+    let value: String
+
+    var id: String { "\(label)-\(value)" }
+}
+
+private enum CustomCertificatePreviewError: LocalizedError {
+    case invalidCertificate
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidCertificate:
+            String(localized: "The certificate could not be converted for preview.")
         }
     }
 }

--- a/Rockxy/Views/Certificate/MacCertificateSetupGuideView.swift
+++ b/Rockxy/Views/Certificate/MacCertificateSetupGuideView.swift
@@ -1,12 +1,15 @@
+import AppKit
 import SwiftUI
 
 // MARK: - MacCertificateSetupGuideView
 
 struct MacCertificateSetupGuideView: View {
+    @Environment(\.openSettings) private var openSettings
     @State private var selectedTab = Tab.automatic
     @State private var snapshot: RootCAStatusSnapshot?
     @State private var isWorking = false
     @State private var errorMessage: String?
+    @State private var manualTrustCopyMessage: String?
 
     var body: some View {
         VStack(spacing: 0) {
@@ -20,7 +23,7 @@ struct MacCertificateSetupGuideView: View {
             .pickerStyle(.segmented)
             .labelsHidden()
             .frame(width: 360)
-            .padding(.top, 20)
+            .padding(.top, 14)
 
             Group {
                 switch selectedTab {
@@ -30,13 +33,13 @@ struct MacCertificateSetupGuideView: View {
                     manualTab
                 }
             }
-            .padding(.horizontal, 32)
-            .padding(.top, 18)
+            .padding(.horizontal, 28)
+            .padding(.top, 14)
 
-            Spacer(minLength: 18)
+            Spacer(minLength: 10)
             footer
         }
-        .frame(minWidth: 900, minHeight: 560)
+        .frame(minWidth: 820, minHeight: 500)
         .task { await refreshStatus(validate: true) }
         .alert(String(localized: "Certificate Setup Failed"), isPresented: Binding(
             get: { errorMessage != nil },
@@ -51,19 +54,19 @@ struct MacCertificateSetupGuideView: View {
     private var header: some View {
         HStack(spacing: 14) {
             Image(systemName: "laptopcomputer")
-                .font(.system(size: 40, weight: .regular))
+                .font(.system(size: 32, weight: .regular))
                 .symbolRenderingMode(.hierarchical)
                 .foregroundStyle(.secondary)
             Text(String(localized: "Mac Setup Guide"))
-                .font(.system(size: 34, weight: .regular))
+                .font(.system(size: 28, weight: .regular))
             Spacer()
         }
-        .padding(.horizontal, 32)
-        .padding(.vertical, 22)
+        .padding(.horizontal, 28)
+        .padding(.vertical, 16)
     }
 
     private var automaticTab: some View {
-        VStack(spacing: 18) {
+        VStack(spacing: 14) {
             statusCard
 
             HStack(spacing: 12) {
@@ -88,9 +91,9 @@ struct MacCertificateSetupGuideView: View {
 
     private var statusCard: some View {
         let state = CertificateSetupState(snapshot: snapshot ?? .empty)
-        return VStack(spacing: 12) {
+        return VStack(spacing: 10) {
             Image(systemName: state.systemImageName)
-                .font(.system(size: 34, weight: .semibold))
+                .font(.system(size: 30, weight: .semibold))
                 .foregroundStyle(state.isReady ? .green : .orange)
                 .symbolRenderingMode(.hierarchical)
 
@@ -117,7 +120,7 @@ struct MacCertificateSetupGuideView: View {
             .background(.quaternary, in: RoundedRectangle(cornerRadius: 8, style: .continuous))
         }
         .frame(maxWidth: .infinity)
-        .padding(28)
+        .padding(22)
         .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 10, style: .continuous))
         .overlay {
             RoundedRectangle(cornerRadius: 10, style: .continuous)
@@ -126,11 +129,11 @@ struct MacCertificateSetupGuideView: View {
     }
 
     private var manualTab: some View {
-        VStack(alignment: .leading, spacing: 22) {
+        VStack(alignment: .leading, spacing: 18) {
             guideSection(
                 number: 1,
                 title: String(localized: "Generate and Add Rockxy CA Certificate to System Keychain"),
-                symbol: "certificate",
+                symbol: "checkmark.shield.fill",
                 lines: [
                     String(localized: "Choose System or login keychain in Keychain Access."),
                     String(localized: "Use Install and Trust to generate the CA, or export the PEM file and drag it into Keychain Access.")
@@ -147,18 +150,10 @@ struct MacCertificateSetupGuideView: View {
                 ]
             )
 
-            guideSection(
-                number: 3,
-                title: String(localized: "Terminal Alternative"),
-                symbol: "terminal",
-                lines: [
-                    String(localized: "Export the PEM certificate, then use security add-trusted-cert with administrator approval."),
-                    String(localized: "Recheck the status above after changing trust settings.")
-                ]
-            )
+            terminalAlternativeSection
         }
         .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(24)
+        .padding(20)
         .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 10, style: .continuous))
         .overlay {
             RoundedRectangle(cornerRadius: 10, style: .continuous)
@@ -183,14 +178,76 @@ struct MacCertificateSetupGuideView: View {
                     .font(.callout)
                     .foregroundStyle(state.isReady ? .green : .secondary)
                     .lineLimit(1)
+
+                if state.isReady {
+                    Button(String(localized: "Manage Certificates")) {
+                        openGeneralSettings()
+                    }
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+                }
             }
 
             if let helpURL = URL(string: "https://github.com/RockxyApp/Rockxy/wiki") {
                 HelpLink(destination: helpURL)
             }
         }
-        .padding(.horizontal, 32)
-        .padding(.bottom, 22)
+        .padding(.horizontal, 28)
+        .padding(.bottom, 16)
+    }
+
+    private var terminalAlternativeSection: some View {
+        HStack(alignment: .top, spacing: 14) {
+            Image(systemName: "terminal")
+                .font(.system(size: 22, weight: .medium))
+                .frame(width: 28)
+                .foregroundStyle(.secondary)
+
+            VStack(alignment: .leading, spacing: 8) {
+                Text(String(localized: "3. Terminal Alternative"))
+                    .font(.headline)
+                Text(String(localized: "Open your favorite Terminal app."))
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+                Text(String(localized: "Copy and paste this command:"))
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+                commandSnippetBox(manualTrustCommand)
+                Text(
+                    String(
+                        localized: "Automatically trusts the Rockxy CA in your System keychain. Administrator approval is required."
+                    )
+                )
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                HStack(spacing: 8) {
+                    Button(String(localized: "Copy")) {
+                        copyManualTrustCommand()
+                    }
+                    .buttonStyle(.bordered)
+
+                    if let manualTrustCopyMessage {
+                        Text(manualTrustCopyMessage)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+        }
+    }
+
+    private func commandSnippetBox(_ command: String) -> some View {
+        ScrollView(.horizontal) {
+            Text(command)
+                .font(.system(size: 12, design: .monospaced))
+                .textSelection(.enabled)
+                .padding(10)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .frame(height: 58)
+        .frame(maxWidth: .infinity)
+        .background(Color(nsColor: .textBackgroundColor))
+        .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
     }
 
     private func guideSection(number: Int, title: String, symbol: String, lines: [String]) -> some View {
@@ -210,6 +267,34 @@ struct MacCertificateSetupGuideView: View {
                 }
             }
         }
+    }
+
+    private var manualTrustCommand: String {
+        [
+            "sudo security add-trusted-cert",
+            "-d",
+            "-r trustRoot",
+            "-k /Library/Keychains/System.keychain",
+            shellQuoted(CertificateStore.rootCACertificateURL.path)
+        ].joined(separator: " ")
+    }
+
+    private func shellQuoted(_ value: String) -> String {
+        let escaped = value
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+        return "\"\(escaped)\""
+    }
+
+    private func copyManualTrustCommand() {
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(manualTrustCommand, forType: .string)
+        manualTrustCopyMessage = String(localized: "Copied.")
+    }
+
+    private func openGeneralSettings() {
+        RockxySettingsTab.select(.general)
+        openSettings()
     }
 
     private func installAndTrust() async {

--- a/Rockxy/Views/Main/MainContentCoordinator.swift
+++ b/Rockxy/Views/Main/MainContentCoordinator.swift
@@ -389,6 +389,23 @@ final class MainContentCoordinator {
         }
     }
 
+    @discardableResult
+    func startProxyOnLaunchIfNeeded(
+        settings: AppSettings = AppSettingsStorage.load(),
+        startHandler: (() -> Void)? = nil
+    ) -> Bool {
+        guard settings.recordOnLaunch, !isProxyRunning, !isProxyStarting else {
+            return false
+        }
+
+        if let startHandler {
+            startHandler()
+        } else {
+            startProxy()
+        }
+        return true
+    }
+
     // MARK: Private
 
     nonisolated(unsafe) private var rulesObserver: NSObjectProtocol?

--- a/Rockxy/Views/Settings/SettingsView.swift
+++ b/Rockxy/Views/Settings/SettingsView.swift
@@ -3,51 +3,84 @@ import SwiftUI
 // Root settings window using macOS native tab-based layout.
 // Each tab is a self-contained settings pane with its own `@AppStorage` bindings.
 
+// MARK: - RockxySettingsTab
+
+enum RockxySettingsTab: String {
+    case general
+    case appearance
+    case privacy
+    case tools
+    case github
+    case plugins
+    case mcp
+    case advanced
+
+    // MARK: Internal
+
+    static let defaultsKey = RockxyIdentity.current.defaultsKey("selectedSettingsTab")
+
+    static func select(_ tab: RockxySettingsTab) {
+        UserDefaults.standard.set(tab.rawValue, forKey: defaultsKey)
+    }
+}
+
 // MARK: - SettingsView
 
 struct SettingsView: View {
     var body: some View {
-        TabView {
+        TabView(selection: $selectedTabID) {
             GeneralSettingsTab()
                 .tabItem {
                     Label(String(localized: "General"), systemImage: "gear")
                 }
+                .tag(RockxySettingsTab.general.rawValue)
 
             AppearanceSettingsTab()
                 .tabItem {
                     Label(String(localized: "Appearance"), systemImage: "sparkles")
                 }
+                .tag(RockxySettingsTab.appearance.rawValue)
 
             PrivacySettingsTab()
                 .tabItem {
                     Label(String(localized: "Privacy"), systemImage: "person.badge.shield.checkmark")
                 }
+                .tag(RockxySettingsTab.privacy.rawValue)
 
             ToolsSettingsTab()
                 .tabItem {
                     Label(String(localized: "Tools"), systemImage: "wrench.and.screwdriver")
                 }
+                .tag(RockxySettingsTab.tools.rawValue)
 
             GitHubSettingsTab()
                 .tabItem {
                     Label(String(localized: "GitHub"), systemImage: "link")
                 }
+                .tag(RockxySettingsTab.github.rawValue)
 
             PluginsSettingsTab()
                 .tabItem {
                     Label(String(localized: "Plugins"), systemImage: "puzzlepiece.extension")
                 }
+                .tag(RockxySettingsTab.plugins.rawValue)
 
             MCPSettingsTab()
                 .tabItem {
                     Label(String(localized: "MCP"), systemImage: "network")
                 }
+                .tag(RockxySettingsTab.mcp.rawValue)
 
             AdvancedSettingsTab()
                 .tabItem {
                     Label(String(localized: "Advanced"), systemImage: "ellipsis.circle")
                 }
+                .tag(RockxySettingsTab.advanced.rawValue)
         }
         .frame(width: 820, height: 600)
     }
+
+    // MARK: Private
+
+    @AppStorage(RockxySettingsTab.defaultsKey) private var selectedTabID = RockxySettingsTab.general.rawValue
 }

--- a/RockxyTests/Core/Certificate/CertificateSetupUXTests.swift
+++ b/RockxyTests/Core/Certificate/CertificateSetupUXTests.swift
@@ -32,6 +32,29 @@ struct CertificateSetupUXTests {
         #expect(router.route(for: .resetAll) == .resetAll)
     }
 
+    @Test("manage certificates targets the General settings tab")
+    func manageCertificatesSelectsGeneralSettings() {
+        UserDefaults.standard.removeObject(forKey: RockxySettingsTab.defaultsKey)
+        defer { UserDefaults.standard.removeObject(forKey: RockxySettingsTab.defaultsKey) }
+
+        RockxySettingsTab.select(.general)
+
+        #expect(UserDefaults.standard.string(forKey: RockxySettingsTab.defaultsKey) == RockxySettingsTab.general.rawValue)
+    }
+
+    @Test("manual trust command uses the public root CA PEM path")
+    func rootCAPublicPEMPath() {
+        let tempDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("rockxy-root-ca-url-\(UUID().uuidString)", isDirectory: true)
+        CertificateStore.storageDirectoryOverride = tempDirectory
+        defer { CertificateStore.storageDirectoryOverride = nil }
+
+        let url = CertificateStore.rootCACertificateURL
+
+        #expect(url.deletingLastPathComponent() == tempDirectory)
+        #expect(url.lastPathComponent == "rootCA.pem")
+    }
+
     @Test("export service builds PEM DER P12 and private key payloads")
     func exportPayloadSuccess() async throws {
         let root = try RootCAGenerator.generate()

--- a/RockxyTests/Core/Certificate/CustomCertificateManagerTests.swift
+++ b/RockxyTests/Core/Certificate/CustomCertificateManagerTests.swift
@@ -1,7 +1,7 @@
 import Crypto
 import Foundation
-import SwiftASN1
 @testable import Rockxy
+import SwiftASN1
 import Testing
 import X509
 
@@ -45,6 +45,41 @@ struct CustomCertificateManagerTests {
         let issuer = try #require(try manager.activeRootIssuer())
         #expect(issuer.certificate.subject == root.certificate.subject)
         #expect(issuer.privateKey.publicKey.subjectPublicKeyInfoBytes == root.certificate.publicKey.subjectPublicKeyInfoBytes)
+    }
+
+    @Test("normalizes DER certificate imports into PEM identity material")
+    func normalizesDERCertificateImports() throws {
+        let root = try RootCAGenerator.generate()
+        let certificateDER = try der(root.certificate)
+
+        let identity = try CustomCertificateImportIdentity.fromCertificateAndPrivateKey(
+            certificateData: certificateDER,
+            privateKeyData: Data(root.privateKey.pemRepresentation.utf8),
+            displayName: "DER Root"
+        )
+
+        let certificate = try Certificate(pemEncoded: identity.certificatePEM)
+        let privateKey = try Certificate.PrivateKey(pemEncoded: identity.privateKeyPEM)
+        #expect(identity.displayName == "DER Root")
+        #expect(certificate.subject == root.certificate.subject)
+        #expect(privateKey.publicKey.subjectPublicKeyInfoBytes == root.certificate.publicKey.subjectPublicKeyInfoBytes)
+    }
+
+    @Test("normalizes P12 imports into PEM identity material")
+    func normalizesPKCS12Imports() throws {
+        let data = try #require(Data(base64Encoded: Self.pkcs12FixtureBase64, options: .ignoreUnknownCharacters))
+
+        let identity = try CustomCertificateImportIdentity.fromPKCS12(
+            data: data,
+            displayName: "P12 Root",
+            passphrase: "rockxy"
+        )
+
+        let certificate = try Certificate(pemEncoded: identity.certificatePEM)
+        let privateKey = try Certificate.PrivateKey(pemEncoded: identity.privateKeyPEM)
+        #expect(identity.displayName == "P12 Root")
+        #expect(String(describing: certificate.subject).contains("Rockxy Test P12"))
+        #expect(privateKey.publicKey.subjectPublicKeyInfoBytes == certificate.publicKey.subjectPublicKeyInfoBytes)
     }
 
     @Test("matches exact and wildcard server certificate hosts")
@@ -130,4 +165,28 @@ struct CustomCertificateManagerTests {
         try certificate.serialize(into: &serializer)
         return PEMDocument(type: "CERTIFICATE", derBytes: serializer.serializedBytes).pemString
     }
+
+    private func der(_ certificate: Certificate) throws -> Data {
+        var serializer = DER.Serializer()
+        try certificate.serialize(into: &serializer)
+        return Data(serializer.serializedBytes)
+    }
+
+    private static let pkcs12FixtureBase64 = """
+    MIIEVAIBAzCCBAIGCSqGSIb3DQEHAaCCA/MEggPvMIID6zCCApoGCSqGSIb3DQEHBqCCAoswggKHAgEAMIICgAYJKoZIhvcNAQcB
+    MF8GCSqGSIb3DQEFDTBSMDEGCSqGSIb3DQEFDDAkBBAxNpLso9in7R8sCZHKAQ/xAgIIADAMBggqhkiG9w0CCQUAMB0GCWCGSAFl
+    AwQBKgQQtIhtwh53A4jQwcbZNZ/0OYCCAhC8RRu7BAQmpemAYSUHfARZl7twbOUeL6EPletqYeFjUeZWHl5QgNrL37lYG0PJMZ85
+    nivPXKtk2vduLcZN3yogsy8U5o7qbXH3dEFbclPBWkf6xGiVhmGWw2M6auOWvMDeoqLZORQBTQpuniDpNqZw0G3Htr8rQwHeHvOH
+    SFu/FqKi8VZMPaiRJ1KCrHSpQ4z/Qjver5Vs83lawuTZpXO3QYEJattVmvpy1ekEcGA/TH0+q6qnMWpdZXAAKFW6McmsBvMOiXZ3I
+    gcNmnrhsqGBmYRa3tozFmZw4JLrq12KaQMQBL0mwMDaezbIbIRFmYuuCdxtEtPHi6tIZTuOtP3GB26L3693YE1uyOv1cmPEHNTD+
+    3+TmgNDhpqf9+gGLLk5SD0D5lDGs9tYPonxGaKvWCL9vjr8ALfFYFN2bjXPmz87gKsxK8JVz1JxYRKqHfPyCn9rc71ClJbpyqfUa
+    W7eWT67tkf3EIEl5aTAxm4UC8iNMhJbp2LboZ3zlzDNUEGTLmhMj/lOgSpePYBi2A28sZOzh1Uyu7PwPd51+2mnElQpRMgDmkr54
+    rfvHWi/ZAA6/fiTaHl8ap4GFE0dXYoKFg75g54a7KhoENbCygMhBHGHC2SfdNeGyIqCvh//H7UrYN9uV+kDJkdYX6CAtvdmAAYDs
+    fzhS6w+X2geQ0a7tCPp1Wey/X6iwTIa/Q2Gxv4wggFJBgkqhkiG9w0BBwGgggE6BIIBNjCCATIwggEuBgsqhkiG9w0BDAoBAqCB
+    9zCB9DBfBgkqhkiG9w0BBQ0wUjAxBgkqhkiG9w0BBQwwJAQQBl3K6hD6S8KYv0PTRbAQSgICCAAwDAYIKoZIhvcNAgkFADAdBglg
+    hkgBZQMEASoEEBP5A+ukk/fjo0zTeE+6KGQEgZDMc5QbtzBFYUW+GBr7rsmOnFFetxPwgHKrhF4sA1+2yTS5Et7geiUS0bRjmD0K
+    918wZ2SnzLV+vvzv6HNJ0S4k8CW1C0lvdt8ZYcoqTkaqX8reOFS43JI/e1uDf+xe2ViAR88gj01iKaZ74pwhUufeYR9vo+SVCHP
+    FhO1DNJ8eH+6lFnGEq+F37180LrCYDEoxJTAjBgkqhkiG9w0BCRUxFgQU9+YayiugoLHt103H3Ff2GbmU5/wwSTAxMA0GCWCGSAFl
+    AwQCAQUABCCJFNm8nMsKzM5csV9O+pPY5WIF5jdz97gF+KzNWYDYPAQQqJeQHo2mDjCsjalH8p7WxwICCAA=
+    """
 }

--- a/RockxyTests/Views/Main/CoordinatorStartupTests.swift
+++ b/RockxyTests/Views/Main/CoordinatorStartupTests.swift
@@ -91,4 +91,58 @@ struct CoordinatorStartupTests {
         await RuleEngine.shared.replaceAll(engineSnapshot)
         await RuleTestLock.shared.release()
     }
+
+    @Test("startProxyOnLaunchIfNeeded starts when recordOnLaunch is enabled")
+    func startProxyOnLaunchIfNeededStartsWhenEnabled() {
+        let coordinator = MainContentCoordinator()
+        var settings = AppSettings()
+        settings.recordOnLaunch = true
+        var startCount = 0
+
+        let didStart = coordinator.startProxyOnLaunchIfNeeded(settings: settings) {
+            startCount += 1
+        }
+
+        #expect(didStart)
+        #expect(startCount == 1)
+    }
+
+    @Test("startProxyOnLaunchIfNeeded skips when recordOnLaunch is disabled")
+    func startProxyOnLaunchIfNeededSkipsWhenDisabled() {
+        let coordinator = MainContentCoordinator()
+        var settings = AppSettings()
+        settings.recordOnLaunch = false
+        var startCount = 0
+
+        let didStart = coordinator.startProxyOnLaunchIfNeeded(settings: settings) {
+            startCount += 1
+        }
+
+        #expect(!didStart)
+        #expect(startCount == 0)
+    }
+
+    @Test("startProxyOnLaunchIfNeeded skips while proxy is already running or starting")
+    func startProxyOnLaunchIfNeededSkipsWhenProxyActive() {
+        var settings = AppSettings()
+        settings.recordOnLaunch = true
+
+        let runningCoordinator = MainContentCoordinator()
+        runningCoordinator.isProxyRunning = true
+        var runningStartCount = 0
+        let didStartRunning = runningCoordinator.startProxyOnLaunchIfNeeded(settings: settings) {
+            runningStartCount += 1
+        }
+        #expect(!didStartRunning)
+        #expect(runningStartCount == 0)
+
+        let startingCoordinator = MainContentCoordinator()
+        startingCoordinator.isProxyStarting = true
+        var startingStartCount = 0
+        let didStartStarting = startingCoordinator.startProxyOnLaunchIfNeeded(settings: settings) {
+            startingStartCount += 1
+        }
+        #expect(!didStartStarting)
+        #expect(startingStartCount == 0)
+    }
 }

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -68,6 +68,7 @@
         "pages": [
           "features/diff",
           "features/scripting",
+          "features/custom-certificates",
           "features/upstream-proxy",
           "features/mcp"
         ]

--- a/docs/features/custom-certificates.mdx
+++ b/docs/features/custom-certificates.mdx
@@ -1,0 +1,265 @@
+---
+title: "Custom Certificates"
+description: "Override Rockxy's root CA, defeat server-side certificate pinning, and supply client certificates for mutual TLS — all from one Custom Certificates window."
+---
+
+# Custom Certificates
+
+Rockxy can substitute its built-in TLS material with certificates you supply. There are three independent slots, each solving a different problem:
+
+| Kind | What it overrides | Used when |
+|---|---|---|
+| **Root** | Rockxy's auto-generated root CA | You want every per-host MITM certificate Rockxy mints to be signed by **your** root (for example a corporate root already trusted across your fleet). |
+| **Server** | The leaf certificate Rockxy presents *to clients* during the handshake | A target app pins a specific server certificate (cert pinning / SPKI pinning) and refuses Rockxy's auto-generated leaf. Supplying the exact cert the app pins lets the connection succeed. |
+| **Client** | The client identity Rockxy presents *to upstream servers* | The upstream endpoint requires **mutual TLS** — the server only accepts requests carrying a specific client certificate. |
+
+All three kinds live in the same window and share the same import flow, but they act at different stages of the TLS handshake.
+
+<Frame caption="Custom Certificates window with the segmented Root / Server / Client picker">
+  <img src="/images/features/CertManagement.png" alt="Custom Certificates window" />
+</Frame>
+
+## Entry Points
+
+| Action | How to Access |
+|--------|---------------|
+| Open Custom Certificates window | **Certificate → Add Custom Certificates…** in the menu bar |
+| Switch between kinds | Segmented picker at the top of the window: **Root Certificate / Server Certificates / Client Certificates** |
+| Import a root certificate | **Root Certificate** tab → **Import ▾ → Import P12…** |
+| Import a server / client certificate | **Server Certificates** or **Client Certificates** tab → **Import ▾ → Import PEM / DER…** or **Import P12…** |
+| Remove a custom root and fall back to Rockxy's default | **Revert** button (visible only on the Root tab) |
+| Remove all custom server / client certificates of the current kind | **Delete** button |
+
+The Custom Certificates window is its own scene (`customCertificates`), so you can keep it open beside the main capture window.
+
+## Custom Root Certificate
+
+By default Rockxy generates its own root CA on first launch, stores the private key in Keychain, and uses it to sign every per-host MITM certificate. Importing a custom root tells Rockxy to use **your** key pair instead for that signing step.
+
+Common reasons to do this:
+
+- **Corporate root already trusted** — your IT team has pushed a custom root CA into every employee's keychain via MDM. Reuse it so users don't have to trust an additional Rockxy CA.
+- **Shared root across machines** — multiple developers share the same MITM root so a captured session opens cleanly on any teammate's Rockxy install.
+- **Long-lived root for CI machines** — install one root with a long validity period instead of regenerating per machine.
+
+### Behavior
+
+- When a custom root is active, the Root tab shows **Custom Root Active** and lists the import date, validity window, and SHA-256 fingerprint of the imported cert.
+- Rockxy uses the most recently imported root. Importing again replaces the previous one.
+- **Revert** removes the custom root and reactivates Rockxy's default root.
+- After importing a custom root, you still need to make sure that root is trusted on every device that will route traffic through Rockxy — Rockxy does **not** push the custom root into the macOS keychain trust store for you.
+
+<Note>
+Generating a root that complies with Apple's TLS server policy is only required if you want devices to **trust** the root for HTTPS interception. The custom root identity you import here must be a PKCS#12 file (`.p12` / `.pfx`) containing both the X.509 root CA certificate and its matching private key — Rockxy uses that key to sign downstream leaf certs.
+</Note>
+
+## Custom Server Certificates
+
+If a target app validates the server certificate against a hard-coded fingerprint or public-key hash (cert pinning), Rockxy's auto-generated MITM leaf will be rejected and the TLS handshake will fail. The fix is to supply the **exact** certificate the app pins, and have Rockxy present that certificate during the client-facing half of the MITM handshake.
+
+### When this works
+
+- You have access to the real server's certificate **and** its matching private key (for example, your own backend).
+- You want Rockxy to behave as that exact server for traffic to a specific host.
+
+### When this does **not** work
+
+- The certificate is pinned to a third-party service you don't control — you won't have the upstream private key, and no amount of certificate import can defeat that pinning.
+- The app uses **SPKI pinning** against the upstream public key and rotates leaf certificates frequently — pinning is by design resistant to MITM.
+
+### Import flow
+
+1. Switch to the **Server Certificates** tab.
+2. Click **Import → Import PEM / DER…** to pick separate certificate and key files, or **Import → Import P12…** to pick a bundled identity.
+3. For PEM / DER import, pick the certificate file, then pick the private key file (Rockxy prompts for them in two separate file pickers). For P12 import, pick the `.p12` / `.pfx` file and enter its password.
+4. Enter the **host pattern** this certificate should apply to (see [Host Patterns](#host-patterns) below).
+5. Rockxy validates the cert/key pair, persists the metadata, and stores the private key in Keychain.
+
+Each subsequent TLS handshake to a matching host is served using the imported leaf — bypassing Rockxy's per-host generator entirely.
+
+## Custom Client Certificates
+
+For endpoints that require **mutual TLS (mTLS)**, the upstream server demands that the client present a certificate during the handshake. Supply that client identity here, scoped to the upstream host pattern that requires it.
+
+### Import flow
+
+Identical to server certificates: import either separate PEM / DER cert + key files or a bundled P12 identity, then enter the host pattern. The difference is **who** the certificate is presented to:
+
+| Kind | Presented during | To |
+|---|---|---|
+| Server | Rockxy → client half of the MITM | The app being debugged |
+| Client | Rockxy → upstream half of the MITM | The real upstream server |
+
+A single mTLS workflow often pairs a client certificate (so Rockxy can talk to the upstream) with a server certificate (so the pinned client app accepts Rockxy's reply).
+
+## File Format
+
+Rockxy accepts both bundled identities and separate certificate/key files:
+
+- **Root Certificate** imports use a PKCS#12 file (`.p12` / `.pfx`) containing the root certificate and matching private key.
+- **Server Certificates** and **Client Certificates** can use either a PKCS#12 file (`.p12` / `.pfx`) or separate files.
+- Separate certificate files can be PEM (`-----BEGIN CERTIFICATE-----`) or DER (`.cer`, `.crt`, `.der`).
+- Separate private key files can be PEM (`-----BEGIN PRIVATE KEY-----`, `-----BEGIN RSA PRIVATE KEY-----`, or `-----BEGIN EC PRIVATE KEY-----`) or DER.
+
+If your material is in a different format, these OpenSSL commands are useful:
+
+```bash
+# PEM cert + PEM key → PKCS#12 (.p12 / .pfx)
+openssl pkcs12 -export -in cert.pem -inkey key.pem -out identity.p12
+
+# PKCS#12 (.p12 / .pfx) → separate PEM cert + PEM key
+openssl pkcs12 -in identity.p12 -clcerts -nokeys -out cert.pem
+openssl pkcs12 -in identity.p12 -nocerts -nodes -out key.pem
+
+# DER (.cer / .der) → PEM
+openssl x509 -inform der -in cert.der -out cert.pem
+```
+
+Rockxy validates the imported pair on import:
+
+- The certificate and the private key must form a matching identity (Rockxy compares the SubjectPublicKeyInfo bytes). Mismatched files raise **"The certificate and private key do not belong to the same identity."**
+- For server and client kinds, the pair is additionally loaded through SwiftNIO's `TLSConfiguration` to confirm it forms a valid server identity at the protocol layer.
+
+## Host Patterns
+
+Server and client certificates apply only to hosts that match the pattern you entered. Custom certificate matching uses a restricted form — **simpler than rule wildcards elsewhere in Rockxy**:
+
+| Pattern | Matches | Does NOT match |
+|---|---|---|
+| `api.example.com` | Exactly `api.example.com` | `example.com`, `api.example.com:8443`, `staging.api.example.com` |
+| `*.example.com` | Any direct or nested subdomain (`api.example.com`, `a.b.example.com`) | The bare root `example.com` |
+
+Rules of thumb:
+
+- Comparison is case-insensitive (`API.Example.COM` matches `api.example.com`).
+- Only a leading `*.` wildcard is recognized — embedded wildcards and regex are **not** supported in this window.
+- When multiple patterns of the same kind would match, the **most recently imported** one wins. Older matching entries are evicted when you re-import the same pattern.
+
+## Storage and Security
+
+| What | Where |
+|---|---|
+| Certificate metadata (display name, host pattern, validity window, fingerprint) | `<Rockxy app support>/Certificates/custom-certificates.json` |
+| Private key material | macOS Keychain, one item per import (account name `custom-certificate.<kind>.<uuid>`) |
+
+The private key never lives in the JSON file. Deleting an entry from the UI removes both the JSON record and the matching Keychain item. **Reset all Rockxy Certificates** (Certificate menu) also wipes custom certificate records along with Rockxy's generated root CA.
+
+<Warning>
+Private keys you import here have the same blast radius as Rockxy's own root: anything holding the key can impersonate the matching identity. Treat exports of cert + key the same way you treat any other TLS private key — store them encrypted, scope filesystem permissions tightly, and rotate if you suspect exposure.
+</Warning>
+
+## How to Generate Self-Signed Certificates (Apple-Compliant)
+
+Apple has tightened its TLS server certificate policy several times. As of macOS 10.15 / iOS 13 a self-signed leaf must satisfy a specific list of requirements or the system rejects it during validation — even if the issuing root is trusted. Use the recipe below when you need a custom server certificate that real macOS/iOS clients will accept (for example, a self-signed server identity you want to pin against).
+
+The full policy is published by Apple at [Requirements for trusted certificates in iOS 13 and macOS 10.15](https://support.apple.com/en-us/HT210176). Key constraints:
+
+- **Key**: RSA ≥ 2048 bits, or ECC curve P-256 / P-384.
+- **Signature**: SHA-256 or stronger (no SHA-1).
+- **Validity**: ≤ 825 days from `notBefore` to `notAfter`.
+- **Extended Key Usage**: must include `id-kp-serverAuth` (`1.3.6.1.5.5.7.3.1`).
+- **Subject Alternative Name**: required. The DNS SAN must list every hostname the cert will serve — the legacy Common Name fallback no longer works.
+
+### 1. Create a self-signed root CA
+
+```bash
+# Root CA private key (P-256 ECC, modern + fast)
+openssl ecparam -name prime256v1 -genkey -noout -out rockxy-root.key
+
+# Root CA certificate, valid 10 years
+openssl req -x509 -new -nodes \
+  -key rockxy-root.key \
+  -sha256 \
+  -days 3650 \
+  -out rockxy-root.pem \
+  -subj "/CN=Rockxy Custom Root CA/O=Your Org"
+```
+
+### 2. Create the leaf certificate
+
+Write an OpenSSL extensions file (`leaf.ext`) describing the SANs and required extensions:
+
+```ini
+authorityKeyIdentifier = keyid,issuer
+basicConstraints       = CA:FALSE
+keyUsage               = digitalSignature, keyEncipherment
+extendedKeyUsage       = serverAuth
+subjectAltName         = @alt_names
+
+[alt_names]
+DNS.1 = api.example.com
+DNS.2 = *.example.com
+```
+
+Generate the leaf key, a CSR, and sign it with the root:
+
+```bash
+# Leaf key
+openssl ecparam -name prime256v1 -genkey -noout -out leaf.key
+
+# CSR (CN can be anything — SAN is what's validated)
+openssl req -new \
+  -key leaf.key \
+  -out leaf.csr \
+  -subj "/CN=api.example.com/O=Your Org"
+
+# Sign with root, applying the extensions file. 825 days = Apple's max.
+openssl x509 -req \
+  -in leaf.csr \
+  -CA rockxy-root.pem \
+  -CAkey rockxy-root.key \
+  -CAcreateserial \
+  -out leaf.pem \
+  -days 825 \
+  -sha256 \
+  -extfile leaf.ext
+```
+
+### 3. Import into Rockxy
+
+- Open **Certificate → Add Custom Certificates…**
+- Choose the **Server Certificates** tab → **Import → Import PEM / DER…**
+- Pick `leaf.pem` when prompted for the certificate, then `leaf.key` for the private key.
+- Enter the host pattern (e.g. `api.example.com` or `*.example.com`) and confirm.
+
+### 4. Trust the root on the device
+
+For real iOS/macOS clients to accept the leaf, the **root** (`rockxy-root.pem`) must be installed and trusted on the device — exactly like Rockxy's default root. See [HTTPS Interception](/features/https-interception) and the platform-specific setup guides under **Setup Guides → Device Debugging**.
+
+<Tip>
+Verify the leaf passes Apple's policy locally before pushing to a device:
+
+```bash
+openssl x509 -in leaf.pem -noout -text | \
+  grep -E "Signature Algorithm|Public Key|DNS:|Extended Key Usage|Not Before|Not After"
+```
+
+Confirm you see `sha256WithRSAEncryption` (or ECDSA-SHA256), at least one `DNS:` SAN, `TLS Web Server Authentication`, and a validity window ≤ 825 days.
+</Tip>
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| "The certificate and private key do not belong to the same identity." | The certificate and key are from different identities. | Re-export the matching pair, or import a `.p12` / `.pfx` bundle that contains both. |
+| "The private key for this certificate could not be found in Keychain." | The Keychain item was deleted out-of-band (manual cleanup, machine migration, etc.) but the JSON metadata still references it. | Delete the orphan entry from the Custom Certificates window and re-import. |
+| Server cert imports but TLS still fails on the device | The pinned app validates more than just the leaf — for example SPKI pinning against the **upstream** public key. | Custom server certs can't defeat upstream SPKI pinning. The app must be repackaged or its pinning disabled. |
+| Custom root active but devices show "not trusted" | The custom root was imported into Rockxy but not into the device's trust store. | Install and trust the root on every device routing through Rockxy — see [HTTPS Interception](/features/https-interception). |
+| mTLS handshake to upstream fails after importing a client cert | The host pattern doesn't match the actual upstream hostname (case, port suffix, or subdomain mismatch). | Re-check the [Host Patterns](#host-patterns) rules. Patterns ignore ports and only match `*.` as a subdomain wildcard. |
+
+## Next Steps
+
+<CardGroup cols={2}>
+  <Card title="HTTPS Interception" icon="lock" href="/features/https-interception">
+    The default MITM flow that custom certificates extend.
+  </Card>
+  <Card title="Upstream Proxy" icon="arrow-right-arrow-left" href="/features/upstream-proxy">
+    Combine custom client certs with an upstream proxy for complex test setups.
+  </Card>
+  <Card title="Device Setup Guides" icon="mobile" href="/setup-guides/device-debugging">
+    Install and trust the root CA on iOS, Android, and other clients.
+  </Card>
+  <Card title="Certificates & Trust" icon="shield" href="/getting-started/certificates-and-trust">
+    First-time setup for Rockxy's default root CA.
+  </Card>
+</CardGroup>

--- a/docs/features/developer-setup-hub.mdx
+++ b/docs/features/developer-setup-hub.mdx
@@ -5,7 +5,11 @@ description: "A single place in Rockxy for runtime snippets, device guides, and 
 
 # Developer Setup Hub
 
-The Developer Setup Hub is a dedicated window that collects everything you need to point a specific runtime, client, device, or framework at Rockxy's local proxy. Open it from the Rockxy menu or the main window toolbar.
+The Developer Setup Hub is a dedicated window that collects everything you need to point a specific runtime, client, device, or framework at Rockxy's local proxy. Open it from **Tools → Debug My App…** in the menu bar. The hub itself lives in its own window (`developerSetupHub`); the automatic and manual setup flows open in two separate companion windows (`automaticSetup`, `manualSetup`) so you can run setup in parallel with active debugging.
+
+<Frame caption="Developer Setup Hub window with source list, detail tabs, and status inspector">
+  <img src="/images/features/DemoDevHub.png" alt="Developer Setup Hub" />
+</Frame>
 
 Layout:
 
@@ -78,21 +82,14 @@ If the preflight sees a problem (proxy stopped, recording paused, certificate no
 
 Validate does not depend on public DNS or a third-party endpoint. If local validation succeeds but your real API call fails, treat that as a separate upstream, network, or application issue after the Rockxy proxy/capture path is known-good.
 
-## Rockxy Pro automation
+## Automatic vs manual setup
 
-Developer Setup Hub is available to all users. Rockxy Pro currently adds one paid automation workflow inside this surface:
+Each target's automation surface is driven by its `SetupAutomationSupport` value in the catalog:
 
-- **React Native Android Setup** for supported Android targets
+- **Automatic Setup** — available for runtime/terminal targets (Python, Node.js, Ruby, Go, Rust, cURL, Java). The Automatic Setup window shows the workflow plan, lets you preview the exact commands in `DeveloperSetupAutomationSheet`, and runs the local probe once you apply.
+- **Manual Setup** — used for every target where Rockxy ships snippets but does not drive the target tool itself (Firefox, Postman, Insomnia, Paw, Docker, ElectronJS, Next.js, Flutter, React Native), and for every guide-only target (devices, simulators, emulators).
 
-That Pro workflow can:
-
-- inspect target readiness
-- show a dry-run plan before changes are applied
-- help apply Android proxy changes
-- optionally apply Metro reverse port forwarding
-- keep a **Manual Setup** fallback visible inside the same flow
-
-If Pro is not active, the manual setup content remains available and Rockxy shows an upgrade prompt at the automation entry point instead of hiding the feature completely.
+The hub never silently bypasses the manual path. Even targets that expose Automatic Setup keep the Manual Setup window reachable from the same inspector.
 
 ### Guide only — concrete manual steps, no in-app snippet generator
 
@@ -129,6 +126,4 @@ The filter at the top of the source list matches on target name, category name, 
 - Guide-only pages carry concrete prerequisites and limitations rather than "coming soon" copy.
 - Every target's Overview tab states exactly what Rockxy does today for that target and what is still manual.
 
-If you run into a target where the copy does not match reality, the catalog lives at `Rockxy/Models/UI/DeveloperSetupCatalog.swift`, the workflow + snippet generators at `Rockxy/Models/UI/DeveloperSetupWorkflow.swift`, and the remaining device/framework guide tips at `Rockxy/Models/UI/DeveloperSetupGuideCatalog.swift`.
-
-For licensing, activation, and upgrade details, see [License Management](/features/license-management).
+If you run into a target where the copy does not match reality, the catalog lives at `Rockxy/Models/UI/DeveloperSetupCatalog.swift`, the workflow + snippet generators at `Rockxy/Models/UI/DeveloperSetupWorkflow.swift`, and the remaining device/framework guide tips at `Rockxy/Models/UI/DeveloperSetupGuideCatalog.swift`. `SetupSupportStatus` (`availableNow` / `guideOnly` / `notYetSupported`) is the source of truth for what each target actually ships.

--- a/docs/features/diff.mdx
+++ b/docs/features/diff.mdx
@@ -12,6 +12,10 @@ Rockxy ships two diff experiences:
 - **Basic Compare** is available in Community and is documented on this page.
 - **Advanced Diff** is available in Rockxy Pro and opens automatically when Pro is active.
 
+<Frame caption="Diff workspace comparing two captured transactions side by side">
+  <img src="/images/features/DemoDiff.png" alt="Request diff workspace" />
+</Frame>
+
 ## Entry Points
 
 | Action | How to Access |

--- a/docs/features/error-analysis.mdx
+++ b/docs/features/error-analysis.mdx
@@ -11,11 +11,6 @@ description: Automatic error detection, pattern grouping, and cross-source corre
 
 The planned Error Analysis surface would detect errors from network traffic and application logs, group them by pattern, and correlate errors across sources. Today, Rockxy exposes the underlying traffic, logs, timing, and filters, but not this grouped analysis workflow.
 
-<Frame caption="The Error Analysis view showing grouped error patterns with occurrence counts.">
-  <img className="block dark:hidden" src="/images/error-analysis.png" alt="Rockxy error analysis view" />
-  <img className="hidden dark:block" src="/images/error-analysis-dark.png" alt="Rockxy error analysis view (dark mode)" />
-</Frame>
-
 ## Current Status
 
 There is no dedicated Errors tab in the current main window. Today, error-oriented debugging happens through the request list status codes, the inspector, the Logs tab, and filtering. The sections below describe the intended design direction, not an available production workflow.

--- a/docs/features/graphql.mdx
+++ b/docs/features/graphql.mdx
@@ -5,11 +5,6 @@ description: "Automatic detection and inspection of GraphQL operations sent as H
 
 Rockxy detects GraphQL-over-HTTP requests and provides a dedicated inspector tab that parses operations into their query text, variables, and response data — so you do not need to dig through raw JSON bodies manually.
 
-<Frame caption="GraphQL inspector showing a detected query with operation name, query text, and variables">
-  <img className="block dark:hidden" src="/images/graphql.png" alt="GraphQL inspector view" />
-  <img className="hidden dark:block" src="/images/graphql-dark.png" alt="GraphQL inspector view (dark mode)" />
-</Frame>
-
 ## Automatic Detection
 
 Rockxy's `GraphQLDetector` identifies GraphQL requests by checking two conditions:
@@ -35,8 +30,13 @@ If your API uses a non-standard endpoint path and does not include `graphql` in 
 |------|-------------|---------|
 | **Query** | Read-only data fetch. The most common GraphQL operation. | `query GetUser { user(id: 1) { name } }` |
 | **Mutation** | Write operation that modifies server-side data. | `mutation CreatePost { createPost(title: "...") { id } }` |
+| **Subscription** | Long-lived operation that streams updates. Classified by keyword when carried over HTTP POST. | `subscription OnMessageAdded { messageAdded { id } }` |
 
 Rockxy parses the operation keyword from the query text to classify each request. If no keyword is present, the operation defaults to `query` per the GraphQL specification.
+
+<Note>
+Subscription transport over WebSocket (`graphql-ws`, `subscriptions-transport-ws`) is not detected — only POST-bodied operations whose keyword reads `subscription` are classified here.
+</Note>
 
 ## Entry Points
 
@@ -45,11 +45,6 @@ The GraphQL tab activates automatically in the request inspector when a matching
 ## GraphQL Inspector
 
 The **GraphQL** tab in the request inspector breaks down each operation into structured sections:
-
-<Frame caption="GraphQL tab showing operation details with syntax-highlighted query and variable tree">
-  <img className="block dark:hidden" src="/images/graphql-inspector.png" alt="GraphQL inspector detail" />
-  <img className="hidden dark:block" src="/images/graphql-inspector-dark.png" alt="GraphQL inspector detail (dark mode)" />
-</Frame>
 
 ### Operation Name
 

--- a/docs/features/https-interception.mdx
+++ b/docs/features/https-interception.mdx
@@ -6,8 +6,7 @@ description: "Man-in-the-middle proxy for inspecting encrypted HTTPS traffic wit
 Rockxy decrypts HTTPS traffic by acting as a man-in-the-middle proxy. It generates a local root Certificate Authority, creates per-host certificates on the fly, and presents them to clients so you can inspect encrypted requests and responses in plain text.
 
 <Frame caption="HTTPS request with decrypted headers and body visible in the inspector">
-  <img className="block dark:hidden" src="/images/https-interception.png" alt="HTTPS interception showing decrypted traffic" />
-  <img className="hidden dark:block" src="/images/https-interception-dark.png" alt="HTTPS interception showing decrypted traffic (dark mode)" />
+  <img src="/images/features/DemoSSLProxy.png" alt="HTTPS interception showing decrypted traffic" />
 </Frame>
 
 ## How It Works
@@ -62,7 +61,7 @@ Rockxy generates its root CA using the swift-certificates library:
 - **Key type** — P-256 (ECDSA)
 - **Validity** — 2 years from generation date
 - **Storage** — private key stored in the macOS Keychain via `SecKeychain`
-- **Subject** — "Rockxy CA" with a unique serial number per installation
+- **Subject** — common name `Rockxy Root CA`, with a unique serial number per installation
 
 The root CA is generated once and reused across sessions. If you delete it from the Keychain, Rockxy will generate a new one on next launch.
 
@@ -76,20 +75,16 @@ When Rockxy encounters an HTTPS request to a new hostname, it generates a certif
 
 - **Signed by** — your local Rockxy root CA
 - **Subject Alternative Name** — matches the requested hostname
-- **Cache** — LRU cache holding approximately 1,000 certificates in memory
-- **Generation time** — typically under 5 ms per certificate
+- **Validity** — 1 year from generation
+- **Cache** — LRU cache holding up to 1,000 host certificates in memory
 
 Cached certificates are reused for subsequent requests to the same host. When the cache reaches capacity, the least recently used certificates are evicted and regenerated on demand.
 
 ## Certificate Inspector
 
-For any HTTPS request, the **Certs** tab in the request inspector displays the full certificate chain from the remote server:
+Open **Certificate** from the menu bar to see the root CA panel, install/trust status, and links to the SSL Proxying list and the Mac Setup Guide. The **Settings > General** root CA panel surfaces the same status alongside the Welcome flow and advanced diagnostics.
 
-- **Leaf certificate** — the server's own certificate with subject, issuer, validity dates, and SANs
-- **Intermediate certificates** — any intermediate CAs in the chain
-- **Root certificate** — the root CA that anchors the chain
-
-This shows the *real* server certificate chain, not the Rockxy-generated one, so you can verify the server's actual TLS configuration.
+When you need to inspect a remote server's actual TLS chain (leaf, intermediates, root), use Keychain Access or a command-line tool such as `openssl s_client -connect host:443 -showcerts` — Rockxy does not expose a per-transaction certificate-chain tab today.
 
 ## SSL Proxying List
 
@@ -121,7 +116,7 @@ Trusting the Rockxy root CA means any certificate signed by it will be accepted 
 To remove the root CA and disable HTTPS interception:
 
 1. Open **Keychain Access**
-2. Search for "Rockxy CA"
+2. Search for "Rockxy Root CA"
 3. Right-click and select **Delete**
 4. Restart any apps that cached the TLS session
 
@@ -131,7 +126,7 @@ To remove the root CA and disable HTTPS interception:
 
 **Symptom:** Browsers show "Your connection is not private" or apps fail with TLS errors.
 
-**Fix:** Open Keychain Access, find "Rockxy CA", and verify the trust setting is "Always Trust". If missing, reinstall via `Certificate → Install on This Mac...`.
+**Fix:** Open Keychain Access, find "Rockxy Root CA", and verify the trust setting is "Always Trust". If missing, reinstall via `Certificate → Install on This Mac...`.
 
 ### App uses certificate pinning
 
@@ -143,7 +138,7 @@ To remove the root CA and disable HTTPS interception:
 
 **Symptom:** Rockxy fails to start with a "port already in use" error.
 
-**Fix:** Another process is using port 9090. Check with `lsof -i :9090` and either stop the conflicting process or change Rockxy's port in Settings.
+**Fix:** Another process is using the configured proxy port (default `9090`). Check with `lsof -i :9090` and either stop the conflicting process or change Rockxy's port in **Settings > General**.
 
 ### Stale TLS sessions
 

--- a/docs/features/license-management.mdx
+++ b/docs/features/license-management.mdx
@@ -1,146 +1,103 @@
 ---
 title: "License Management"
-description: "Understand Rockxy Pro's perpetual license, updates window, activation states, and how to activate, deactivate, restore, or transfer a license on macOS."
+description: "Planned license model for Rockxy Pro. The current open-source build does not ship a License settings tab or any activation, restore, or transfer UI."
 ---
 
 # License Management
 
-This page explains how Rockxy Pro licensing works from an end-user perspective: what a perpetual license means, how long updates last, what the app's license states mean, and how to activate, restore, deactivate, or move your license to another Mac.
+<Note>
+The current open-source Rockxy build does **not** ship a License settings tab. The Settings window today exposes: General, Appearance, Privacy, Tools, GitHub, Plugins, MCP, and Advanced. None of the flows described below — Activate, Restore on This Mac, Deactivate, Retry Validation — exist in the source yet.
 
-Rockxy uses the same app for Community and Pro. License management lives in **Settings → License**.
+This page describes the planned licensing model so it stays consistent with the `AppPolicy` contract already in the code. It will be rewritten to match the real UI when the License tab ships.
+</Note>
 
-## License Model
+## How Pro fits into the open-source binary
 
-### Perpetual License
+Rockxy is designed to ship Pro inside the same app binary as Community. The split is governed by `AppPolicy` (`Rockxy/Models/Settings/AppPolicy.swift`), a `Sendable` protocol injected into `MainContentCoordinator.init(policy:)`. The open-source build always uses `DefaultAppPolicy`; a Pro build swaps in an unlimited variant. There is no `isPro` boolean to check anywhere in the code.
 
-Rockxy Pro uses a perpetual license model. In practical terms, that means:
+When the License tab ships, it will be the only surface that swaps the active `AppPolicy` at runtime.
 
-- you buy Rockxy Pro once for the plan you selected
+## Planned license model
+
+### Perpetual license
+
+Rockxy Pro is planned as a perpetual license:
+
+- one purchase per plan
 - the license remains yours permanently
-- your purchase includes updates through the date shown in **Settings → License**
-- you can keep using versions released within that covered updates window
+- updates are included through a date recorded with the license
+- versions released within that window remain usable on Pro indefinitely
 
-The important distinction is this:
+Perpetual does not mean unlimited future updates — it means continued Pro on every build released within the covered updates window.
 
-- **Perpetual** does not mean unlimited future updates forever
-- it means continued use of eligible versions that fall within your license coverage
+### Updates window
 
-### Updates Window
+A planned **Updates until** date will gate which app builds Pro unlocks on:
 
-Rockxy shows an **Updates until** date for perpetual licenses in **Settings → License**.
+- If the installed build was released on or before that date, Pro stays active on that version.
+- If you install a build released after that date, Pro will not unlock on that newer build until you renew updates or install an eligible version.
 
-That date controls whether a given Rockxy build is still covered:
+## Planned license states
 
-- If your installed build was released on or before that date, Pro can stay active on that version.
-- If you install a build released after that date, Rockxy can no longer unlock Pro on that newer build until you renew updates or install an eligible version.
+The future **Status** field in the License tab is intended to surface these states:
 
-## License States You May See
-
-The **Status** field in **Settings → License** is the best source of truth for your current state.
-
-| Status in the app | What it means |
+| Status | Meaning |
 | --- | --- |
 | **Community** | No Pro license is active on this Mac. |
-| **Pro (active)** | Pro is active and fully unlocked on this Mac. |
-| **Pro (current version only)** | Your updates period ended, but this installed Rockxy build is still covered. |
-| **This Build Is Newer Than Your License** | The installed build is outside your covered updates window, so Pro is not unlocked on this build. |
-| **Validation failed** | Rockxy could not verify the stored license on this Mac and needs recovery. |
+| **Pro (active)** | Pro is active and fully unlocked. |
+| **Pro (current version only)** | Updates window ended, but the installed build is still covered. |
+| **This Build Is Newer Than Your License** | The installed build is outside the covered updates window, so Pro is not unlocked here. |
+| **Validation failed** | The stored license could not be verified on this Mac. |
 | **Suspended** | The license is not currently available for use. |
 | **Deactivated** | Pro was explicitly removed from this Mac. |
 
-## Current Plan Names
-
-Rockxy currently recognizes these Pro plan labels in the app:
+## Planned plan names
 
 | Plan | Activation scope |
 | --- | --- |
 | Pro Standard | 1 Mac |
 | Pro Personal | 2 Macs |
 
-## Activate Rockxy Pro
+## Planned activation, restore, deactivate, and transfer flows
 
-Use these steps on the Mac where you want Pro enabled:
+When the License tab ships it will live at **Rockxy → Settings → License** and is expected to include:
 
-1. Open **Rockxy → Settings** or press <kbd>Cmd</kbd>+<kbd>,</kbd>.
-2. Open the **License** tab.
-3. Click **Enter License Key…**
-4. Enter your license key.
-5. Enter the purchase account email used at checkout.
-6. Click **Activate Pro**.
-7. If macOS asks for confirmation to store the license securely, click **Continue**.
+- **Enter License Key…** — enter the key and purchase email, then **Activate Pro**.
+- **Restore on This Mac** — recover a previously activated license whose secure storage is no longer reachable.
+- **Deactivate on this Mac** — remove Pro from the current Mac and release the activation seat.
+- **Retry Validation Now** — re-run validation after a temporary network or service issue.
 
-After a successful activation, the **License** tab shows your status, plan, activation usage, and the updates date for perpetual licenses.
+Transferring Pro to another Mac will follow the standard pattern: deactivate on the old Mac, then activate with the same key and email on the new Mac.
 
-## Restore, Deactivate, and Transfer
+## Planned failure messages
 
-### Restore on the same Mac
+The future License tab is expected to surface these conditions:
 
-If Rockxy already knows this Mac was activated but can no longer reach the stored license securely, the **License** tab shows **Restore on This Mac** instead of asking you to start over.
-
-Use **Restore on This Mac** when:
-
-- you previously denied secure access
-- macOS no longer grants access to the stored license
-- Rockxy asks you to restore secure license access before validating again
-
-### Deactivate on the current Mac
-
-To remove Pro from the Mac you are using:
-
-1. Open **Rockxy → Settings → License**.
-2. Click **Deactivate on this Mac**.
-3. Confirm **Deactivate Rockxy Pro on this Mac?**
-
-Rockxy then removes Pro from that Mac and releases the activation seat so you can use it elsewhere.
-
-### Transfer Pro to another Mac
-
-To move your license cleanly:
-
-1. Deactivate Pro on the old Mac.
-2. Install or open Rockxy on the new Mac.
-3. Open **Settings → License** on the new Mac.
-4. Activate with the same license key and purchase email.
-
-If you skip the deactivation step and your plan has already used all of its activations, the new Mac may refuse activation until a seat is freed.
-
-## When Activation or Validation Fails
-
-Rockxy surfaces license problems in the **License** tab and, when relevant, through an upgrade or warning banner. Use the table below for the most common cases.
-
-| What you see | What it usually means | What to do |
+| Condition | What it means | What to do |
 | --- | --- | --- |
-| **This license key could not be validated.** | The key is invalid or was entered incorrectly. | Re-enter the key carefully and avoid extra spaces. |
-| **The checkout email does not match this license key.** | The purchase email does not match the license record. | Use the exact email used during checkout. |
-| **This license key is not valid for Rockxy Pro on macOS.** | The key belongs to a different product or variant. | Use a Rockxy Pro macOS license. |
-| **This license key has reached its activation limit.** | All seats for the current plan are already in use. | Deactivate an older Mac first, then activate again. |
-| **This license has expired.** or **This Build Is Newer Than Your License** | Your updates period does not cover the current build. | Renew updates or install a Rockxy version released within your covered period. |
-| **License verification failed** | Rockxy could not verify the stored license on this Mac. | Click **Restore on This Mac** first, then **Retry Validation Now** or re-enter the key if needed. |
-| **Rockxy could not reach the licensing provider...** | A temporary network or service problem blocked validation. | Check your connection and try **Retry Validation Now** again later. |
-| **Rockxy needs your confirmation...** | macOS blocked access to the stored license. | Retry the action and allow secure access when prompted. |
-| **This license is disabled right now** | The license is not currently active for use. | Contact support if you believe this is an error. |
-
-## Troubleshooting Checklist
-
-- Make sure you are using the same purchase email that was used when the license was bought.
-- If you changed Macs, deactivate the old Mac first when possible.
-- If Rockxy shows **Restore on This Mac**, use that before re-entering your key.
-- If validation is failing temporarily, try **Retry Validation Now** from **Settings → License**.
-- If the app says the build is newer than your license covers, install an eligible version or renew updates.
+| Invalid license key | The key is wrong or mistyped. | Re-enter carefully, avoid extra spaces. |
+| Email does not match | The checkout email does not match the license record. | Use the exact email from checkout. |
+| Wrong product / platform | The key is not a Rockxy Pro macOS license. | Use a Rockxy Pro macOS license. |
+| Activation limit reached | All seats are in use. | Deactivate an older Mac first. |
+| Build newer than coverage | The current build is outside the covered updates window. | Renew updates or install an eligible version. |
+| Verification failed | Stored license could not be verified. | Restore on This Mac, then retry validation. |
+| Provider unreachable | Temporary network or service problem. | Retry later. |
+| Secure access blocked | macOS blocked access to the stored license. | Allow secure access on retry. |
+| License disabled | License is not active for use. | Contact support. |
 
 ## Related Pages
 
 <CardGroup cols={2}>
   <Card title="Pro Features" icon="sparkles" href="/features/pro-features">
-    See what Rockxy Pro unlocks today and what stays in Community.
+    What ships in the open-source build today and what is planned for Pro.
   </Card>
   <Card title="Settings" icon="gear" href="/customization/settings">
-    Review the exact License tab location and actions.
+    The current Settings tabs (no License tab yet).
   </Card>
   <Card title="FAQ" icon="circle-question" href="/troubleshooting/faq">
-    Quick answers to common Pro and license questions.
+    Common questions about Rockxy and Pro.
   </Card>
   <Card title="Developer Setup Hub" icon="screwdriver-wrench" href="/features/developer-setup-hub">
-    See where Pro adds in-app Android automation.
+    Runtime, client, device, and framework setup.
   </Card>
 </CardGroup>

--- a/docs/features/log-intelligence.mdx
+++ b/docs/features/log-intelligence.mdx
@@ -7,11 +7,6 @@ description: Capture OSLog streams, correlate application logs with network requ
 
 Rockxy captures application logs alongside network traffic and correlates them by timestamp. When a network request fails, nearby log output can help you line up app behavior with proxy traffic without switching to Console.app.
 
-<Frame caption="The Logs tab showing captured OSLog entries correlated with network requests.">
-  <img className="block dark:hidden" src="/images/log-intelligence.png" alt="Rockxy log intelligence view" />
-  <img className="hidden dark:block" src="/images/log-intelligence-dark.png" alt="Rockxy log intelligence view (dark mode)" />
-</Frame>
-
 ## Entry Points
 
 | Action | How to Access |
@@ -36,17 +31,11 @@ Rockxy captures application logs alongside network traffic and correlates them b
 
 ## Capturing Logs
 
-When log capture is enabled in app settings, Rockxy streams logs in real time from configured sources.
+When log capture is enabled, Rockxy streams entries in real time from the configured sources. OSLog entries are pulled from `OSLogStore` (scoped to the current process, polled every 500 ms) and rendered as they arrive.
 
-To reduce noise, filter by specific apps or subsystems:
-
-1. Click the **Filter** button in the Logs toolbar.
-2. Select the target application, subsystem, or category.
-3. Only matching log entries appear in the list.
-
-<Tip>
-Filter by your app's OSLog subsystem (e.g., `com.yourcompany.yourapp`) to eliminate system noise and focus on your own log output. You can add multiple subsystem filters.
-</Tip>
+<Note>
+The current Logs tab renders a chronological list with a color-coded severity badge per row. Source, subsystem, level, keyword, and time-range filtering are planned — they are not yet exposed in the UI.
+</Note>
 
 ## Log Levels
 
@@ -59,7 +48,7 @@ Filter by your app's OSLog subsystem (e.g., `com.yourcompany.yourapp`) to elimin
 | Error | Error conditions that caused a failure | Red |
 | Fault | Critical system-level failures | Purple |
 
-Click any level badge in the filter bar to show or hide entries at that level. Combine level filters with source and keyword filters for precise results.
+Levels mirror Apple's OSLog severity ladder. Each entry's badge in the Logs list is colored using the values above.
 
 ## Log-Request Correlation
 
@@ -81,7 +70,7 @@ The current Settings UI does not expose a dedicated Logs tab or buffer-size cont
 
 ## Log Filtering
 
-Filter the log list using any combination of:
+Filtering is a planned addition to the Logs surface. Once it lands, you will be able to combine:
 
 - **Level** — show only entries at or above a minimum severity level.
 - **Source** — OSLog, stdout/stderr, or custom plugin sources.
@@ -89,7 +78,7 @@ Filter the log list using any combination of:
 - **Time Range** — restrict to entries within a specific time window.
 - **Process** — filter by process name or PID.
 
-Filters are combinable — for example, show only Error-level entries from a specific subsystem containing the word "timeout" in the last 5 minutes.
+Today, the Logs tab shows every captured entry in chronological order; narrow the noise at the source by enabling capture only when you need it.
 
 ## Next Steps
 

--- a/docs/features/mcp.mdx
+++ b/docs/features/mcp.mdx
@@ -7,6 +7,10 @@ description: "Connect Rockxy to Claude CLI or Claude Desktop through Rockxy's lo
 
 Rockxy includes a bundled local MCP bridge so compatible AI tools can inspect captured traffic, read proxy and certificate status, list rules, and export requests as cURL without leaving the chat.
 
+<Frame caption="MCP settings tab and an AI tool consuming Rockxy's local MCP bridge">
+  <img src="/images/features/DemoMCP.png" alt="MCP integration" />
+</Frame>
+
 Rockxy's MCP integration is **local-only**:
 
 - Rockxy starts a local server on `127.0.0.1`

--- a/docs/features/network-conditions.mdx
+++ b/docs/features/network-conditions.mdx
@@ -9,11 +9,15 @@ Network Conditions adds artificial latency to matching requests using named pres
 
 Phase 1 simulates added request-start latency only. Bandwidth shaping, packet loss, and jitter are planned for a future release.
 
+<Frame caption="Network Conditions window with latency presets">
+  <img src="/images/features/DemoNetworkConnection.png" alt="Network Conditions window" />
+</Frame>
+
 ## Entry Points
 
 | Action | How to Access |
 |--------|---------------|
-| Network Conditions window | **Tools > Network Conditions...** (`Cmd+Opt+N`) |
+| Network Conditions window | **Tools > Network Conditions...** |
 | Quick-create from request | Right-click a captured request > **Tools > Network Conditions...** |
 | Quick-create from domain | Right-click a domain in the sidebar > **Tools > Network Conditions** |
 
@@ -38,7 +42,7 @@ A warning banner appears in the Network Conditions window if multiple rules are 
 
 ## Window Layout
 
-The Network Conditions window (880 x 480) follows the standard Rockxy tool-window layout:
+The Network Conditions window (1198 x 641) follows the standard Rockxy tool-window layout:
 
 1. **Inline Toolbar** — Disable All button, Search field, Add Rule button
 2. **Info Bar** — help text describing the feature
@@ -49,7 +53,7 @@ The Network Conditions window (880 x 480) follows the standard Rockxy tool-windo
 
 ### From the dedicated window
 
-1. Open **Tools > Network Conditions...** or press `Cmd+Opt+N`.
+1. Open **Tools > Network Conditions...** from the Tools menu.
 2. Click **Add Rule** or the **+** button.
 3. Enter a rule name and URL pattern (Exact Path, Subpaths, or Regex).
 4. Select a preset or choose Custom and enter a latency value in milliseconds.
@@ -80,7 +84,7 @@ HTTPS requests are delayed after TLS interception, so the delay applies to the d
 
 ## Persistence
 
-Network Conditions rules are persisted alongside all other rules in `~/Library/Application Support/com.amunx.rockxy.community/rules.json` for the Community build. They survive app restarts and can be exported/imported through the standard rule system.
+Network Conditions rules are persisted alongside all other rules under `~/Library/Application Support/com.amunx.rockxy/` (the directory is bundle-driven via `RockxyIdentity.current.appSupportDirectoryName`). They survive app restarts and can be exported or imported through the standard rule system.
 
 ## Limitations
 

--- a/docs/features/performance-insights.mdx
+++ b/docs/features/performance-insights.mdx
@@ -11,11 +11,6 @@ description: Latency percentile analysis, slow request detection, payload tracki
 
 The planned Performance Insights surface would turn captured timing and size data into per-endpoint statistics. Today, Rockxy exposes the raw timing data through the request table, inspector Timing tab, and Timeline tab.
 
-<Frame caption="The Performance Insights dashboard showing latency percentiles and slow request flags.">
-  <img className="block dark:hidden" src="/images/performance-insights.png" alt="Rockxy performance insights dashboard" />
-  <img className="hidden dark:block" src="/images/performance-insights-dark.png" alt="Rockxy performance insights dashboard (dark mode)" />
-</Frame>
-
 ## Current Status
 
 There is no dedicated Performance tab or performance-threshold settings page in the current main window. Available performance-oriented surfaces today are:
@@ -72,20 +67,15 @@ Large API responses are a common source of mobile performance problems. Use payl
 
 The timeline view shows a visual waterfall chart of all requests in the current session, ordered by start time. Each request bar is broken into timing phases:
 
-| Phase | Description |
-|---|---|
-| **DNS** | Domain name resolution |
-| **Connect** | TCP connection establishment |
-| **TLS** | TLS handshake (HTTPS only) |
-| **TTFB** | Time to first byte — waiting for the server to respond |
-| **Transfer** | Response body transfer |
+| Phase | Description | Color |
+|---|---|---|
+| **DNS** | Domain name resolution | Cyan |
+| **TCP** | TCP connection establishment | Green |
+| **TLS** | TLS handshake (HTTPS only) | Purple |
+| **TTFB** | Time to first byte — waiting for the server to respond | Orange |
+| **Transfer** | Response body transfer | Blue |
 
 The waterfall makes it easy to spot sequential chains (requests that start only after the previous one completes) and parallel groups (requests that overlap in time).
-
-<Frame caption="Request timeline waterfall showing timing phases and dependency chains.">
-  <img className="block dark:hidden" src="/images/request-timeline.png" alt="Rockxy request timeline waterfall" />
-  <img className="hidden dark:block" src="/images/request-timeline-dark.png" alt="Rockxy request timeline waterfall (dark mode)" />
-</Frame>
 
 ## Dependency Detection
 

--- a/docs/features/pro-features.mdx
+++ b/docs/features/pro-features.mdx
@@ -1,104 +1,69 @@
 ---
 title: "Pro Features"
-description: "Understand what Rockxy Pro unlocks today, what remains in Community, and where Pro adds value in the current app."
+description: "What the open-source Rockxy build includes today, the capacity limits applied by DefaultAppPolicy, and which Pro extensions are planned but not yet shipping in this binary."
 ---
 
 # Pro Features
 
-Rockxy Pro is the paid layer on top of the same Rockxy app. You do not install a separate product. Community stays fully usable for everyday local debugging, and Pro adds higher-scale usage plus a small set of paid workflows that are currently shipped in the app.
+Rockxy is designed so that Pro ships inside the same app binary as Community. There is no separate download. The split is governed by `AppPolicy` (`Rockxy/Models/Settings/AppPolicy.swift`) — a `Sendable` protocol injected into `MainContentCoordinator.init(policy:)`. The open-source build always uses `DefaultAppPolicy`; a Pro build swaps in an unlimited variant of the same protocol. There is no `isPro` boolean to branch on, and the current open-source repo does not include a license UI, an upgrade screen, or a Pro policy implementation.
 
-This page describes the Pro experience that is available in the current app build. It does not describe roadmap items or internal licensing mechanics.
+This page describes what the current build actually ships and what is planned but not yet wired up.
 
-## What Pro Unlocks Today
+## What the open-source build includes today
 
-Rockxy Pro currently unlocks three categories of value:
+Everything below is available without any license:
 
-1. **Unlimited usage caps** for high-volume local work
-2. **Advanced Diff** for deeper side-by-side request comparison workflows
-3. **One-click Mobile Setup** for the in-app React Native Android automation flow in Developer Setup Hub
+- HTTP, HTTPS, WebSocket, and GraphQL capture
+- Request replay and editing
+- Map Local, Map Remote, Block, Modify Headers, Network Conditions, Breakpoints
+- Compare workspace (Diff window)
+- Scripting (`scriptingList` + `scriptEditor` windows)
+- Sessions and HAR import / export
+- Developer Setup Hub manual setup and automatic setup for runtime targets
+- MCP server with read-only flow / rule / status tools
 
-## Community vs Pro
+## Capacity limits applied by DefaultAppPolicy
 
-| Area | Community | Pro |
-| --- | --- | --- |
-| Workspace tabs | Up to 8 | Unlimited |
-| Domain favorites | Up to 5 | Unlimited |
-| Active rules per tool | Up to 10 | Unlimited |
-| Enabled scripts | Up to 10 | Unlimited |
-| Live history retention | Up to 1,000 entries | Unlimited |
-| Diff | Basic Compare workspace | Advanced Diff workspace |
-| Developer Setup Hub | Manual setup guidance and validation flows | Adds React Native Android automation |
+These caps are hardcoded in `DefaultAppPolicy` and enforced by the rule, script, workspace, and history layers via the policy gates (`RulePolicyGate`, `ScriptPolicyGate`, etc.) bound at app startup:
 
-## What Stays Available in Community
+| Area | DefaultAppPolicy cap |
+| --- | --- |
+| Workspace tabs | 8 |
+| Domain favorites | 5 |
+| Active rules per tool | 10 |
+| Enabled scripts | 10 |
+| Live history retention | 1,000 entries |
+| Upstream proxy bypass entries | 3 |
+| Upstream SOCKS5 | disabled |
+| Upstream proxy authentication | disabled |
+| Protobuf schema upload | disabled |
+| Stored protobuf schemas | 0 |
 
-Upgrading to Pro does not move Rockxy's core debugging value behind a paywall. Community still includes:
+A Pro build would inject an `AppPolicy` implementation that lifts these limits and turns on the gated upstream-proxy and protobuf capabilities. The current open-source binary always reports the values above.
 
-- HTTP and HTTPS capture
-- WebSocket and GraphQL inspection
-- Request replay
-- Rules and breakpoints
-- Scripting foundations
-- Sessions and HAR import/export
-- Developer Setup Hub manual setup flows
-- Local MCP read workflows
+## Planned Pro extensions (not in this build)
 
-If you never need the higher limits, Advanced Diff, or React Native Android automation, you can keep using Rockxy without a Pro license.
+The following items are part of the planned Pro layer but are **not** present in the current open-source source tree. Treat them as roadmap, not shipping features:
 
-## Shipped Pro Workflows
+- An **Advanced Diff** workspace built on top of the existing Compare flow (Compare History, pinned pairs, section summaries, additional action shortcuts).
+- Additional automation inside Developer Setup Hub for mobile targets (for example a guided React Native Android flow). Today every mobile / framework target with `automationSupport: .none` uses the Manual Setup window.
+- A **License** tab inside Settings, license activation/restore/deactivate flows, and license-state surfacing.
 
-### Advanced Diff
-
-Community includes Rockxy's standard Compare workflow. Pro replaces that with the larger **Advanced Diff** workspace when your license is active.
-
-Advanced Diff adds:
-
-- a larger comparison workspace
-- local **Compare History**
-- pinned comparison pairs
-- section summaries and jump navigation
-- workflow shortcuts such as **Edit & Repeat**, **Replay**, **Map Local**, **Map Remote**, **Breakpoint**, **Network Conditions**, **Copy cURL**, and **Export HAR**
-
-If Pro is not active, Rockxy continues to use the standard Compare workspace instead of Advanced Diff.
-
-### One-click Mobile Setup
-
-Community already includes Developer Setup Hub and its manual setup guides. Pro adds the in-app **React Native Android Setup** automation sheet for supported Android targets.
-
-That Pro workflow helps you:
-
-- review Android target readiness
-- inspect a dry-run plan before any changes are applied
-- confirm Android proxy changes explicitly
-- optionally apply Metro reverse port forwarding
-- keep a manual fallback path available
-
-This is a Pro convenience layer on top of the existing manual guidance. Manual Android setup remains available even without Pro.
-
-## License and Activation
-
-Rockxy Pro licensing now has its own dedicated guide.
-
-Go to [License Management](/features/license-management) for:
-
-- how the perpetual license works
-- what the **Updates until** date means
-- the difference between active, validation-failed, deactivated, and out-of-coverage states
-- activation, restore, deactivation, and transfer steps
-- troubleshooting for activation and validation failures
+When these ship, this page and `License Management` will be updated to describe the actual UI rather than the policy contract.
 
 ## Related Pages
 
 <CardGroup cols={2}>
   <Card title="Request Diff" icon="code-compare" href="/features/diff">
-    Learn the standard Compare workflow and how Advanced Diff fits into it.
+    The Compare workspace that ships in the open-source build today.
   </Card>
   <Card title="Developer Setup Hub" icon="screwdriver-wrench" href="/features/developer-setup-hub">
-    See where Pro adds React Native Android automation.
+    Runtime, client, device, and framework setup — automatic for runtimes, manual for everything else.
   </Card>
   <Card title="License Management" icon="key" href="/features/license-management">
-    Learn how perpetual licensing, updates coverage, activation, and transfer work.
+    Planned licensing model. No license UI ships in the current build.
   </Card>
   <Card title="Settings" icon="gear" href="/customization/settings">
-    Review the exact License tab location and settings-window terminology.
+    Current settings tabs: General, Appearance, Privacy, Tools, GitHub, Plugins, MCP, Advanced.
   </Card>
 </CardGroup>

--- a/docs/features/request-replay.mdx
+++ b/docs/features/request-replay.mdx
@@ -9,19 +9,23 @@ Rockxy can re-send any captured HTTP or HTTPS request. There are two replay path
 
 Replay uses a proxy-bypass session (an ephemeral `URLSession` with proxy settings disabled), so replayed traffic does **not** re-enter Rockxy's proxy pipeline. This avoids infinite loops and means active rules (breakpoints, throttle, header modifications) do not apply to replayed requests.
 
+<Frame caption="Repeating a captured request from the traffic list">
+  <img src="/images/RepeatRockxy.png" alt="Request replay" />
+</Frame>
+
 ## Entry Points
 
 | Action | How to Access |
 |--------|---------------|
-| Repeat | Right-click a request > **Repeat**, or **Flow > Repeat** (`Cmd+Return`) |
-| Edit and Repeat | Right-click a request > **Edit and Repeat...**, or **Flow > Edit and Repeat...** (`Cmd+Opt+Return`) |
+| Repeat | Right-click a request > **Repeat**, or **Flow > Repeat** (`Cmd+R`) |
+| Edit and Repeat | Right-click a request > **Edit and Repeat...**, or **Flow > Edit and Repeat...** (`Cmd+E`) |
 
 ## Repeat (Fast Replay)
 
 **Repeat** re-sends the selected request with the same method, URL, headers, and body as the original. No editing step — the request goes out immediately.
 
 1. Select a request in the traffic list.
-2. Right-click and choose **Repeat**, or press `Cmd+Return`.
+2. Right-click and choose **Repeat**, or press `Cmd+R`.
 3. The response appears inline with status code, headers, and body.
 
 ## Edit and Repeat

--- a/docs/features/rules.mdx
+++ b/docs/features/rules.mdx
@@ -9,6 +9,10 @@ Traffic rules are how you move from passive inspection to active debugging. Once
 
 Rockxy currently exposes rule types through dedicated tool windows rather than one single generic rules editor. That keeps each workflow explicit and makes it easier to see what the app truly supports today.
 
+<Frame caption="Block List window — one of Rockxy's dedicated rule tool windows">
+  <img src="/images/features/DemoBlockList.png" alt="Block List rule window" />
+</Frame>
+
 ## Entry Points
 
 | Action | How to Access |
@@ -25,7 +29,7 @@ Rockxy currently exposes rule types through dedicated tool windows rather than o
 | Allow List quick-create | Right-click a captured request > **Tools > Allow List...** |
 | Allow List sidebar quick-create | Right-click a domain in the sidebar > **Tools > Create Allow List Rule…** |
 | Modify Headers window | **Tools > Modify Headers...** |
-| Network Conditions window | **Tools > Network Conditions...** (`Cmd+Opt+N`) |
+| Network Conditions window | **Tools > Network Conditions...** |
 | Network Conditions quick-create | Right-click a captured request > **Tools > Network Conditions...** |
 | Add Breakpoint for selected | Right-click a captured request > **Tools > Breakpoint...** |
 

--- a/docs/features/scripting.mdx
+++ b/docs/features/scripting.mdx
@@ -7,6 +7,10 @@ description: "Create JavaScript scripts to inspect, modify, mock, or filter traf
 
 Rockxy includes a JavaScript scripting engine (JavaScriptCore) that lets you write scripts to inspect, modify, mock, or filter traffic. Scripts run against matched requests in the proxy pipeline with a 5-second execution timeout. Enabled scripts are loaded at app launch and run automatically — you do not need to keep the Scripting window open.
 
+<Frame caption="Scripting window with the script list, editor, and matching rules">
+  <img src="/images/features/DemoScripting.png" alt="JavaScript scripting window" />
+</Frame>
+
 ## Entry Points
 
 | Action | How to Access |

--- a/docs/features/sessions.mdx
+++ b/docs/features/sessions.mdx
@@ -7,6 +7,10 @@ description: "Save, open, import, and export captured traffic using native .rock
 
 Rockxy supports saving and restoring captured traffic in two formats: the native `.rockxysession` format for full-fidelity session files, and the industry-standard HAR (HTTP Archive) format for cross-tool compatibility.
 
+<Frame caption="Saving and exporting a captured session">
+  <img src="/images/features/DemoSessionExport.png" alt="Session save and export" />
+</Frame>
+
 ## Native .rockxysession Format
 
 Rockxy's native format preserves the full session including metadata, user annotations, and all captured transactions.
@@ -78,18 +82,19 @@ Import errors (invalid format, oversized file, deserialization failure) are show
 
 You can also export individual requests via right-click > **Export > Export as HAR...** in the request list.
 
-<Callout type="info">
+<Note>
   Exported HAR files may contain request bodies, cookies, and authorization headers. Review exports before sharing.
-</Callout>
+</Note>
 
 ## Other Export Options
 
-Beyond file-level session save/export, Rockxy supports copying individual requests in several formats via the right-click context menu:
+Beyond file-level session save/export, Rockxy supports copying individual requests via the right-click **Copy as** submenu in the request list:
 
-- **Copy as cURL** — ready-to-run cURL command.
-- **Copy as Raw HTTP** — full HTTP/1.1 text dump.
-- **Copy as JSON** — structured JSON representation.
-- **Export as HAR...** — save a single request as a `.har` file.
+- **JSON** — structured JSON representation.
+- **HAR Entry** — single-request HAR entry payload.
+- **Raw Request** / **Raw Response** — full HTTP/1.1 text dump of either side.
+- **Request Headers** / **Response Headers** / **Request Body** / **Response Body** / **Request Cookies** / **Response Cookies** — surgical clipboard copies.
+- **Copy as cURL** — available from **Edit > Copy as cURL** (`Cmd+Shift+C`) for the selected request.
 
 ## Limitations
 

--- a/docs/features/traffic-capture.mdx
+++ b/docs/features/traffic-capture.mdx
@@ -3,16 +3,15 @@ title: "Traffic Capture"
 description: "Capture, inspect, and filter HTTP/HTTPS network traffic from any application"
 ---
 
-Rockxy captures every HTTP and HTTPS request flowing through your Mac by running a local proxy server on port 9090. Point any app at the proxy — or let Rockxy configure the system proxy automatically — and watch requests stream in real time.
+Rockxy captures every HTTP and HTTPS request flowing through your Mac by running a local proxy server (port 9090 by default; configurable in Settings > General). Point any app at the proxy — or let Rockxy configure the system proxy automatically — and watch requests stream in real time.
 
 <Frame caption="Traffic list showing captured HTTP/HTTPS requests with method, host, status, and timing columns">
-  <img className="block dark:hidden" src="/images/traffic-capture.png" alt="Traffic capture list view" />
-  <img className="hidden dark:block" src="/images/traffic-capture-dark.png" alt="Traffic capture list view (dark mode)" />
+  <img src="/images/features/TrafficCapture.png" alt="Traffic capture list view" />
 </Frame>
 
 ## How It Works
 
-Rockxy runs a SwiftNIO-based proxy server that accepts HTTP and HTTPS CONNECT requests on `localhost:9090`. When you start capturing, Rockxy can automatically configure the macOS system proxy settings so all HTTP/HTTPS traffic from every application routes through the proxy.
+Rockxy runs a SwiftNIO-based proxy server that accepts HTTP and HTTPS CONNECT requests on `localhost:9090` (default). When you start capturing, Rockxy can automatically configure the macOS system proxy settings so all HTTP/HTTPS traffic from every application routes through the proxy.
 
 The proxy intercepts each request, records the full request and response (headers, body, timing), and forwards traffic to the destination server. For HTTPS, Rockxy performs a man-in-the-middle interception using a locally generated root CA — see [HTTPS Interception](/features/https-interception) for details.
 
@@ -26,10 +25,11 @@ Use the toolbar controls or keyboard shortcuts to manage capture state:
 
 | Action | Shortcut | Description |
 |--------|----------|-------------|
-| Start Capture | `Cmd + Shift + R` | Start the proxy server and begin capturing traffic |
-| Stop Capture | `Cmd + .` | Stop the proxy server and restore system proxy settings |
-| Toggle Recording | `Cmd + Shift + D` | Pause/resume recording without stopping the proxy |
-| Clear Session | `Cmd + Option + Shift + Delete` | Remove all captured requests from the current session |
+| Start Proxy | _no shortcut_ | **Tools > Start Proxy** — start the proxy server and begin capturing traffic |
+| Stop Proxy | `Cmd + .` | Stop the proxy server and restore system proxy settings |
+| Toggle Recording | `Cmd + P` | Pause/resume recording without stopping the proxy |
+| Clear Session | `Cmd + K` | Remove all captured requests from the current session |
+| Clear Session and Filters | `Cmd + Shift + K` | Clear captured requests and reset the active filters |
 
 When recording is paused, the proxy stays active (so apps don't lose connectivity) but new requests are not added to the traffic list.
 
@@ -66,11 +66,11 @@ Combine multiple filters to isolate exactly the traffic you need. For example, f
 
 ## Request Inspector
 
-Select any request in the traffic list to open the inspector panel on the right. The inspector provides tabbed views into every aspect of the request:
+Select any request in the traffic list to open the inspector panel. The inspector splits into a request side (Headers, Query, Body, Cookies, Raw, Synopsis, Comments) and a response side (Headers, Body, Set-Cookie, Auth, Timeline — plus WebSocket and GraphQL when applicable). Switch tabs to inspect each part of the transaction:
 
 ### Headers
 
-Displays request and response headers in a searchable key-value table. Request headers appear at the top, response headers below, each with their own section.
+Request and response headers each have their own tab on their respective side of the inspector, shown as a searchable key-value table.
 
 ### Body
 
@@ -81,11 +81,11 @@ Auto-detects the content type and renders the body accordingly:
 - **Binary** — hex dump with ASCII sidebar
 - **Text** — raw text with line numbers
 
-### Cookies
+### Cookies / Set-Cookie
 
-Shows request cookies (sent via `Cookie` header) and response cookies (from `Set-Cookie` headers) with parsed attributes: domain, path, expiry, secure, httpOnly, sameSite.
+The request-side **Cookies** tab parses outbound `Cookie` headers. The response-side **Set-Cookie** tab parses inbound `Set-Cookie` headers with their attributes (domain, path, expiry, secure, httpOnly, sameSite).
 
-### Timing
+### Timeline
 
 Visual waterfall bar breaking down the request lifecycle:
 - **DNS Lookup** — domain resolution time
@@ -96,25 +96,21 @@ Visual waterfall bar breaking down the request lifecycle:
 
 ### Raw
 
-Full HTTP/1.1 text dump of the request and response, exactly as sent/received on the wire. Useful for debugging protocol-level issues.
-
-### Certificates
-
-For HTTPS requests, displays the full certificate chain from the remote server. See [HTTPS Interception](/features/https-interception) for more on certificate handling.
+Full HTTP/1.1 text dump of the request, exactly as sent on the wire. Useful for debugging protocol-level issues.
 
 ### WebSocket
 
-For WebSocket connections, shows the frame list after the HTTP upgrade. See [WebSocket Inspection](/features/websocket) for details.
+On the response side, shows the frame list for any connection that completed an `Upgrade: websocket` handshake. See [WebSocket Inspection](/features/websocket) for details.
 
 ### GraphQL
 
-For detected GraphQL requests, shows the parsed operation with query text and variables. See [GraphQL Support](/features/graphql) for details.
+On the response side, shows the parsed operation with query text and variables for any detected GraphQL request. See [GraphQL Support](/features/graphql) for details.
 
 ## Session Management
 
-Rockxy stores active traffic in a high-performance in-memory buffer with a default capacity of 50,000 transactions. When the live buffer exceeds the limit, the oldest overflow is evicted from the active workspace so the UI remains responsive.
+Rockxy stores active traffic in an in-memory ring buffer with a default capacity of 50,000 transactions. When the buffer exceeds the limit, the oldest entries are evicted from the active workspace so the UI stays responsive.
 
-Completed sessions are persisted to a local SQLite database, so you can quit and relaunch Rockxy without losing your captured data. Response bodies larger than 1 MB are stored as separate files on disk to keep the database lean.
+Saved sessions are persisted to a local SQLite database, so you can quit and relaunch Rockxy without losing captured data you have explicitly saved. Bodies larger than 1 MB are written to separate files on disk (under `~/Library/Application Support/<bundle>/bodies/`) and loaded on demand by the inspector. Per-request and per-response body capture is capped at 100 MB — larger payloads are truncated in the capture buffer but continue to relay to the client.
 
 <Note>
 When the live buffer reaches capacity, older active rows are evicted automatically. If you need to preserve specific requests, pin/save them or export them before the buffer fills. Use **Flow > Clear Session** to manually clear the session and free memory.

--- a/docs/features/upstream-proxy.mdx
+++ b/docs/features/upstream-proxy.mdx
@@ -7,6 +7,10 @@ description: "Route captured outbound traffic through static upstream proxies or
 
 Upstream Proxy lets Rockxy chain outbound requests through another proxy server after Rockxy has captured, decrypted, and applied rules to the traffic. This is useful when a team network, test lab, VPN-adjacent workflow, or debugging setup requires outbound traffic to leave through a fixed proxy endpoint or a network-provided PAC file.
 
+<Frame caption="Bypass Proxy list — domains that skip the upstream proxy">
+  <img src="/images/features/DemoByPassProxy.png" alt="Upstream proxy bypass list" />
+</Frame>
+
 ## Entry Points
 
 | Action | How to Access |

--- a/docs/features/websocket-protobuf.mdx
+++ b/docs/features/websocket-protobuf.mdx
@@ -13,9 +13,9 @@ WebSocket Protobuf Decoding adds an on-demand decoder for binary WebSocket frame
 |--------|---------------|
 | Capture WebSocket frames | Response inspector > WebSocket tab |
 | Inspect a binary frame | Select a WebSocket binary frame |
-| Decode as Protobuf | Select Protobuf in the frame detail view |
-| Manage mapping rules | Tools > Protobuf... |
-| Review schema list | Tools > Protobuf... > Protobuf Schema... |
+| Decode as Protobuf | Switch the frame detail's payload picker to **Protobuf** (auto-selected when a frame looks like Protobuf) |
+| Manage mapping rules | **Tools > Protobuf…** (`Cmd + Option + U`) |
+| Review schema list | **Tools > Protobuf…** > **Protobuf Schema…** |
 
 The decoder runs on demand when the inspector requests it. WebSocket capture itself stays on the existing hot path, so Rockxy does not decode every frame while proxying traffic.
 

--- a/docs/features/websocket.mdx
+++ b/docs/features/websocket.mdx
@@ -5,11 +5,6 @@ description: "Capture and inspect WebSocket frames including text, binary, ping/
 
 Rockxy captures WebSocket traffic at the frame level, letting you see every message exchanged between client and server after the initial HTTP upgrade handshake.
 
-<Frame caption="WebSocket frame list showing text and binary messages with direction, timestamps, and payload preview">
-  <img className="block dark:hidden" src="/images/websocket.png" alt="WebSocket frame inspector" />
-  <img className="hidden dark:block" src="/images/websocket-dark.png" alt="WebSocket frame inspector (dark mode)" />
-</Frame>
-
 ## Entry Points
 
 | Action | How to Access |
@@ -40,11 +35,6 @@ Select a WebSocket connection in the traffic list. The **WebSocket** tab auto-se
 | Timestamp | When the frame was captured, with millisecond precision |
 | Size | Payload size in bytes |
 
-<Frame caption="Frame detail view showing a JSON text frame with formatted payload">
-  <img className="block dark:hidden" src="/images/websocket-frame-detail.png" alt="WebSocket frame detail" />
-  <img className="hidden dark:block" src="/images/websocket-frame-detail-dark.png" alt="WebSocket frame detail (dark mode)" />
-</Frame>
-
 Click any frame to expand its full payload in the detail pane below the frame list.
 
 **Direction filter** — use the segmented filter above the frame list to show All frames, only Sent (client → server), or only Received (server → client). Frame counts update in real time.
@@ -69,9 +59,9 @@ A WebSocket connection in Rockxy follows this lifecycle:
 1. **Upgrade Request** — the initial HTTP request with `Upgrade: websocket` appears in the traffic list as a standard HTTP transaction with status `101`.
 2. **Open** — the connection is established. The WebSocket tab becomes active in the inspector.
 3. **Frames** — text, binary, ping, and pong frames are captured and displayed in real time as they flow through the proxy.
-4. **Close** — a close frame (from either side) terminates the connection. The close code and reason are displayed.
+4. **Close** — a close frame (from either side) terminates the connection. The close frame appears in the frame list with its `Close` opcode badge; its payload (status code + reason, per RFC 6455) is visible in the frame detail.
 
-The inspector header shows connection statistics: total frame count, frames sent vs. received, total bytes transferred, and connection duration.
+The inspector header shows the connection state (Active / Closed), connection duration, and per-direction counts and byte totals (Sent: N frames / X KB, Received: N frames / X KB).
 
 ## Supported Opcodes
 

--- a/docs/features/workspaces.mdx
+++ b/docs/features/workspaces.mdx
@@ -7,6 +7,10 @@ description: "Native macOS tabs that split a single capture into independently f
 
 A workspace is an independent view onto the same live traffic stream. Each tab keeps its own filter, sort, sidebar selection, inspector tab, and inspector layout — but every tab is reading the **same underlying capture**, so traffic shows up in all of them at once. Workspaces are native macOS tabs at the window level: drag, reorder, rename in place, and `Cmd`-click as expected.
 
+<Frame caption="Multiple workspace tabs in the main window">
+  <img src="/images/features/DemoMultipleTabWorkingSpace.png" alt="Workspace tabs" />
+</Frame>
+
 ## Why workspaces
 
 A single capture often serves several investigations at once:
@@ -47,8 +51,7 @@ In other words, you cannot "stop recording" in one tab and "keep recording" in a
 | Next tab | <kbd>Cmd</kbd>+<kbd>Shift</kbd>+<kbd>]</kbd> |
 | Previous tab | <kbd>Cmd</kbd>+<kbd>Shift</kbd>+<kbd>[</kbd> |
 | Reorder | Drag the tab to a new position |
-| Duplicate | Right-click the tab → **Duplicate Tab** (preserves filter and selection) |
-| Close other tabs | Right-click the tab → **Close Other Tabs** |
+| Tab context menu | Right-click a tab for **Rename Tab**, **Close Tab**, and **New Tab** |
 
 Up to **8 tabs** can be open at a time (`AppPolicy.maxWorkspaceTabs`). Hitting the limit silently no-ops the new-tab action — close one to make room.
 
@@ -68,7 +71,7 @@ Keep your default **All Traffic** tab unchanged. In a second tab, set a filter r
 
 ### Replay and compare
 
-When replaying a request, open the request in a fresh tab via the favorites context menu (**Open in New Tab**). The new tab inherits the originating filter and selection, so the replayed flow lands next to its source request rather than buried in the global list.
+When focusing on a specific app or domain, use the sidebar context menu **Open in New Tab** to spawn a fresh workspace filtered to that source. The replayed flow then lands next to its source request rather than buried in the global list.
 
 ## Per-tab sort
 


### PR DESCRIPTION
## Summary
- Polish certificate setup and custom certificate management flows, including docs links, import menus, certificate metadata, and preview handling.
- Wire the General setting for starting capture on launch into the main app startup lifecycle.
- Add coordinator regression coverage for launch capture startup behavior.

## Validation
- swiftlint lint --strict Rockxy/ContentView.swift Rockxy/Views/Main/MainContentCoordinator.swift RockxyTests/Views/Main/CoordinatorStartupTests.swift
- xcodebuild -project Rockxy.xcodeproj -scheme Rockxy -destination 'platform=macOS' -only-testing:RockxyTests/CoordinatorStartupTests test
- xcodebuild -project Rockxy.xcodeproj -scheme Rockxy -configuration Debug build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added custom certificate import with support for PKCS#12 and PEM/DER formats, including certificate preview and validation.
  * Settings tab selection now persists across app launches.
  * Manual trust certificate installation now includes a copy-to-clipboard command feature.
  * Proxy can automatically start on app launch when configured.

* **Documentation**
  * Added comprehensive guide for custom certificates feature.
  * Updated multiple feature documentation pages with refreshed descriptions and visuals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->