### PR TITLE
fix: hide favorite URL filter in new tabs

### DIFF
--- a/Rockxy/Models/UI/FilterCriteria.swift
+++ b/Rockxy/Models/UI/FilterCriteria.swift
@@ -31,12 +31,14 @@ struct FilterCriteria {
     var sidebarPathPrefix: String?
     var sidebarApp: String?
     var sidebarScope: SidebarScope = .allTraffic
+    var exactTransactionID: UUID?
 
     var isEmpty: Bool {
         (!isSearchEnabled || searchText.isEmpty) && methods.isEmpty && statusCodes.isEmpty
             && contentTypes.isEmpty && domains.isEmpty && logLevels.isEmpty
             && activeProtocolFilters.isEmpty && sidebarDomain == nil
             && sidebarPathPrefix == nil && sidebarApp == nil && sidebarScope == .allTraffic
+            && exactTransactionID == nil
     }
 
     var activeFilterCount: Int {

--- a/Rockxy/Views/Main/Extensions/MainContentCoordinator+ContextMenu.swift
+++ b/Rockxy/Views/Main/Extensions/MainContentCoordinator+ContextMenu.swift
@@ -298,8 +298,7 @@ extension MainContentCoordinator {
         }
 
         var filter = FilterCriteria.empty
-        filter.searchField = .url
-        filter.searchText = transaction.request.url.absoluteString
+        filter.exactTransactionID = transaction.id
         filter.sidebarScope = switch section {
         case .pinned: .pinned
         case .saved: .saved

--- a/Rockxy/Views/Main/Extensions/MainContentCoordinator+Filtering.swift
+++ b/Rockxy/Views/Main/Extensions/MainContentCoordinator+Filtering.swift
@@ -95,6 +95,11 @@ extension MainContentCoordinator {
             if transaction.isTLSFailure {
                 return false
             }
+            if let exactTransactionID = filterCriteria.exactTransactionID,
+               transaction.id != exactTransactionID
+            {
+                return false
+            }
             if let sidebarDomain = filterCriteria.sidebarDomain {
                 guard DomainGrouping.host(transaction.request.host, matchesDomain: sidebarDomain) else {
                     return false
@@ -248,6 +253,11 @@ extension MainContentCoordinator {
         }
         workspace.filteredTransactions = baseList.filter { transaction in
             if transaction.isTLSFailure {
+                return false
+            }
+            if let exactTransactionID = workspace.filterCriteria.exactTransactionID,
+               transaction.id != exactTransactionID
+            {
                 return false
             }
             if let sidebarDomain = workspace.filterCriteria.sidebarDomain {

--- a/Rockxy/Views/Main/Extensions/MainContentCoordinator+Selection.swift
+++ b/Rockxy/Views/Main/Extensions/MainContentCoordinator+Selection.swift
@@ -25,6 +25,7 @@ extension MainContentCoordinator {
             filterCriteria.sidebarPathPrefix = nil
             filterCriteria.sidebarApp = nil
             filterCriteria.sidebarScope = .allTraffic
+            filterCriteria.exactTransactionID = nil
             recomputeFilteredTransactions()
             return
         }
@@ -35,18 +36,21 @@ extension MainContentCoordinator {
             filterCriteria.sidebarPathPrefix = nil
             filterCriteria.sidebarApp = nil
             filterCriteria.sidebarScope = .allTraffic
+            filterCriteria.exactTransactionID = nil
             recomputeFilteredTransactions()
         case let .domainPath(domain, pathPrefix):
             filterCriteria.sidebarDomain = domain
             filterCriteria.sidebarPathPrefix = pathPrefix
             filterCriteria.sidebarApp = nil
             filterCriteria.sidebarScope = .allTraffic
+            filterCriteria.exactTransactionID = nil
             recomputeFilteredTransactions()
         case let .app(name, _):
             filterCriteria.sidebarDomain = nil
             filterCriteria.sidebarPathPrefix = nil
             filterCriteria.sidebarApp = name
             filterCriteria.sidebarScope = .allTraffic
+            filterCriteria.exactTransactionID = nil
             recomputeFilteredTransactions()
         case .allApps,
              .allDomains:
@@ -54,12 +58,14 @@ extension MainContentCoordinator {
             filterCriteria.sidebarPathPrefix = nil
             filterCriteria.sidebarApp = nil
             filterCriteria.sidebarScope = .allTraffic
+            filterCriteria.exactTransactionID = nil
             recomputeFilteredTransactions()
         case .allSaved:
             filterCriteria.sidebarDomain = nil
             filterCriteria.sidebarPathPrefix = nil
             filterCriteria.sidebarApp = nil
             filterCriteria.sidebarScope = .saved
+            filterCriteria.exactTransactionID = nil
             selectedTransaction = nil
             recomputeFilteredTransactions()
         case .allPinned:
@@ -67,6 +73,7 @@ extension MainContentCoordinator {
             filterCriteria.sidebarPathPrefix = nil
             filterCriteria.sidebarApp = nil
             filterCriteria.sidebarScope = .pinned
+            filterCriteria.exactTransactionID = nil
             selectedTransaction = nil
             recomputeFilteredTransactions()
         case let .pinnedTransaction(id):
@@ -74,6 +81,7 @@ extension MainContentCoordinator {
             filterCriteria.sidebarPathPrefix = nil
             filterCriteria.sidebarApp = nil
             filterCriteria.sidebarScope = .pinned
+            filterCriteria.exactTransactionID = nil
             recomputeFilteredTransactions()
             selectedTransaction = transaction(for: id)
         case let .savedTransaction(id):
@@ -81,6 +89,7 @@ extension MainContentCoordinator {
             filterCriteria.sidebarPathPrefix = nil
             filterCriteria.sidebarApp = nil
             filterCriteria.sidebarScope = .saved
+            filterCriteria.exactTransactionID = nil
             recomputeFilteredTransactions()
             selectedTransaction = transaction(for: id)
         default:
@@ -88,6 +97,7 @@ extension MainContentCoordinator {
             filterCriteria.sidebarPathPrefix = nil
             filterCriteria.sidebarApp = nil
             filterCriteria.sidebarScope = .allTraffic
+            filterCriteria.exactTransactionID = nil
             recomputeFilteredTransactions()
         }
     }

--- a/Rockxy/Views/Toolbar/ActiveFilterSummaryBar.swift
+++ b/Rockxy/Views/Toolbar/ActiveFilterSummaryBar.swift
@@ -43,6 +43,7 @@ struct ActiveFilterSummaryBar: View {
                     if coordinator.filterCriteria.sidebarScope == .saved {
                         FilterChip(label: String(localized: "Saved")) {
                             coordinator.filterCriteria.sidebarScope = .allTraffic
+                            coordinator.filterCriteria.exactTransactionID = nil
                             coordinator.sidebarSelection = nil
                             coordinator.recomputeFilteredTransactions()
                         }
@@ -51,6 +52,7 @@ struct ActiveFilterSummaryBar: View {
                     if coordinator.filterCriteria.sidebarScope == .pinned {
                         FilterChip(label: String(localized: "Pinned")) {
                             coordinator.filterCriteria.sidebarScope = .allTraffic
+                            coordinator.filterCriteria.exactTransactionID = nil
                             coordinator.sidebarSelection = nil
                             coordinator.recomputeFilteredTransactions()
                         }

--- a/RockxyTests/Views/Main/FavoriteTransactionContextMenuTests.swift
+++ b/RockxyTests/Views/Main/FavoriteTransactionContextMenuTests.swift
@@ -136,20 +136,22 @@ struct FavoriteTransactionContextMenuTests {
         #expect(loaded.isEmpty)
     }
 
-    @Test("Open in new tab scopes the workspace to the exact request URL")
-    func openInNewTabUsesExactURLFilter() {
+    @Test("Open in new tab scopes the workspace to the exact request without exposing the URL as search text")
+    func openInNewTabUsesHiddenExactTransactionFilter() {
         let coordinator = MainContentCoordinator()
         let transaction = TestFixtures.makeTransaction(url: "https://api.example.com/v1/users?page=1")
+        let duplicateURL = TestFixtures.makeTransaction(url: "https://api.example.com/v1/users?page=1")
         transaction.isPinned = true
-        coordinator.transactions = [transaction]
+        duplicateURL.isPinned = true
+        coordinator.transactions = [transaction, duplicateURL]
 
         coordinator.openFavoriteTransactionInNewTab(transaction, from: .pinned)
 
         #expect(coordinator.workspaceStore.workspaces.count == 2)
         let workspace = coordinator.workspaceStore.workspaces[1]
         #expect(workspace.filterCriteria.sidebarScope == .pinned)
-        #expect(workspace.filterCriteria.searchField == .url)
-        #expect(workspace.filterCriteria.searchText == transaction.request.url.absoluteString)
+        #expect(workspace.filterCriteria.exactTransactionID == transaction.id)
+        #expect(workspace.filterCriteria.searchText.isEmpty)
         #expect(workspace.filteredTransactions.map(\.id) == [transaction.id])
         #expect(workspace.filteredRows.map(\.id) == [transaction.id])
     }
@@ -165,6 +167,8 @@ struct FavoriteTransactionContextMenuTests {
 
         let workspace = coordinator.workspaceStore.workspaces[1]
         #expect(workspace.filterCriteria.sidebarScope == .saved)
+        #expect(workspace.filterCriteria.exactTransactionID == transaction.id)
+        #expect(workspace.filterCriteria.searchText.isEmpty)
         #expect(workspace.filteredTransactions.map(\.id) == [transaction.id])
         #expect(workspace.filteredRows.map(\.id) == [transaction.id])
     }


### PR DESCRIPTION
## Summary
- Use a hidden exact transaction filter when opening saved/pinned requests in a new tab
- Keep the visible search field empty so fixture/request URLs are not exposed as toolbar filter chips
- Clear the hidden exact-transaction filter when sidebar/scope filters are reset

## Tests
- xcodebuild -scheme "Rockxy" -destination 'platform=macOS' test -only-testing:RockxyTests/FavoriteTransactionContextMenuTests -only-testing:RockxyTests/FilteringTests