### PR TITLE
Release: promote develop to main

### DIFF
--- a/Rockxy/AppDelegate.swift
+++ b/Rockxy/AppDelegate.swift
@@ -10,7 +10,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSUserInterfaceValidat
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         let defaults = UserDefaults.standard
-        let theme = defaults.string(forKey: Self.identity.defaultsKey("appTheme")) ?? "system"
+        let theme = AppSettingsStorage.load().appTheme.rawValue
         AppThemeApplier.apply(theme)
 
         defaults.register(defaults: [

--- a/Rockxy/ContentView.swift
+++ b/Rockxy/ContentView.swift
@@ -141,6 +141,7 @@ struct ContentView: View {
                 }
             }
         }
+        .appUIDisplayMetrics(AppUIDisplayMetrics(settings: settingsManager.settings.appUI))
     }
 
     // MARK: Private
@@ -149,6 +150,7 @@ struct ContentView: View {
     @Environment(\.openSettings) private var openSettings
     @Bindable private var coordinator: MainContentCoordinator
     @State private var columnVisibility: NavigationSplitViewVisibility = .all
+    private let settingsManager = AppSettingsManager.shared
     private let managesLifecycle: Bool
     private let representedWorkspaceID: UUID?
 

--- a/Rockxy/Core/Storage/AppSettingsManager.swift
+++ b/Rockxy/Core/Storage/AppSettingsManager.swift
@@ -32,6 +32,33 @@ final class AppSettingsManager {
         save()
     }
 
+    func updateAppTheme(_ theme: AppTheme) {
+        settings.appTheme = theme
+        save()
+        AppThemeApplier.apply(theme.rawValue)
+    }
+
+    func updateAppUI(_ appUI: AppUISettings) {
+        var validated = appUI
+        validated.fontSize = AppUISettings.validFontSize(appUI.fontSize)
+        validated.tabWidth = AppUISettings.validTabWidth(appUI.tabWidth)
+        settings.appUI = validated
+        save()
+    }
+
+    func updateAppUI(_ update: (inout AppUISettings) -> Void) {
+        var appUI = settings.appUI
+        update(&appUI)
+        updateAppUI(appUI)
+    }
+
+    func restoreAppearanceDefaults() {
+        settings.appTheme = .system
+        settings.appUI = .default
+        save()
+        AppThemeApplier.apply(AppTheme.system.rawValue)
+    }
+
     func updateMCPServerEnabled(_ enabled: Bool) {
         settings.mcpServerEnabled = enabled
         save()

--- a/Rockxy/Core/Storage/AppSettingsStorage.swift
+++ b/Rockxy/Core/Storage/AppSettingsStorage.swift
@@ -20,6 +20,24 @@ enum AppSettingsStorage {
         settings.listenIPv6 = defaults.bool(forKey: listenIPv6Key)
         settings.autoSelectPort = defaults.object(forKey: autoSelectPortKey) != nil
             ? defaults.bool(forKey: autoSelectPortKey) : true
+        if let theme = defaults.string(forKey: appThemeKey).flatMap(AppTheme.init(rawValue:)) {
+            settings.appTheme = theme
+        }
+        if defaults.object(forKey: appUIFontSizeKey) != nil {
+            settings.appUI.fontSize = AppUISettings.validFontSize(defaults.integer(forKey: appUIFontSizeKey))
+        }
+        if defaults.object(forKey: appUITabWidthKey) != nil {
+            settings.appUI.tabWidth = AppUISettings.validTabWidth(defaults.integer(forKey: appUITabWidthKey))
+        }
+        settings.appUI.useMonospacedFont = defaults.bool(forKey: appUIUseMonospacedFontKey)
+        settings.appUI.bodyWordWrap = defaults.object(forKey: appUIBodyWordWrapKey) != nil
+            ? defaults.bool(forKey: appUIBodyWordWrapKey) : true
+        settings.appUI.bodyShowInvisibles = defaults.bool(forKey: appUIBodyShowInvisiblesKey)
+        settings.appUI.bodyShowMinimap = defaults.bool(forKey: appUIBodyShowMinimapKey)
+        settings.appUI.bodyScrollBeyondLastLine = defaults.bool(forKey: appUIBodyScrollBeyondLastLineKey)
+        settings.appUI.useAlternatingRowBackgroundColors = defaults
+            .object(forKey: appUIUseAlternatingRowBackgroundColorsKey) != nil
+            ? defaults.bool(forKey: appUIUseAlternatingRowBackgroundColorsKey) : true
         settings.scriptingToolEnabled = defaults.object(forKey: scriptingToolEnabledKey) != nil
             ? defaults.bool(forKey: scriptingToolEnabledKey) : true
         settings.allowSystemEnvVars = defaults.bool(forKey: allowSystemEnvVarsKey)
@@ -58,6 +76,18 @@ enum AppSettingsStorage {
         defaults.set(settings.onlyListenOnLocalhost, forKey: onlyListenOnLocalhostKey)
         defaults.set(settings.listenIPv6, forKey: listenIPv6Key)
         defaults.set(settings.autoSelectPort, forKey: autoSelectPortKey)
+        defaults.set(settings.appTheme.rawValue, forKey: appThemeKey)
+        defaults.set(settings.appUI.fontSize, forKey: appUIFontSizeKey)
+        defaults.set(settings.appUI.tabWidth, forKey: appUITabWidthKey)
+        defaults.set(settings.appUI.useMonospacedFont, forKey: appUIUseMonospacedFontKey)
+        defaults.set(settings.appUI.bodyWordWrap, forKey: appUIBodyWordWrapKey)
+        defaults.set(settings.appUI.bodyShowInvisibles, forKey: appUIBodyShowInvisiblesKey)
+        defaults.set(settings.appUI.bodyShowMinimap, forKey: appUIBodyShowMinimapKey)
+        defaults.set(settings.appUI.bodyScrollBeyondLastLine, forKey: appUIBodyScrollBeyondLastLineKey)
+        defaults.set(
+            settings.appUI.useAlternatingRowBackgroundColors,
+            forKey: appUIUseAlternatingRowBackgroundColorsKey
+        )
         defaults.set(settings.scriptingToolEnabled, forKey: scriptingToolEnabledKey)
         defaults.set(settings.allowSystemEnvVars, forKey: allowSystemEnvVarsKey)
         defaults.set(settings.allowMultipleScriptsPerRequest, forKey: allowMultipleScriptsPerRequestKey)
@@ -83,6 +113,17 @@ enum AppSettingsStorage {
     private static let onlyListenOnLocalhostKey = RockxyIdentity.current.defaultsKey("onlyListenOnLocalhost")
     private static let listenIPv6Key = RockxyIdentity.current.defaultsKey("listenIPv6")
     private static let autoSelectPortKey = RockxyIdentity.current.defaultsKey("autoSelectPort")
+    private static let appThemeKey = RockxyIdentity.current.defaultsKey("appTheme")
+    private static let appUIFontSizeKey = RockxyIdentity.current.defaultsKey("appearance.fontSize")
+    private static let appUITabWidthKey = RockxyIdentity.current.defaultsKey("appearance.tabWidth")
+    private static let appUIUseMonospacedFontKey = RockxyIdentity.current.defaultsKey("appearance.useMonospacedFont")
+    private static let appUIBodyWordWrapKey = RockxyIdentity.current.defaultsKey("appearance.bodyWordWrap")
+    private static let appUIBodyShowInvisiblesKey = RockxyIdentity.current.defaultsKey("appearance.bodyShowInvisibles")
+    private static let appUIBodyShowMinimapKey = RockxyIdentity.current.defaultsKey("appearance.bodyShowMinimap")
+    private static let appUIBodyScrollBeyondLastLineKey = RockxyIdentity.current
+        .defaultsKey("appearance.bodyScrollBeyondLastLine")
+    private static let appUIUseAlternatingRowBackgroundColorsKey = RockxyIdentity.current
+        .defaultsKey("appearance.useAlternatingRowBackgroundColors")
     private static let scriptingToolEnabledKey = RockxyIdentity.current.defaultsKey("scripting.toolEnabled")
     private static let allowSystemEnvVarsKey = RockxyIdentity.current.defaultsKey("scripting.allowSystemEnvVars")
     private static let allowMultipleScriptsPerRequestKey = RockxyIdentity.current

--- a/Rockxy/Core/Utilities/JSONPath/JSONPathEvaluator.swift
+++ b/Rockxy/Core/Utilities/JSONPath/JSONPathEvaluator.swift
@@ -29,7 +29,7 @@ struct JSONPathEvaluator: Sendable {
             try Task.checkCancellation()
             nodes = try apply(segment, to: nodes, visited: &visited)
             if nodes.count > limits.maxResultNodes {
-                nodes = Array(nodes.prefix(limits.maxResultNodes))
+                nodes = Array(nodes.prefix(limits.maxResultNodes + 1))
                 break
             }
         }
@@ -84,8 +84,8 @@ struct JSONPathEvaluator: Sendable {
                 for selector in selectors {
                     try Task.checkCancellation()
                     results.append(contentsOf: try apply(selector, to: candidate))
-                    if results.count >= limits.maxResultNodes {
-                        return Array(results.prefix(limits.maxResultNodes))
+                    if results.count > limits.maxResultNodes {
+                        return Array(results.prefix(limits.maxResultNodes + 1))
                     }
                 }
             }
@@ -287,7 +287,7 @@ private extension JSONPathEvaluator {
         case .subsetof:
             let lhs = Set(arrayValues(left))
             let rhs = Set(arrayValues(right))
-            return .bool(lhs.isSubset(of: rhs))
+            return .bool(!lhs.isEmpty && lhs.isSubset(of: rhs))
         case .anyof:
             let lhs = Set(arrayValues(left))
             let rhs = Set(arrayValues(right))

--- a/Rockxy/Models/Settings/AppSettings.swift
+++ b/Rockxy/Models/Settings/AppSettings.swift
@@ -1,5 +1,51 @@
 import Foundation
 
+// MARK: - AppTheme
+
+enum AppTheme: String, CaseIterable, Identifiable {
+    case system
+    case light
+    case dark
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .system: String(localized: "System")
+        case .light: String(localized: "Light")
+        case .dark: String(localized: "Dark")
+        }
+    }
+}
+
+// MARK: - AppUISettings
+
+struct AppUISettings: Equatable {
+    var fontSize: Int = Self.defaultFontSize
+    var tabWidth: Int = Self.defaultTabWidth
+    var useMonospacedFont = false
+    var bodyWordWrap = true
+    var bodyShowInvisibles = false
+    var bodyShowMinimap = false
+    var bodyScrollBeyondLastLine = false
+    var useAlternatingRowBackgroundColors = true
+
+    static let defaultFontSize = 12
+    static let defaultTabWidth = 2
+    static let allowedFontSizes = [10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 24, 28]
+    static let allowedTabWidths = [2, 4]
+
+    static let `default` = AppUISettings()
+
+    static func validFontSize(_ value: Int) -> Int {
+        allowedFontSizes.contains(value) ? value : defaultFontSize
+    }
+
+    static func validTabWidth(_ value: Int) -> Int {
+        allowedTabWidths.contains(value) ? value : defaultTabWidth
+    }
+}
+
 /// In-memory representation of user preferences, backed by `AppSettingsStorage` (UserDefaults).
 /// Default values match the settings UI's initial state.
 struct AppSettings {
@@ -12,6 +58,8 @@ struct AppSettings {
     var onlyListenOnLocalhost: Bool = true
     var listenIPv6: Bool = false
     var autoSelectPort: Bool = true
+    var appTheme: AppTheme = .system
+    var appUI: AppUISettings = .default
 
     /// Master toggle for the Scripting List window. When false, scripts are loaded
     /// but not executed in the proxy pipeline. Default true for backward compat.

--- a/Rockxy/Models/UI/AppUIDisplayMetrics.swift
+++ b/Rockxy/Models/UI/AppUIDisplayMetrics.swift
@@ -1,0 +1,148 @@
+import AppKit
+import SwiftUI
+
+// MARK: - AppUIDisplayMetrics
+
+struct AppUIDisplayMetrics: Equatable {
+    let settings: AppUISettings
+
+    init(settings: AppUISettings = .default) {
+        self.settings = settings
+    }
+
+    var fontSize: CGFloat {
+        CGFloat(settings.fontSize)
+    }
+
+    var secondaryFontSize: CGFloat {
+        max(9, fontSize - 1)
+    }
+
+    var badgeFontSize: CGFloat {
+        max(9, fontSize - 3)
+    }
+
+    var tableRowHeight: CGFloat {
+        max(24, fontSize + 16)
+    }
+
+    var tableTextHeight: CGFloat {
+        max(17, fontSize + 5)
+    }
+
+    var statusBarHeight: CGFloat {
+        max(34, fontSize + 22)
+    }
+
+    var filterBarHeight: CGFloat {
+        max(26, fontSize + 14)
+    }
+
+    var inspectorTabHeight: CGFloat {
+        max(22, fontSize + 10)
+    }
+
+    var inspectorTextEditorSettings: InspectorTextEditorSettings {
+        InspectorTextEditorSettings(appUI: settings)
+    }
+
+    var appKitBodyFont: NSFont {
+        settings.useMonospacedFont
+            ? .monospacedSystemFont(ofSize: fontSize, weight: .regular)
+            : .systemFont(ofSize: fontSize, weight: .regular)
+    }
+
+    var appKitMonospacedFont: NSFont {
+        .monospacedSystemFont(ofSize: fontSize, weight: .regular)
+    }
+
+    func appKitFont(weight: NSFont.Weight = .regular, monospaced: Bool = false) -> NSFont {
+        if monospaced || settings.useMonospacedFont {
+            return .monospacedSystemFont(ofSize: fontSize, weight: weight)
+        }
+        return .systemFont(ofSize: fontSize, weight: weight)
+    }
+
+    func swiftUIFont(weight: Font.Weight = .regular, monospaced: Bool = false) -> Font {
+        if monospaced || settings.useMonospacedFont {
+            return .system(size: fontSize, weight: weight, design: .monospaced)
+        }
+        return .system(size: fontSize, weight: weight)
+    }
+}
+
+// MARK: - InspectorTextEditorSettings
+
+struct InspectorTextEditorSettings: Equatable, Sendable {
+    var fontSize: Int = AppUISettings.defaultFontSize
+    var tabWidth: Int = AppUISettings.defaultTabWidth
+    var useMonospacedFont = false
+    var wordWrap = true
+    var showInvisibles = false
+    var showMinimap = false
+    var scrollBeyondLastLine = false
+
+    init(
+        fontSize: Int = AppUISettings.defaultFontSize,
+        tabWidth: Int = AppUISettings.defaultTabWidth,
+        useMonospacedFont: Bool = false,
+        wordWrap: Bool = true,
+        showInvisibles: Bool = false,
+        showMinimap: Bool = false,
+        scrollBeyondLastLine: Bool = false
+    ) {
+        self.fontSize = AppUISettings.validFontSize(fontSize)
+        self.tabWidth = AppUISettings.validTabWidth(tabWidth)
+        self.useMonospacedFont = useMonospacedFont
+        self.wordWrap = wordWrap
+        self.showInvisibles = showInvisibles
+        self.showMinimap = showMinimap
+        self.scrollBeyondLastLine = scrollBeyondLastLine
+    }
+
+    init(appUI: AppUISettings) {
+        self.init(
+            fontSize: appUI.fontSize,
+            tabWidth: appUI.tabWidth,
+            useMonospacedFont: appUI.useMonospacedFont,
+            wordWrap: appUI.bodyWordWrap,
+            showInvisibles: appUI.bodyShowInvisibles,
+            showMinimap: appUI.bodyShowMinimap,
+            scrollBeyondLastLine: appUI.bodyScrollBeyondLastLine
+        )
+    }
+
+    var cgFontSize: CGFloat {
+        CGFloat(fontSize)
+    }
+
+    var appKitFont: NSFont {
+        useMonospacedFont
+            ? .monospacedSystemFont(ofSize: cgFontSize, weight: .regular)
+            : .systemFont(ofSize: cgFontSize, weight: .regular)
+    }
+
+    var tabInterval: CGFloat {
+        let spaceWidth = (" " as NSString).size(withAttributes: [.font: appKitFont]).width
+        return max(1, spaceWidth * CGFloat(tabWidth))
+    }
+}
+
+// MARK: - AppUIDisplayMetricsKey
+
+private struct AppUIDisplayMetricsKey: EnvironmentKey {
+    static let defaultValue = AppUIDisplayMetrics()
+}
+
+extension EnvironmentValues {
+    var appUIDisplayMetrics: AppUIDisplayMetrics {
+        get { self[AppUIDisplayMetricsKey.self] }
+        set { self[AppUIDisplayMetricsKey.self] = newValue }
+    }
+}
+
+extension View {
+    func appUIDisplayMetrics(_ metrics: AppUIDisplayMetrics) -> some View {
+        environment(\.appUIDisplayMetrics, metrics)
+    }
+}

--- a/Rockxy/Models/UI/FilterCriteria.swift
+++ b/Rockxy/Models/UI/FilterCriteria.swift
@@ -31,12 +31,14 @@ struct FilterCriteria {
     var sidebarPathPrefix: String?
     var sidebarApp: String?
     var sidebarScope: SidebarScope = .allTraffic
+    var exactTransactionID: UUID?
 
     var isEmpty: Bool {
         (!isSearchEnabled || searchText.isEmpty) && methods.isEmpty && statusCodes.isEmpty
             && contentTypes.isEmpty && domains.isEmpty && logLevels.isEmpty
             && activeProtocolFilters.isEmpty && sidebarDomain == nil
             && sidebarPathPrefix == nil && sidebarApp == nil && sidebarScope == .allTraffic
+            && exactTransactionID == nil
     }
 
     var activeFilterCount: Int {

--- a/Rockxy/Theme/Theme.swift
+++ b/Rockxy/Theme/Theme.swift
@@ -133,7 +133,12 @@ enum Theme {
         static let matchHighlightText = Color(nsColor: matchHighlightTextNS)
 
         static let matchHighlightNS = NSColor.systemYellow.withAlphaComponent(0.36)
-        static let matchHighlightTextNS = NSColor.labelColor
+        static let matchHighlightTextNS = NSColor(name: nil) { appearance in
+            let bestMatch = appearance.bestMatch(from: [.darkAqua, .aqua])
+            return bestMatch == .darkAqua
+                ? NSColor(calibratedWhite: 1.0, alpha: 1.0)
+                : NSColor(calibratedWhite: 0.0, alpha: 1.0)
+        }
     }
 
     // MARK: - Plugin

--- a/Rockxy/Views/Components/JSONTreeView.swift
+++ b/Rockxy/Views/Components/JSONTreeView.swift
@@ -58,6 +58,7 @@ struct JSONTreeView: View {
     @State private var selectedMatchPath: String?
 
     @FocusState private var isSearchFocused: Bool
+    @Environment(\.appUIDisplayMetrics) private var metrics
 
     private var queryTaskID: String {
         switch state {
@@ -75,7 +76,7 @@ struct JSONTreeView: View {
                 ProgressView()
                     .controlSize(.small)
                 Text(String(localized: "Parsing JSON..."))
-                    .font(.system(size: 12))
+                    .font(metrics.swiftUIFont())
                     .foregroundStyle(.secondary)
             }
             .frame(maxWidth: .infinity, alignment: .leading)
@@ -90,7 +91,7 @@ struct JSONTreeView: View {
 
         case let .text(text):
             Text(text)
-                .font(.system(size: 12, design: .monospaced))
+                .font(.system(size: metrics.fontSize, design: .monospaced))
                 .textSelection(.enabled)
 
         case .unavailable:
@@ -122,12 +123,12 @@ struct JSONTreeView: View {
             .frame(width: 118)
 
             Image(systemName: "magnifyingglass")
-                .font(.system(size: 12))
+                .font(.system(size: metrics.fontSize))
                 .foregroundStyle(.secondary)
 
             TextField(filterMode.placeholder, text: $query)
                 .textFieldStyle(.plain)
-                .font(.system(size: 12, design: .monospaced))
+                .font(.system(size: metrics.fontSize, design: .monospaced))
                 .focused($isSearchFocused)
                 .onSubmit {
                     advanceSelection()
@@ -148,7 +149,7 @@ struct JSONTreeView: View {
                 .frame(height: 14)
 
             Text(statusText)
-                .font(.system(size: 11, weight: .medium))
+                .font(.system(size: metrics.secondaryFontSize, weight: .medium))
                 .foregroundStyle(queryError == nil ? Color.secondary : Color.red)
                 .frame(minWidth: 86, alignment: .trailing)
         }
@@ -394,6 +395,7 @@ private struct JSONTreeNodeView: View {
     private static let indentWidth: CGFloat = 16
 
     @State private var isExpanded = true
+    @Environment(\.appUIDisplayMetrics) private var metrics
 
     private var effectiveExpanded: Bool {
         filter == nil ? isExpanded : true
@@ -406,10 +408,10 @@ private struct JSONTreeNodeView: View {
     @ViewBuilder private var keyLabel: some View {
         if let key = node.key {
             Text("\"\(key)\"")
-                .font(.system(size: 12, weight: .medium, design: .monospaced))
+                .font(.system(size: metrics.fontSize, weight: .medium, design: .monospaced))
                 .foregroundStyle(Theme.JSON.key)
             Text(": ")
-                .font(.system(size: 12, design: .monospaced))
+                .font(.system(size: metrics.fontSize, design: .monospaced))
                 .foregroundStyle(.secondary)
         }
     }
@@ -421,7 +423,7 @@ private struct JSONTreeNodeView: View {
             }
         } label: {
             Image(systemName: effectiveExpanded ? "chevron.down" : "chevron.right")
-                .font(.system(size: 9))
+                .font(.system(size: metrics.badgeFontSize))
                 .foregroundStyle(.secondary)
                 .frame(width: 16, height: 16)
         }
@@ -455,11 +457,11 @@ private struct JSONTreeNodeView: View {
                 disclosureButton
                 keyLabel
                 Text(effectiveExpanded ? openBracket : "\(openBracket)...\(closeBracket)\(comma)")
-                    .font(.system(size: 12, design: .monospaced))
+                    .font(.system(size: metrics.fontSize, design: .monospaced))
                     .foregroundStyle(Theme.JSON.bracket)
                 if !effectiveExpanded {
                     Text(" // \(count) items")
-                        .font(.system(size: 11))
+                        .font(.system(size: metrics.secondaryFontSize))
                         .foregroundStyle(.tertiary)
                 }
             }
@@ -472,7 +474,7 @@ private struct JSONTreeNodeView: View {
 
                 HStack(spacing: 0) {
                     Text("\(closeBracket)\(comma)")
-                        .font(.system(size: 12, design: .monospaced))
+                        .font(.system(size: metrics.fontSize, design: .monospaced))
                         .foregroundStyle(Theme.JSON.bracket)
                 }
                 .padding(.leading, CGFloat(depth) * Self.indentWidth)
@@ -490,10 +492,10 @@ private struct JSONTreeNodeView: View {
                 .frame(width: 16)
             keyLabel
             valueContent()
-                .font(.system(size: 12, design: .monospaced))
+                .font(.system(size: metrics.fontSize, design: .monospaced))
                 .textSelection(.enabled)
             Text(comma)
-                .font(.system(size: 12, design: .monospaced))
+                .font(.system(size: metrics.fontSize, design: .monospaced))
                 .foregroundStyle(Theme.JSON.bracket)
         }
         .padding(.leading, CGFloat(depth) * Self.indentWidth)

--- a/Rockxy/Views/Inspector/BodyInspectorView.swift
+++ b/Rockxy/Views/Inspector/BodyInspectorView.swift
@@ -10,7 +10,6 @@ struct BodyInspectorView: View {
         if let body = transaction.response?.body {
             AsyncInspectorTextEditor(
                 renderID: "\(transaction.id.uuidString)-legacy-body-\(body.count)",
-                fontSize: 12,
                 highlightContext: highlightContext
             ) {
                 InspectorPayloadFormatter.requestBodyText(body)

--- a/Rockxy/Views/Inspector/HeaderKeyValueTable.swift
+++ b/Rockxy/Views/Inspector/HeaderKeyValueTable.swift
@@ -27,17 +27,19 @@ struct HeaderKeyValueTable: View {
         .clipShape(RoundedRectangle(cornerRadius: 6))
     }
 
+    @Environment(\.appUIDisplayMetrics) private var metrics
+
     private var headerRow: some View {
         HStack(spacing: 0) {
             Text(String(localized: "Key"))
-                .font(.system(size: 12, weight: .semibold))
+                .font(.system(size: metrics.fontSize, weight: .semibold))
                 .foregroundStyle(.primary)
                 .frame(width: 180, alignment: .leading)
                 .padding(.horizontal, 10)
                 .padding(.vertical, 7)
             Divider()
             Text(String(localized: "Value"))
-                .font(.system(size: 12, weight: .semibold))
+                .font(.system(size: metrics.fontSize, weight: .semibold))
                 .foregroundStyle(.primary)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(.horizontal, 10)
@@ -49,7 +51,7 @@ struct HeaderKeyValueTable: View {
     private func row(_ header: HTTPHeader) -> some View {
         HStack(spacing: 0) {
             HighlightedInspectorText(text: header.name, highlightContext: highlightContext)
-                .font(.system(.caption, design: .monospaced))
+                .font(.system(size: metrics.secondaryFontSize, design: .monospaced))
                 .fontWeight(.semibold)
                 .foregroundStyle(.primary)
                 .lineLimit(2)
@@ -60,13 +62,13 @@ struct HeaderKeyValueTable: View {
             Divider()
             HStack(alignment: .top, spacing: 6) {
                 HighlightedInspectorText(text: header.value, highlightContext: highlightContext)
-                    .font(.system(.caption, design: .monospaced))
+                    .font(.system(size: metrics.secondaryFontSize, design: .monospaced))
                     .foregroundStyle(.primary)
                     .textSelection(.enabled)
                     .frame(maxWidth: .infinity, alignment: .topLeading)
                 if let badge = HeaderDebugBadge.classify(header.name) {
                     Text(badge.title)
-                        .font(.caption2.weight(.semibold))
+                        .font(.system(size: metrics.badgeFontSize, weight: .semibold))
                         .foregroundStyle(badge.foreground)
                         .padding(.horizontal, 5)
                         .padding(.vertical, 2)

--- a/Rockxy/Views/Inspector/HexDumpView.swift
+++ b/Rockxy/Views/Inspector/HexDumpView.swift
@@ -8,10 +8,12 @@ struct HexDumpView: View {
     var body: some View {
         ScrollView([.horizontal, .vertical]) {
             Text(hexText)
-                .font(.system(size: 11, design: .monospaced))
+                .font(.system(size: metrics.secondaryFontSize, design: .monospaced))
                 .textSelection(.enabled)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(12)
         }
     }
+
+    @Environment(\.appUIDisplayMetrics) private var metrics
 }

--- a/Rockxy/Views/Inspector/InspectorBodyTextEditor.swift
+++ b/Rockxy/Views/Inspector/InspectorBodyTextEditor.swift
@@ -6,8 +6,29 @@ import SwiftUI
 /// horizontal scrolling, and lightweight syntax coloring.
 struct InspectorBodyTextEditor: NSViewRepresentable {
     let text: String
-    var fontSize: CGFloat = 12
+    var editorID: String = UUID().uuidString
+    var editorSettings = InspectorTextEditorSettings()
     var highlightContext: InspectorHighlightContext = .empty
+
+    init(
+        text: String,
+        editorID: String = UUID().uuidString,
+        editorSettings: InspectorTextEditorSettings = InspectorTextEditorSettings(),
+        highlightContext: InspectorHighlightContext = .empty
+    ) {
+        self.text = text
+        self.editorID = editorID
+        self.editorSettings = editorSettings
+        self.highlightContext = highlightContext
+    }
+
+    init(text: String, fontSize: CGFloat, highlightContext: InspectorHighlightContext = .empty) {
+        self.init(
+            text: text,
+            editorSettings: InspectorTextEditorSettings(fontSize: Int(fontSize)),
+            highlightContext: highlightContext
+        )
+    }
 
     func makeCoordinator() -> Coordinator {
         Coordinator()
@@ -15,6 +36,8 @@ struct InspectorBodyTextEditor: NSViewRepresentable {
 
     func makeNSView(context: Context) -> NSScrollView {
         let scrollView = makeScrollView(context: context)
+        context.coordinator.editorID = editorID
+        context.coordinator.scrollView = scrollView
         configure(scrollView)
         apply(text, to: scrollView, coordinator: context.coordinator)
         return scrollView
@@ -24,14 +47,17 @@ struct InspectorBodyTextEditor: NSViewRepresentable {
         guard let textView = nsView.documentView as? NSTextView else {
             return
         }
-        if textView.string != text || textView.font?.pointSize != fontSize {
+        context.coordinator.editorID = editorID
+        context.coordinator.scrollView = nsView
+        applyEditorSettings(to: nsView)
+        if textView.string != text || context.coordinator.lastEditorSettings != editorSettings {
             let selectedRange = textView.selectedRange()
             apply(text, to: nsView, coordinator: context.coordinator)
             textView.setSelectedRange(clamped(range: selectedRange, length: (text as NSString).length))
         } else if context.coordinator.lastHighlightIdentity != highlightContext.identity {
             context.coordinator.scheduleHighlight(
                 text: text,
-                fontSize: fontSize,
+                editorSettings: editorSettings,
                 highlightContext: highlightContext,
                 in: nsView
             )
@@ -43,10 +69,29 @@ struct InspectorBodyTextEditor: NSViewRepresentable {
     final class Coordinator {
         var highlightTask: Task<Void, Never>?
         var lastHighlightIdentity = ""
+        var lastEditorSettings = InspectorTextEditorSettings()
+        var editorID = ""
+        weak var scrollView: NSScrollView?
+        private var scrollObserver: NSObjectProtocol?
         private var previewPopover: NSPopover?
+
+        init() {
+            scrollObserver = NotificationCenter.default.addObserver(
+                forName: .inspectorTextMinimapScrollRequested,
+                object: nil,
+                queue: .main
+            ) { [weak self] notification in
+                Task { @MainActor in
+                    self?.handleMinimapScroll(notification)
+                }
+            }
+        }
 
         deinit {
             highlightTask?.cancel()
+            if let scrollObserver {
+                NotificationCenter.default.removeObserver(scrollObserver)
+            }
         }
 
         @MainActor
@@ -63,12 +108,13 @@ struct InspectorBodyTextEditor: NSViewRepresentable {
         @MainActor
         func scheduleHighlight(
             text: String,
-            fontSize: CGFloat,
+            editorSettings: InspectorTextEditorSettings,
             highlightContext: InspectorHighlightContext,
             in scrollView: NSScrollView
         ) {
             highlightTask?.cancel()
             lastHighlightIdentity = highlightContext.identity
+            lastEditorSettings = editorSettings
 
             highlightTask = Task { [weak scrollView] in
                 let spans = await Task.detached(priority: .utility) {
@@ -85,7 +131,7 @@ struct InspectorBodyTextEditor: NSViewRepresentable {
                 }
 
                 let selectedRange = textView.selectedRange()
-                let attributed = Self.baseAttributedString(text, fontSize: fontSize)
+                let attributed = Self.baseAttributedString(text, editorSettings: editorSettings)
                 for span in spans where NSMaxRange(span.range) <= attributed.length {
                     attributed.addAttribute(.foregroundColor, value: span.role.color, range: span.range)
                 }
@@ -99,15 +145,44 @@ struct InspectorBodyTextEditor: NSViewRepresentable {
             }
         }
 
-        private static func baseAttributedString(_ text: String, fontSize: CGFloat) -> NSMutableAttributedString {
+        private static func baseAttributedString(
+            _ text: String,
+            editorSettings: InspectorTextEditorSettings
+        )
+            -> NSMutableAttributedString
+        {
             NSMutableAttributedString(
                 string: text,
                 attributes: [
-                    .font: NSFont.monospacedSystemFont(ofSize: fontSize, weight: .regular),
+                    .font: editorSettings.appKitFont,
                     .foregroundColor: NSColor.textColor,
                     .backgroundColor: NSColor.textBackgroundColor,
+                    .paragraphStyle: paragraphStyle(for: editorSettings),
                 ]
             )
+        }
+
+        private static func paragraphStyle(for editorSettings: InspectorTextEditorSettings) -> NSParagraphStyle {
+            let style = NSMutableParagraphStyle()
+            style.defaultTabInterval = editorSettings.tabInterval
+            return style
+        }
+
+        @MainActor
+        private func handleMinimapScroll(_ notification: Notification) {
+            guard let requestedID = notification.userInfo?["editorID"] as? String,
+                  requestedID == editorID,
+                  let fraction = notification.userInfo?["fraction"] as? CGFloat,
+                  let scrollView,
+                  let documentView = scrollView.documentView else
+            {
+                return
+            }
+            let visibleHeight = scrollView.contentView.bounds.height
+            let maxY = max(0, documentView.bounds.height - visibleHeight + scrollView.contentInsets.bottom)
+            let y = min(max(0, fraction), 1) * maxY
+            scrollView.contentView.scroll(to: NSPoint(x: scrollView.contentView.bounds.origin.x, y: y))
+            scrollView.reflectScrolledClipView(scrollView.contentView)
         }
 
         nonisolated private static func highlightSpans(for text: String) -> [HighlightSpan] {
@@ -185,25 +260,17 @@ struct InspectorBodyTextEditor: NSViewRepresentable {
         textView.isAutomaticDashSubstitutionEnabled = false
         textView.isAutomaticTextReplacementEnabled = false
         textView.isAutomaticSpellingCorrectionEnabled = false
-        textView.font = .monospacedSystemFont(ofSize: fontSize, weight: .regular)
         textView.textColor = .textColor
         textView.backgroundColor = .textBackgroundColor
-        textView.textContainerInset = NSSize(width: 8, height: 8)
-        textView.isHorizontallyResizable = true
         textView.isVerticallyResizable = true
         textView.minSize = NSSize(width: 0, height: 0)
         textView.maxSize = NSSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude)
-        textView.autoresizingMask = [.width]
-        textView.textContainer?.containerSize = NSSize(
-            width: CGFloat.greatestFiniteMagnitude,
-            height: CGFloat.greatestFiniteMagnitude
-        )
-        textView.textContainer?.widthTracksTextView = false
 
         let ruler = ScriptCodeEditorRulerView(textView: textView)
         scrollView.verticalRulerView = ruler
         scrollView.hasVerticalRuler = true
         scrollView.rulersVisible = true
+        applyEditorSettings(to: scrollView)
     }
 
     private func makeScrollView(context: Context) -> NSScrollView {
@@ -234,24 +301,96 @@ struct InspectorBodyTextEditor: NSViewRepresentable {
             return
         }
         textView.string = text
-        textView.font = .monospacedSystemFont(ofSize: fontSize, weight: .regular)
+        applyEditorSettings(to: scrollView)
+        textView.font = editorSettings.appKitFont
         textView.textColor = .textColor
         textView.backgroundColor = .textBackgroundColor
         textView.typingAttributes = [
-            .font: NSFont.monospacedSystemFont(ofSize: fontSize, weight: .regular),
+            .font: editorSettings.appKitFont,
             .foregroundColor: NSColor.textColor,
             .backgroundColor: NSColor.textBackgroundColor,
+            .paragraphStyle: paragraphStyle(for: editorSettings),
         ]
 
         if let coordinator {
             coordinator.scheduleHighlight(
                 text: text,
-                fontSize: fontSize,
+                editorSettings: editorSettings,
                 highlightContext: highlightContext,
                 in: scrollView
             )
         }
         (scrollView.verticalRulerView as? ScriptCodeEditorRulerView)?.invalidateLineNumbers()
+    }
+
+    private func applyEditorSettings(to scrollView: NSScrollView) {
+        Self.applyEditorSettings(editorSettings, to: scrollView)
+    }
+
+    static func applyEditorSettings(_ editorSettings: InspectorTextEditorSettings, to scrollView: NSScrollView) {
+        guard let textView = scrollView.documentView as? NSTextView else {
+            return
+        }
+        scrollView.hasHorizontalScroller = !editorSettings.wordWrap
+        scrollView.contentInsets = NSEdgeInsets(
+            top: 0,
+            left: 0,
+            bottom: editorSettings.scrollBeyondLastLine ? 160 : 0,
+            right: 0
+        )
+
+        textView.font = editorSettings.appKitFont
+        textView.textContainerInset = NSSize(width: 8, height: 8)
+        textView.isHorizontallyResizable = !editorSettings.wordWrap
+        textView.autoresizingMask = editorSettings.wordWrap ? [.width] : []
+        textView.layoutManager?.showsInvisibleCharacters = editorSettings.showInvisibles
+        textView.layoutManager?.showsControlCharacters = editorSettings.showInvisibles
+
+        if editorSettings.wordWrap {
+            textView.frame.size.width = max(scrollView.contentSize.width, 1)
+            textView.textContainer?.containerSize = NSSize(
+                width: max(scrollView.contentSize.width, 0),
+                height: CGFloat.greatestFiniteMagnitude
+            )
+            textView.textContainer?.widthTracksTextView = true
+        } else {
+            textView.frame.size.width = max(textView.frame.width, scrollView.contentSize.width)
+            textView.textContainer?.containerSize = NSSize(
+                width: CGFloat.greatestFiniteMagnitude,
+                height: CGFloat.greatestFiniteMagnitude
+            )
+            textView.textContainer?.widthTracksTextView = false
+        }
+        applyTextStorageSettings(editorSettings, to: textView)
+        textView.layoutManager?.invalidateLayout(forCharacterRange: NSRange(location: 0, length: textView.string.utf16.count), actualCharacterRange: nil)
+        textView.needsDisplay = true
+    }
+
+    private static func applyTextStorageSettings(_ editorSettings: InspectorTextEditorSettings, to textView: NSTextView) {
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.defaultTabInterval = editorSettings.tabInterval
+        let fullRange = NSRange(location: 0, length: (textView.string as NSString).length)
+        textView.typingAttributes = [
+            .font: editorSettings.appKitFont,
+            .foregroundColor: NSColor.textColor,
+            .backgroundColor: NSColor.textBackgroundColor,
+            .paragraphStyle: paragraphStyle,
+        ]
+        guard fullRange.length > 0, let textStorage = textView.textStorage else {
+            return
+        }
+        textStorage.beginEditing()
+        textStorage.addAttributes([
+            .font: editorSettings.appKitFont,
+            .paragraphStyle: paragraphStyle,
+        ], range: fullRange)
+        textStorage.endEditing()
+    }
+
+    private func paragraphStyle(for editorSettings: InspectorTextEditorSettings) -> NSParagraphStyle {
+        let style = NSMutableParagraphStyle()
+        style.defaultTabInterval = editorSettings.tabInterval
+        return style
     }
 
     private struct HighlightSpan: Sendable {
@@ -353,7 +492,6 @@ final class InspectorSelectableTextView: NSTextView {
 
 struct AsyncInspectorTextEditor: View {
     let renderID: String
-    var fontSize: CGFloat = 12
     var highlightContext: InspectorHighlightContext = .empty
     let render: @Sendable () -> InspectorTextRenderResult
 
@@ -371,14 +509,29 @@ struct AsyncInspectorTextEditor: View {
         }
     }
 
+    @Environment(\.appUIDisplayMetrics) private var metrics
     @State private var state: InspectorTextLoadState = .loading
 
     @ViewBuilder
     private func loadedContent(_ result: InspectorTextRenderResult) -> some View {
         switch result {
         case let .text(text):
-            InspectorBodyTextEditor(text: text, fontSize: fontSize, highlightContext: highlightContext)
+            let editorSettings = metrics.inspectorTextEditorSettings
+            HStack(spacing: 0) {
+                InspectorBodyTextEditor(
+                    text: text,
+                    editorID: renderID,
+                    editorSettings: editorSettings,
+                    highlightContext: highlightContext
+                )
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
+
+                if editorSettings.showMinimap {
+                    InspectorTextMinimapView(text: text, editorID: renderID)
+                        .frame(width: 48)
+                        .transition(.opacity)
+                }
+            }
         case let .unavailable(title, systemImage, description):
             InspectorEmptyStateView(title, systemImage: systemImage, description: description)
         }
@@ -395,6 +548,69 @@ struct AsyncInspectorTextEditor: View {
         }
         state = .loaded(result)
     }
+}
+
+// MARK: - InspectorTextMinimapView
+
+struct InspectorTextMinimapView: View {
+    let text: String
+    let editorID: String
+
+    var body: some View {
+        GeometryReader { proxy in
+            Canvas { context, size in
+                let lines = sampledLines
+                guard !lines.isEmpty else {
+                    return
+                }
+                let rowHeight = max(1, size.height / CGFloat(lines.count))
+                for (index, line) in lines.enumerated() {
+                    let trimmed = line.trimmingCharacters(in: .whitespaces)
+                    let ratio = min(1, CGFloat(trimmed.count) / 120)
+                    let width = max(6, ratio * (size.width - 10))
+                    let rect = CGRect(
+                        x: 5,
+                        y: CGFloat(index) * rowHeight,
+                        width: width,
+                        height: max(1, rowHeight * 0.55)
+                    )
+                    context.fill(Path(roundedRect: rect, cornerRadius: 1), with: .color(.secondary.opacity(0.36)))
+                }
+            }
+            .background(Color(nsColor: .controlBackgroundColor).opacity(0.48))
+            .overlay(alignment: .leading) {
+                Divider()
+            }
+            .contentShape(Rectangle())
+            .gesture(
+                DragGesture(minimumDistance: 0)
+                    .onChanged { value in
+                        let fraction = min(max(value.location.y / max(proxy.size.height, 1), 0), 1)
+                        NotificationCenter.default.post(
+                            name: .inspectorTextMinimapScrollRequested,
+                            object: nil,
+                            userInfo: ["editorID": editorID, "fraction": fraction]
+                        )
+                    }
+            )
+            .help(String(localized: "Click or drag to scroll body text"))
+        }
+    }
+
+    private var sampledLines: [String] {
+        let lines = text.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+        guard lines.count > Self.maxLines else {
+            return lines
+        }
+        let step = max(1, lines.count / Self.maxLines)
+        return stride(from: 0, to: lines.count, by: step).map { lines[$0] }
+    }
+
+    private static let maxLines = 900
+}
+
+private extension Notification.Name {
+    static let inspectorTextMinimapScrollRequested = Notification.Name("InspectorTextMinimapScrollRequested")
 }
 
 // MARK: - AsyncHexDumpView

--- a/Rockxy/Views/Inspector/InspectorTabButton.swift
+++ b/Rockxy/Views/Inspector/InspectorTabButton.swift
@@ -10,7 +10,7 @@ struct InspectorTabButton: View {
     var body: some View {
         Button(action: action) {
             Text(title)
-                .font(.system(size: 11, weight: isActive ? .bold : .regular))
+                .font(.system(size: metrics.secondaryFontSize, weight: isActive ? .bold : .regular))
                 .foregroundStyle(isActive ? Theme.Inspector.tabActive : Theme.Inspector.tabInactive)
                 .lineLimit(1)
                 .fixedSize(horizontal: true, vertical: false)
@@ -19,4 +19,6 @@ struct InspectorTabButton: View {
         .padding(.horizontal, 6)
         .padding(.vertical, 2)
     }
+
+    @Environment(\.appUIDisplayMetrics) private var metrics
 }

--- a/Rockxy/Views/Inspector/PreviewTabContentView.swift
+++ b/Rockxy/Views/Inspector/PreviewTabContentView.swift
@@ -105,6 +105,7 @@ private struct AsyncPreviewTabRenderView: View {
     }
 
     @State private var state: AsyncPreviewLoadState = .loading
+    @Environment(\.appUIDisplayMetrics) private var metrics
 
     @ViewBuilder
     private func loadedContent(_ result: AsyncPreviewResult) -> some View {
@@ -113,8 +114,20 @@ private struct AsyncPreviewTabRenderView: View {
             if mode == .htmlPreview {
                 HTMLPreviewView(html: text, baseURL: baseURL)
             } else {
-                InspectorBodyTextEditor(text: text, fontSize: 12)
+                let editorSettings = metrics.inspectorTextEditorSettings
+                HStack(spacing: 0) {
+                    InspectorBodyTextEditor(
+                        text: text,
+                        editorID: renderID,
+                        editorSettings: editorSettings
+                    )
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
+
+                    if editorSettings.showMinimap {
+                        InspectorTextMinimapView(text: text, editorID: renderID)
+                            .frame(width: 48)
+                    }
+                }
             }
         case let .hex(text):
             HexDumpView(hexText: text)

--- a/Rockxy/Views/Inspector/QuickPreviewPopoverView.swift
+++ b/Rockxy/Views/Inspector/QuickPreviewPopoverView.swift
@@ -19,6 +19,7 @@ struct QuickPreviewPopoverView: View {
     }
 
     @State private var copied = false
+    @Environment(\.appUIDisplayMetrics) private var metrics
 
     private var title: String {
         switch result {
@@ -54,7 +55,7 @@ struct QuickPreviewPopoverView: View {
         switch result {
         case let .json(_, text),
              let .text(_, text):
-            InspectorBodyTextEditor(text: text, fontSize: 12)
+            InspectorBodyTextEditor(text: text, editorSettings: metrics.inspectorTextEditorSettings)
                 .frame(minHeight: 220)
         case let .keyValue(_, rows):
             ScrollView {
@@ -62,10 +63,10 @@ struct QuickPreviewPopoverView: View {
                     ForEach(rows) { row in
                         HStack(alignment: .top, spacing: 8) {
                             Text(row.key)
-                                .font(.system(size: 12, weight: .semibold, design: .monospaced))
+                                .font(.system(size: metrics.fontSize, weight: .semibold, design: .monospaced))
                                 .frame(width: 150, alignment: .topLeading)
                             Text(row.value)
-                                .font(.system(size: 12, design: .monospaced))
+                                .font(.system(size: metrics.fontSize, design: .monospaced))
                                 .textSelection(.enabled)
                                 .frame(maxWidth: .infinity, alignment: .topLeading)
                         }
@@ -115,11 +116,14 @@ struct QuickPreviewPopoverView: View {
             }
 
             TabView {
-                InspectorBodyTextEditor(text: preview.headerText, fontSize: 12)
+                InspectorBodyTextEditor(text: preview.headerText, editorSettings: metrics.inspectorTextEditorSettings)
                     .tabItem { Text(String(localized: "Header")) }
-                InspectorBodyTextEditor(text: preview.payloadText, fontSize: 12)
+                InspectorBodyTextEditor(text: preview.payloadText, editorSettings: metrics.inspectorTextEditorSettings)
                     .tabItem { Text(String(localized: "Payload")) }
-                InspectorBodyTextEditor(text: preview.signaturePreview, fontSize: 12)
+                InspectorBodyTextEditor(
+                    text: preview.signaturePreview,
+                    editorSettings: metrics.inspectorTextEditorSettings
+                )
                     .tabItem { Text(String(localized: "Signature")) }
             }
             .frame(minHeight: 210)

--- a/Rockxy/Views/Inspector/RawInspectorView.swift
+++ b/Rockxy/Views/Inspector/RawInspectorView.swift
@@ -12,7 +12,6 @@ struct RawInspectorView: View {
         let snapshot = InspectorTransactionSnapshot(transaction: transaction)
         AsyncInspectorTextEditor(
             renderID: "\(snapshot.id.uuidString)-full-raw-\(snapshot.response?.body?.count ?? 0)",
-            fontSize: 12,
             highlightContext: highlightContext
         ) {
             var text = InspectorPayloadFormatter.rawRequest(snapshot.request)

--- a/Rockxy/Views/Inspector/RequestInspectorView.swift
+++ b/Rockxy/Views/Inspector/RequestInspectorView.swift
@@ -13,7 +13,7 @@ struct RequestInspectorView: View {
     var body: some View {
         VStack(spacing: 0) {
             Text(String(localized: "Request"))
-                .font(.system(size: 12, weight: .bold))
+                .font(.system(size: metrics.fontSize, weight: .bold))
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(.horizontal, 8)
                 .padding(.top, 8)
@@ -31,6 +31,7 @@ struct RequestInspectorView: View {
     @State private var selectedPreviewTab: PreviewTab?
 
     @State private var showPreviewPopover = false
+    @Environment(\.appUIDisplayMetrics) private var metrics
 
     private var inspectorTabBar: some View {
         InspectorTabStrip {
@@ -139,7 +140,6 @@ struct RequestInspectorView: View {
         if let body = transaction.request.body {
             AsyncInspectorTextEditor(
                 renderID: "\(transaction.id.uuidString)-request-body-\(body.count)",
-                fontSize: 12,
                 highlightContext: highlightContext
             ) {
                 InspectorPayloadFormatter.requestBodyText(body)
@@ -157,7 +157,6 @@ struct RequestInspectorView: View {
         let snapshot = InspectorTransactionSnapshot(transaction: transaction)
         return AsyncInspectorTextEditor(
             renderID: "\(snapshot.id.uuidString)-request-raw-\(snapshot.request.body?.count ?? 0)",
-            fontSize: 12,
             highlightContext: highlightContext
         ) {
             .text(InspectorPayloadFormatter.rawRequest(snapshot.request))

--- a/Rockxy/Views/Inspector/ResponseInspectorView.swift
+++ b/Rockxy/Views/Inspector/ResponseInspectorView.swift
@@ -21,7 +21,7 @@ struct ResponseInspectorView: View {
     var body: some View {
         VStack(spacing: 0) {
             Text(String(localized: "Response"))
-                .font(.system(size: 12, weight: .bold))
+                .font(.system(size: metrics.fontSize, weight: .bold))
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(.horizontal, 8)
                 .padding(.top, 8)
@@ -45,10 +45,10 @@ struct ResponseInspectorView: View {
     @State private var selectionIntent: ResponseSelectionIntent = .automatic
     @State private var bodyDisplayMode: ResponseBodyDisplayMode = .json
     @State private var sortJSONKeys = true
-    @State private var bodyFontSize: CGFloat = 12
 
     @State private var showPreviewPopover = false
     @Environment(\.openWindow) private var openWindow
+    @Environment(\.appUIDisplayMetrics) private var metrics
 
     private var hasProtocolTab: Bool {
         transaction.webSocketConnection != nil || transaction.graphQLInfo != nil
@@ -202,14 +202,6 @@ struct ResponseInspectorView: View {
 
             Menu(String(localized: "Settings")) {
                 Toggle(String(localized: "Sort JSON Keys"), isOn: $sortJSONKeys)
-                Menu(String(localized: "Font Size")) {
-                    Button("11") { bodyFontSize = 11 }
-                    Button("12") { bodyFontSize = 12 }
-                    Button("13") { bodyFontSize = 13 }
-                    Button("14") { bodyFontSize = 14 }
-                }
-                Button(String(localized: "Theme…")) {}
-                    .disabled(true)
             }
 
             Menu(String(localized: "Format with")) {
@@ -267,9 +259,9 @@ struct ResponseInspectorView: View {
         } label: {
             HStack(spacing: 4) {
                 Text(bodyDisplayMode.displayName)
-                    .font(.system(size: 11, weight: .medium))
+                    .font(.system(size: metrics.secondaryFontSize, weight: .medium))
                 Image(systemName: "chevron.up.chevron.down")
-                    .font(.system(size: 8, weight: .semibold))
+                    .font(.system(size: metrics.badgeFontSize, weight: .semibold))
                     .foregroundStyle(Color(nsColor: .tertiaryLabelColor))
             }
             .padding(.horizontal, 7)
@@ -395,7 +387,6 @@ struct ResponseInspectorView: View {
         let snapshot = InspectorTransactionSnapshot(transaction: transaction)
         AsyncInspectorTextEditor(
             renderID: "\(snapshot.id.uuidString)-response-raw-\(snapshot.response?.body?.count ?? 0)",
-            fontSize: bodyFontSize,
             highlightContext: highlightContext
         ) {
             if let text = InspectorPayloadFormatter.rawResponse(snapshot.response) {
@@ -414,7 +405,6 @@ struct ResponseInspectorView: View {
         let sortedKeys = sortJSONKeys
         AsyncInspectorTextEditor(
             renderID: "\(transaction.id.uuidString)-response-json-\(sortedKeys)-\(body.count)",
-            fontSize: bodyFontSize,
             highlightContext: highlightContext
         ) {
             if let text = InspectorPayloadFormatter.responseDisplayText(body: body, sortedKeys: sortedKeys) {

--- a/Rockxy/Views/Inspector/WebSocketInspectorView.swift
+++ b/Rockxy/Views/Inspector/WebSocketInspectorView.swift
@@ -305,8 +305,7 @@ struct WebSocketInspectorView: View {
         {
             let payload = frame.payload
             AsyncInspectorTextEditor(
-                renderID: "\(frame.id.uuidString)-payload-text-\(payload.count)",
-                fontSize: 11
+                renderID: "\(frame.id.uuidString)-payload-text-\(payload.count)"
             ) {
                 if let text = String(data: payload, encoding: .utf8) {
                     return .text(text)

--- a/Rockxy/Views/Main/Extensions/MainContentCoordinator+ContextMenu.swift
+++ b/Rockxy/Views/Main/Extensions/MainContentCoordinator+ContextMenu.swift
@@ -298,8 +298,7 @@ extension MainContentCoordinator {
         }
 
         var filter = FilterCriteria.empty
-        filter.searchField = .url
-        filter.searchText = transaction.request.url.absoluteString
+        filter.exactTransactionID = transaction.id
         filter.sidebarScope = switch section {
         case .pinned: .pinned
         case .saved: .saved

--- a/Rockxy/Views/Main/Extensions/MainContentCoordinator+Filtering.swift
+++ b/Rockxy/Views/Main/Extensions/MainContentCoordinator+Filtering.swift
@@ -95,6 +95,11 @@ extension MainContentCoordinator {
             if transaction.isTLSFailure {
                 return false
             }
+            if let exactTransactionID = filterCriteria.exactTransactionID,
+               transaction.id != exactTransactionID
+            {
+                return false
+            }
             if let sidebarDomain = filterCriteria.sidebarDomain {
                 guard DomainGrouping.host(transaction.request.host, matchesDomain: sidebarDomain) else {
                     return false
@@ -248,6 +253,11 @@ extension MainContentCoordinator {
         }
         workspace.filteredTransactions = baseList.filter { transaction in
             if transaction.isTLSFailure {
+                return false
+            }
+            if let exactTransactionID = workspace.filterCriteria.exactTransactionID,
+               transaction.id != exactTransactionID
+            {
                 return false
             }
             if let sidebarDomain = workspace.filterCriteria.sidebarDomain {

--- a/Rockxy/Views/Main/Extensions/MainContentCoordinator+Selection.swift
+++ b/Rockxy/Views/Main/Extensions/MainContentCoordinator+Selection.swift
@@ -25,6 +25,7 @@ extension MainContentCoordinator {
             filterCriteria.sidebarPathPrefix = nil
             filterCriteria.sidebarApp = nil
             filterCriteria.sidebarScope = .allTraffic
+            filterCriteria.exactTransactionID = nil
             recomputeFilteredTransactions()
             return
         }
@@ -35,18 +36,21 @@ extension MainContentCoordinator {
             filterCriteria.sidebarPathPrefix = nil
             filterCriteria.sidebarApp = nil
             filterCriteria.sidebarScope = .allTraffic
+            filterCriteria.exactTransactionID = nil
             recomputeFilteredTransactions()
         case let .domainPath(domain, pathPrefix):
             filterCriteria.sidebarDomain = domain
             filterCriteria.sidebarPathPrefix = pathPrefix
             filterCriteria.sidebarApp = nil
             filterCriteria.sidebarScope = .allTraffic
+            filterCriteria.exactTransactionID = nil
             recomputeFilteredTransactions()
         case let .app(name, _):
             filterCriteria.sidebarDomain = nil
             filterCriteria.sidebarPathPrefix = nil
             filterCriteria.sidebarApp = name
             filterCriteria.sidebarScope = .allTraffic
+            filterCriteria.exactTransactionID = nil
             recomputeFilteredTransactions()
         case .allApps,
              .allDomains:
@@ -54,12 +58,14 @@ extension MainContentCoordinator {
             filterCriteria.sidebarPathPrefix = nil
             filterCriteria.sidebarApp = nil
             filterCriteria.sidebarScope = .allTraffic
+            filterCriteria.exactTransactionID = nil
             recomputeFilteredTransactions()
         case .allSaved:
             filterCriteria.sidebarDomain = nil
             filterCriteria.sidebarPathPrefix = nil
             filterCriteria.sidebarApp = nil
             filterCriteria.sidebarScope = .saved
+            filterCriteria.exactTransactionID = nil
             selectedTransaction = nil
             recomputeFilteredTransactions()
         case .allPinned:
@@ -67,6 +73,7 @@ extension MainContentCoordinator {
             filterCriteria.sidebarPathPrefix = nil
             filterCriteria.sidebarApp = nil
             filterCriteria.sidebarScope = .pinned
+            filterCriteria.exactTransactionID = nil
             selectedTransaction = nil
             recomputeFilteredTransactions()
         case let .pinnedTransaction(id):
@@ -74,6 +81,7 @@ extension MainContentCoordinator {
             filterCriteria.sidebarPathPrefix = nil
             filterCriteria.sidebarApp = nil
             filterCriteria.sidebarScope = .pinned
+            filterCriteria.exactTransactionID = nil
             recomputeFilteredTransactions()
             selectedTransaction = transaction(for: id)
         case let .savedTransaction(id):
@@ -81,6 +89,7 @@ extension MainContentCoordinator {
             filterCriteria.sidebarPathPrefix = nil
             filterCriteria.sidebarApp = nil
             filterCriteria.sidebarScope = .saved
+            filterCriteria.exactTransactionID = nil
             recomputeFilteredTransactions()
             selectedTransaction = transaction(for: id)
         default:
@@ -88,6 +97,7 @@ extension MainContentCoordinator {
             filterCriteria.sidebarPathPrefix = nil
             filterCriteria.sidebarApp = nil
             filterCriteria.sidebarScope = .allTraffic
+            filterCriteria.exactTransactionID = nil
             recomputeFilteredTransactions()
         }
     }

--- a/Rockxy/Views/RequestList/RequestTableView.swift
+++ b/Rockxy/Views/RequestList/RequestTableView.swift
@@ -19,7 +19,9 @@ struct RequestTableView: NSViewRepresentable {
     let rows: [RequestListRow]
     let refreshToken: Int
     let isAppendOnly: Bool
+    var displayMetricsOverride: AppUIDisplayMetrics?
     @Binding var selectedIDs: Set<UUID>
+    @Environment(\.appUIDisplayMetrics) private var displayMetrics
 
     var onSelectionChanged: ((Set<UUID>) -> Void)?
     var onDoubleClick: ((HTTPTransaction) -> Void)?
@@ -38,7 +40,6 @@ struct RequestTableView: NSViewRepresentable {
         tableView.allowsColumnReordering = true
         tableView.columnAutoresizingStyle = .uniformColumnAutoresizingStyle
         tableView.intercellSpacing = NSSize(width: 4, height: 0)
-        tableView.rowHeight = 28
         tableView.headerView = NSTableHeaderView()
         tableView.dataSource = context.coordinator
         tableView.delegate = context.coordinator
@@ -97,6 +98,7 @@ struct RequestTableView: NSViewRepresentable {
         scrollView.autoresizingMask = [.width, .height]
         tableView.sizeLastColumnToFit()
         context.coordinator.tableView = tableView
+        context.coordinator.applyDisplayMetrics(to: tableView)
 
         return scrollView
     }
@@ -118,7 +120,12 @@ struct RequestTableView: NSViewRepresentable {
         coordinator.lastRefreshToken = newToken
         coordinator.lastWorkspaceID = workspaceID
 
-        if workspaceChanged || newToken != oldToken {
+        let displayChanged = coordinator.applyDisplayMetrics(to: tableView)
+
+        if displayChanged {
+            tableView.reloadData()
+            coordinator.previousRowCount = rows.count
+        } else if workspaceChanged || newToken != oldToken {
             let newCount = rows.count
             if !workspaceChanged,
                isAppendOnly,
@@ -172,6 +179,10 @@ struct RequestTableView: NSViewRepresentable {
     }
 
     // MARK: Private
+
+    private var effectiveDisplayMetrics: AppUIDisplayMetrics {
+        displayMetricsOverride ?? displayMetrics
+    }
 
     private static let timeFormatter: DateFormatter = {
         let formatter = DateFormatter()
@@ -257,6 +268,7 @@ extension RequestTableView {
         var lastClickedColumn: String?
         var lastRefreshToken: Int = 0
         var previousRowCount: Int = 0
+        var lastAppliedDisplayMetrics: AppUIDisplayMetrics?
 
         /// Guard flag to prevent feedback loops: when we programmatically update NSTableView
         /// selection from SwiftUI state, we suppress the delegate callback that would
@@ -273,6 +285,22 @@ extension RequestTableView {
 
         func numberOfRows(in tableView: NSTableView) -> Int {
             rows.count
+        }
+
+        @discardableResult
+        func applyDisplayMetrics(to tableView: NSTableView) -> Bool {
+            let metrics = parent.effectiveDisplayMetrics
+            guard lastAppliedDisplayMetrics != metrics else {
+                return false
+            }
+            tableView.rowHeight = metrics.tableRowHeight
+            tableView.usesAlternatingRowBackgroundColors = metrics.settings.useAlternatingRowBackgroundColors
+            for column in tableView.tableColumns {
+                column.headerCell.font = .systemFont(ofSize: metrics.secondaryFontSize, weight: .medium)
+            }
+            lastAppliedDisplayMetrics = metrics
+            hasAutoSizedColumns = false
+            return true
         }
 
         func tableView(_ tableView: NSTableView, sortDescriptorsDidChange oldDescriptors: [NSSortDescriptor]) {
@@ -389,6 +417,7 @@ extension RequestTableView {
             let visibleRange = tableView.rows(in: tableView.visibleRect)
             let start = max(0, visibleRange.location)
             let end = min(rows.count, visibleRange.location + visibleRange.length)
+            let metrics = parent.effectiveDisplayMetrics
 
             for rowIdx in start ..< end {
                 let rowData = rows[rowIdx]
@@ -398,35 +427,35 @@ extension RequestTableView {
                 switch columnID {
                 case "url":
                     text = rowData.host + rowData.path
-                    font = .monospacedSystemFont(ofSize: 12, weight: .regular)
+                    font = metrics.appKitFont(monospaced: true)
                 case "client":
                     text = rowData.clientApp ?? ""
-                    font = .systemFont(ofSize: 12)
+                    font = metrics.appKitFont()
                 case "method":
                     text = rowData.method
-                    font = .systemFont(ofSize: 12, weight: .semibold)
+                    font = metrics.appKitFont(weight: .semibold)
                 case "state":
                     text = errorStatusBadgeTitle(for: rowData) ?? rowData.displayStatus
                     font = isErrorStatus(rowData)
-                        ? .systemFont(ofSize: 12, weight: .bold)
-                        : .systemFont(ofSize: 12, weight: .medium)
+                        ? metrics.appKitFont(weight: .bold)
+                        : metrics.appKitFont(weight: .medium)
                 case "code":
                     text = rowData.statusCode.map { "\($0)" } ?? ""
-                    font = .monospacedDigitSystemFont(ofSize: 12, weight: .medium)
+                    font = .monospacedDigitSystemFont(ofSize: metrics.fontSize, weight: .medium)
                 case "time":
                     text = RequestTableView.timeFormatter.string(from: rowData.timestamp)
-                    font = .monospacedDigitSystemFont(ofSize: 11, weight: .regular)
+                    font = .monospacedDigitSystemFont(ofSize: metrics.secondaryFontSize, weight: .regular)
                 case "duration":
                     text = rowData.totalDuration.map {
                         DurationFormatter.format(seconds: $0)
                     } ?? "—"
-                    font = .monospacedDigitSystemFont(ofSize: 11, weight: .regular)
+                    font = .monospacedDigitSystemFont(ofSize: metrics.secondaryFontSize, weight: .regular)
                 case "requestSize":
                     text = rowData.requestSize.map { SizeFormatter.format(bytes: $0) } ?? "—"
-                    font = .monospacedDigitSystemFont(ofSize: 11, weight: .regular)
+                    font = .monospacedDigitSystemFont(ofSize: metrics.secondaryFontSize, weight: .regular)
                 case "responseSize":
                     text = rowData.responseSize.map { SizeFormatter.format(bytes: $0) } ?? "—"
-                    font = .monospacedDigitSystemFont(ofSize: 11, weight: .regular)
+                    font = .monospacedDigitSystemFont(ofSize: metrics.secondaryFontSize, weight: .regular)
                 case "queryName":
                     // Unified display: WS rows show frame count, others show GraphQL op name
                     if rowData.isWebSocket {
@@ -435,14 +464,14 @@ extension RequestTableView {
                     } else {
                         text = rowData.graphQLOpName ?? ""
                     }
-                    font = .systemFont(ofSize: 12)
+                    font = metrics.appKitFont()
                 default:
                     if columnID.hasPrefix("reqHeader.") || columnID.hasPrefix("resHeader.") {
                         text = RequestListRow.resolveHeaderValue(for: columnID, row: rowData)
-                        font = .monospacedSystemFont(ofSize: 11, weight: .regular)
+                        font = metrics.appKitFont(monospaced: true)
                     } else {
                         text = ""
-                        font = .systemFont(ofSize: 12)
+                        font = metrics.appKitFont()
                     }
                 }
 
@@ -1445,7 +1474,6 @@ extension RequestTableView {
         {
             let cellID = NSUserInterfaceItemIdentifier("Cell_status")
             let dotSize: CGFloat = 9
-            let rowHeight: CGFloat = 28
 
             if let existing = tableView.makeView(withIdentifier: cellID, owner: nil),
                let imageView = existing.subviews.first as? NSImageView
@@ -1457,18 +1485,20 @@ extension RequestTableView {
             let container = NSView()
             container.identifier = cellID
 
-            let imageView = NSImageView(frame: NSRect(
-                x: (22 - dotSize) / 2,
-                y: (rowHeight - dotSize) / 2,
-                width: dotSize,
-                height: dotSize
-            ))
+            let imageView = NSImageView()
+            imageView.translatesAutoresizingMaskIntoConstraints = false
 
             if let image = NSImage(systemSymbolName: "circle.fill", accessibilityDescription: nil) {
                 imageView.image = image
             }
             imageView.contentTintColor = statusDotColor(for: row)
             container.addSubview(imageView)
+            NSLayoutConstraint.activate([
+                imageView.centerXAnchor.constraint(equalTo: container.centerXAnchor),
+                imageView.centerYAnchor.constraint(equalTo: container.centerYAnchor),
+                imageView.widthAnchor.constraint(equalToConstant: dotSize),
+                imageView.heightAnchor.constraint(equalToConstant: dotSize),
+            ])
             return container
         }
 
@@ -1480,7 +1510,6 @@ extension RequestTableView {
         {
             let cellID = NSUserInterfaceItemIdentifier("Cell_ssl")
             let iconSize: CGFloat = 12
-            let rowHeight: CGFloat = 28
 
             if let existing = tableView.makeView(withIdentifier: cellID, owner: nil),
                let imageView = existing.subviews.first as? NSImageView
@@ -1493,8 +1522,8 @@ extension RequestTableView {
             let container = NSView()
             container.identifier = cellID
 
-            let imageView = NSImageView(frame: NSRect(x: 0, y: 0, width: iconSize, height: rowHeight))
-            imageView.symbolConfiguration = NSImage.SymbolConfiguration(pointSize: 11, weight: .medium)
+            let imageView = NSImageView(frame: NSRect(x: 0, y: 0, width: iconSize, height: iconSize))
+            imageView.symbolConfiguration = NSImage.SymbolConfiguration(pointSize: parent.effectiveDisplayMetrics.secondaryFontSize, weight: .medium)
             configureSSLImageView(imageView, row: row)
             container.addSubview(imageView)
             centerSSLImageView(imageView, in: container)
@@ -1569,7 +1598,6 @@ extension RequestTableView {
 
                 label = NSTextField(labelWithString: "")
                 label.alignment = .center
-                label.font = .systemFont(ofSize: 12, weight: .bold)
                 label.textColor = .white
                 label.lineBreakMode = .byTruncatingTail
                 label.wantsLayer = true
@@ -1582,10 +1610,11 @@ extension RequestTableView {
                     label.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: 4),
                     label.trailingAnchor.constraint(lessThanOrEqualTo: container.trailingAnchor, constant: -4),
                     label.centerYAnchor.constraint(equalTo: container.centerYAnchor),
-                    label.heightAnchor.constraint(equalToConstant: 18),
+                    label.heightAnchor.constraint(greaterThanOrEqualToConstant: 18),
                 ])
             }
 
+            label.font = parent.effectiveDisplayMetrics.appKitFont(weight: .bold)
             label.stringValue = errorStatusBadgeTitle(for: row) ?? row.displayStatus
             label.layer?.backgroundColor = NSColor.systemRed.cgColor
             return container
@@ -1670,9 +1699,8 @@ extension RequestTableView {
         {
             let iconSize: CGFloat = 16
             let gap: CGFloat = 4
-            let rowHeight: CGFloat = 28
+            let rowHeight = parent.effectiveDisplayMetrics.tableRowHeight
             let iconY = (rowHeight - iconSize) / 2
-            let labelHeight: CGFloat = 18
 
             // Reuse existing cell: subviews order is [imageView, fallbackView, nameLabel]
             if let existing = tableView.makeView(withIdentifier: identifier, owner: nil),
@@ -1683,6 +1711,7 @@ extension RequestTableView {
                 let nameLabel = existing.subviews[2] as? NSTextField
 
                 nameLabel?.stringValue = appName
+                nameLabel?.font = parent.effectiveDisplayMetrics.appKitFont()
                 if let icon = appIcon(for: appName) {
                     imageView?.image = icon
                     imageView?.isHidden = false
@@ -1721,7 +1750,7 @@ extension RequestTableView {
 
             // Subview 2: app name label
             let nameLabel = NSTextField(labelWithString: "")
-            nameLabel.font = .systemFont(ofSize: 12)
+            nameLabel.font = parent.effectiveDisplayMetrics.appKitFont()
             nameLabel.textColor = .secondaryLabelColor
             nameLabel.lineBreakMode = .byTruncatingTail
             nameLabel.translatesAutoresizingMaskIntoConstraints = false
@@ -1731,7 +1760,6 @@ extension RequestTableView {
                 nameLabel.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: iconSize + gap),
                 nameLabel.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -2),
                 nameLabel.centerYAnchor.constraint(equalTo: container.centerYAnchor),
-                nameLabel.heightAnchor.constraint(equalToConstant: labelHeight),
             ])
 
             // Populate content
@@ -1754,10 +1782,9 @@ extension RequestTableView {
             let container = NSView()
             container.identifier = identifier
 
-            let textHeight: CGFloat = 17
             let field = NSTextField(labelWithString: "")
             field.lineBreakMode = .byTruncatingTail
-            field.font = .systemFont(ofSize: 12)
+            field.font = parent.effectiveDisplayMetrics.appKitFont()
             field.textColor = .labelColor
             field.isBordered = false
             field.drawsBackground = false
@@ -1768,7 +1795,6 @@ extension RequestTableView {
                 field.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: 4),
                 field.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -2),
                 field.centerYAnchor.constraint(equalTo: container.centerYAnchor),
-                field.heightAnchor.constraint(equalToConstant: textHeight),
             ])
 
             return container
@@ -1780,21 +1806,22 @@ extension RequestTableView {
             row: Int,
             rowData: RequestListRow
         ) {
+            let metrics = parent.effectiveDisplayMetrics
             cell.stringValue = ""
             cell.textColor = .labelColor
             cell.alignment = .left
-            cell.font = .systemFont(ofSize: 12)
+            cell.font = metrics.appKitFont()
 
             switch column {
             case "row":
                 cell.stringValue = "\(rowData.sequenceNumber)"
                 cell.alignment = .right
-                cell.font = .monospacedDigitSystemFont(ofSize: 11, weight: .regular)
+                cell.font = .monospacedDigitSystemFont(ofSize: metrics.secondaryFontSize, weight: .regular)
                 cell.textColor = .secondaryLabelColor
 
             case "url":
                 cell.stringValue = rowData.host + rowData.path
-                cell.font = .monospacedSystemFont(ofSize: 12, weight: .regular)
+                cell.font = metrics.appKitFont(monospaced: true)
                 cell.textColor = .labelColor
 
             case "method":
@@ -1805,7 +1832,7 @@ extension RequestTableView {
                     string: method,
                     attributes: [
                         .foregroundColor: color,
-                        .font: NSFont.systemFont(ofSize: 12, weight: .semibold),
+                        .font: metrics.appKitFont(weight: .semibold),
                     ]
                 )
 
@@ -1813,7 +1840,7 @@ extension RequestTableView {
                 cell.alignment = .left
                 cell.stringValue = rowData.displayStatus
                 cell.textColor = statusTextColor(for: rowData.state)
-                cell.font = .systemFont(ofSize: 12, weight: .medium)
+                cell.font = metrics.appKitFont(weight: .medium)
 
             case "code":
                 cell.alignment = .center
@@ -1823,18 +1850,18 @@ extension RequestTableView {
                         string: "\(code)",
                         attributes: [
                             .foregroundColor: color,
-                            .font: NSFont.monospacedDigitSystemFont(ofSize: 12, weight: .medium),
+                            .font: NSFont.monospacedDigitSystemFont(ofSize: metrics.fontSize, weight: .medium),
                         ]
                     )
                 } else {
                     cell.stringValue = stateLabel(for: rowData.state)
                     cell.textColor = .tertiaryLabelColor
-                    cell.font = .systemFont(ofSize: 11)
+                    cell.font = metrics.appKitFont()
                 }
 
             case "time":
                 cell.stringValue = RequestTableView.timeFormatter.string(from: rowData.timestamp)
-                cell.font = .monospacedDigitSystemFont(ofSize: 11, weight: .regular)
+                cell.font = .monospacedDigitSystemFont(ofSize: metrics.secondaryFontSize, weight: .regular)
                 cell.textColor = .secondaryLabelColor
 
             case "duration":
@@ -1844,7 +1871,7 @@ extension RequestTableView {
                 } else {
                     cell.stringValue = "—"
                 }
-                cell.font = .monospacedDigitSystemFont(ofSize: 11, weight: .regular)
+                cell.font = .monospacedDigitSystemFont(ofSize: metrics.secondaryFontSize, weight: .regular)
                 cell.textColor = .secondaryLabelColor
 
             case "requestSize":
@@ -1854,7 +1881,7 @@ extension RequestTableView {
                 } else {
                     cell.stringValue = "—"
                 }
-                cell.font = .monospacedDigitSystemFont(ofSize: 11, weight: .regular)
+                cell.font = .monospacedDigitSystemFont(ofSize: metrics.secondaryFontSize, weight: .regular)
                 cell.textColor = .secondaryLabelColor
 
             case "responseSize":
@@ -1864,7 +1891,7 @@ extension RequestTableView {
                 } else {
                     cell.stringValue = "—"
                 }
-                cell.font = .monospacedDigitSystemFont(ofSize: 11, weight: .regular)
+                cell.font = .monospacedDigitSystemFont(ofSize: metrics.secondaryFontSize, weight: .regular)
                 cell.textColor = .secondaryLabelColor
 
             case "queryName":
@@ -1880,7 +1907,7 @@ extension RequestTableView {
             default:
                 if column.hasPrefix("reqHeader.") || column.hasPrefix("resHeader.") {
                     cell.stringValue = RequestListRow.resolveHeaderValue(for: column, row: rowData)
-                    cell.font = .monospacedSystemFont(ofSize: 11, weight: .regular)
+                    cell.font = metrics.appKitFont(monospaced: true)
                     cell.textColor = .secondaryLabelColor
                 } else {
                     cell.stringValue = ""

--- a/Rockxy/Views/RequestList/StatusBarView.swift
+++ b/Rockxy/Views/RequestList/StatusBarView.swift
@@ -199,7 +199,7 @@ private struct FooterToolingChrome: ViewModifier {
 
     func body(content: Content) -> some View {
         content
-            .font(.caption2.weight(.semibold))
+            .font(.system(size: metrics.badgeFontSize, weight: .semibold))
             .foregroundStyle(Color.white)
             .lineLimit(1)
             .padding(.horizontal, 9)
@@ -207,6 +207,8 @@ private struct FooterToolingChrome: ViewModifier {
             .background(backgroundColor, in: Capsule())
             .opacity(isEnabled ? 1 : 0.45)
     }
+
+    @Environment(\.appUIDisplayMetrics) private var metrics
 
     private var backgroundColor: Color {
         if isActive {
@@ -229,7 +231,7 @@ private struct FooterPrimaryButton: View {
     var body: some View {
         Button(action: action) {
             Text(title)
-                .font(.callout)
+                .font(metrics.swiftUIFont())
                 .foregroundStyle(isActive ? Color.accentColor : Color(nsColor: .labelColor))
                 .lineLimit(1)
                 .padding(.horizontal, 16)
@@ -243,6 +245,7 @@ private struct FooterPrimaryButton: View {
     // MARK: Private
 
     @State private var isHovered = false
+    @Environment(\.appUIDisplayMetrics) private var metrics
 
     private var backgroundColor: Color {
         if isActive {
@@ -295,7 +298,7 @@ struct StatusBarView: View {
             rightStats
         }
         .padding(.horizontal, 12)
-        .frame(height: 34)
+        .frame(height: metrics.statusBarHeight)
         .background(Theme.StatusBar.background)
         .overlay(alignment: .top) {
             Divider()
@@ -340,13 +343,13 @@ struct StatusBarView: View {
         Group {
             if let provenance = sessionProvenance {
                 Text(provenance.displayText)
-                    .font(.system(size: 11, weight: .medium))
+                    .font(.system(size: metrics.secondaryFontSize, weight: .medium))
                     .foregroundStyle(Color.accentColor)
                     .lineLimit(1)
                     .truncationMode(.middle)
             } else {
                 Text(statusText)
-                    .font(.system(size: 11))
+                    .font(.system(size: metrics.secondaryFontSize))
                     .foregroundStyle(Color(nsColor: .secondaryLabelColor))
             }
         }
@@ -356,7 +359,7 @@ struct StatusBarView: View {
         HStack(spacing: 8) {
             if let selectedRequestInfo {
                 Text(selectedRequestInfo)
-                    .font(.system(size: 11))
+                    .font(.system(size: metrics.secondaryFontSize))
                     .foregroundStyle(Color(nsColor: .secondaryLabelColor))
                     .lineLimit(1)
 
@@ -367,9 +370,9 @@ struct StatusBarView: View {
             if errorCount > 0 {
                 HStack(spacing: 3) {
                     Image(systemName: "exclamationmark.triangle.fill")
-                        .font(.system(size: 9))
+                        .font(.system(size: metrics.badgeFontSize))
                     Text(String(localized: "\(errorCount) errors"))
-                        .font(.system(size: 11))
+                        .font(.system(size: metrics.secondaryFontSize))
                 }
                 .foregroundStyle(Color(nsColor: .systemRed))
             }
@@ -379,17 +382,17 @@ struct StatusBarView: View {
             }
 
             Text("\(formattedDataSize) total")
-                .font(.system(size: 11))
+                .font(.system(size: metrics.secondaryFontSize))
                 .foregroundStyle(Color(nsColor: .tertiaryLabelColor))
                 .help("Total captured payload bytes")
 
             Text("↑ \(formattedSpeed(uploadSpeed))")
-                .font(.system(size: 11))
+                .font(.system(size: metrics.secondaryFontSize))
                 .foregroundStyle(Color(nsColor: .systemGreen))
                 .help("Captured upload throughput")
 
             Text("↓ \(formattedSpeed(downloadSpeed))")
-                .font(.system(size: 11))
+                .font(.system(size: metrics.secondaryFontSize))
                 .foregroundStyle(Color.accentColor)
                 .help("Captured download throughput")
 
@@ -418,6 +421,7 @@ struct StatusBarView: View {
     }
 
     @Environment(\.openWindow) private var openWindow
+    @Environment(\.appUIDisplayMetrics) private var metrics
 
     @ViewBuilder
     private var toolingButtons: some View {
@@ -442,7 +446,7 @@ struct StatusBarView: View {
 
     private func statusPill(_ title: String, color: Color) -> some View {
         Text(title)
-            .font(.caption2.weight(.semibold))
+            .font(.system(size: metrics.badgeFontSize, weight: .semibold))
             .foregroundStyle(.white)
             .lineLimit(1)
             .padding(.horizontal, 9)
@@ -483,9 +487,9 @@ private struct SessionDurationView: View {
     var body: some View {
         HStack(spacing: 3) {
             Image(systemName: "clock")
-                .font(.system(size: 9))
+                .font(.system(size: metrics.badgeFontSize))
             Text(formattedDuration)
-                .font(.system(size: 11).monospacedDigit())
+                .font(.system(size: metrics.secondaryFontSize).monospacedDigit())
         }
         .foregroundStyle(Color(nsColor: .tertiaryLabelColor))
         .onReceive(timer) { tick in
@@ -496,6 +500,7 @@ private struct SessionDurationView: View {
     // MARK: Private
 
     @State private var now = Date()
+    @Environment(\.appUIDisplayMetrics) private var metrics
 
     private let timer = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
 

--- a/Rockxy/Views/Settings/AppearanceSettingsTab.swift
+++ b/Rockxy/Views/Settings/AppearanceSettingsTab.swift
@@ -1,75 +1,293 @@
 import SwiftUI
 
-/// Application-wide theme selection (System / Light / Dark).
+/// Application-wide appearance and readability settings.
 struct AppearanceSettingsTab: View {
     // MARK: Internal
 
     var body: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: 16) {
-                settingsRow(label: String(localized: "App Theme:")) {
-                    VStack(alignment: .leading, spacing: 12) {
-                        HStack(spacing: 16) {
-                            themeOption(title: String(localized: "System"), value: "system")
-                            themeOption(title: String(localized: "Light"), value: "light")
-                            themeOption(title: String(localized: "Dark"), value: "dark")
-                        }
-                    }
-                }
-                .onChange(of: appTheme) {
-                    AppThemeApplier.apply(appTheme)
-                }
+        VStack(alignment: .leading, spacing: 0) {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 16) {
+                    Text(String(localized: "App UI"))
+                        .font(.system(size: 13, weight: .medium))
 
-                Spacer()
+                    appUISection
+
+                    Text(String(localized: "App Theme"))
+                        .font(.system(size: 13, weight: .medium))
+
+                    themeSection
+                }
+                .padding(.horizontal, 18)
+                .padding(.top, 18)
+                .padding(.bottom, 18)
+                .frame(maxWidth: .infinity, alignment: .topLeading)
             }
-            .padding(.horizontal, 32)
-            .padding(.top, 20)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+
+            restoreDefaultsButton
+                .padding(.horizontal, 18)
+                .padding(.top, 12)
+                .padding(.bottom, 24)
         }
+        .appUIDisplayMetrics(AppUIDisplayMetrics(settings: settingsManager.settings.appUI))
     }
 
     // MARK: Private
 
-    @AppStorage(RockxyIdentity.current.defaultsKey("appTheme")) private var appTheme = "system"
+    private let settingsManager = AppSettingsManager.shared
 
-    private func settingsRow(
+    private var appUI: AppUISettings {
+        settingsManager.settings.appUI
+    }
+
+    private var appTheme: AppTheme {
+        settingsManager.settings.appTheme
+    }
+
+    private var appUISection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            appearanceControlGroup {
+                HStack(alignment: .top, spacing: 28) {
+                    HStack(spacing: 8) {
+                        Text(String(localized: "Font Size:"))
+                            .frame(width: 84, alignment: .trailing)
+                        Picker("", selection: fontSizeBinding) {
+                            ForEach(AppUISettings.allowedFontSizes, id: \.self) { size in
+                                Text("\(size)").tag(size)
+                            }
+                        }
+                        .labelsHidden()
+                        .frame(width: 72)
+                    }
+
+                    HStack(spacing: 8) {
+                        Text(String(localized: "Tab Width:"))
+                        Picker("", selection: tabWidthBinding) {
+                            ForEach(AppUISettings.allowedTabWidths, id: \.self) { width in
+                                Text(String(localized: "\(width) Spaces")).tag(width)
+                            }
+                        }
+                        .labelsHidden()
+                        .frame(width: 112)
+                    }
+                }
+
+                optionRow(label: "") {
+                    Toggle(String(localized: "Use Monospaced Font"), isOn: appUIToggle(\.useMonospacedFont))
+                        .toggleStyle(.checkbox)
+                }
+
+                Text(String(localized: "Apply to all tabs in the Request and Response Panel and the main table."))
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+                    .padding(.leading, 192)
+            }
+
+            appearanceControlGroup {
+                optionRow(label: String(localized: "Body Tab:")) {
+                    VStack(alignment: .leading, spacing: 5) {
+                        Toggle(String(localized: "Word Wrap"), isOn: appUIToggle(\.bodyWordWrap))
+                        Toggle(String(localized: "Show Invisibles"), isOn: appUIToggle(\.bodyShowInvisibles))
+                        Toggle(String(localized: "Show Minimap"), isOn: appUIToggle(\.bodyShowMinimap))
+                        Toggle(String(localized: "Scroll Beyond The Last Line"), isOn: appUIToggle(\.bodyScrollBeyondLastLine))
+                    }
+                    .toggleStyle(.checkbox)
+                }
+            }
+
+            appearanceControlGroup {
+                optionRow(label: String(localized: "Other:")) {
+                    Toggle(
+                        String(localized: "Alternative Rows Background Colors"),
+                        isOn: appUIToggle(\.useAlternatingRowBackgroundColors)
+                    )
+                    .toggleStyle(.checkbox)
+                }
+            }
+        }
+        .font(.system(size: 13))
+        .padding(.horizontal, 112)
+        .padding(.vertical, 12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            Color(nsColor: .controlBackgroundColor).opacity(0.82),
+            in: RoundedRectangle(cornerRadius: 8)
+        )
+        .overlay {
+            RoundedRectangle(cornerRadius: 8)
+                .stroke(Color(nsColor: .separatorColor).opacity(0.22), lineWidth: 0.5)
+        }
+    }
+
+    private var themeSection: some View {
+        HStack(spacing: 56) {
+            ForEach(AppTheme.allCases) { theme in
+                themeOption(theme)
+            }
+        }
+        .padding(.vertical, 18)
+        .frame(maxWidth: .infinity)
+        .overlay {
+            Rectangle()
+                .stroke(Color(nsColor: .separatorColor), lineWidth: 1)
+        }
+    }
+
+    private var restoreDefaultsButton: some View {
+        HStack(spacing: 8) {
+            Button(String(localized: "Restore Defaults")) {
+                settingsManager.restoreAppearanceDefaults()
+            }
+            .controlSize(.regular)
+
+            Button {
+                settingsManager.restoreAppearanceDefaults()
+            } label: {
+                Image(systemName: "arrow.clockwise")
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundStyle(.secondary)
+            }
+            .buttonStyle(.borderless)
+            .controlSize(.small)
+            .help(String(localized: "Restore Defaults"))
+
+            Spacer()
+        }
+        .font(.system(size: 13))
+    }
+
+    private var fontSizeBinding: Binding<Int> {
+        Binding(
+            get: { appUI.fontSize },
+            set: { newValue in
+                settingsManager.updateAppUI { $0.fontSize = newValue }
+            }
+        )
+    }
+
+    private var tabWidthBinding: Binding<Int> {
+        Binding(
+            get: { appUI.tabWidth },
+            set: { newValue in
+                settingsManager.updateAppUI { $0.tabWidth = newValue }
+            }
+        )
+    }
+
+    private func appUIToggle(_ keyPath: WritableKeyPath<AppUISettings, Bool>) -> Binding<Bool> {
+        Binding(
+            get: { appUI[keyPath: keyPath] },
+            set: { newValue in
+                settingsManager.updateAppUI { $0[keyPath: keyPath] = newValue }
+            }
+        )
+    }
+
+    private func optionRow<Content: View>(
         label: String,
-        @ViewBuilder content: () -> some View
+        @ViewBuilder content: () -> Content
     )
         -> some View
     {
-        HStack(alignment: .top, spacing: 0) {
+        HStack(alignment: .top, spacing: 8) {
             Text(label)
-                .font(.system(size: 13, weight: .medium))
-                .frame(width: 160, alignment: .trailing)
-                .padding(.trailing, 16)
-                .padding(.top, 2)
+                .frame(width: 84, alignment: .trailing)
             content()
         }
     }
 
-    private func themeOption(title: String, value: String) -> some View {
-        VStack(spacing: 6) {
-            RoundedRectangle(cornerRadius: 8)
-                .fill(value == "dark" ? Color(nsColor: .darkGray) : Color(nsColor: .windowBackgroundColor))
-                .frame(width: 100, height: 64)
-                .overlay(
-                    RoundedRectangle(cornerRadius: 8)
-                        .stroke(
-                            appTheme == value ? Color.accentColor : Color(nsColor: .separatorColor),
-                            lineWidth: appTheme == value ? 2 : 1
-                        )
-                )
-                .onTapGesture { appTheme = value }
+    private func appearanceControlGroup<Content: View>(@ViewBuilder content: () -> Content) -> some View {
+        content()
+            .padding(.vertical, 2)
+            .frame(maxWidth: .infinity, alignment: .leading)
+    }
 
-            HStack(spacing: 5) {
-                Circle()
-                    .strokeBorder(appTheme == value ? Color.accentColor : Color.gray, lineWidth: 1)
-                    .background(Circle().fill(appTheme == value ? Color.accentColor : Color.clear).padding(4))
-                    .frame(width: 14, height: 14)
-                Text(title)
-                    .font(.system(size: 12))
+    private func themeOption(_ theme: AppTheme) -> some View {
+        Button {
+            settingsManager.updateAppTheme(theme)
+        } label: {
+            VStack(spacing: 8) {
+                ThemePreviewCard(theme: theme)
+                    .frame(width: 78, height: 54)
+
+                HStack(spacing: 6) {
+                    if appTheme == theme {
+                        Image(systemName: "checkmark.circle.fill")
+                            .font(.system(size: 13, weight: .semibold))
+                            .foregroundStyle(Color(nsColor: .systemGreen))
+                    }
+                    Text(theme.displayName)
+                        .font(.system(size: 13))
+                        .foregroundStyle(.primary)
+                }
+                .frame(minWidth: 82)
             }
-            .onTapGesture { appTheme = value }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(theme.displayName)
+        .accessibilityAddTraits(appTheme == theme ? [.isButton, .isSelected] : .isButton)
+    }
+}
+
+// MARK: - ThemePreviewCard
+
+private struct ThemePreviewCard: View {
+    let theme: AppTheme
+
+    var body: some View {
+        ZStack(alignment: .topLeading) {
+            RoundedRectangle(cornerRadius: 6)
+                .fill(background)
+
+            if theme == .system {
+                GeometryReader { proxy in
+                    Path { path in
+                        path.move(to: CGPoint(x: 0, y: proxy.size.height))
+                        path.addLine(to: CGPoint(x: proxy.size.width, y: 0))
+                        path.addLine(to: CGPoint(x: proxy.size.width, y: proxy.size.height))
+                        path.closeSubpath()
+                    }
+                    .fill(Color(nsColor: .controlBackgroundColor))
+                }
+                .clipShape(RoundedRectangle(cornerRadius: 6))
+            }
+
+            HStack(spacing: 4) {
+                Circle().fill(Color(nsColor: .systemRed))
+                Circle().fill(Color(nsColor: .systemYellow))
+                Circle().fill(Color(nsColor: .systemGreen))
+            }
+            .frame(width: 34, height: 6)
+            .padding(7)
+
+            if theme != .system {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("HTTP/1.1 OK 200")
+                        .foregroundStyle(.green)
+                    Text("Vary: Origin")
+                        .foregroundStyle(.purple)
+                    Text("Connection: close")
+                        .foregroundStyle(.blue)
+                }
+                .font(.system(size: 4.5, design: .monospaced))
+                .padding(.top, 22)
+                .padding(.leading, 11)
+            }
+        }
+        .overlay {
+            RoundedRectangle(cornerRadius: 6)
+                .stroke(Color(nsColor: .separatorColor), lineWidth: 0.5)
+        }
+    }
+
+    private var background: Color {
+        switch theme {
+        case .system, .light:
+            Color(nsColor: .textBackgroundColor)
+        case .dark:
+            Color(nsColor: .windowBackgroundColor)
         }
     }
 }

--- a/Rockxy/Views/Settings/SettingsView.swift
+++ b/Rockxy/Views/Settings/SettingsView.swift
@@ -78,9 +78,11 @@ struct SettingsView: View {
                 .tag(RockxySettingsTab.advanced.rawValue)
         }
         .frame(width: 820, height: 600)
+        .appUIDisplayMetrics(AppUIDisplayMetrics(settings: settingsManager.settings.appUI))
     }
 
     // MARK: Private
 
     @AppStorage(RockxySettingsTab.defaultsKey) private var selectedTabID = RockxySettingsTab.general.rawValue
+    private let settingsManager = AppSettingsManager.shared
 }

--- a/Rockxy/Views/Sidebar/SidebarBottomBar.swift
+++ b/Rockxy/Views/Sidebar/SidebarBottomBar.swift
@@ -15,27 +15,27 @@ struct SidebarBottomBar: View {
                 isAddFavoritePresented = true
             } label: {
                 Image(systemName: "plus")
-                    .font(.system(size: 13))
+                    .font(.system(size: metrics.fontSize))
             }
             .buttonStyle(.borderless)
             .help(String(localized: "Add favorite app or domain"))
 
             HStack(spacing: 4) {
                 Image(systemName: "line.3.horizontal.decrease.circle")
-                    .font(.system(size: 11))
+                    .font(.system(size: metrics.secondaryFontSize))
                     .foregroundStyle(.secondary)
                 TextField(
                     String(localized: "Filter (\u{2318}\u{21E7}F)"),
                     text: $filterText
                 )
                 .textFieldStyle(.plain)
-                .font(.system(size: 11))
+                .font(metrics.swiftUIFont())
                 if !filterText.isEmpty {
                     Button {
                         filterText = ""
                     } label: {
                         Image(systemName: "xmark.circle.fill")
-                            .font(.system(size: 10))
+                            .font(.system(size: metrics.badgeFontSize))
                             .foregroundStyle(.secondary)
                     }
                     .buttonStyle(.borderless)
@@ -51,4 +51,6 @@ struct SidebarBottomBar: View {
         .background(Color(nsColor: .windowBackgroundColor))
         .overlay(alignment: .top) { Divider() }
     }
+
+    @Environment(\.appUIDisplayMetrics) private var metrics
 }

--- a/Rockxy/Views/Toolbar/ActiveFilterSummaryBar.swift
+++ b/Rockxy/Views/Toolbar/ActiveFilterSummaryBar.swift
@@ -99,19 +99,21 @@ struct ActiveFilterSummaryBar: View {
                     Button(String(localized: "Clear All")) {
                         clearAllFilters()
                     }
-                    .font(.system(size: 11, weight: .medium))
+                    .font(.system(size: metrics.secondaryFontSize, weight: .medium))
                     .foregroundStyle(Color.accentColor)
                     .buttonStyle(.borderless)
                 }
                 .padding(.horizontal, 8)
             }
-            .frame(height: 26)
+            .frame(height: metrics.filterBarHeight)
             .background(Color(nsColor: .controlBackgroundColor).opacity(0.5))
             .overlay(alignment: .bottom) { Divider() }
         }
     }
 
     // MARK: Private
+
+    @Environment(\.appUIDisplayMetrics) private var metrics
 
     private var hasActiveFilters: Bool {
         coordinator.filterCriteria.sidebarDomain != nil
@@ -145,12 +147,12 @@ private struct FilterChip: View {
     var body: some View {
         HStack(spacing: 4) {
             Text(label)
-                .font(.system(size: 11))
+                .font(.system(size: metrics.secondaryFontSize))
                 .lineLimit(1)
 
             Button(action: onRemove) {
                 Image(systemName: "xmark.circle.fill")
-                    .font(.system(size: 10))
+                    .font(.system(size: metrics.badgeFontSize))
                     .foregroundStyle(.secondary)
             }
             .buttonStyle(.borderless)
@@ -166,4 +168,6 @@ private struct FilterChip: View {
                 )
         )
     }
+
+    @Environment(\.appUIDisplayMetrics) private var metrics
 }

--- a/Rockxy/Views/Toolbar/ActiveFilterSummaryBar.swift
+++ b/Rockxy/Views/Toolbar/ActiveFilterSummaryBar.swift
@@ -43,6 +43,7 @@ struct ActiveFilterSummaryBar: View {
                     if coordinator.filterCriteria.sidebarScope == .saved {
                         FilterChip(label: String(localized: "Saved")) {
                             coordinator.filterCriteria.sidebarScope = .allTraffic
+                            coordinator.filterCriteria.exactTransactionID = nil
                             coordinator.sidebarSelection = nil
                             coordinator.recomputeFilteredTransactions()
                         }
@@ -51,6 +52,7 @@ struct ActiveFilterSummaryBar: View {
                     if coordinator.filterCriteria.sidebarScope == .pinned {
                         FilterChip(label: String(localized: "Pinned")) {
                             coordinator.filterCriteria.sidebarScope = .allTraffic
+                            coordinator.filterCriteria.exactTransactionID = nil
                             coordinator.sidebarSelection = nil
                             coordinator.recomputeFilteredTransactions()
                         }

--- a/Rockxy/Views/Toolbar/AdvancedFilterBar.swift
+++ b/Rockxy/Views/Toolbar/AdvancedFilterBar.swift
@@ -38,7 +38,7 @@ struct AdvancedFilterBar: View {
             Text("On/Off: ⌘B")
             Text("Hide: ESC")
         }
-        .font(.system(size: 10.5))
+        .font(.system(size: max(10.5, metrics.secondaryFontSize - 0.5)))
         .foregroundStyle(Color(nsColor: .tertiaryLabelColor))
         .padding(.horizontal, 12)
         .padding(.vertical, 6)
@@ -53,7 +53,7 @@ struct AdvancedFilterBar: View {
 
             if isFirst {
                 Text("Where")
-                    .font(.system(size: 11, weight: .medium))
+                    .font(.system(size: metrics.secondaryFontSize, weight: .medium))
                     .foregroundStyle(.secondary)
                     .frame(width: Self.connectorWidth, alignment: .leading)
             } else {
@@ -83,7 +83,7 @@ struct AdvancedFilterBar: View {
 
             TextField(String(localized: "Text"), text: $rules[index].value)
                 .textFieldStyle(.roundedBorder)
-                .font(.system(size: 12))
+                .font(metrics.swiftUIFont())
 
             Button {
                 removeRule(at: index)
@@ -110,7 +110,7 @@ struct AdvancedFilterBar: View {
         .padding(.horizontal, 12)
         .padding(.top, index == 0 ? 8 : 4)
         .padding(.bottom, 0)
-        .frame(minHeight: 30)
+        .frame(minHeight: max(30, metrics.fontSize + 18))
         .opacity(rules[index].isEnabled ? 1.0 : 0.5)
     }
 
@@ -134,6 +134,8 @@ struct AdvancedFilterBar: View {
 
     private static let enableToggleWidth: CGFloat = 22
     private static let connectorWidth: CGFloat = 76
+
+    @Environment(\.appUIDisplayMetrics) private var metrics
 
     private var presetMenu: some View {
         Menu {

--- a/Rockxy/Views/Toolbar/FilterPillButton.swift
+++ b/Rockxy/Views/Toolbar/FilterPillButton.swift
@@ -14,14 +14,14 @@ struct FilterPillButton: View {
     var body: some View {
         Button(action: action) {
             Text(title)
-                .font(.system(size: 11, weight: isActive ? .semibold : .regular))
+                .font(.system(size: metrics.secondaryFontSize, weight: isActive ? .semibold : .regular))
                 .foregroundStyle(
                     isActive
                         ? Theme.FilterPill.activeForeground
                         : Theme.FilterPill.inactiveForeground
                 )
                 .padding(.horizontal, 8)
-                .padding(.vertical, 3)
+                .padding(.vertical, max(3, (metrics.fontSize - 10) / 3))
                 .background(
                     isActive
                         ? Theme.FilterPill.activeBackground
@@ -31,4 +31,6 @@ struct FilterPillButton: View {
         }
         .buttonStyle(.borderless)
     }
+
+    @Environment(\.appUIDisplayMetrics) private var metrics
 }

--- a/Rockxy/Views/Toolbar/ProtocolFilterBar.swift
+++ b/Rockxy/Views/Toolbar/ProtocolFilterBar.swift
@@ -42,19 +42,21 @@ struct ProtocolFilterBar: View {
                         activeFilters.removeAll()
                     }
                     .buttonStyle(.borderless)
-                    .font(.system(size: 11))
+                    .font(.system(size: metrics.secondaryFontSize))
                     .foregroundStyle(.secondary)
                 }
             }
             .padding(.horizontal, 8)
         }
-        .padding(.vertical, 4)
+        .padding(.vertical, max(4, (metrics.fontSize - 10) / 3))
         .background(Color(nsColor: .windowBackgroundColor))
         .overlay(alignment: .bottom) { Divider() }
         .fixedSize(horizontal: false, vertical: true)
     }
 
     // MARK: Private
+
+    @Environment(\.appUIDisplayMetrics) private var metrics
 
     private func isActive(_ filter: ProtocolFilter) -> Bool {
         if filter == .all {

--- a/Rockxy/Views/Toolbar/SearchFilterBar.swift
+++ b/Rockxy/Views/Toolbar/SearchFilterBar.swift
@@ -25,6 +25,7 @@ struct SearchFilterBar: View {
 
             TextField(String(localized: "Search..."), text: $searchText)
                 .textFieldStyle(.roundedBorder)
+                .font(metrics.swiftUIFont())
                 .focused($isSearchFocused)
 
             if !searchText.isEmpty {
@@ -38,7 +39,7 @@ struct SearchFilterBar: View {
             }
         }
         .padding(.horizontal, 8)
-        .padding(.vertical, 4)
+        .padding(.vertical, max(4, (metrics.fontSize - 10) / 3))
         .background(Color(nsColor: .windowBackgroundColor))
         .overlay(alignment: .bottom) { Divider() }
         .onReceive(NotificationCenter.default.publisher(for: .focusMainSearchField)) { _ in
@@ -48,4 +49,5 @@ struct SearchFilterBar: View {
     }
 
     @FocusState private var isSearchFocused: Bool
+    @Environment(\.appUIDisplayMetrics) private var metrics
 }

--- a/RockxyTests/Core/Storage/StorageTests.swift
+++ b/RockxyTests/Core/Storage/StorageTests.swift
@@ -108,6 +108,17 @@ struct AppSettingsStorageTests {
         settings.onlyListenOnLocalhost = false
         settings.listenIPv6 = true
         settings.autoSelectPort = true
+        settings.appTheme = .dark
+        settings.appUI = AppUISettings(
+            fontSize: 20,
+            tabWidth: 4,
+            useMonospacedFont: true,
+            bodyWordWrap: false,
+            bodyShowInvisibles: true,
+            bodyShowMinimap: true,
+            bodyScrollBeyondLastLine: true
+        )
+        settings.appUI.useAlternatingRowBackgroundColors = false
         settings.lastExportedRootCAPath = "/tmp/RockxyRootCA.pem"
 
         AppSettingsStorage.save(settings)
@@ -119,6 +130,15 @@ struct AppSettingsStorageTests {
         #expect(loaded.onlyListenOnLocalhost == false)
         #expect(loaded.listenIPv6 == true)
         #expect(loaded.autoSelectPort == true)
+        #expect(loaded.appTheme == .dark)
+        #expect(loaded.appUI.fontSize == 20)
+        #expect(loaded.appUI.tabWidth == 4)
+        #expect(loaded.appUI.useMonospacedFont == true)
+        #expect(loaded.appUI.bodyWordWrap == false)
+        #expect(loaded.appUI.bodyShowInvisibles == true)
+        #expect(loaded.appUI.bodyShowMinimap == true)
+        #expect(loaded.appUI.bodyScrollBeyondLastLine == true)
+        #expect(loaded.appUI.useAlternatingRowBackgroundColors == false)
         #expect(loaded.lastExportedRootCAPath == "/tmp/RockxyRootCA.pem")
 
         settings.lastExportedRootCAPath = nil
@@ -136,7 +156,57 @@ struct AppSettingsStorageTests {
         #expect(defaultSettings.autoStartProxy == false)
         #expect(defaultSettings.listenIPv6 == false)
         #expect(defaultSettings.autoSelectPort == true)
+        #expect(defaultSettings.appTheme == .system)
+        #expect(defaultSettings.appUI == .default)
         #expect(defaultSettings.lastExportedRootCAPath == nil)
+    }
+
+    @Test("appearance settings reject invalid stored menu values")
+    func invalidAppearanceStoredValuesFallBackToDefaults() {
+        let cleanup = installSettingsTestGuard()
+        defer { cleanup() }
+
+        let defaults = UserDefaults.standard
+        defaults.set("neon", forKey: RockxyIdentity.current.defaultsKey("appTheme"))
+        defaults.set(99, forKey: RockxyIdentity.current.defaultsKey("appearance.fontSize"))
+        defaults.set(3, forKey: RockxyIdentity.current.defaultsKey("appearance.tabWidth"))
+
+        let loaded = AppSettingsStorage.load()
+
+        #expect(loaded.appTheme == .system)
+        #expect(loaded.appUI.fontSize == AppUISettings.defaultFontSize)
+        #expect(loaded.appUI.tabWidth == AppUISettings.defaultTabWidth)
+    }
+
+    @MainActor
+    @Test("restore appearance defaults resets only appearance values")
+    func restoreAppearanceDefaults() {
+        let cleanup = installSettingsTestGuard()
+        defer {
+            AppSettingsManager.shared.settings = AppSettingsStorage.load()
+            cleanup()
+        }
+
+        var settings = AppSettings()
+        settings.proxyPort = 8_181
+        settings.appTheme = .dark
+        settings.appUI = AppUISettings(
+            fontSize: 24,
+            tabWidth: 4,
+            useMonospacedFont: true,
+            bodyWordWrap: false,
+            bodyShowInvisibles: true,
+            bodyShowMinimap: true,
+            bodyScrollBeyondLastLine: true
+        )
+        settings.appUI.useAlternatingRowBackgroundColors = false
+        AppSettingsManager.shared.settings = settings
+
+        AppSettingsManager.shared.restoreAppearanceDefaults()
+
+        #expect(AppSettingsManager.shared.settings.proxyPort == 8_181)
+        #expect(AppSettingsManager.shared.settings.appTheme == .system)
+        #expect(AppSettingsManager.shared.settings.appUI == .default)
     }
 
     // MARK: Private

--- a/RockxyTests/Helpers/SettingsTestHelpers.swift
+++ b/RockxyTests/Helpers/SettingsTestHelpers.swift
@@ -10,6 +10,15 @@ let appSettingsKeys = Array(Set(TestIdentity.appSettingsKeys + [
     "onlyListenOnLocalhost",
     "listenIPv6",
     "autoSelectPort",
+    "appTheme",
+    "appearance.fontSize",
+    "appearance.tabWidth",
+    "appearance.useMonospacedFont",
+    "appearance.bodyWordWrap",
+    "appearance.bodyShowInvisibles",
+    "appearance.bodyShowMinimap",
+    "appearance.bodyScrollBeyondLastLine",
+    "appearance.useAlternatingRowBackgroundColors",
     "certificate.lastExportedRootCAPath",
 ].map { RockxyIdentity.current.defaultsKey($0) }))
 

--- a/RockxyTests/Helpers/TestIdentity.swift
+++ b/RockxyTests/Helpers/TestIdentity.swift
@@ -23,6 +23,15 @@ enum TestIdentity {
         "onlyListenOnLocalhost",
         "listenIPv6",
         "autoSelectPort",
+        "appTheme",
+        "appearance.fontSize",
+        "appearance.tabWidth",
+        "appearance.useMonospacedFont",
+        "appearance.bodyWordWrap",
+        "appearance.bodyShowInvisibles",
+        "appearance.bodyShowMinimap",
+        "appearance.bodyScrollBeyondLastLine",
+        "appearance.useAlternatingRowBackgroundColors",
         "certificate.lastExportedRootCAPath",
     ].map { "\(defaultsPrefix).\($0)" }
 

--- a/RockxyTests/Views/Inspector/InspectorTextEditorSettingsTests.swift
+++ b/RockxyTests/Views/Inspector/InspectorTextEditorSettingsTests.swift
@@ -1,0 +1,95 @@
+import AppKit
+@testable import Rockxy
+import Testing
+
+@MainActor
+struct InspectorTextEditorSettingsTests {
+    @Test("Inspector editor settings configure word wrap and horizontal scrolling")
+    func configureWordWrapAndHorizontalScrolling() throws {
+        let scrollView = makeEditorScrollView()
+        let settings = InspectorTextEditorSettings(fontSize: 16, wordWrap: true)
+
+        InspectorBodyTextEditor.applyEditorSettings(settings, to: scrollView)
+
+        let textView = try #require(scrollView.documentView as? NSTextView)
+        #expect(scrollView.hasHorizontalScroller == false)
+        #expect(textView.isHorizontallyResizable == false)
+        #expect(textView.textContainer?.widthTracksTextView == true)
+    }
+
+    @Test("Inspector editor settings configure tab width invisibles and bottom inset")
+    func configureTabWidthInvisiblesAndBottomInset() throws {
+        let scrollView = makeEditorScrollView()
+        let settings = InspectorTextEditorSettings(
+            fontSize: 18,
+            tabWidth: 4,
+            useMonospacedFont: true,
+            wordWrap: false,
+            showInvisibles: true,
+            scrollBeyondLastLine: true
+        )
+
+        InspectorBodyTextEditor.applyEditorSettings(settings, to: scrollView)
+
+        let textView = try #require(scrollView.documentView as? NSTextView)
+        #expect(scrollView.hasHorizontalScroller == true)
+        #expect(scrollView.contentInsets.bottom == 160)
+        #expect(textView.isHorizontallyResizable == true)
+        #expect(textView.textContainer?.widthTracksTextView == false)
+        #expect(textView.layoutManager?.showsInvisibleCharacters == true)
+        #expect(textView.layoutManager?.showsControlCharacters == true)
+        #expect(settings.tabInterval > 0)
+    }
+
+    @Test("Inspector editor settings update existing attributed text storage")
+    func updateExistingAttributedTextStorage() throws {
+        let scrollView = makeEditorScrollView(text: "alpha\tbeta")
+        let settings = InspectorTextEditorSettings(fontSize: 17, tabWidth: 4, useMonospacedFont: true)
+
+        InspectorBodyTextEditor.applyEditorSettings(settings, to: scrollView)
+
+        let textView = try #require(scrollView.documentView as? NSTextView)
+        let font = try #require(textView.textStorage?.attribute(.font, at: 0, effectiveRange: nil) as? NSFont)
+        let paragraphStyle = try #require(
+            textView.textStorage?.attribute(.paragraphStyle, at: 0, effectiveRange: nil) as? NSParagraphStyle
+        )
+        #expect(font.pointSize == 17)
+        #expect(font.fontDescriptor.symbolicTraits.contains(.monoSpace))
+        #expect(paragraphStyle.defaultTabInterval == settings.tabInterval)
+    }
+
+    @Test("Inspector editor settings can switch body display options live")
+    func switchBodyDisplayOptionsLive() throws {
+        let scrollView = makeEditorScrollView(text: "alpha\tbeta")
+        let wrapped = InspectorTextEditorSettings(wordWrap: true, showInvisibles: false, scrollBeyondLastLine: false)
+        let expanded = InspectorTextEditorSettings(wordWrap: false, showInvisibles: true, scrollBeyondLastLine: true)
+
+        InspectorBodyTextEditor.applyEditorSettings(wrapped, to: scrollView)
+        InspectorBodyTextEditor.applyEditorSettings(expanded, to: scrollView)
+
+        let textView = try #require(scrollView.documentView as? NSTextView)
+        #expect(scrollView.hasHorizontalScroller == true)
+        #expect(scrollView.contentInsets.bottom == 160)
+        #expect(textView.isHorizontallyResizable == true)
+        #expect(textView.textContainer?.widthTracksTextView == false)
+        #expect(textView.layoutManager?.showsInvisibleCharacters == true)
+        #expect(textView.layoutManager?.showsControlCharacters == true)
+    }
+
+    private func makeEditorScrollView() -> NSScrollView {
+        makeEditorScrollView(text: "")
+    }
+
+    private func makeEditorScrollView(text: String) -> NSScrollView {
+        let scrollView = NSScrollView(frame: NSRect(x: 0, y: 0, width: 320, height: 240))
+        let textStorage = NSTextStorage()
+        let layoutManager = NSLayoutManager()
+        let textContainer = NSTextContainer(containerSize: scrollView.contentSize)
+        textStorage.addLayoutManager(layoutManager)
+        layoutManager.addTextContainer(textContainer)
+        let textView = NSTextView(frame: NSRect(origin: .zero, size: scrollView.contentSize), textContainer: textContainer)
+        textView.string = text
+        scrollView.documentView = textView
+        return scrollView
+    }
+}

--- a/RockxyTests/Views/Main/FavoriteTransactionContextMenuTests.swift
+++ b/RockxyTests/Views/Main/FavoriteTransactionContextMenuTests.swift
@@ -136,20 +136,22 @@ struct FavoriteTransactionContextMenuTests {
         #expect(loaded.isEmpty)
     }
 
-    @Test("Open in new tab scopes the workspace to the exact request URL")
-    func openInNewTabUsesExactURLFilter() {
+    @Test("Open in new tab scopes the workspace to the exact request without exposing the URL as search text")
+    func openInNewTabUsesHiddenExactTransactionFilter() {
         let coordinator = MainContentCoordinator()
         let transaction = TestFixtures.makeTransaction(url: "https://api.example.com/v1/users?page=1")
+        let duplicateURL = TestFixtures.makeTransaction(url: "https://api.example.com/v1/users?page=1")
         transaction.isPinned = true
-        coordinator.transactions = [transaction]
+        duplicateURL.isPinned = true
+        coordinator.transactions = [transaction, duplicateURL]
 
         coordinator.openFavoriteTransactionInNewTab(transaction, from: .pinned)
 
         #expect(coordinator.workspaceStore.workspaces.count == 2)
         let workspace = coordinator.workspaceStore.workspaces[1]
         #expect(workspace.filterCriteria.sidebarScope == .pinned)
-        #expect(workspace.filterCriteria.searchField == .url)
-        #expect(workspace.filterCriteria.searchText == transaction.request.url.absoluteString)
+        #expect(workspace.filterCriteria.exactTransactionID == transaction.id)
+        #expect(workspace.filterCriteria.searchText.isEmpty)
         #expect(workspace.filteredTransactions.map(\.id) == [transaction.id])
         #expect(workspace.filteredRows.map(\.id) == [transaction.id])
     }
@@ -165,6 +167,8 @@ struct FavoriteTransactionContextMenuTests {
 
         let workspace = coordinator.workspaceStore.workspaces[1]
         #expect(workspace.filterCriteria.sidebarScope == .saved)
+        #expect(workspace.filterCriteria.exactTransactionID == transaction.id)
+        #expect(workspace.filterCriteria.searchText.isEmpty)
         #expect(workspace.filteredTransactions.map(\.id) == [transaction.id])
         #expect(workspace.filteredRows.map(\.id) == [transaction.id])
     }

--- a/RockxyTests/Views/RequestList/RequestTableSelectionScrollTests.swift
+++ b/RockxyTests/Views/RequestList/RequestTableSelectionScrollTests.swift
@@ -43,6 +43,32 @@ struct RequestTableSelectionScrollTests {
         #expect(scrollView.contentView.bounds.origin.y == preservedOrigin.y)
     }
 
+    @Test("Request table applies appearance display metrics")
+    func requestTableAppliesAppearanceDisplayMetrics() {
+        var selectedIDs = Set<UUID>()
+        var appUI = AppUISettings()
+        appUI.fontSize = 24
+        appUI.useAlternatingRowBackgroundColors = false
+        let parent = RequestTableView(
+            workspaceID: UUID(),
+            rows: [],
+            refreshToken: 0,
+            isAppendOnly: false,
+            displayMetricsOverride: AppUIDisplayMetrics(settings: appUI),
+            selectedIDs: Binding(
+                get: { selectedIDs },
+                set: { selectedIDs = $0 }
+            )
+        )
+        let coordinator = RequestTableView.Coordinator(parent: parent)
+        let tableView = makeTableView(rowCount: 1, coordinator: coordinator)
+
+        coordinator.applyDisplayMetrics(to: tableView)
+
+        #expect(tableView.rowHeight == 40)
+        #expect(tableView.usesAlternatingRowBackgroundColors == false)
+    }
+
     private func makeScrollView(documentView: NSTableView) -> NSScrollView {
         let scrollView = NSScrollView(frame: NSRect(x: 0, y: 0, width: 480, height: 120))
         scrollView.hasVerticalScroller = true


### PR DESCRIPTION
## Summary
- Promote the latest `develop` changes into `main`.
- Fix hidden exact-transaction filtering so favorite URL filters do not leak into new tabs.
- Add the redesigned Appearance settings experience with live readability controls for the main workspace, request table, inspector panels, toolbar controls, status bar, and related shared UI surfaces.
- Persist Appearance defaults and fallback behavior for theme, font size, tab width, body display options, minimap, scroll behavior, and alternating rows.
- Add focused regression coverage for settings persistence, inspector editor settings, and request table scaling/selection behavior.

## Validation
- `swiftlint lint --strict`
- `xcodebuild -project Rockxy.xcodeproj -scheme Rockxy -destination 'platform=macOS' test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Theme selection: Choose between system, light, or dark themes
  * Appearance customization: Adjust font size, tab width, text display options (word wrap, invisibles visibility, minimap), and row backgrounds
  * Minimap navigation in text editors for easier content scrolling
  * Enhanced transaction filtering with exact ID matching

* **Improvements**
  * Dynamic typography and layout scaling across all UI components
  * Unified appearance settings for consistent visual theming throughout the app

<!-- end of auto-generated comment: release notes by coderabbit.ai -->