### PR TITLE
Promote Appearance scanability improvements to main

### DIFF
--- a/Rockxy/ContentView.swift
+++ b/Rockxy/ContentView.swift
@@ -141,7 +141,7 @@ struct ContentView: View {
                 }
             }
         }
-        .appUIDisplayMetrics(AppUIDisplayMetrics(settings: settingsManager.settings.appUI))
+        .appUIDisplayMetrics(AppUIDisplayMetrics(settings: settingsManager.appUI))
     }
 
     // MARK: Private

--- a/Rockxy/Core/Services/Infrastructure/AppNotifications.swift
+++ b/Rockxy/Core/Services/Infrastructure/AppNotifications.swift
@@ -23,6 +23,7 @@ extension Notification.Name {
     static let sslProxyingStateDidChange = identity.notificationName("sslProxyingStateDidChange")
     static let bypassProxyListDidChange = identity.notificationName("bypassProxyListDidChange")
     static let upstreamProxyConfigurationDidChange = identity.notificationName("upstreamProxyConfigurationDidChange")
+    static let appearanceDidChange = identity.notificationName("appearanceDidChange")
     static let breakpointHit = identity.notificationName("breakpointHit")
     static let rulesDidChange = identity.notificationName("rulesDidChange")
     static let scriptsDidChange = identity.notificationName("scriptsDidChange")

--- a/Rockxy/Core/Storage/AppSettingsManager.swift
+++ b/Rockxy/Core/Storage/AppSettingsManager.swift
@@ -9,14 +9,24 @@ final class AppSettingsManager {
     // MARK: Lifecycle
 
     private init() {
-        settings = AppSettingsStorage.load()
+        let loadedSettings = AppSettingsStorage.load()
+        settings = loadedSettings
+        appUI = loadedSettings.appUI
+        appTheme = loadedSettings.appTheme
     }
 
     // MARK: Internal
 
     static let shared = AppSettingsManager()
 
-    var settings: AppSettings
+    var settings: AppSettings {
+        didSet {
+            syncAppearanceStateFromSettings()
+        }
+    }
+
+    var appUI: AppUISettings
+    var appTheme: AppTheme
 
     func save() {
         AppSettingsStorage.save(settings)
@@ -33,8 +43,12 @@ final class AppSettingsManager {
     }
 
     func updateAppTheme(_ theme: AppTheme) {
+        guard theme != appTheme else {
+            return
+        }
+        appTheme = theme
         settings.appTheme = theme
-        save()
+        AppSettingsStorage.saveAppearance(appTheme: appTheme, appUI: appUI)
         AppThemeApplier.apply(theme.rawValue)
     }
 
@@ -42,20 +56,31 @@ final class AppSettingsManager {
         var validated = appUI
         validated.fontSize = AppUISettings.validFontSize(appUI.fontSize)
         validated.tabWidth = AppUISettings.validTabWidth(appUI.tabWidth)
+        guard validated != self.appUI else {
+            return
+        }
+        self.appUI = validated
         settings.appUI = validated
-        save()
+        AppSettingsStorage.saveAppearance(appTheme: appTheme, appUI: validated)
     }
 
     func updateAppUI(_ update: (inout AppUISettings) -> Void) {
-        var appUI = settings.appUI
+        var appUI = appUI
         update(&appUI)
         updateAppUI(appUI)
     }
 
     func restoreAppearanceDefaults() {
+        let defaultTheme = AppTheme.system
+        let defaultUI = AppUISettings.default
+        guard appTheme != defaultTheme || appUI != defaultUI else {
+            return
+        }
+        appTheme = defaultTheme
+        appUI = defaultUI
         settings.appTheme = .system
         settings.appUI = .default
-        save()
+        AppSettingsStorage.saveAppearance(appTheme: defaultTheme, appUI: defaultUI)
         AppThemeApplier.apply(AppTheme.system.rawValue)
     }
 
@@ -111,4 +136,13 @@ final class AppSettingsManager {
     // MARK: Private
 
     private static let logger = Logger(subsystem: RockxyIdentity.current.logSubsystem, category: "AppSettingsManager")
+
+    private func syncAppearanceStateFromSettings() {
+        if appUI != settings.appUI {
+            appUI = settings.appUI
+        }
+        if appTheme != settings.appTheme {
+            appTheme = settings.appTheme
+        }
+    }
 }

--- a/Rockxy/Core/Storage/AppSettingsManager.swift
+++ b/Rockxy/Core/Storage/AppSettingsManager.swift
@@ -50,6 +50,7 @@ final class AppSettingsManager {
         settings.appTheme = theme
         AppSettingsStorage.saveAppearance(appTheme: appTheme, appUI: appUI)
         AppThemeApplier.apply(theme.rawValue)
+        notifyAppearanceDidChange()
     }
 
     func updateAppUI(_ appUI: AppUISettings) {
@@ -62,6 +63,7 @@ final class AppSettingsManager {
         self.appUI = validated
         settings.appUI = validated
         AppSettingsStorage.saveAppearance(appTheme: appTheme, appUI: validated)
+        notifyAppearanceDidChange()
     }
 
     func updateAppUI(_ update: (inout AppUISettings) -> Void) {
@@ -82,6 +84,7 @@ final class AppSettingsManager {
         settings.appUI = .default
         AppSettingsStorage.saveAppearance(appTheme: defaultTheme, appUI: defaultUI)
         AppThemeApplier.apply(AppTheme.system.rawValue)
+        notifyAppearanceDidChange()
     }
 
     func updateMCPServerEnabled(_ enabled: Bool) {
@@ -144,5 +147,16 @@ final class AppSettingsManager {
         if appTheme != settings.appTheme {
             appTheme = settings.appTheme
         }
+    }
+
+    private func notifyAppearanceDidChange() {
+        NotificationCenter.default.post(
+            name: .appearanceDidChange,
+            object: self,
+            userInfo: [
+                "fontSize": appUI.fontSize,
+                "theme": appTheme.rawValue,
+            ]
+        )
     }
 }

--- a/Rockxy/Core/Storage/AppSettingsStorage.swift
+++ b/Rockxy/Core/Storage/AppSettingsStorage.swift
@@ -77,17 +77,7 @@ enum AppSettingsStorage {
         defaults.set(settings.listenIPv6, forKey: listenIPv6Key)
         defaults.set(settings.autoSelectPort, forKey: autoSelectPortKey)
         defaults.set(settings.appTheme.rawValue, forKey: appThemeKey)
-        defaults.set(settings.appUI.fontSize, forKey: appUIFontSizeKey)
-        defaults.set(settings.appUI.tabWidth, forKey: appUITabWidthKey)
-        defaults.set(settings.appUI.useMonospacedFont, forKey: appUIUseMonospacedFontKey)
-        defaults.set(settings.appUI.bodyWordWrap, forKey: appUIBodyWordWrapKey)
-        defaults.set(settings.appUI.bodyShowInvisibles, forKey: appUIBodyShowInvisiblesKey)
-        defaults.set(settings.appUI.bodyShowMinimap, forKey: appUIBodyShowMinimapKey)
-        defaults.set(settings.appUI.bodyScrollBeyondLastLine, forKey: appUIBodyScrollBeyondLastLineKey)
-        defaults.set(
-            settings.appUI.useAlternatingRowBackgroundColors,
-            forKey: appUIUseAlternatingRowBackgroundColorsKey
-        )
+        saveAppUI(settings.appUI, to: defaults)
         defaults.set(settings.scriptingToolEnabled, forKey: scriptingToolEnabledKey)
         defaults.set(settings.allowSystemEnvVars, forKey: allowSystemEnvVarsKey)
         defaults.set(settings.allowMultipleScriptsPerRequest, forKey: allowMultipleScriptsPerRequestKey)
@@ -101,6 +91,13 @@ enum AppSettingsStorage {
         defaults.set(settings.githubGistCopyURLToClipboard, forKey: githubGistCopyURLToClipboardKey)
         defaults.set(settings.lastExportedRootCAPath, forKey: lastExportedRootCAPathKey)
         logger.info("Settings saved")
+    }
+
+    static func saveAppearance(appTheme: AppTheme, appUI: AppUISettings) {
+        let defaults = UserDefaults.standard
+        defaults.set(appTheme.rawValue, forKey: appThemeKey)
+        saveAppUI(appUI, to: defaults)
+        logger.info("Appearance settings saved")
     }
 
     // MARK: Private
@@ -140,4 +137,18 @@ enum AppSettingsStorage {
     private static let githubGistCopyURLToClipboardKey = RockxyIdentity.current
         .defaultsKey("github.gist.copyURLToClipboard")
     private static let lastExportedRootCAPathKey = RockxyIdentity.current.defaultsKey("certificate.lastExportedRootCAPath")
+
+    private static func saveAppUI(_ appUI: AppUISettings, to defaults: UserDefaults) {
+        defaults.set(appUI.fontSize, forKey: appUIFontSizeKey)
+        defaults.set(appUI.tabWidth, forKey: appUITabWidthKey)
+        defaults.set(appUI.useMonospacedFont, forKey: appUIUseMonospacedFontKey)
+        defaults.set(appUI.bodyWordWrap, forKey: appUIBodyWordWrapKey)
+        defaults.set(appUI.bodyShowInvisibles, forKey: appUIBodyShowInvisiblesKey)
+        defaults.set(appUI.bodyShowMinimap, forKey: appUIBodyShowMinimapKey)
+        defaults.set(appUI.bodyScrollBeyondLastLine, forKey: appUIBodyScrollBeyondLastLineKey)
+        defaults.set(
+            appUI.useAlternatingRowBackgroundColors,
+            forKey: appUIUseAlternatingRowBackgroundColorsKey
+        )
+    }
 }

--- a/Rockxy/Models/Settings/AppSettings.swift
+++ b/Rockxy/Models/Settings/AppSettings.swift
@@ -30,7 +30,7 @@ struct AppUISettings: Equatable {
     var bodyScrollBeyondLastLine = false
     var useAlternatingRowBackgroundColors = true
 
-    static let defaultFontSize = 12
+    static let defaultFontSize = 13
     static let defaultTabWidth = 2
     static let allowedFontSizes = [10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 24, 28]
     static let allowedTabWidths = [2, 4]

--- a/Rockxy/Models/UI/AppUIDisplayMetrics.swift
+++ b/Rockxy/Models/UI/AppUIDisplayMetrics.swift
@@ -280,3 +280,20 @@ extension View {
         environment(\.appUIDisplayMetrics, metrics)
     }
 }
+
+// MARK: - AppUIDisplayMetricsProvider
+
+struct AppUIDisplayMetricsProvider<Content: View>: View {
+    let content: Content
+
+    init(@ViewBuilder content: () -> Content) {
+        self.content = content()
+    }
+
+    var body: some View {
+        content
+            .appUIDisplayMetrics(AppUIDisplayMetrics(settings: settingsManager.appUI))
+    }
+
+    private let settingsManager = AppSettingsManager.shared
+}

--- a/Rockxy/Models/UI/AppUIDisplayMetrics.swift
+++ b/Rockxy/Models/UI/AppUIDisplayMetrics.swift
@@ -78,6 +78,38 @@ struct AppUIDisplayMetrics: Equatable {
         max(14, min(fontSize + 3, 18))
     }
 
+    var chromeFontSize: CGFloat {
+        controlFontSize
+    }
+
+    var chromeSecondaryFontSize: CGFloat {
+        secondaryFontSize
+    }
+
+    var chromeIconFontSize: CGFloat {
+        max(11, controlFontSize)
+    }
+
+    var chromeBadgeFontSize: CGFloat {
+        max(10, controlFontSize)
+    }
+
+    var chromeStatusDotSize: CGFloat {
+        max(8, min(controlFontSize - 2, 14))
+    }
+
+    var chromeControlHeight: CGFloat {
+        max(32, controlFontSize + 16)
+    }
+
+    var chromeBadgeHeight: CGFloat {
+        max(24, controlFontSize + 11)
+    }
+
+    var workspaceTabFontSize: CGFloat {
+        max(13, min(controlFontSize, 18))
+    }
+
     var tableRowHeight: CGFloat {
         if fontSize <= 12 {
             return max(24, fontSize + 16)

--- a/Rockxy/Models/UI/AppUIDisplayMetrics.swift
+++ b/Rockxy/Models/UI/AppUIDisplayMetrics.swift
@@ -14,16 +14,78 @@ struct AppUIDisplayMetrics: Equatable {
         CGFloat(settings.fontSize)
     }
 
+    var primaryFontSize: CGFloat {
+        fontSize
+    }
+
+    var controlFontSize: CGFloat {
+        max(11, fontSize - 1)
+    }
+
     var secondaryFontSize: CGFloat {
         max(9, fontSize - 1)
     }
 
+    var metadataFontSize: CGFloat {
+        max(10, fontSize - 2)
+    }
+
     var badgeFontSize: CGFloat {
-        max(9, fontSize - 3)
+        max(10, fontSize - 3)
+    }
+
+    var monospacedContentFontSize: CGFloat {
+        fontSize
+    }
+
+    var sidebarNavigationFontSize: CGFloat {
+        max(11, fontSize)
+    }
+
+    var sidebarSecondaryFontSize: CGFloat {
+        max(10, fontSize - 1)
+    }
+
+    var sidebarSectionHeaderFontSize: CGFloat {
+        max(10, fontSize - 2)
+    }
+
+    var sidebarBadgeFontSize: CGFloat {
+        max(10, fontSize - 2)
+    }
+
+    var sidebarIconFontSize: CGFloat {
+        max(12, fontSize)
+    }
+
+    var sidebarAppIconSize: CGFloat {
+        max(20, min(fontSize + 7, 32))
+    }
+
+    var sidebarRowHeight: CGFloat {
+        max(24, fontSize + 12)
+    }
+
+    var tableStatusDotSize: CGFloat {
+        max(8, min(fontSize - 3, 12))
+    }
+
+    var tableSSLIconSize: CGFloat {
+        max(10, min(fontSize - 1, 16))
+    }
+
+    var tableClientIconSize: CGFloat {
+        max(14, min(fontSize + 3, 18))
     }
 
     var tableRowHeight: CGFloat {
-        max(24, fontSize + 16)
+        if fontSize <= 12 {
+            return max(24, fontSize + 16)
+        }
+        if fontSize <= 13 {
+            return 28
+        }
+        return fontSize + 16
     }
 
     var tableTextHeight: CGFloat {
@@ -68,6 +130,78 @@ struct AppUIDisplayMetrics: Equatable {
             return .system(size: fontSize, weight: weight, design: .monospaced)
         }
         return .system(size: fontSize, weight: weight)
+    }
+}
+
+// MARK: - DeveloperSetupDisplayMetrics
+
+struct DeveloperSetupDisplayMetrics: Equatable {
+    let appMetrics: AppUIDisplayMetrics
+
+    init(appMetrics: AppUIDisplayMetrics = AppUIDisplayMetrics()) {
+        self.appMetrics = appMetrics
+    }
+
+    var titleFontSize: CGFloat {
+        max(15, appMetrics.primaryFontSize + 5)
+    }
+
+    var sectionTitleFontSize: CGFloat {
+        max(13, appMetrics.primaryFontSize + 1)
+    }
+
+    var bodyFontSize: CGFloat {
+        appMetrics.primaryFontSize
+    }
+
+    var controlFontSize: CGFloat {
+        appMetrics.controlFontSize
+    }
+
+    var secondaryFontSize: CGFloat {
+        max(11, appMetrics.primaryFontSize - 1)
+    }
+
+    var metadataFontSize: CGFloat {
+        appMetrics.metadataFontSize
+    }
+
+    var badgeFontSize: CGFloat {
+        appMetrics.badgeFontSize
+    }
+
+    var iconFontSize: CGFloat {
+        max(13, appMetrics.controlFontSize + 1)
+    }
+
+    var prominentIconFontSize: CGFloat {
+        max(20, appMetrics.primaryFontSize + 9)
+    }
+
+    var snippetFontSize: CGFloat {
+        appMetrics.monospacedContentFontSize
+    }
+
+    var sidebarRowHeight: CGFloat {
+        max(36, appMetrics.primaryFontSize + 24)
+    }
+
+    var cardMinimumHeight: CGFloat {
+        max(82, appMetrics.primaryFontSize + 68)
+    }
+
+    func font(weight: Font.Weight = .regular, monospaced: Bool = false) -> Font {
+        if monospaced || appMetrics.settings.useMonospacedFont {
+            return .system(size: bodyFontSize, weight: weight, design: .monospaced)
+        }
+        return .system(size: bodyFontSize, weight: weight)
+    }
+
+    func secondaryFont(weight: Font.Weight = .regular, monospaced: Bool = false) -> Font {
+        if monospaced || appMetrics.settings.useMonospacedFont {
+            return .system(size: secondaryFontSize, weight: weight, design: .monospaced)
+        }
+        return .system(size: secondaryFontSize, weight: weight)
     }
 }
 

--- a/Rockxy/Models/UI/WorkspaceState.swift
+++ b/Rockxy/Models/UI/WorkspaceState.swift
@@ -58,6 +58,7 @@ final class WorkspaceState: Identifiable {
 
     // Sidebar (per-workspace view of captured data)
     var domainTree: [DomainNode] = []
+    var totalDomainCount = 0
     var domainIndexMap: [String: Int] = [:]
     var domainGroupingIndex = DomainGroupingIndex()
     var appNodes: [AppInfo] = []
@@ -72,6 +73,7 @@ final class WorkspaceState: Identifiable {
         selectedLogEntry = nil
         selectedTransactionIDs.removeAll()
         domainTree.removeAll()
+        totalDomainCount = 0
         domainIndexMap.removeAll()
         domainGroupingIndex.removeAll()
         appNodes.removeAll()

--- a/Rockxy/RockxyApp.swift
+++ b/Rockxy/RockxyApp.swift
@@ -42,8 +42,9 @@ struct RockxyApp: App {
         .windowResizability(.contentSize)
 
         Window(String(localized: "Developer Setup Hub"), id: "developerSetupHub") {
-            DeveloperSetupWindowView(coordinator: mainCoordinator)
-                .appUIDisplayMetrics(AppUIDisplayMetrics(settings: AppSettingsManager.shared.settings.appUI))
+            AppUIDisplayMetricsProvider {
+                DeveloperSetupWindowView(coordinator: mainCoordinator)
+            }
         }
         .commandsRemoved()
         .defaultSize(width: 1_180, height: 760)
@@ -67,8 +68,9 @@ struct RockxyApp: App {
         .windowToolbarStyle(.unifiedCompact)
 
         Window(String(localized: "Automatic Setup"), id: "automaticSetup") {
-            DeveloperSetupAutomaticWindowView(coordinator: mainCoordinator)
-                .appUIDisplayMetrics(AppUIDisplayMetrics(settings: AppSettingsManager.shared.settings.appUI))
+            AppUIDisplayMetricsProvider {
+                DeveloperSetupAutomaticWindowView(coordinator: mainCoordinator)
+            }
         }
         .commandsRemoved()
         .defaultSize(width: 760, height: 500)
@@ -77,8 +79,9 @@ struct RockxyApp: App {
         .windowResizability(.contentSize)
 
         Window(String(localized: "Manual Setup"), id: "manualSetup") {
-            DeveloperSetupManualWindowView(coordinator: mainCoordinator)
-                .appUIDisplayMetrics(AppUIDisplayMetrics(settings: AppSettingsManager.shared.settings.appUI))
+            AppUIDisplayMetricsProvider {
+                DeveloperSetupManualWindowView(coordinator: mainCoordinator)
+            }
         }
         .commandsRemoved()
         .defaultSize(width: 780, height: 540)

--- a/Rockxy/RockxyApp.swift
+++ b/Rockxy/RockxyApp.swift
@@ -25,10 +25,12 @@ struct RockxyApp: App {
 
     var body: some Scene {
         Window(RockxyIdentity.current.displayName, id: "main") {
-            MainWindowContent(
-                lifecycleState: lifecycleState,
-                coordinator: mainCoordinator
-            )
+            AppUIDisplayMetricsProvider {
+                MainWindowContent(
+                    lifecycleState: lifecycleState,
+                    coordinator: mainCoordinator
+                )
+            }
         }
         .windowToolbarStyle(.unified)
         .commands {

--- a/Rockxy/RockxyApp.swift
+++ b/Rockxy/RockxyApp.swift
@@ -43,6 +43,7 @@ struct RockxyApp: App {
 
         Window(String(localized: "Developer Setup Hub"), id: "developerSetupHub") {
             DeveloperSetupWindowView(coordinator: mainCoordinator)
+                .appUIDisplayMetrics(AppUIDisplayMetrics(settings: AppSettingsManager.shared.settings.appUI))
         }
         .commandsRemoved()
         .defaultSize(width: 1_180, height: 760)
@@ -67,6 +68,7 @@ struct RockxyApp: App {
 
         Window(String(localized: "Automatic Setup"), id: "automaticSetup") {
             DeveloperSetupAutomaticWindowView(coordinator: mainCoordinator)
+                .appUIDisplayMetrics(AppUIDisplayMetrics(settings: AppSettingsManager.shared.settings.appUI))
         }
         .commandsRemoved()
         .defaultSize(width: 760, height: 500)
@@ -76,6 +78,7 @@ struct RockxyApp: App {
 
         Window(String(localized: "Manual Setup"), id: "manualSetup") {
             DeveloperSetupManualWindowView(coordinator: mainCoordinator)
+                .appUIDisplayMetrics(AppUIDisplayMetrics(settings: AppSettingsManager.shared.settings.appUI))
         }
         .commandsRemoved()
         .defaultSize(width: 780, height: 540)

--- a/Rockxy/Views/DeveloperSetup/DeveloperSetupAutomaticWindowView.swift
+++ b/Rockxy/Views/DeveloperSetup/DeveloperSetupAutomaticWindowView.swift
@@ -37,17 +37,22 @@ struct DeveloperSetupAutomaticWindowView: View {
     // MARK: Private
 
     @State private var viewModel: DeveloperSetupSessionSetupViewModel
+    @Environment(\.appUIDisplayMetrics) private var appMetrics
+
+    private var setupMetrics: DeveloperSetupDisplayMetrics {
+        DeveloperSetupDisplayMetrics(appMetrics: appMetrics)
+    }
 
     private var header: some View {
         VStack(alignment: .leading, spacing: 12) {
             HStack(alignment: .center, spacing: 12) {
                 Image(systemName: "gearshape.2.fill")
-                    .font(.system(size: 24, weight: .regular))
+                    .font(.system(size: setupMetrics.prominentIconFontSize, weight: .regular))
                     .symbolRenderingMode(.hierarchical)
                     .foregroundStyle(.secondary)
 
                 Text(String(localized: "Automatic Setup"))
-                    .font(.title2.weight(.semibold))
+                    .font(.system(size: setupMetrics.titleFontSize, weight: .semibold))
                     .foregroundStyle(.primary)
             }
 
@@ -71,15 +76,15 @@ struct DeveloperSetupAutomaticWindowView: View {
     private var terminalSection: some View {
         VStack(alignment: .leading, spacing: 8) {
             Text(String(localized: "Terminal App"))
-                .font(.headline)
+                .font(.system(size: setupMetrics.sectionTitleFontSize, weight: .semibold))
 
             VStack(alignment: .leading, spacing: 10) {
                 Text(String(localized: "Open a prepared terminal session that points supported tools at Rockxy."))
-                    .font(.callout)
+                    .font(.system(size: setupMetrics.bodyFontSize))
                     .foregroundStyle(.secondary)
 
                 Text(String(localized: "Supports Node.js, Ruby, Python, Go, cURL, and shell workflows that do not follow the system proxy."))
-                    .font(.callout)
+                    .font(.system(size: setupMetrics.bodyFontSize))
                     .foregroundStyle(.secondary)
 
                 Divider()
@@ -117,11 +122,11 @@ struct DeveloperSetupAutomaticWindowView: View {
     private var browserSection: some View {
         VStack(alignment: .leading, spacing: 8) {
             Text(String(localized: "Web Browsers"))
-                .font(.headline)
+                .font(.system(size: setupMetrics.sectionTitleFontSize, weight: .semibold))
 
             VStack(alignment: .leading, spacing: 10) {
                 Text(String(localized: "Open a prepared browser profile with Rockxy proxy and certificate guidance scoped to that profile."))
-                    .font(.callout)
+                    .font(.system(size: setupMetrics.bodyFontSize))
                     .foregroundStyle(.secondary)
 
                 HStack(spacing: 12) {
@@ -155,10 +160,10 @@ struct DeveloperSetupAutomaticWindowView: View {
         HStack(spacing: 12) {
             VStack(alignment: .leading, spacing: 2) {
                 Text(viewModel.statusMessage ?? String(localized: "Rockxy will generate a scoped setup script before launching."))
-                    .font(.caption)
+                    .font(.system(size: setupMetrics.secondaryFontSize))
                     .foregroundStyle(.secondary)
                 Text(String(localized: "Proxy: \(viewModel.proxyEndpointText). \(viewModel.certificateStatusText)"))
-                    .font(.caption2)
+                    .font(.system(size: setupMetrics.metadataFontSize))
                     .foregroundStyle(.tertiary)
             }
 
@@ -182,13 +187,13 @@ struct DeveloperSetupAutomaticWindowView: View {
     private func benefitRow(systemImage: String, text: String) -> some View {
         HStack(alignment: .firstTextBaseline, spacing: 10) {
             Image(systemName: systemImage)
-                .font(.system(size: 14, weight: .semibold))
+                .font(.system(size: setupMetrics.iconFontSize, weight: .semibold))
                 .symbolRenderingMode(.hierarchical)
                 .foregroundStyle(Color(nsColor: .systemGreen))
                 .frame(width: 18)
 
             Text(text)
-                .font(.callout)
+                .font(.system(size: setupMetrics.bodyFontSize))
                 .foregroundStyle(.primary)
                 .fixedSize(horizontal: false, vertical: true)
         }

--- a/Rockxy/Views/DeveloperSetup/DeveloperSetupAutomationSheet.swift
+++ b/Rockxy/Views/DeveloperSetup/DeveloperSetupAutomationSheet.swift
@@ -32,15 +32,20 @@ struct DeveloperSetupAutomationSheet: View {
     // MARK: Private
 
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.appUIDisplayMetrics) private var appMetrics
+
+    private var setupMetrics: DeveloperSetupDisplayMetrics {
+        DeveloperSetupDisplayMetrics(appMetrics: appMetrics)
+    }
 
     private var header: some View {
         VStack(alignment: .leading, spacing: 10) {
             HStack(alignment: .center, spacing: 10) {
                 VStack(alignment: .leading, spacing: 4) {
                     Text(preview.title)
-                        .font(.title3.weight(.semibold))
+                        .font(.system(size: setupMetrics.titleFontSize, weight: .semibold))
                     Text(target.title)
-                        .font(.caption)
+                        .font(.system(size: setupMetrics.secondaryFontSize))
                         .foregroundStyle(.secondary)
                 }
 
@@ -50,7 +55,7 @@ struct DeveloperSetupAutomationSheet: View {
             }
 
             Text(preview.summary)
-                .font(.subheadline)
+                .font(.system(size: setupMetrics.bodyFontSize))
                 .foregroundStyle(.secondary)
         }
         .padding(.horizontal, 20)
@@ -60,7 +65,7 @@ struct DeveloperSetupAutomationSheet: View {
 
     private var automationBadge: some View {
         Text(target.automationSupport.badgeTitle)
-            .font(.caption.weight(.semibold))
+            .font(.system(size: setupMetrics.metadataFontSize, weight: .semibold))
             .foregroundStyle(Color(nsColor: .systemBlue))
             .padding(.horizontal, 10)
             .padding(.vertical, 5)
@@ -78,11 +83,11 @@ struct DeveloperSetupAutomationSheet: View {
         card(title: String(localized: "Primary action"), systemImage: "terminal") {
             VStack(alignment: .leading, spacing: 8) {
                 Text(preview.primaryActionTitle)
-                    .font(.headline)
+                    .font(.system(size: setupMetrics.sectionTitleFontSize, weight: .semibold))
 
                 Text(preview.summary)
-                .font(.caption)
-                .foregroundStyle(.secondary)
+                    .font(.system(size: setupMetrics.secondaryFontSize))
+                    .foregroundStyle(.secondary)
             }
         }
     }
@@ -93,9 +98,9 @@ struct DeveloperSetupAutomationSheet: View {
                 ForEach(preview.steps) { step in
                     VStack(alignment: .leading, spacing: 4) {
                         Text(step.title)
-                            .font(.subheadline.weight(.semibold))
+                            .font(.system(size: setupMetrics.bodyFontSize, weight: .semibold))
                         Text(step.description)
-                            .font(.caption)
+                            .font(.system(size: setupMetrics.secondaryFontSize))
                             .foregroundStyle(.secondary)
                             .fixedSize(horizontal: false, vertical: true)
                     }
@@ -108,7 +113,7 @@ struct DeveloperSetupAutomationSheet: View {
     private var fallbackCard: some View {
         card(title: String(localized: "Manual Setup fallback"), systemImage: "arrow.uturn.backward") {
             Text(preview.supplementaryNote)
-                .font(.subheadline)
+                .font(.system(size: setupMetrics.bodyFontSize))
                 .foregroundStyle(.primary)
         }
     }
@@ -136,7 +141,7 @@ struct DeveloperSetupAutomationSheet: View {
     private func card<Content: View>(title: String, systemImage: String, @ViewBuilder content: () -> Content) -> some View {
         VStack(alignment: .leading, spacing: 12) {
             Label(title, systemImage: systemImage)
-                .font(.subheadline.weight(.semibold))
+                .font(.system(size: setupMetrics.sectionTitleFontSize, weight: .semibold))
 
             content()
         }

--- a/Rockxy/Views/DeveloperSetup/DeveloperSetupInspector.swift
+++ b/Rockxy/Views/DeveloperSetup/DeveloperSetupInspector.swift
@@ -50,7 +50,7 @@ struct DeveloperSetupInspector: View {
             VStack(alignment: .leading, spacing: 10) {
                 HStack(spacing: 8) {
                     Text(String(localized: "Use"))
-                        .font(.caption)
+                        .font(.system(size: setupMetrics.secondaryFontSize))
                         .foregroundStyle(.secondary)
 
                     Picker("", selection: $selectedSetupMode) {
@@ -72,12 +72,12 @@ struct DeveloperSetupInspector: View {
                 }
 
                 Text(selectedSetupModeCaption)
-                    .font(.caption)
+                    .font(.system(size: setupMetrics.secondaryFontSize))
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
 
                 Text(setupReadinessHint)
-                    .font(.caption2)
+                    .font(.system(size: setupMetrics.metadataFontSize))
                     .foregroundStyle(.tertiary)
                     .fixedSize(horizontal: false, vertical: true)
             }
@@ -126,11 +126,11 @@ struct DeveloperSetupInspector: View {
         ) {
             VStack(alignment: .leading, spacing: 10) {
                 Text(snapshot.verificationState.title)
-                    .font(.subheadline.weight(.semibold))
+                    .font(.system(size: setupMetrics.bodyFontSize, weight: .semibold))
 
                 if let host = snapshot.matchedHost, let method = snapshot.matchedMethod {
                     Text("\(method) \(host)")
-                        .font(.caption)
+                        .font(.system(size: setupMetrics.secondaryFontSize))
                         .foregroundStyle(.secondary)
                 } else {
                     Text(
@@ -138,7 +138,7 @@ struct DeveloperSetupInspector: View {
                             ? validationInstruction
                             : String(localized: "Interactive validation is not available for this target.")
                     )
-                    .font(.caption)
+                    .font(.system(size: setupMetrics.secondaryFontSize))
                     .foregroundStyle(.secondary)
                 }
 
@@ -170,16 +170,16 @@ struct DeveloperSetupInspector: View {
                 if let activeIssue {
                     VStack(alignment: .leading, spacing: 4) {
                         Text(activeIssue.title)
-                            .font(.subheadline.weight(.semibold))
+                            .font(.system(size: setupMetrics.bodyFontSize, weight: .semibold))
                         Text(activeIssue.message)
-                            .font(.caption)
+                            .font(.system(size: setupMetrics.secondaryFontSize))
                             .foregroundStyle(.secondary)
                     }
                 } else {
                     Text(String(localized: "No active issue"))
-                        .font(.subheadline.weight(.semibold))
+                        .font(.system(size: setupMetrics.bodyFontSize, weight: .semibold))
                     Text(String(localized: "Rockxy is ready for the selected flow."))
-                        .font(.caption)
+                        .font(.system(size: setupMetrics.secondaryFontSize))
                         .foregroundStyle(.secondary)
                 }
 
@@ -210,11 +210,11 @@ struct DeveloperSetupInspector: View {
     private func readinessRow(title: String, value: String) -> some View {
         HStack(spacing: 8) {
             Text(title)
-                .font(.caption)
+                .font(.system(size: setupMetrics.secondaryFontSize))
                 .foregroundStyle(.secondary)
             Spacer(minLength: 8)
             Text(value)
-                .font(.caption.weight(.medium))
+                .font(.system(size: setupMetrics.secondaryFontSize, weight: .medium))
                 .foregroundStyle(.primary)
         }
     }
@@ -264,7 +264,7 @@ struct DeveloperSetupInspector: View {
     ) -> some View {
         VStack(alignment: .leading, spacing: 12) {
             Label(title, systemImage: systemImage)
-                .font(.system(size: 14, weight: .semibold))
+                .font(.system(size: setupMetrics.sectionTitleFontSize, weight: .semibold))
                 .foregroundStyle(.primary)
 
             content()
@@ -279,5 +279,11 @@ struct DeveloperSetupInspector: View {
                         .stroke(Color(nsColor: .separatorColor).opacity(0.28))
                 )
         )
+    }
+
+    @Environment(\.appUIDisplayMetrics) private var appMetrics
+
+    private var setupMetrics: DeveloperSetupDisplayMetrics {
+        DeveloperSetupDisplayMetrics(appMetrics: appMetrics)
     }
 }

--- a/Rockxy/Views/DeveloperSetup/DeveloperSetupManualWindowView.swift
+++ b/Rockxy/Views/DeveloperSetup/DeveloperSetupManualWindowView.swift
@@ -34,17 +34,22 @@ struct DeveloperSetupManualWindowView: View {
     // MARK: Private
 
     @State private var viewModel: DeveloperSetupSessionSetupViewModel
+    @Environment(\.appUIDisplayMetrics) private var appMetrics
+
+    private var setupMetrics: DeveloperSetupDisplayMetrics {
+        DeveloperSetupDisplayMetrics(appMetrics: appMetrics)
+    }
 
     private var header: some View {
         VStack(alignment: .leading, spacing: 12) {
             HStack(alignment: .center, spacing: 12) {
                 Image(systemName: "shippingbox.fill")
-                    .font(.system(size: 24, weight: .regular))
+                    .font(.system(size: setupMetrics.prominentIconFontSize, weight: .regular))
                     .symbolRenderingMode(.hierarchical)
                     .foregroundStyle(.secondary)
 
                 Text(String(localized: "Manual Setup"))
-                    .font(.title2.weight(.semibold))
+                    .font(.system(size: setupMetrics.titleFontSize, weight: .semibold))
                     .foregroundStyle(.primary)
             }
 
@@ -64,7 +69,7 @@ struct DeveloperSetupManualWindowView: View {
     private var terminalCard: some View {
         VStack(alignment: .leading, spacing: 8) {
             Text(String(localized: "Terminal app"))
-                .font(.headline)
+                .font(.system(size: setupMetrics.sectionTitleFontSize, weight: .semibold))
 
             VStack(alignment: .leading, spacing: 16) {
                 instructionStep(
@@ -74,7 +79,7 @@ struct DeveloperSetupManualWindowView: View {
 
                 VStack(alignment: .leading, spacing: 10) {
                     Text(String(localized: "2. Copy and paste this command into that terminal"))
-                        .font(.callout.weight(.semibold))
+                        .font(.system(size: setupMetrics.bodyFontSize, weight: .semibold))
                         .foregroundStyle(.primary)
 
                     commandBox
@@ -106,7 +111,7 @@ struct DeveloperSetupManualWindowView: View {
         HStack(spacing: 0) {
             ScrollView(.horizontal) {
                 Text(viewModel.manualSourceCommand)
-                    .font(.system(size: 12, design: .monospaced))
+                    .font(.system(size: setupMetrics.snippetFontSize, design: .monospaced))
                     .textSelection(.enabled)
                     .padding(10)
                     .frame(maxWidth: .infinity, alignment: .leading)
@@ -135,13 +140,13 @@ struct DeveloperSetupManualWindowView: View {
     private func benefitRow(systemImage: String, text: String) -> some View {
         HStack(alignment: .firstTextBaseline, spacing: 10) {
             Image(systemName: systemImage)
-                .font(.system(size: 14, weight: .semibold))
+                .font(.system(size: setupMetrics.iconFontSize, weight: .semibold))
                 .symbolRenderingMode(.hierarchical)
                 .foregroundStyle(Color(nsColor: .systemGreen))
                 .frame(width: 18)
 
             Text(text)
-                .font(.callout)
+                .font(.system(size: setupMetrics.bodyFontSize))
                 .foregroundStyle(.primary)
                 .fixedSize(horizontal: false, vertical: true)
         }
@@ -155,18 +160,18 @@ struct DeveloperSetupManualWindowView: View {
         VStack(alignment: .leading, spacing: 8) {
             HStack(alignment: .firstTextBaseline, spacing: 8) {
                 Text(title)
-                    .font(.callout.weight(.semibold))
+                    .font(.system(size: setupMetrics.bodyFontSize, weight: .semibold))
                     .foregroundStyle(.primary)
 
                 if let trailingSystemImage {
                     Image(systemName: trailingSystemImage)
-                        .font(.system(size: 14, weight: .bold))
+                        .font(.system(size: setupMetrics.iconFontSize, weight: .bold))
                         .foregroundStyle(Color(nsColor: .systemGreen))
                 }
             }
 
             Text(caption)
-                .font(.callout)
+                .font(.system(size: setupMetrics.bodyFontSize))
                 .foregroundStyle(.secondary)
                 .padding(.leading, 24)
         }

--- a/Rockxy/Views/DeveloperSetup/DeveloperSetupSourceList.swift
+++ b/Rockxy/Views/DeveloperSetup/DeveloperSetupSourceList.swift
@@ -35,9 +35,9 @@ struct DeveloperSetupSourceList: View {
     private var emptySearchState: some View {
         VStack(alignment: .leading, spacing: 6) {
             Text(String(localized: "No matching setups"))
-                .font(.system(size: 13, weight: .semibold))
+                .font(.system(size: setupMetrics.bodyFontSize, weight: .semibold))
             Text(String(localized: "Try another runtime, browser, framework, environment, or category name."))
-                .font(.caption)
+                .font(.system(size: setupMetrics.secondaryFontSize))
                 .foregroundStyle(.secondary)
         }
         .padding(.horizontal, 8)
@@ -48,14 +48,14 @@ struct DeveloperSetupSourceList: View {
     private func sectionView(category: SetupTargetCategory, targets: [SetupTarget]) -> some View {
         VStack(alignment: .leading, spacing: 6) {
             Text(category.title)
-                .font(.caption.weight(.semibold))
+                .font(.system(size: setupMetrics.metadataFontSize, weight: .semibold))
                 .foregroundStyle(.secondary)
                 .textCase(.uppercase)
                 .padding(.horizontal, 8)
 
             if targets.isEmpty {
                 Text(emptySectionTitle(for: category))
-                    .font(.caption)
+                    .font(.system(size: setupMetrics.secondaryFontSize))
                     .foregroundStyle(.tertiary)
                     .padding(.horizontal, 8)
                     .padding(.vertical, 6)
@@ -67,18 +67,18 @@ struct DeveloperSetupSourceList: View {
                         } label: {
                             HStack(spacing: 10) {
                                 Image(systemName: target.iconName)
-                                    .font(.system(size: 13, weight: .medium))
+                                    .font(.system(size: setupMetrics.iconFontSize, weight: .medium))
                                     .foregroundStyle(selectedTarget.id == target.id ? .primary : .secondary)
                                     .frame(width: 16)
 
                                 VStack(alignment: .leading, spacing: 1) {
                                     Text(target.title)
-                                        .font(.system(size: 13, weight: selectedTarget.id == target.id ? .semibold : .regular))
+                                        .font(.system(size: setupMetrics.bodyFontSize, weight: selectedTarget.id == target.id ? .semibold : .regular))
                                         .foregroundStyle(.primary)
                                         .lineLimit(1)
 
                                     Text(target.supportStatus.title)
-                                        .font(.caption2)
+                                        .font(.system(size: setupMetrics.metadataFontSize))
                                         .foregroundStyle(.secondary)
                                         .lineLimit(1)
                                 }
@@ -87,6 +87,7 @@ struct DeveloperSetupSourceList: View {
                             }
                             .padding(.horizontal, 8)
                             .padding(.vertical, 7)
+                            .frame(minHeight: setupMetrics.sidebarRowHeight)
                             .frame(maxWidth: .infinity, alignment: .leading)
                         }
                         .buttonStyle(.plain)
@@ -115,7 +116,7 @@ struct DeveloperSetupSourceList: View {
             onTogglePinned(target)
         } label: {
             Image(systemName: isPinned(target) ? "pin.fill" : "pin")
-                .font(.system(size: 11, weight: .semibold))
+                .font(.system(size: setupMetrics.metadataFontSize, weight: .semibold))
                 .foregroundStyle(isPinned(target) ? Color(nsColor: .systemBlue) : Color.secondary)
                 .frame(width: 20, height: 20)
                 .background(
@@ -144,5 +145,11 @@ struct DeveloperSetupSourceList: View {
         default:
             String(localized: "No setups in this section")
         }
+    }
+
+    @Environment(\.appUIDisplayMetrics) private var appMetrics
+
+    private var setupMetrics: DeveloperSetupDisplayMetrics {
+        DeveloperSetupDisplayMetrics(appMetrics: appMetrics)
     }
 }

--- a/Rockxy/Views/DeveloperSetup/DeveloperSetupWindowView.swift
+++ b/Rockxy/Views/DeveloperSetup/DeveloperSetupWindowView.swift
@@ -84,6 +84,7 @@ struct DeveloperSetupWindowView: View {
 
     @Environment(\.openSettings) private var openSettings
     @Environment(\.openWindow) private var openWindow
+    @Environment(\.appUIDisplayMetrics) private var appMetrics
     @State private var viewModel: DeveloperSetupViewModel
     @State private var routeStore = DeveloperSetupRouteStore.shared
     @StateObject private var caShareController = CAShareController()
@@ -110,6 +111,10 @@ struct DeveloperSetupWindowView: View {
         )
     }
 
+    private var setupMetrics: DeveloperSetupDisplayMetrics {
+        DeveloperSetupDisplayMetrics(appMetrics: appMetrics)
+    }
+
     private func applyPendingRouteIfNeeded() {
         guard let route = routeStore.consumePendingRoute(),
               let target = SetupTarget.target(for: route.targetID) else {
@@ -123,9 +128,9 @@ struct DeveloperSetupWindowView: View {
         HStack(spacing: 10) {
             VStack(alignment: .leading, spacing: 3) {
                 Text(String(localized: "Developer Setup Hub"))
-                    .font(.headline)
+                    .font(.system(size: setupMetrics.bodyFontSize, weight: .semibold))
                 Text(viewModel.selectedTarget.title)
-                    .font(.caption)
+                    .font(.system(size: setupMetrics.secondaryFontSize))
                     .foregroundStyle(.secondary)
             }
 
@@ -162,10 +167,10 @@ struct DeveloperSetupWindowView: View {
                 .foregroundStyle(.secondary)
             VStack(alignment: .leading, spacing: 2) {
                 Text(viewModel.selectedTarget.supportStatus.bannerTitle)
-                    .font(.caption.weight(.semibold))
+                    .font(.system(size: setupMetrics.secondaryFontSize, weight: .semibold))
                     .foregroundStyle(.secondary)
                 Text(viewModel.infoBannerText)
-                    .font(.caption)
+                    .font(.system(size: setupMetrics.secondaryFontSize))
                     .foregroundStyle(.secondary)
             }
             Spacer(minLength: 12)
@@ -225,9 +230,9 @@ struct DeveloperSetupWindowView: View {
             HStack(alignment: .center, spacing: 16) {
                 VStack(alignment: .leading, spacing: 4) {
                     Text(viewModel.selectedTarget.title)
-                        .font(.system(size: 18, weight: .semibold))
+                        .font(.system(size: setupMetrics.titleFontSize, weight: .semibold))
                     Text(viewModel.selectedTarget.shortSummary)
-                        .font(.caption)
+                        .font(.system(size: setupMetrics.secondaryFontSize))
                         .foregroundStyle(.secondary)
                         .lineLimit(2)
                 }
@@ -318,10 +323,10 @@ struct DeveloperSetupWindowView: View {
                 systemImage: "checkmark.shield"
             ) {
                 Text(viewModel.selectedTarget.currentSupportSummary)
-                    .font(.subheadline)
+                    .font(.system(size: setupMetrics.bodyFontSize))
                     .foregroundStyle(.primary)
                 Text(viewModel.selectedTarget.manualSummary)
-                    .font(.caption)
+                    .font(.system(size: setupMetrics.secondaryFontSize))
                     .foregroundStyle(.secondary)
             }
         }
@@ -417,7 +422,7 @@ struct DeveloperSetupWindowView: View {
 
                 ScrollView(.horizontal) {
                     Text(currentSnippetText)
-                        .font(.system(size: 12, design: .monospaced))
+                        .font(.system(size: setupMetrics.snippetFontSize, design: .monospaced))
                         .textSelection(.enabled)
                         .padding(16)
                         .frame(maxWidth: .infinity, alignment: .leading)
@@ -463,17 +468,17 @@ struct DeveloperSetupWindowView: View {
                     systemImage: "bolt.horizontal.circle"
                 ) {
                     Text(viewModel.validationInstruction)
-                        .font(.subheadline)
+                        .font(.system(size: setupMetrics.bodyFontSize))
                     Text(viewModel.snapshot.verificationState.title)
-                        .font(.caption)
+                        .font(.system(size: setupMetrics.secondaryFontSize))
                         .foregroundStyle(.secondary)
                     if let issue = viewModel.activeIssue {
                         Divider()
                         VStack(alignment: .leading, spacing: 6) {
                             Text(issue.title)
-                                .font(.subheadline.weight(.semibold))
+                                .font(.system(size: setupMetrics.bodyFontSize, weight: .semibold))
                             Text(issue.message)
-                                .font(.caption)
+                                .font(.system(size: setupMetrics.secondaryFontSize))
                                 .foregroundStyle(.secondary)
                             Button(issue.actionTitle) {
                                 handleIssueAction(issue)
@@ -485,7 +490,7 @@ struct DeveloperSetupWindowView: View {
 
                 ScrollView(.horizontal) {
                     Text(currentSnippetText)
-                        .font(.system(size: 12, design: .monospaced))
+                        .font(.system(size: setupMetrics.snippetFontSize, design: .monospaced))
                         .textSelection(.enabled)
                         .padding(16)
                         .frame(maxWidth: .infinity, alignment: .leading)
@@ -543,7 +548,7 @@ struct DeveloperSetupWindowView: View {
                 ForEach(viewModel.troubleshootingIssues) { issue in
                     detailCard(title: issue.title, systemImage: "exclamationmark.triangle") {
                         Text(issue.message)
-                            .font(.subheadline)
+                            .font(.system(size: setupMetrics.bodyFontSize))
                             .foregroundStyle(.primary)
                         HStack(spacing: 8) {
                             Button(issue.actionTitle) {
@@ -567,14 +572,14 @@ struct DeveloperSetupWindowView: View {
     private var bottomBar: some View {
         HStack(spacing: 8) {
             Text(certificateShareStatusMessage ?? viewModel.bottomStatusText)
-                .font(.caption)
+                .font(.system(size: setupMetrics.secondaryFontSize))
                 .foregroundStyle(.secondary)
 
             Spacer(minLength: 8)
 
             if let warning = viewModel.snapshot.readinessWarningMessage {
                 Text(warning)
-                    .font(.caption)
+                    .font(.system(size: setupMetrics.secondaryFontSize))
                     .foregroundStyle(.tertiary)
                     .lineLimit(1)
             }
@@ -597,7 +602,7 @@ struct DeveloperSetupWindowView: View {
                     """
                 )
             )
-            .font(.subheadline)
+            .font(.system(size: setupMetrics.bodyFontSize))
             .foregroundStyle(.primary)
 
             Text(
@@ -605,7 +610,7 @@ struct DeveloperSetupWindowView: View {
                     localized: "The link only serves the public PEM, expires automatically, and stops when this sheet closes."
                 )
             )
-            .font(.caption)
+            .font(.system(size: setupMetrics.secondaryFontSize))
             .foregroundStyle(.secondary)
 
             HStack(spacing: 8) {
@@ -625,12 +630,12 @@ struct DeveloperSetupWindowView: View {
     private var toolbarSearchField: some View {
         HStack(spacing: 6) {
             Image(systemName: "magnifyingglass")
-                .font(.system(size: 12))
+                .font(.system(size: setupMetrics.controlFontSize))
                 .foregroundStyle(.secondary)
 
             TextField(String(localized: "Search setups"), text: $viewModel.sourceListSearchText)
                 .textFieldStyle(.plain)
-                .font(.system(size: 13))
+                .font(.system(size: setupMetrics.controlFontSize))
                 .frame(width: 180)
 
             if !viewModel.sourceListSearchText.isEmpty {
@@ -638,7 +643,7 @@ struct DeveloperSetupWindowView: View {
                     viewModel.sourceListSearchText = ""
                 } label: {
                     Image(systemName: "xmark.circle.fill")
-                        .font(.system(size: 11))
+                        .font(.system(size: setupMetrics.metadataFontSize))
                         .foregroundStyle(.secondary)
                 }
                 .buttonStyle(.borderless)
@@ -657,12 +662,12 @@ struct DeveloperSetupWindowView: View {
     private func statusCard(title: String, value: String, caption: String) -> some View {
         VStack(alignment: .leading, spacing: 6) {
             Text(title)
-                .font(.caption.weight(.semibold))
+                .font(.system(size: setupMetrics.metadataFontSize, weight: .semibold))
                 .foregroundStyle(.secondary)
             Text(value)
-                .font(.system(size: 18, weight: .semibold))
+                .font(.system(size: setupMetrics.titleFontSize, weight: .semibold))
             Text(caption)
-                .font(.caption)
+                .font(.system(size: setupMetrics.secondaryFontSize))
                 .foregroundStyle(.secondary)
                 .lineLimit(3)
         }
@@ -678,14 +683,14 @@ struct DeveloperSetupWindowView: View {
         HStack(alignment: .top, spacing: 12) {
             Image(systemName: step.isComplete ? "checkmark.circle.fill" : "circle")
                 .foregroundStyle(step.isComplete ? .green : .secondary)
-                .font(.system(size: 16, weight: .medium))
+                .font(.system(size: setupMetrics.iconFontSize, weight: .medium))
                 .padding(.top, 2)
 
             VStack(alignment: .leading, spacing: 4) {
                 Text(step.title)
-                    .font(.subheadline.weight(.semibold))
+                    .font(.system(size: setupMetrics.bodyFontSize, weight: .semibold))
                 Text(step.description)
-                    .font(.caption)
+                    .font(.system(size: setupMetrics.secondaryFontSize))
                     .foregroundStyle(.secondary)
             }
 
@@ -707,7 +712,7 @@ struct DeveloperSetupWindowView: View {
     private func detailCard(title: String, systemImage: String, @ViewBuilder content: () -> some View) -> some View {
         VStack(alignment: .leading, spacing: 10) {
             Label(title, systemImage: systemImage)
-                .font(.subheadline.weight(.semibold))
+                .font(.system(size: setupMetrics.sectionTitleFontSize, weight: .semibold))
             content()
         }
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -720,7 +725,7 @@ struct DeveloperSetupWindowView: View {
 
     private func supportBadge(title: String, fill: Color, stroke: Color, textColor: Color) -> some View {
         Text(title)
-            .font(.caption.weight(.semibold))
+            .font(.system(size: setupMetrics.metadataFontSize, weight: .semibold))
             .foregroundStyle(textColor)
             .padding(.horizontal, 10)
             .padding(.vertical, 5)
@@ -737,13 +742,13 @@ struct DeveloperSetupWindowView: View {
     private func guideOnlyContent(title: String, message: String) -> some View {
         detailCard(title: title, systemImage: "info.circle") {
             Text(message)
-                .font(.subheadline)
+                .font(.system(size: setupMetrics.bodyFontSize))
             Text(
                 String(
                     localized: "Rockxy shows this target now so the long-term hub taxonomy stays stable, but this target remains guidance-only today."
                 )
             )
-            .font(.caption)
+            .font(.system(size: setupMetrics.secondaryFontSize))
             .foregroundStyle(.secondary)
         }
     }
@@ -754,10 +759,10 @@ struct DeveloperSetupWindowView: View {
                 ForEach(tips) { tip in
                     VStack(alignment: .leading, spacing: 4) {
                         Text(tip.title)
-                            .font(.subheadline.weight(.semibold))
+                            .font(.system(size: setupMetrics.bodyFontSize, weight: .semibold))
                             .foregroundStyle(.primary)
                         Text(tip.message)
-                            .font(.caption)
+                            .font(.system(size: setupMetrics.secondaryFontSize))
                             .foregroundStyle(.secondary)
                             .fixedSize(horizontal: false, vertical: true)
                     }
@@ -770,13 +775,13 @@ struct DeveloperSetupWindowView: View {
     private func guideOnlyEmptyState(title: String, message: String) -> some View {
         VStack(alignment: .center, spacing: 10) {
             Image(systemName: "square.dashed")
-                .font(.system(size: 22))
+                .font(.system(size: setupMetrics.prominentIconFontSize))
                 .foregroundStyle(.tertiary)
             Text(title)
-                .font(.system(size: 14, weight: .semibold))
+                .font(.system(size: setupMetrics.sectionTitleFontSize, weight: .semibold))
                 .foregroundStyle(.secondary)
             Text(message)
-                .font(.caption)
+                .font(.system(size: setupMetrics.secondaryFontSize))
                 .foregroundStyle(.tertiary)
                 .multilineTextAlignment(.center)
                 .frame(maxWidth: 420)
@@ -787,10 +792,10 @@ struct DeveloperSetupWindowView: View {
     private func metadataItem(title: String, value: String) -> some View {
         VStack(alignment: .leading, spacing: 2) {
             Text(title)
-                .font(.caption2.weight(.semibold))
+                .font(.system(size: setupMetrics.metadataFontSize, weight: .semibold))
                 .foregroundStyle(.secondary)
             Text(value)
-                .font(.caption)
+                .font(.system(size: setupMetrics.secondaryFontSize))
                 .foregroundStyle(.primary)
         }
     }

--- a/Rockxy/Views/Inspector/AuthInspectorView.swift
+++ b/Rockxy/Views/Inspector/AuthInspectorView.swift
@@ -53,13 +53,15 @@ struct AuthInspectorView: View {
     private func labelRow(_ label: String, _ value: String) -> some View {
         VStack(alignment: .leading, spacing: 4) {
             Text(label)
-                .font(.caption)
+                .font(.system(size: metrics.secondaryFontSize))
                 .foregroundStyle(.secondary)
             HighlightedInspectorText(text: value, highlightContext: highlightContext)
-                .font(.system(.caption, design: .monospaced))
+                .font(.system(size: metrics.secondaryFontSize, design: .monospaced))
                 .textSelection(.enabled)
         }
     }
+
+    @Environment(\.appUIDisplayMetrics) private var metrics
 
     private func findAuthHeader() -> String? {
         transaction.request.headers

--- a/Rockxy/Views/Inspector/CommentsTabView.swift
+++ b/Rockxy/Views/Inspector/CommentsTabView.swift
@@ -9,7 +9,7 @@ struct CommentsTabView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             TextEditor(text: $commentText)
-                .font(.system(size: 12))
+                .font(.system(size: metrics.primaryFontSize))
                 .scrollContentBackground(.hidden)
                 .padding(8)
         }
@@ -24,4 +24,5 @@ struct CommentsTabView: View {
     // MARK: Private
 
     @State private var commentText: String = ""
+    @Environment(\.appUIDisplayMetrics) private var metrics
 }

--- a/Rockxy/Views/Inspector/CookiesInspectorView.swift
+++ b/Rockxy/Views/Inspector/CookiesInspectorView.swift
@@ -12,6 +12,7 @@ struct CookiesInspectorView: View {
         ScrollView {
             if transaction.request.cookies.isEmpty, responseCookies.isEmpty {
                 Text("No cookies")
+                    .font(.system(size: metrics.secondaryFontSize))
                     .foregroundStyle(.secondary)
                     .padding()
             } else {
@@ -46,57 +47,57 @@ struct CookiesInspectorView: View {
         ], spacing: 4) {
             ForEach(Array(cookies.enumerated()), id: \.offset) { _, cookie in
                 Text("Name")
-                    .font(.system(.caption, design: .monospaced))
+                    .font(.system(size: metrics.secondaryFontSize, design: .monospaced))
                     .fontWeight(.semibold)
                 HighlightedInspectorText(text: cookie.name, highlightContext: highlightContext)
-                    .font(.system(.caption, design: .monospaced))
+                    .font(.system(size: metrics.secondaryFontSize, design: .monospaced))
                     .textSelection(.enabled)
 
                 Text("Value")
-                    .font(.system(.caption, design: .monospaced))
+                    .font(.system(size: metrics.secondaryFontSize, design: .monospaced))
                     .fontWeight(.semibold)
                 HighlightedInspectorText(text: cookie.value, highlightContext: highlightContext)
-                    .font(.system(.caption, design: .monospaced))
+                    .font(.system(size: metrics.secondaryFontSize, design: .monospaced))
                     .textSelection(.enabled)
 
                 Text("Domain")
-                    .font(.system(.caption, design: .monospaced))
+                    .font(.system(size: metrics.secondaryFontSize, design: .monospaced))
                     .fontWeight(.semibold)
                 HighlightedInspectorText(text: cookie.domain, highlightContext: highlightContext)
-                    .font(.system(.caption, design: .monospaced))
+                    .font(.system(size: metrics.secondaryFontSize, design: .monospaced))
                     .textSelection(.enabled)
 
                 Text("Path")
-                    .font(.system(.caption, design: .monospaced))
+                    .font(.system(size: metrics.secondaryFontSize, design: .monospaced))
                     .fontWeight(.semibold)
                 HighlightedInspectorText(text: cookie.path, highlightContext: highlightContext)
-                    .font(.system(.caption, design: .monospaced))
+                    .font(.system(size: metrics.secondaryFontSize, design: .monospaced))
                     .textSelection(.enabled)
 
                 if cookie.isSecure {
                     Text("Secure")
-                        .font(.system(.caption, design: .monospaced))
+                        .font(.system(size: metrics.secondaryFontSize, design: .monospaced))
                         .fontWeight(.semibold)
                     Text("Yes")
-                        .font(.system(.caption, design: .monospaced))
+                        .font(.system(size: metrics.secondaryFontSize, design: .monospaced))
                         .textSelection(.enabled)
                 }
 
                 if cookie.isHTTPOnly {
                     Text("HttpOnly")
-                        .font(.system(.caption, design: .monospaced))
+                        .font(.system(size: metrics.secondaryFontSize, design: .monospaced))
                         .fontWeight(.semibold)
                     Text("Yes")
-                        .font(.system(.caption, design: .monospaced))
+                        .font(.system(size: metrics.secondaryFontSize, design: .monospaced))
                         .textSelection(.enabled)
                 }
 
                 if let expires = cookie.expiresDate {
                     Text("Expires")
-                        .font(.system(.caption, design: .monospaced))
+                        .font(.system(size: metrics.secondaryFontSize, design: .monospaced))
                         .fontWeight(.semibold)
                     Text(expires.formatted(.dateTime))
-                        .font(.system(.caption, design: .monospaced))
+                        .font(.system(size: metrics.secondaryFontSize, design: .monospaced))
                         .textSelection(.enabled)
                 }
 
@@ -105,4 +106,6 @@ struct CookiesInspectorView: View {
             }
         }
     }
+
+    @Environment(\.appUIDisplayMetrics) private var metrics
 }

--- a/Rockxy/Views/Inspector/GraphQLInspectorView.swift
+++ b/Rockxy/Views/Inspector/GraphQLInspectorView.swift
@@ -12,7 +12,7 @@ struct GraphQLInspectorView: View {
                     if let name = info.operationName {
                         LabeledContent("Operation") {
                             Text(name)
-                                .font(.system(.body, design: .monospaced))
+                                .font(.system(size: metrics.primaryFontSize, design: .monospaced))
                         }
                     }
 
@@ -23,7 +23,7 @@ struct GraphQLInspectorView: View {
                     Text("Query")
                         .fontWeight(.semibold)
                     Text(info.query)
-                        .font(.system(.caption, design: .monospaced))
+                        .font(.system(size: metrics.secondaryFontSize, design: .monospaced))
                         .textSelection(.enabled)
                         .padding(8)
                         .background(.quaternary)
@@ -33,7 +33,7 @@ struct GraphQLInspectorView: View {
                         Text("Variables")
                             .fontWeight(.semibold)
                         Text(variables)
-                            .font(.system(.caption, design: .monospaced))
+                            .font(.system(size: metrics.secondaryFontSize, design: .monospaced))
                             .textSelection(.enabled)
                             .padding(8)
                             .background(.quaternary)
@@ -50,4 +50,6 @@ struct GraphQLInspectorView: View {
             )
         }
     }
+
+    @Environment(\.appUIDisplayMetrics) private var metrics
 }

--- a/Rockxy/Views/Inspector/ImagePreviewView.swift
+++ b/Rockxy/Views/Inspector/ImagePreviewView.swift
@@ -18,7 +18,7 @@ struct ImagePreviewView: View {
                 let width = rep?.pixelsWide ?? Int(nsImage.size.width)
                 let height = rep?.pixelsHigh ?? Int(nsImage.size.height)
                 Text("\(width) × \(height) — \(SizeFormatter.format(bytes: data.count))")
-                    .font(.system(size: 11))
+                    .font(.system(size: metrics.secondaryFontSize))
                     .foregroundStyle(.secondary)
                 Spacer()
             }
@@ -31,4 +31,6 @@ struct ImagePreviewView: View {
             }
         }
     }
+
+    @Environment(\.appUIDisplayMetrics) private var metrics
 }

--- a/Rockxy/Views/Inspector/InspectorBodyTextEditor.swift
+++ b/Rockxy/Views/Inspector/InspectorBodyTextEditor.swift
@@ -44,18 +44,37 @@ struct InspectorBodyTextEditor: NSViewRepresentable {
     }
 
     func updateNSView(_ nsView: NSScrollView, context: Context) {
+        applyUpdate(to: nsView, coordinator: context.coordinator)
+    }
+
+    // MARK: Internal
+
+    func applyUpdate(to nsView: NSScrollView, coordinator: Coordinator) {
         guard let textView = nsView.documentView as? NSTextView else {
             return
         }
-        context.coordinator.editorID = editorID
-        context.coordinator.scrollView = nsView
-        applyEditorSettings(to: nsView)
-        if textView.string != text || context.coordinator.lastEditorSettings != editorSettings {
+        coordinator.editorID = editorID
+        coordinator.scrollView = nsView
+
+        let textChanged = textView.string != text
+        let settingsChanged = coordinator.lastEditorSettings != editorSettings
+        let highlightChanged = coordinator.lastHighlightIdentity != highlightContext.identity
+
+        if textChanged {
             let selectedRange = textView.selectedRange()
-            apply(text, to: nsView, coordinator: context.coordinator)
+            let visibleOrigin = nsView.contentView.bounds.origin
+            apply(text, to: nsView, coordinator: coordinator)
             textView.setSelectedRange(clamped(range: selectedRange, length: (text as NSString).length))
-        } else if context.coordinator.lastHighlightIdentity != highlightContext.identity {
-            context.coordinator.scheduleHighlight(
+            restoreVisibleOrigin(visibleOrigin, in: nsView)
+        } else if settingsChanged {
+            let selectedRange = textView.selectedRange()
+            let visibleOrigin = nsView.contentView.bounds.origin
+            applyEditorSettings(to: nsView)
+            coordinator.lastEditorSettings = editorSettings
+            textView.setSelectedRange(clamped(range: selectedRange, length: (text as NSString).length))
+            restoreVisibleOrigin(visibleOrigin, in: nsView)
+        } else if highlightChanged {
+            coordinator.scheduleHighlight(
                 text: text,
                 editorSettings: editorSettings,
                 highlightContext: highlightContext,
@@ -63,8 +82,6 @@ struct InspectorBodyTextEditor: NSViewRepresentable {
             )
         }
     }
-
-    // MARK: Internal
 
     final class Coordinator {
         var highlightTask: Task<Void, Never>?
@@ -399,6 +416,18 @@ struct InspectorBodyTextEditor: NSViewRepresentable {
         let style = NSMutableParagraphStyle()
         style.defaultTabInterval = editorSettings.tabInterval
         return style
+    }
+
+    private func restoreVisibleOrigin(_ origin: NSPoint, in scrollView: NSScrollView) {
+        let clipView = scrollView.contentView
+        let documentHeight = scrollView.documentView?.bounds.height ?? clipView.bounds.height
+        let maxY = max(0, documentHeight - clipView.bounds.height + scrollView.contentInsets.bottom)
+        let restoredOrigin = NSPoint(
+            x: max(0, origin.x),
+            y: min(max(0, origin.y), maxY)
+        )
+        clipView.scroll(to: restoredOrigin)
+        scrollView.reflectScrolledClipView(clipView)
     }
 
     private struct HighlightSpan: Sendable {

--- a/Rockxy/Views/Inspector/InspectorBodyTextEditor.swift
+++ b/Rockxy/Views/Inspector/InspectorBodyTextEditor.swift
@@ -263,6 +263,7 @@ struct InspectorBodyTextEditor: NSViewRepresentable {
         textView.textColor = .textColor
         textView.backgroundColor = .textBackgroundColor
         textView.isVerticallyResizable = true
+        textView.clipsToBounds = true
         textView.minSize = NSSize(width: 0, height: 0)
         textView.maxSize = NSSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude)
 
@@ -275,6 +276,8 @@ struct InspectorBodyTextEditor: NSViewRepresentable {
 
     private func makeScrollView(context: Context) -> NSScrollView {
         let scrollView = NSScrollView()
+        scrollView.clipsToBounds = true
+        scrollView.contentView.clipsToBounds = true
         let contentSize = scrollView.contentSize
         let textStorage = NSTextStorage()
         let layoutManager = NSLayoutManager()
@@ -331,6 +334,9 @@ struct InspectorBodyTextEditor: NSViewRepresentable {
         guard let textView = scrollView.documentView as? NSTextView else {
             return
         }
+        scrollView.clipsToBounds = true
+        scrollView.contentView.clipsToBounds = true
+        textView.clipsToBounds = true
         scrollView.hasHorizontalScroller = !editorSettings.wordWrap
         scrollView.contentInsets = NSEdgeInsets(
             top: 0,
@@ -347,20 +353,22 @@ struct InspectorBodyTextEditor: NSViewRepresentable {
         textView.layoutManager?.showsControlCharacters = editorSettings.showInvisibles
 
         if editorSettings.wordWrap {
-            textView.frame.size.width = max(scrollView.contentSize.width, 1)
+            textView.frame.size.width = max(scrollView.contentView.bounds.width, 1)
             textView.textContainer?.containerSize = NSSize(
-                width: max(scrollView.contentSize.width, 0),
+                width: max(scrollView.contentView.bounds.width, 0),
                 height: CGFloat.greatestFiniteMagnitude
             )
             textView.textContainer?.widthTracksTextView = true
         } else {
-            textView.frame.size.width = max(textView.frame.width, scrollView.contentSize.width)
+            textView.frame.size.width = max(textView.frame.width, scrollView.contentView.bounds.width)
             textView.textContainer?.containerSize = NSSize(
                 width: CGFloat.greatestFiniteMagnitude,
                 height: CGFloat.greatestFiniteMagnitude
             )
             textView.textContainer?.widthTracksTextView = false
         }
+        scrollView.tile()
+        scrollView.verticalRulerView?.needsDisplay = true
         applyTextStorageSettings(editorSettings, to: textView)
         textView.layoutManager?.invalidateLayout(forCharacterRange: NSRange(location: 0, length: textView.string.utf16.count), actualCharacterRange: nil)
         textView.needsDisplay = true
@@ -524,7 +532,8 @@ struct AsyncInspectorTextEditor: View {
                     editorSettings: editorSettings,
                     highlightContext: highlightContext
                 )
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .frame(minWidth: 0, maxWidth: .infinity, maxHeight: .infinity)
+                .clipped()
 
                 if editorSettings.showMinimap {
                     InspectorTextMinimapView(text: text, editorID: renderID)
@@ -659,12 +668,14 @@ struct InspectorLoadingStateView: View {
             ProgressView()
                 .controlSize(.small)
             Text(title)
-                .font(.system(size: 12))
+                .font(.system(size: metrics.controlFontSize))
                 .foregroundStyle(.secondary)
         }
         .padding(12)
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
     }
+
+    @Environment(\.appUIDisplayMetrics) private var metrics
 }
 
 // MARK: - InspectorTextRenderResult

--- a/Rockxy/Views/Inspector/InspectorTabButton.swift
+++ b/Rockxy/Views/Inspector/InspectorTabButton.swift
@@ -10,14 +10,14 @@ struct InspectorTabButton: View {
     var body: some View {
         Button(action: action) {
             Text(title)
-                .font(.system(size: metrics.secondaryFontSize, weight: isActive ? .bold : .regular))
+                .font(.system(size: metrics.controlFontSize, weight: isActive ? .bold : .regular))
                 .foregroundStyle(isActive ? Theme.Inspector.tabActive : Theme.Inspector.tabInactive)
                 .lineLimit(1)
                 .fixedSize(horizontal: true, vertical: false)
         }
         .buttonStyle(.plain)
         .padding(.horizontal, 6)
-        .padding(.vertical, 2)
+        .frame(minHeight: metrics.inspectorTabHeight)
     }
 
     @Environment(\.appUIDisplayMetrics) private var metrics

--- a/Rockxy/Views/Inspector/InspectorTabStrip.swift
+++ b/Rockxy/Views/Inspector/InspectorTabStrip.swift
@@ -20,7 +20,6 @@ struct InspectorTabStrip<Content: View, TrailingContent: View>: View {
                 HStack(spacing: 0) {
                     content
                 }
-                .padding(.vertical, 4)
                 .padding(.leading, 4)
                 .frame(minWidth: 0, alignment: .leading)
             }
@@ -33,5 +32,8 @@ struct InspectorTabStrip<Content: View, TrailingContent: View>: View {
                 .padding(.leading, 4)
                 .padding(.trailing, 4)
         }
+        .frame(minHeight: metrics.inspectorTabHeight)
     }
+
+    @Environment(\.appUIDisplayMetrics) private var metrics
 }

--- a/Rockxy/Views/Inspector/InspectorURLBar.swift
+++ b/Rockxy/Views/Inspector/InspectorURLBar.swift
@@ -14,7 +14,7 @@ struct InspectorURLBar: View {
             if let response = transaction.response {
                 StatusCodeBadge(statusCode: response.statusCode)
                 Text(response.statusMessage)
-                    .font(.system(size: 11))
+                    .font(.system(size: metrics.controlFontSize))
                     .foregroundStyle(.secondary)
             } else {
                 transactionStatePill
@@ -32,7 +32,7 @@ struct InspectorURLBar: View {
     @ViewBuilder private var methodBadge: some View {
         if transaction.request.method == "CONNECT" {
             Text(transaction.request.method)
-                .font(.system(size: 10, weight: .bold, design: .monospaced))
+                .font(.system(size: metrics.badgeFontSize, weight: .bold, design: .monospaced))
                 .foregroundStyle(.white)
                 .padding(.horizontal, 6)
                 .padding(.vertical, 2)
@@ -61,7 +61,7 @@ struct InspectorURLBar: View {
             backgroundColor = .clear
         }
         return Text(label)
-            .font(.system(size: 9, weight: .bold))
+            .font(.system(size: metrics.badgeFontSize, weight: .bold))
             .foregroundStyle(.black)
             .padding(.horizontal, 5)
             .padding(.vertical, 1)
@@ -79,7 +79,7 @@ struct InspectorURLBar: View {
         if !highlightContext.isEmpty {
             return AnyView(
                 HighlightedInspectorText(text: urlString, highlightContext: highlightContext)
-                    .font(.system(size: 11, design: .monospaced))
+                    .font(.system(size: metrics.controlFontSize, design: .monospaced))
                     .lineLimit(1)
                     .truncationMode(.middle)
                     .textSelection(.enabled)
@@ -89,19 +89,21 @@ struct InspectorURLBar: View {
         return AnyView(HStack(spacing: 0) {
             if let hostRange = urlString.range(of: host), !host.isEmpty {
                 Text(urlString[urlString.startIndex ..< hostRange.lowerBound])
-                    .font(.system(size: 11, design: .monospaced))
+                    .font(.system(size: metrics.controlFontSize, design: .monospaced))
                 Text(urlString[hostRange])
-                    .font(.system(size: 11, design: .monospaced))
+                    .font(.system(size: metrics.controlFontSize, design: .monospaced))
                     .foregroundStyle(Color.teal)
                 Text(urlString[hostRange.upperBound...])
-                    .font(.system(size: 11, design: .monospaced))
+                    .font(.system(size: metrics.controlFontSize, design: .monospaced))
             } else {
                 Text(urlString)
-                    .font(.system(size: 11, design: .monospaced))
+                    .font(.system(size: metrics.controlFontSize, design: .monospaced))
             }
         }
             .lineLimit(1)
             .truncationMode(.middle)
             .textSelection(.enabled))
     }
+
+    @Environment(\.appUIDisplayMetrics) private var metrics
 }

--- a/Rockxy/Views/Inspector/PreviewTabContentView.swift
+++ b/Rockxy/Views/Inspector/PreviewTabContentView.swift
@@ -121,7 +121,8 @@ private struct AsyncPreviewTabRenderView: View {
                         editorID: renderID,
                         editorSettings: editorSettings
                     )
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .frame(minWidth: 0, maxWidth: .infinity, maxHeight: .infinity)
+                    .clipped()
 
                     if editorSettings.showMinimap {
                         InspectorTextMinimapView(text: text, editorID: renderID)

--- a/Rockxy/Views/Inspector/PreviewTabPopover.swift
+++ b/Rockxy/Views/Inspector/PreviewTabPopover.swift
@@ -11,7 +11,7 @@ struct PreviewTabPopover: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
             Text(String(localized: "Preview Tabs"))
-                .font(.system(size: 12, weight: .semibold))
+                .font(.system(size: metrics.controlFontSize, weight: .semibold))
 
             VStack(alignment: .leading, spacing: 4) {
                 ForEach(PreviewRenderMode.allCases) { mode in
@@ -26,7 +26,7 @@ struct PreviewTabPopover: View {
                         }
                     ))
                     .toggleStyle(.checkbox)
-                    .font(.system(size: 12))
+                    .font(.system(size: metrics.controlFontSize))
                 }
             }
 
@@ -37,11 +37,13 @@ struct PreviewTabPopover: View {
                 set: { store.autoBeautify = $0 }
             )) {
                 Text(String(localized: "Auto beautify"))
-                    .font(.system(size: 11))
+                    .font(.system(size: metrics.secondaryFontSize))
             }
             .toggleStyle(.checkbox)
         }
         .padding(12)
         .frame(width: 220)
     }
+
+    @Environment(\.appUIDisplayMetrics) private var metrics
 }

--- a/Rockxy/Views/Inspector/ProtobufTreeView.swift
+++ b/Rockxy/Views/Inspector/ProtobufTreeView.swift
@@ -30,12 +30,14 @@ struct ProtobufTreeView: View {
             Text(String(localized: "Best Guess Value"))
             Spacer()
         }
-        .font(.system(size: 10, weight: .semibold))
+        .font(.system(size: metrics.metadataFontSize, weight: .semibold))
         .foregroundStyle(.secondary)
         .padding(.horizontal, 10)
         .padding(.vertical, 6)
         .background(Color(nsColor: .controlBackgroundColor))
     }
+
+    @Environment(\.appUIDisplayMetrics) private var metrics
 }
 
 // MARK: - ProtobufFieldRow
@@ -52,31 +54,31 @@ private struct ProtobufFieldRow: View {
                 HStack(spacing: 4) {
                     if nestedTree != nil {
                         Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
-                            .font(.system(size: 9, weight: .semibold))
+                            .font(.system(size: metrics.badgeFontSize, weight: .semibold))
                             .frame(width: 10)
                     } else {
                         Color.clear.frame(width: 10)
                     }
                     Text("\(field.fieldNumber)")
-                        .font(.system(size: 11, weight: .medium, design: .monospaced))
+                        .font(.system(size: metrics.secondaryFontSize, weight: .medium, design: .monospaced))
                 }
                 .padding(.leading, CGFloat(depth) * 16)
                 .frame(width: 120, alignment: .leading)
 
                 Text(field.wireType.displayName)
-                    .font(.system(size: 10, design: .monospaced))
+                    .font(.system(size: metrics.metadataFontSize, design: .monospaced))
                     .foregroundStyle(.secondary)
                     .frame(width: 130, alignment: .leading)
 
                 Text(valuePreview)
-                    .font(.system(size: 11, design: .monospaced))
+                    .font(.system(size: metrics.secondaryFontSize, design: .monospaced))
                     .lineLimit(1)
                     .truncationMode(.middle)
 
                 Spacer()
 
                 Text(SizeFormatter.format(bytes: field.rawBytes.count))
-                    .font(.system(size: 10, design: .monospaced))
+                    .font(.system(size: metrics.metadataFontSize, design: .monospaced))
                     .foregroundStyle(.tertiary)
             }
             .padding(.horizontal, 10)
@@ -99,6 +101,7 @@ private struct ProtobufFieldRow: View {
     // MARK: Private
 
     @State private var isExpanded = true
+    @Environment(\.appUIDisplayMetrics) private var metrics
 
     private var nestedTree: ProtobufDecodedTree? {
         if case let .message(tree) = field.value {

--- a/Rockxy/Views/Inspector/QueryInspectorView.swift
+++ b/Rockxy/Views/Inspector/QueryInspectorView.swift
@@ -22,20 +22,20 @@ struct QueryInspectorView: View {
                         GridItem(.flexible(), alignment: .topLeading),
                     ], spacing: 4) {
                         Text(String(localized: "Name"))
-                            .font(.system(.caption, design: .monospaced))
+                            .font(.system(size: metrics.secondaryFontSize, design: .monospaced))
                             .fontWeight(.bold)
                             .foregroundStyle(.secondary)
                         Text(String(localized: "Value"))
-                            .font(.system(.caption, design: .monospaced))
+                            .font(.system(size: metrics.secondaryFontSize, design: .monospaced))
                             .fontWeight(.bold)
                             .foregroundStyle(.secondary)
 
                         ForEach(Array(queryItems.enumerated()), id: \.offset) { _, item in
                             HighlightedInspectorText(text: item.name, highlightContext: highlightContext)
-                                .font(.system(.caption, design: .monospaced))
+                                .font(.system(size: metrics.secondaryFontSize, design: .monospaced))
                                 .fontWeight(.semibold)
                             HighlightedInspectorText(text: item.value ?? "", highlightContext: highlightContext)
-                                .font(.system(.caption, design: .monospaced))
+                                .font(.system(size: metrics.secondaryFontSize, design: .monospaced))
                                 .textSelection(.enabled)
                         }
                     }
@@ -45,4 +45,6 @@ struct QueryInspectorView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
     }
+
+    @Environment(\.appUIDisplayMetrics) private var metrics
 }

--- a/Rockxy/Views/Inspector/QuickPreviewPopoverView.swift
+++ b/Rockxy/Views/Inspector/QuickPreviewPopoverView.swift
@@ -37,7 +37,7 @@ struct QuickPreviewPopoverView: View {
     private var header: some View {
         HStack {
             Text(title)
-                .font(.system(size: 13, weight: .semibold))
+                .font(.system(size: metrics.primaryFontSize, weight: .semibold))
             Spacer()
             Button {
                 NSPasteboard.general.clearContents()
@@ -47,15 +47,17 @@ struct QuickPreviewPopoverView: View {
                 Label(copied ? String(localized: "Copied") : String(localized: "Copy"), systemImage: copied ? "checkmark" : "doc.on.doc")
             }
             .buttonStyle(.borderless)
-            .font(.system(size: 12))
+            .font(.system(size: metrics.controlFontSize))
         }
     }
 
     @ViewBuilder private var content: some View {
         switch result {
         case let .json(_, text),
-             let .text(_, text):
+            let .text(_, text):
             InspectorBodyTextEditor(text: text, editorSettings: metrics.inspectorTextEditorSettings)
+                .frame(minWidth: 0)
+                .clipped()
                 .frame(minHeight: 220)
         case let .keyValue(_, rows):
             ScrollView {
@@ -94,7 +96,7 @@ struct QuickPreviewPopoverView: View {
                 VStack(alignment: .leading, spacing: 4) {
                     ForEach(Array(preview.warnings.enumerated()), id: \.offset) { _, warning in
                         Label(warning.message, systemImage: warning.severity == .warning ? "exclamationmark.triangle" : "info.circle")
-                            .font(.system(size: 11))
+                            .font(.system(size: metrics.secondaryFontSize))
                             .foregroundStyle(warning.severity == .warning ? .orange : .secondary)
                     }
                 }
@@ -105,10 +107,10 @@ struct QuickPreviewPopoverView: View {
                     ForEach(preview.claims.summaryRows) { row in
                         VStack(alignment: .leading, spacing: 2) {
                             Text(row.key)
-                                .font(.system(size: 10, weight: .semibold))
+                                .font(.system(size: metrics.metadataFontSize, weight: .semibold))
                                 .foregroundStyle(.secondary)
                             Text(row.value)
-                                .font(.system(size: 11, design: .monospaced))
+                                .font(.system(size: metrics.secondaryFontSize, design: .monospaced))
                                 .lineLimit(2)
                         }
                     }
@@ -117,13 +119,19 @@ struct QuickPreviewPopoverView: View {
 
             TabView {
                 InspectorBodyTextEditor(text: preview.headerText, editorSettings: metrics.inspectorTextEditorSettings)
+                    .frame(minWidth: 0)
+                    .clipped()
                     .tabItem { Text(String(localized: "Header")) }
                 InspectorBodyTextEditor(text: preview.payloadText, editorSettings: metrics.inspectorTextEditorSettings)
+                    .frame(minWidth: 0)
+                    .clipped()
                     .tabItem { Text(String(localized: "Payload")) }
                 InspectorBodyTextEditor(
                     text: preview.signaturePreview,
                     editorSettings: metrics.inspectorTextEditorSettings
                 )
+                    .frame(minWidth: 0)
+                    .clipped()
                     .tabItem { Text(String(localized: "Signature")) }
             }
             .frame(minHeight: 210)
@@ -132,7 +140,7 @@ struct QuickPreviewPopoverView: View {
 
     private var footer: some View {
         Text(String(localized: "Preview is local. JWT signatures are decoded, not verified."))
-            .font(.system(size: 11))
+            .font(.system(size: metrics.secondaryFontSize))
             .foregroundStyle(.secondary)
             .frame(maxWidth: .infinity, alignment: .leading)
     }

--- a/Rockxy/Views/Inspector/RequestInspectorView.swift
+++ b/Rockxy/Views/Inspector/RequestInspectorView.swift
@@ -47,7 +47,7 @@ struct RequestInspectorView: View {
 
             if !previewTabStore.requestTabs.isEmpty {
                 Divider()
-                    .frame(height: 14)
+                    .frame(height: max(14, metrics.controlFontSize + 2))
                     .padding(.horizontal, 4)
 
                 ForEach(previewTabStore.requestTabs) { tab in
@@ -61,7 +61,7 @@ struct RequestInspectorView: View {
             }
 
             Divider()
-                .frame(height: 14)
+                .frame(height: max(14, metrics.controlFontSize + 2))
                 .padding(.horizontal, 4)
 
             previewTabMenuButton
@@ -75,9 +75,9 @@ struct RequestInspectorView: View {
             showPreviewPopover.toggle()
         } label: {
             Image(systemName: "plus")
-                .font(.system(size: 10, weight: .medium))
+                .font(.system(size: metrics.controlFontSize, weight: .medium))
                 .foregroundStyle(Color(nsColor: .tertiaryLabelColor))
-                .frame(width: 20, height: 20)
+                .frame(width: metrics.inspectorTabHeight, height: metrics.inspectorTabHeight)
         }
         .buttonStyle(.plain)
         .help(String(localized: "Preview Tabs"))

--- a/Rockxy/Views/Inspector/ResponseInspectorView.swift
+++ b/Rockxy/Views/Inspector/ResponseInspectorView.swift
@@ -92,7 +92,7 @@ struct ResponseInspectorView: View {
 
             if hasProtocolTab {
                 Divider()
-                    .frame(height: 14)
+                    .frame(height: max(14, metrics.controlFontSize + 2))
                     .padding(.horizontal, 4)
 
                 if transaction.webSocketConnection != nil {
@@ -120,7 +120,7 @@ struct ResponseInspectorView: View {
 
             if !previewTabStore.responseTabs.isEmpty {
                 Divider()
-                    .frame(height: 14)
+                    .frame(height: max(14, metrics.controlFontSize + 2))
                     .padding(.horizontal, 4)
 
                 ForEach(previewTabStore.responseTabs) { tab in
@@ -136,7 +136,7 @@ struct ResponseInspectorView: View {
             }
 
             Divider()
-                .frame(height: 14)
+                .frame(height: max(14, metrics.controlFontSize + 2))
                 .padding(.horizontal, 4)
 
             previewTabMenuButton
@@ -150,9 +150,9 @@ struct ResponseInspectorView: View {
             showPreviewPopover.toggle()
         } label: {
             Image(systemName: "plus")
-                .font(.system(size: 10, weight: .medium))
+                .font(.system(size: metrics.controlFontSize, weight: .medium))
                 .foregroundStyle(Color(nsColor: .tertiaryLabelColor))
-                .frame(width: 20, height: 20)
+                .frame(width: metrics.inspectorTabHeight, height: metrics.inspectorTabHeight)
         }
         .buttonStyle(.plain)
         .help(String(localized: "Preview Tabs"))
@@ -259,7 +259,7 @@ struct ResponseInspectorView: View {
         } label: {
             HStack(spacing: 4) {
                 Text(bodyDisplayMode.displayName)
-                    .font(.system(size: metrics.secondaryFontSize, weight: .medium))
+                    .font(.system(size: metrics.controlFontSize, weight: .medium))
                 Image(systemName: "chevron.up.chevron.down")
                     .font(.system(size: metrics.badgeFontSize, weight: .semibold))
                     .foregroundStyle(Color(nsColor: .tertiaryLabelColor))
@@ -425,16 +425,16 @@ struct ResponseInspectorView: View {
             VStack(spacing: 18) {
                 HStack(spacing: 10) {
                     Image(systemName: "lock")
-                        .font(.system(size: 28, weight: .regular))
+                        .font(.system(size: max(24, metrics.primaryFontSize + 15), weight: .regular))
                         .foregroundStyle(Color(nsColor: .secondaryLabelColor))
 
                     Text(prompt.title)
-                        .font(.system(size: 24, weight: .regular))
+                        .font(.system(size: max(20, metrics.primaryFontSize + 11), weight: .regular))
                         .foregroundStyle(Color(nsColor: .secondaryLabelColor))
                 }
 
                 Text(prompt.message)
-                    .font(.system(size: 14, weight: .regular))
+                    .font(.system(size: max(metrics.primaryFontSize, metrics.controlFontSize), weight: .regular))
                     .foregroundStyle(Color(nsColor: .tertiaryLabelColor))
                     .multilineTextAlignment(.center)
                     .frame(maxWidth: 320)
@@ -452,7 +452,7 @@ struct ResponseInspectorView: View {
                    let secondaryAction = prompt.secondaryAction
                 {
                     Text(String(localized: "or"))
-                        .font(.system(size: 12, weight: .medium))
+                        .font(.system(size: metrics.controlFontSize, weight: .medium))
                         .foregroundStyle(Color(nsColor: .tertiaryLabelColor))
 
                     Button {

--- a/Rockxy/Views/Inspector/SetCookieInspectorView.swift
+++ b/Rockxy/Views/Inspector/SetCookieInspectorView.swift
@@ -40,10 +40,10 @@ struct SetCookieInspectorView: View {
     private func cookieRow(_ cookie: HTTPCookie) -> some View {
         VStack(alignment: .leading, spacing: 4) {
             HighlightedInspectorText(text: cookie.name, highlightContext: highlightContext)
-                .font(.system(.caption, design: .monospaced))
+                .font(.system(size: metrics.secondaryFontSize, design: .monospaced))
                 .fontWeight(.bold)
             HighlightedInspectorText(text: cookie.value, highlightContext: highlightContext)
-                .font(.system(.caption, design: .monospaced))
+                .font(.system(size: metrics.secondaryFontSize, design: .monospaced))
                 .textSelection(.enabled)
                 .foregroundStyle(.secondary)
 
@@ -54,12 +54,12 @@ struct SetCookieInspectorView: View {
                 labelValue(String(localized: "Path"), cookie.path)
                 if cookie.isSecure {
                     Text(String(localized: "Secure"))
-                        .font(.caption2)
+                        .font(.system(size: metrics.metadataFontSize))
                         .foregroundStyle(.green)
                 }
                 if cookie.isHTTPOnly {
                     Text("HttpOnly")
-                        .font(.caption2)
+                        .font(.system(size: metrics.metadataFontSize))
                         .foregroundStyle(.orange)
                 }
             }
@@ -69,10 +69,12 @@ struct SetCookieInspectorView: View {
     private func labelValue(_ label: String, _ value: String) -> some View {
         HStack(spacing: 2) {
             Text(label + ":")
-                .font(.caption2)
+                .font(.system(size: metrics.metadataFontSize))
                 .foregroundStyle(.secondary)
             HighlightedInspectorText(text: value, highlightContext: highlightContext)
-                .font(.system(.caption2, design: .monospaced))
+                .font(.system(size: metrics.metadataFontSize, design: .monospaced))
         }
     }
+
+    @Environment(\.appUIDisplayMetrics) private var metrics
 }

--- a/Rockxy/Views/Inspector/SynopsisInspectorView.swift
+++ b/Rockxy/Views/Inspector/SynopsisInspectorView.swift
@@ -60,11 +60,13 @@ struct SynopsisInspectorView: View {
     private func synopsisRow(_ label: String, _ value: String) -> some View {
         VStack(alignment: .leading, spacing: 2) {
             Text(label)
-                .font(.caption)
+                .font(.system(size: metrics.secondaryFontSize))
                 .foregroundStyle(.secondary)
             Text(value)
-                .font(.system(.caption, design: .monospaced))
+                .font(.system(size: metrics.secondaryFontSize, design: .monospaced))
                 .textSelection(.enabled)
         }
     }
+
+    @Environment(\.appUIDisplayMetrics) private var metrics
 }

--- a/Rockxy/Views/Inspector/TimingInspectorView.swift
+++ b/Rockxy/Views/Inspector/TimingInspectorView.swift
@@ -45,14 +45,16 @@ struct TimingInspectorView: View {
     private func timingRow(_ label: String, duration: TimeInterval, color: Color) -> some View {
         HStack {
             Text(label)
-                .font(.caption)
+                .font(.system(size: metrics.secondaryFontSize))
             Spacer()
             RoundedRectangle(cornerRadius: 2)
                 .fill(color)
                 .frame(width: max(2, CGFloat(duration * 200)), height: 12)
             Text(DurationFormatter.format(seconds: duration))
-                .font(.caption)
+                .font(.system(size: metrics.secondaryFontSize))
                 .frame(width: 60, alignment: .trailing)
         }
     }
+
+    @Environment(\.appUIDisplayMetrics) private var metrics
 }

--- a/Rockxy/Views/Inspector/WebSocketInspectorView.swift
+++ b/Rockxy/Views/Inspector/WebSocketInspectorView.swift
@@ -51,6 +51,7 @@ struct WebSocketInspectorView: View {
     @State private var directionFilterValue: FrameDirection?
     @State private var showDetail = true
     @State private var payloadMode: WebSocketPayloadInspectorMode = .payload
+    @Environment(\.appUIDisplayMetrics) private var metrics
 
     private var selectedFrame: WebSocketFrameData? {
         guard let id = selectedFrameID,
@@ -72,9 +73,9 @@ struct WebSocketInspectorView: View {
             } label: {
                 HStack(spacing: 4) {
                     Image(systemName: showDetail ? "chevron.down" : "chevron.right")
-                        .font(.caption2)
+                        .font(.system(size: metrics.badgeFontSize))
                     Text(String(localized: "Frame Detail"))
-                        .font(.caption)
+                        .font(.system(size: metrics.secondaryFontSize))
                         .fontWeight(.medium)
                 }
                 .foregroundStyle(.secondary)
@@ -104,7 +105,7 @@ struct WebSocketInspectorView: View {
                         Text(SizeFormatter.format(bytes: frame.payload.count))
                     }
                 }
-                .font(.system(size: 10))
+                .font(.system(size: metrics.metadataFontSize))
                 .padding(.horizontal, 12)
                 .padding(.bottom, 4)
 
@@ -136,7 +137,7 @@ struct WebSocketInspectorView: View {
                     Text(transaction.state == .completed
                         ? String(localized: "Closed")
                         : String(localized: "Active"))
-                        .font(.system(size: 11, design: .monospaced))
+                        .font(.system(size: metrics.secondaryFontSize, design: .monospaced))
                 }
                 if let duration = connectionDuration(connection) {
                     summaryRow(String(localized: "Duration"), value: duration)
@@ -162,7 +163,7 @@ struct WebSocketInspectorView: View {
         HStack(spacing: 4) {
             summaryLabel(label)
             Text(value)
-                .font(.system(size: 11, design: .monospaced))
+                .font(.system(size: metrics.secondaryFontSize, design: .monospaced))
                 .lineLimit(1)
                 .truncationMode(.middle)
                 .textSelection(.enabled)
@@ -171,7 +172,7 @@ struct WebSocketInspectorView: View {
 
     private func summaryLabel(_ text: String) -> some View {
         Text(text)
-            .font(.system(size: 11))
+            .font(.system(size: metrics.secondaryFontSize))
             .foregroundStyle(.secondary)
     }
 
@@ -218,12 +219,12 @@ struct WebSocketInspectorView: View {
     private func frameRow(_ frame: WebSocketFrameData) -> some View {
         HStack(spacing: 4) {
             Text(formatTimestamp(frame.timestamp))
-                .font(.system(size: 10, design: .monospaced))
+                .font(.system(size: metrics.metadataFontSize, design: .monospaced))
                 .foregroundStyle(.secondary)
                 .frame(width: 54, alignment: .leading)
 
             Image(systemName: frame.direction == .sent ? "arrow.up.circle" : "arrow.down.circle")
-                .font(.system(size: 11))
+                .font(.system(size: metrics.secondaryFontSize))
                 .foregroundStyle(frame.direction == .sent ? .blue : .green)
                 .frame(width: 16)
 
@@ -231,7 +232,7 @@ struct WebSocketInspectorView: View {
                 .frame(width: 42, alignment: .leading)
 
             Text(payloadPreview(frame))
-                .font(.system(size: 10, design: .monospaced))
+                .font(.system(size: metrics.metadataFontSize, design: .monospaced))
                 .foregroundStyle(.secondary)
                 .lineLimit(1)
                 .truncationMode(.tail)
@@ -239,7 +240,7 @@ struct WebSocketInspectorView: View {
             Spacer()
 
             Text(SizeFormatter.format(bytes: frame.payload.count))
-                .font(.system(size: 10, design: .monospaced))
+                .font(.system(size: metrics.metadataFontSize, design: .monospaced))
                 .foregroundStyle(.tertiary)
                 .frame(width: 48, alignment: .trailing)
         }
@@ -249,7 +250,7 @@ struct WebSocketInspectorView: View {
     private func opcodeBadge(_ opcode: FrameOpcode) -> some View {
         let (label, color) = opcodeInfo(opcode)
         return Text(label)
-            .font(.system(size: 9, weight: .medium, design: .monospaced))
+            .font(.system(size: metrics.badgeFontSize, weight: .medium, design: .monospaced))
             .padding(.horizontal, 3)
             .padding(.vertical, 1)
             .background(color.opacity(0.15))
@@ -261,7 +262,7 @@ struct WebSocketInspectorView: View {
     private func framePayloadView(_ frame: WebSocketFrameData) -> some View {
         if frame.payload.isEmpty {
             Text(String(localized: "(empty payload)"))
-                .font(.system(size: 11, design: .monospaced))
+                .font(.system(size: metrics.secondaryFontSize, design: .monospaced))
                 .foregroundStyle(.tertiary)
                 .padding(12)
         } else {
@@ -277,7 +278,7 @@ struct WebSocketInspectorView: View {
 
                     if ProtobufDetector.isLikelyProtobuf(frame.payload) {
                         Label(String(localized: "Likely Protobuf"), systemImage: "sparkles")
-                            .font(.system(size: 10))
+                            .font(.system(size: metrics.metadataFontSize))
                             .foregroundStyle(.secondary)
                     }
 

--- a/Rockxy/Views/Main/Extensions/MainContentCoordinator+ContextMenu.swift
+++ b/Rockxy/Views/Main/Extensions/MainContentCoordinator+ContextMenu.swift
@@ -127,6 +127,7 @@ extension MainContentCoordinator {
 
     func togglePin(for transaction: HTTPTransaction) {
         transaction.isPinned.toggle()
+        invalidateSidebarFavoriteCache()
         persistTransaction(transaction)
         refreshRowsAfterMutation()
     }
@@ -252,6 +253,7 @@ extension MainContentCoordinator {
 
     func saveRequest(_ transaction: HTTPTransaction) {
         transaction.isSaved.toggle()
+        invalidateSidebarFavoriteCache()
         persistTransaction(transaction)
         refreshRowsAfterMutation()
     }
@@ -322,6 +324,7 @@ extension MainContentCoordinator {
             transaction.isSaved = false
         }
 
+        invalidateSidebarFavoriteCache()
         updatePersistedFavoriteCache(after: transaction)
         persistTransaction(transaction)
         refreshRowsAfterMutation()
@@ -500,6 +503,7 @@ extension MainContentCoordinator {
         transactions.removeAll { ids.contains($0.id) }
         rebuildObservedDomainsByApp()
         persistedFavorites.removeAll { ids.contains($0.id) }
+        invalidateSidebarFavoriteCache()
 
         // Update all workspaces (same consistency as eviction)
         for workspace in workspaceStore.workspaces {

--- a/Rockxy/Views/Main/Extensions/MainContentCoordinator+Workspaces.swift
+++ b/Rockxy/Views/Main/Extensions/MainContentCoordinator+Workspaces.swift
@@ -60,6 +60,7 @@ extension MainContentCoordinator {
 
     func refreshDomainTree(for workspace: WorkspaceState, alphabetical: Bool = false) {
         workspace.domainTree = workspace.domainGroupingIndex.makeTree(alphabetical: alphabetical)
+        workspace.totalDomainCount = workspace.domainTree.reduce(0) { $0 + $1.requestCount }
         workspace.domainIndexMap.removeAll(keepingCapacity: true)
         for (index, node) in workspace.domainTree.enumerated() {
             workspace.domainIndexMap[node.selectionDomain] = index

--- a/Rockxy/Views/Main/MainContentCoordinator.swift
+++ b/Rockxy/Views/Main/MainContentCoordinator.swift
@@ -60,6 +60,18 @@ final class MainContentCoordinator {
         let generation: UInt
     }
 
+    struct SidebarFavoritesCacheKey: Equatable {
+        let transactionCount: Int
+        let persistedFavoriteCount: Int
+        let sessionGeneration: UInt
+    }
+
+    struct SidebarFavoritesCache {
+        let key: SidebarFavoritesCacheKey
+        let pinned: [HTTPTransaction]
+        let saved: [HTTPTransaction]
+    }
+
     static let logger = Logger(subsystem: RockxyIdentity.current.logSubsystem, category: "MainContentCoordinator")
 
     let policy: any AppPolicy
@@ -88,6 +100,7 @@ final class MainContentCoordinator {
 
     var transactions: [HTTPTransaction] = []
     var persistedFavorites: [HTTPTransaction] = []
+    @ObservationIgnored private var sidebarFavoritesCache: SidebarFavoritesCache?
     var isProxyRunning = false
     var isProxyStarting = false
     var activeProxyPort = AppSettingsManager.shared.settings.proxyPort
@@ -276,17 +289,46 @@ final class MainContentCoordinator {
     // MARK: - Sidebar Favorites (live + persisted, deduplicated)
 
     var allPinnedTransactions: [HTTPTransaction] {
-        let live = transactions.filter(\.isPinned)
-        let persisted = persistedFavorites.filter(\.isPinned)
-        let liveIds = Set(live.map(\.id))
-        return live + persisted.filter { !liveIds.contains($0.id) }
+        sidebarFavoriteTransactions().pinned
     }
 
     var allSavedTransactions: [HTTPTransaction] {
-        let live = transactions.filter(\.isSaved)
-        let persisted = persistedFavorites.filter(\.isSaved)
-        let liveIds = Set(live.map(\.id))
-        return live + persisted.filter { !liveIds.contains($0.id) }
+        sidebarFavoriteTransactions().saved
+    }
+
+    var totalDomainCount: Int {
+        activeWorkspace.totalDomainCount
+    }
+
+    func invalidateSidebarFavoriteCache() {
+        sidebarFavoritesCache = nil
+    }
+
+    private func sidebarFavoriteTransactions() -> SidebarFavoritesCache {
+        let key = SidebarFavoritesCacheKey(
+            transactionCount: transactions.count,
+            persistedFavoriteCount: persistedFavorites.count,
+            sessionGeneration: sessionGeneration
+        )
+        if let cache = sidebarFavoritesCache,
+           cache.key == key
+        {
+            return cache
+        }
+
+        let livePinned = transactions.filter(\.isPinned)
+        let persistedPinned = persistedFavorites.filter(\.isPinned)
+        let livePinnedIds = Set(livePinned.map(\.id))
+        let liveSaved = transactions.filter(\.isSaved)
+        let persistedSaved = persistedFavorites.filter(\.isSaved)
+        let liveSavedIds = Set(liveSaved.map(\.id))
+        let cache = SidebarFavoritesCache(
+            key: key,
+            pinned: livePinned + persistedPinned.filter { !livePinnedIds.contains($0.id) },
+            saved: liveSaved + persistedSaved.filter { !liveSavedIds.contains($0.id) }
+        )
+        sidebarFavoritesCache = cache
+        return cache
     }
 
     /// Configure shared policy gates. Called once from the app's main
@@ -373,6 +415,7 @@ final class MainContentCoordinator {
                 do {
                     let persisted = try await store.loadPinnedAndSavedTransactions()
                     self.persistedFavorites = persisted
+                    self.invalidateSidebarFavoriteCache()
                     // Assign deterministic sequence numbers starting from current counter
                     // to avoid collisions with live rows assigned while the load suspended
                     let base = self.nextSequenceNumber

--- a/Rockxy/Views/Main/WorkspaceWindowManager.swift
+++ b/Rockxy/Views/Main/WorkspaceWindowManager.swift
@@ -381,11 +381,24 @@ private final class WorkspaceTabBarView: NSView, NSTextFieldDelegate {
         super.init(frame: NSRect(x: 0, y: 0, width: 900, height: WorkspaceTabBarMetrics.barHeight))
         autoresizingMask = [.width]
         wantsLayer = false
+        appearanceObserver = NotificationCenter.default.addObserver(
+            forName: .appearanceDidChange,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            self?.appearanceDidChange()
+        }
     }
 
     @available(*, unavailable)
     required init?(coder: NSCoder) {
         fatalError("WorkspaceTabBarView does not support NSCoder init")
+    }
+
+    deinit {
+        if let appearanceObserver {
+            NotificationCenter.default.removeObserver(appearanceObserver)
+        }
     }
 
     // MARK: Internal
@@ -603,7 +616,7 @@ private final class WorkspaceTabBarView: NSView, NSTextFieldDelegate {
 
         let field = WorkspaceInlineTabTextField(frame: editorFrame(in: tabFrame))
         field.stringValue = workspace.title
-        field.font = .systemFont(ofSize: 13, weight: .medium)
+        field.font = workspaceTabFont(weight: .medium)
         field.alignment = .center
         field.delegate = self
         field.onCommit = { [weak self] in self?.endEditing(commit: true) }
@@ -689,6 +702,21 @@ private final class WorkspaceTabBarView: NSView, NSTextFieldDelegate {
     private var originalTitle = ""
     private var editField: WorkspaceInlineTabTextField?
     private var editMonitor: Any?
+    private var appearanceObserver: NSObjectProtocol?
+
+    private var displayMetrics: AppUIDisplayMetrics {
+        AppUIDisplayMetrics(settings: AppSettingsManager.shared.appUI)
+    }
+
+    private func workspaceTabFont(weight: NSFont.Weight) -> NSFont {
+        .systemFont(ofSize: displayMetrics.workspaceTabFontSize, weight: weight)
+    }
+
+    private func appearanceDidChange() {
+        editField?.font = workspaceTabFont(weight: .medium)
+        needsLayout = true
+        needsDisplay = true
+    }
 
     private func recalculateFrames() {
         guard let coordinator else {
@@ -851,7 +879,7 @@ private final class WorkspaceTabBarView: NSView, NSTextFieldDelegate {
         paragraph.alignment = .center
         paragraph.lineBreakMode = .byTruncatingMiddle
         let attributes: [NSAttributedString.Key: Any] = [
-            .font: NSFont.systemFont(ofSize: 13, weight: isActive ? .medium : .regular),
+            .font: workspaceTabFont(weight: isActive ? .medium : .regular),
             .foregroundColor: (isActive ? activeTitleColor : inactiveTitleColor).withAlphaComponent(alpha),
             .paragraphStyle: paragraph
         ]

--- a/Rockxy/Views/RequestList/RequestTableView.swift
+++ b/Rockxy/Views/RequestList/RequestTableView.swift
@@ -120,6 +120,7 @@ struct RequestTableView: NSViewRepresentable {
         coordinator.lastRefreshToken = newToken
         coordinator.lastWorkspaceID = workspaceID
 
+        let scrollAnchor = !workspaceChanged ? coordinator.makeScrollAnchor(in: tableView) : nil
         let displayChange = coordinator.applyDisplayMetrics(to: tableView)
 
         if workspaceChanged || newToken != oldToken {
@@ -132,6 +133,9 @@ struct RequestTableView: NSViewRepresentable {
                 // Append-only fast path: coordinator confirmed rows were only appended
                 let newIndexes = IndexSet(integersIn: coordinator.previousRowCount ..< newCount)
                 tableView.insertRows(at: newIndexes, withAnimation: [])
+                if displayChange?.reloadVisibleRows == true {
+                    coordinator.reloadVisibleRows(in: tableView)
+                }
             } else {
                 tableView.reloadData()
             }
@@ -140,18 +144,7 @@ struct RequestTableView: NSViewRepresentable {
             coordinator.reloadVisibleRows(in: tableView)
         }
 
-        if !coordinator.hasAutoSizedColumns, rows.count > 10 {
-            coordinator.hasAutoSizedColumns = true
-            DispatchQueue.main.async {
-                for (index, column) in tableView.tableColumns.enumerated() {
-                    let colID = column.identifier.rawValue
-                    if colID == "client" || colID == "url" {
-                        let width = coordinator.tableView(tableView, sizeToFitWidthOfColumn: index)
-                        column.width = width
-                    }
-                }
-            }
-        }
+        coordinator.scheduleInitialAutosizeIfNeeded(in: tableView)
 
         coordinator.syncHeaderColumns(in: tableView)
         coordinator.syncSelection(to: selectedIDs, in: tableView)
@@ -171,6 +164,12 @@ struct RequestTableView: NSViewRepresentable {
             from: mainCoordinator?.activeSortDescriptors ?? [],
             into: tableView
         )
+
+        if displayChange?.rowHeightChanged == true,
+           let scrollAnchor
+        {
+            coordinator.restoreScrollAnchor(scrollAnchor, in: tableView)
+        }
     }
 
     func makeCoordinator() -> Coordinator {
@@ -243,6 +242,48 @@ private struct ColumnSpec {
     let minWidth: CGFloat
 }
 
+// MARK: - FixedIconCellView
+
+private final class FixedIconCellView: NSView {
+    let imageView = NSImageView()
+
+    private var widthConstraint: NSLayoutConstraint?
+    private var heightConstraint: NSLayoutConstraint?
+
+    init(identifier: NSUserInterfaceItemIdentifier) {
+        super.init(frame: .zero)
+        self.identifier = identifier
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(imageView)
+
+        let widthConstraint = imageView.widthAnchor.constraint(equalToConstant: 0)
+        let heightConstraint = imageView.heightAnchor.constraint(equalToConstant: 0)
+        self.widthConstraint = widthConstraint
+        self.heightConstraint = heightConstraint
+
+        NSLayoutConstraint.activate([
+            imageView.centerXAnchor.constraint(equalTo: centerXAnchor),
+            imageView.centerYAnchor.constraint(equalTo: centerYAnchor),
+            widthConstraint,
+            heightConstraint,
+        ])
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        nil
+    }
+
+    func updateIconSize(_ size: CGFloat) {
+        if widthConstraint?.constant != size {
+            widthConstraint?.constant = size
+        }
+        if heightConstraint?.constant != size {
+            heightConstraint?.constant = size
+        }
+    }
+}
+
 // MARK: - RequestTableAppliedMetrics
 
 private struct RequestTableAppliedMetrics: Equatable {
@@ -296,6 +337,7 @@ extension RequestTableView {
         var lastRefreshToken: Int = 0
         var previousRowCount: Int = 0
         var lastAppliedDisplayMetrics: AppUIDisplayMetrics?
+        private var autosizeGeneration = 0
         private var lastAppliedRequestTableMetrics: RequestTableAppliedMetrics?
 
         /// Guard flag to prevent feedback loops: when we programmatically update NSTableView
@@ -318,6 +360,14 @@ extension RequestTableView {
         struct DisplayMetricsChange: Equatable {
             let reloadVisibleRows: Bool
             let autosizeContentColumns: Bool
+            let rowHeightChanged: Bool
+            let contentMetricsChanged: Bool
+        }
+
+        struct ScrollAnchor: Equatable {
+            let row: Int
+            let intraRowOffset: CGFloat
+            let xOffset: CGFloat
         }
 
         @discardableResult
@@ -343,16 +393,70 @@ extension RequestTableView {
             let contentMetricsChanged = previousTableMetrics?.contentMetrics != tableMetrics.contentMetrics
             let rowHeightChanged = previousTableMetrics?.rowHeight != tableMetrics.rowHeight
             let reloadVisibleRows = previousTableMetrics == nil || contentMetricsChanged || rowHeightChanged
-            let autosizeContentColumns = previousTableMetrics == nil || contentMetricsChanged
-
-            if autosizeContentColumns {
-                hasAutoSizedColumns = false
-            }
+            let autosizeContentColumns = previousTableMetrics == nil
 
             return DisplayMetricsChange(
                 reloadVisibleRows: reloadVisibleRows,
-                autosizeContentColumns: autosizeContentColumns
+                autosizeContentColumns: autosizeContentColumns,
+                rowHeightChanged: rowHeightChanged,
+                contentMetricsChanged: contentMetricsChanged
             )
+        }
+
+        func makeScrollAnchor(in tableView: NSTableView) -> ScrollAnchor? {
+            let visibleRect = tableView.visibleRect
+            let visibleRange = tableView.rows(in: visibleRect)
+            guard visibleRange.location != NSNotFound,
+                  visibleRange.location >= 0,
+                  visibleRange.location < rows.count else
+            {
+                return nil
+            }
+            let rowRect = tableView.rect(ofRow: visibleRange.location)
+            let intraRowOffset = max(0, visibleRect.minY - rowRect.minY)
+            return ScrollAnchor(
+                row: visibleRange.location,
+                intraRowOffset: intraRowOffset,
+                xOffset: visibleRect.minX
+            )
+        }
+
+        func restoreScrollAnchor(_ anchor: ScrollAnchor, in tableView: NSTableView) {
+            guard let scrollView = tableView.enclosingScrollView,
+                  anchor.row >= 0,
+                  anchor.row < rows.count else
+            {
+                return
+            }
+            let rowRect = tableView.rect(ofRow: anchor.row)
+            let maxY = max(0, tableView.bounds.height - scrollView.contentView.bounds.height)
+            let restoredY = min(max(0, rowRect.minY + anchor.intraRowOffset), maxY)
+            scrollView.contentView.scroll(to: NSPoint(x: anchor.xOffset, y: restoredY))
+            scrollView.reflectScrolledClipView(scrollView.contentView)
+        }
+
+        func scheduleInitialAutosizeIfNeeded(in tableView: NSTableView) {
+            guard !hasAutoSizedColumns, rows.count > 10 else {
+                return
+            }
+            hasAutoSizedColumns = true
+            autosizeGeneration += 1
+            let generation = autosizeGeneration
+            DispatchQueue.main.async { [weak self, weak tableView] in
+                guard let self,
+                      let tableView,
+                      self.autosizeGeneration == generation else
+                {
+                    return
+                }
+                for (index, column) in tableView.tableColumns.enumerated() {
+                    let colID = column.identifier.rawValue
+                    if colID == "client" || colID == "url" {
+                        let width = self.tableView(tableView, sizeToFitWidthOfColumn: index)
+                        column.width = width
+                    }
+                }
+            }
         }
 
         func reloadVisibleRows(in tableView: NSTableView) {
@@ -975,6 +1079,13 @@ extension RequestTableView {
         // MARK: - Client Cell with App Icons
 
         private static var appIconCache: [String: NSImage] = [:]
+        private static var resizedAppIconCache: [AppIconCacheKey: NSImage] = [:]
+        private static var missingAppIconNames: Set<String> = []
+
+        private struct AppIconCacheKey: Hashable {
+            let appName: String
+            let iconSize: Int
+        }
 
         private static let bundleIDByAppName: [String: String] = [
             "Chrome": "com.google.Chrome",
@@ -1544,26 +1655,14 @@ extension RequestTableView {
             let cellID = NSUserInterfaceItemIdentifier("Cell_status")
             let dotSize = parent.effectiveDisplayMetrics.tableStatusDotSize
 
-            if let existing = tableView.makeView(withIdentifier: cellID, owner: nil),
-               let imageView = existing.subviews.first as? NSImageView
+            if let existing = tableView.makeView(withIdentifier: cellID, owner: nil) as? FixedIconCellView
             {
-                imageView.contentTintColor = statusDotColor(for: row)
-                applyFixedSize(dotSize, to: imageView, in: existing)
+                configureStatusDotCell(existing, row: row, dotSize: dotSize)
                 return existing
             }
 
-            let container = NSView()
-            container.identifier = cellID
-
-            let imageView = NSImageView()
-            imageView.translatesAutoresizingMaskIntoConstraints = false
-
-            if let image = NSImage(systemSymbolName: "circle.fill", accessibilityDescription: nil) {
-                imageView.image = image
-            }
-            imageView.contentTintColor = statusDotColor(for: row)
-            container.addSubview(imageView)
-            applyFixedSize(dotSize, to: imageView, in: container)
+            let container = FixedIconCellView(identifier: cellID)
+            configureStatusDotCell(container, row: row, dotSize: dotSize)
             return container
         }
 
@@ -1576,22 +1675,29 @@ extension RequestTableView {
             let cellID = NSUserInterfaceItemIdentifier("Cell_ssl")
             let iconSize = parent.effectiveDisplayMetrics.tableSSLIconSize
 
-            if let existing = tableView.makeView(withIdentifier: cellID, owner: nil),
-               let imageView = existing.subviews.first as? NSImageView
+            if let existing = tableView.makeView(withIdentifier: cellID, owner: nil) as? FixedIconCellView
             {
-                configureSSLImageView(imageView, row: row)
-                applyFixedSize(iconSize, to: imageView, in: existing)
+                configureSSLImageView(existing.imageView, row: row)
+                existing.updateIconSize(iconSize)
                 return existing
             }
 
-            let container = NSView()
-            container.identifier = cellID
-
-            let imageView = NSImageView(frame: NSRect(x: 0, y: 0, width: iconSize, height: iconSize))
-            configureSSLImageView(imageView, row: row)
-            container.addSubview(imageView)
-            applyFixedSize(iconSize, to: imageView, in: container)
+            let container = FixedIconCellView(identifier: cellID)
+            configureSSLImageView(container.imageView, row: row)
+            container.updateIconSize(iconSize)
             return container
+        }
+
+        private func configureStatusDotCell(
+            _ cell: FixedIconCellView,
+            row: RequestListRow,
+            dotSize: CGFloat
+        ) {
+            cell.imageView.imageScaling = .scaleProportionallyUpOrDown
+            cell.imageView.symbolConfiguration = NSImage.SymbolConfiguration(pointSize: dotSize, weight: .regular)
+            cell.imageView.image = NSImage(systemSymbolName: "circle.fill", accessibilityDescription: nil)
+            cell.imageView.contentTintColor = statusDotColor(for: row)
+            cell.updateIconSize(dotSize)
         }
 
         private func statusDotColor(for row: RequestListRow) -> NSColor {
@@ -1707,34 +1813,27 @@ extension RequestTableView {
             imageView.contentTintColor = tintColor
         }
 
-        private func applyFixedSize(_ size: CGFloat, to imageView: NSImageView, in container: NSView) {
-            imageView.translatesAutoresizingMaskIntoConstraints = false
-            NSLayoutConstraint.deactivate(container.constraints.filter { constraint in
-                constraint.firstItem as AnyObject? === imageView || constraint.secondItem as AnyObject? === imageView
-            })
-            NSLayoutConstraint.deactivate(imageView.constraints.filter { constraint in
-                constraint.firstAttribute == .width || constraint.firstAttribute == .height
-            })
-            NSLayoutConstraint.activate([
-                imageView.centerXAnchor.constraint(equalTo: container.centerXAnchor),
-                imageView.centerYAnchor.constraint(equalTo: container.centerYAnchor),
-                imageView.widthAnchor.constraint(equalToConstant: size),
-                imageView.heightAnchor.constraint(equalToConstant: size),
-            ])
-        }
-
         private func appIcon(for appName: String) -> NSImage? {
+            let iconSize = parent.effectiveDisplayMetrics.tableClientIconSize
+            let cacheKey = AppIconCacheKey(appName: appName, iconSize: Int(iconSize.rounded()))
+            if let cached = Self.resizedAppIconCache[cacheKey] {
+                return cached
+            }
             guard let source = appIconSource(for: appName),
-                  let icon = source.copy() as? NSImage else
-            {
+                  let icon = source.copy() as? NSImage else {
                 return nil
             }
-            let iconSize = parent.effectiveDisplayMetrics.tableClientIconSize
             icon.size = NSSize(width: iconSize, height: iconSize)
+            Self.resizedAppIconCache[cacheKey] = icon
             return icon
         }
 
         private func appIconSource(for appName: String) -> NSImage? {
+            guard !appName.isEmpty,
+                  !Self.missingAppIconNames.contains(appName) else
+            {
+                return nil
+            }
             if let cached = Self.appIconCache[appName] {
                 return cached
             }
@@ -1766,6 +1865,7 @@ extension RequestTableView {
                 }
             }
 
+            Self.missingAppIconNames.insert(appName)
             return nil
         }
 
@@ -1882,11 +1982,20 @@ extension RequestTableView {
             iconSize: CGFloat,
             gap: CGFloat
         ) {
-            NSLayoutConstraint.deactivate(container.constraints.filter { constraint in
-                constraint.firstItem as AnyObject? === nameLabel || constraint.secondItem as AnyObject? === nameLabel
-            })
+            let leadingConstant = iconSize + gap
+            if let leadingConstraint = container.constraints.first(where: { constraint in
+                constraint.firstItem as AnyObject? === nameLabel
+                    && constraint.firstAttribute == .leading
+                    && constraint.secondItem as AnyObject? === container
+            }) {
+                if leadingConstraint.constant != leadingConstant {
+                    leadingConstraint.constant = leadingConstant
+                }
+                return
+            }
+
             NSLayoutConstraint.activate([
-                nameLabel.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: iconSize + gap),
+                nameLabel.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: leadingConstant),
                 nameLabel.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -2),
                 nameLabel.centerYAnchor.constraint(equalTo: container.centerYAnchor),
             ])

--- a/Rockxy/Views/RequestList/RequestTableView.swift
+++ b/Rockxy/Views/RequestList/RequestTableView.swift
@@ -122,6 +122,7 @@ struct RequestTableView: NSViewRepresentable {
 
         let scrollAnchor = !workspaceChanged ? coordinator.makeScrollAnchor(in: tableView) : nil
         let displayChange = coordinator.applyDisplayMetrics(to: tableView)
+        var reloadedVisibleRowsForMetrics = false
 
         if workspaceChanged || newToken != oldToken {
             let newCount = rows.count
@@ -135,18 +136,24 @@ struct RequestTableView: NSViewRepresentable {
                 tableView.insertRows(at: newIndexes, withAnimation: [])
                 if displayChange?.reloadVisibleRows == true {
                     coordinator.reloadVisibleRows(in: tableView)
+                    reloadedVisibleRowsForMetrics = true
                 }
             } else {
                 tableView.reloadData()
+                reloadedVisibleRowsForMetrics = displayChange?.reloadVisibleRows == true
             }
             coordinator.previousRowCount = newCount
         } else if displayChange?.reloadVisibleRows == true {
             coordinator.reloadVisibleRows(in: tableView)
+            reloadedVisibleRowsForMetrics = true
         }
 
         coordinator.scheduleInitialAutosizeIfNeeded(in: tableView)
 
         coordinator.syncHeaderColumns(in: tableView)
+        if displayChange != nil {
+            coordinator.applyHeaderMetrics(to: tableView)
+        }
         coordinator.syncSelection(to: selectedIDs, in: tableView)
 
         // Re-apply HeaderColumnStore visibility on every update (single source of truth)
@@ -169,6 +176,10 @@ struct RequestTableView: NSViewRepresentable {
            let scrollAnchor
         {
             coordinator.restoreScrollAnchor(scrollAnchor, in: tableView)
+        }
+
+        if reloadedVisibleRowsForMetrics {
+            coordinator.scheduleVisibleMetricsRefresh(in: tableView, preserving: scrollAnchor)
         }
     }
 
@@ -303,11 +314,17 @@ private struct RequestTableAppliedMetrics: Equatable {
 private struct RequestTableContentMetrics: Equatable {
     let fontSize: CGFloat
     let secondaryFontSize: CGFloat
+    let statusDotSize: CGFloat
+    let sslIconSize: CGFloat
+    let clientIconSize: CGFloat
     let useMonospacedFont: Bool
 
     init(metrics: AppUIDisplayMetrics) {
         fontSize = metrics.fontSize
         secondaryFontSize = metrics.secondaryFontSize
+        statusDotSize = metrics.tableStatusDotSize
+        sslIconSize = metrics.tableSSLIconSize
+        clientIconSize = metrics.tableClientIconSize
         useMonospacedFont = metrics.settings.useMonospacedFont
     }
 }
@@ -350,6 +367,7 @@ extension RequestTableView {
         private(set) var isUpdatingSortDescriptors = false
 
         private var lastSyncedSelectionIDs: Set<UUID> = []
+        private var visibleMetricsRefreshGeneration = 0
 
         // MARK: - NSTableViewDataSource
 
@@ -382,9 +400,7 @@ extension RequestTableView {
             let previousTableMetrics = lastAppliedRequestTableMetrics
             tableView.rowHeight = metrics.tableRowHeight
             tableView.usesAlternatingRowBackgroundColors = metrics.settings.useAlternatingRowBackgroundColors
-            for column in tableView.tableColumns {
-                column.headerCell.font = .systemFont(ofSize: metrics.secondaryFontSize, weight: .medium)
-            }
+            applyHeaderMetrics(to: tableView)
             tableView.needsDisplay = true
 
             lastAppliedDisplayMetrics = metrics
@@ -401,6 +417,14 @@ extension RequestTableView {
                 rowHeightChanged: rowHeightChanged,
                 contentMetricsChanged: contentMetricsChanged
             )
+        }
+
+        func applyHeaderMetrics(to tableView: NSTableView) {
+            let metrics = parent.effectiveDisplayMetrics
+            for column in tableView.tableColumns {
+                column.headerCell.font = .systemFont(ofSize: metrics.secondaryFontSize, weight: .medium)
+            }
+            tableView.headerView?.needsDisplay = true
         }
 
         func makeScrollAnchor(in tableView: NSTableView) -> ScrollAnchor? {
@@ -474,6 +498,30 @@ extension RequestTableView {
                 forRowIndexes: IndexSet(integersIn: rowStart ..< rowEnd),
                 columnIndexes: IndexSet(integersIn: 0 ..< tableView.numberOfColumns)
             )
+        }
+
+        func scheduleVisibleMetricsRefresh(
+            in tableView: NSTableView,
+            preserving scrollAnchor: ScrollAnchor?
+        ) {
+            visibleMetricsRefreshGeneration += 1
+            let generation = visibleMetricsRefreshGeneration
+            DispatchQueue.main.async { [weak self, weak tableView] in
+                guard let self,
+                      let tableView,
+                      self.visibleMetricsRefreshGeneration == generation else
+                {
+                    return
+                }
+                tableView.layoutSubtreeIfNeeded()
+                self.reloadVisibleRows(in: tableView)
+                self.applyHeaderMetrics(to: tableView)
+                tableView.needsDisplay = true
+                if let scrollAnchor {
+                    self.restoreScrollAnchor(scrollAnchor, in: tableView)
+                }
+                tableView.layoutSubtreeIfNeeded()
+            }
         }
 
         func tableView(_ tableView: NSTableView, sortDescriptorsDidChange oldDescriptors: [NSSortDescriptor]) {

--- a/Rockxy/Views/RequestList/RequestTableView.swift
+++ b/Rockxy/Views/RequestList/RequestTableView.swift
@@ -120,12 +120,9 @@ struct RequestTableView: NSViewRepresentable {
         coordinator.lastRefreshToken = newToken
         coordinator.lastWorkspaceID = workspaceID
 
-        let displayChanged = coordinator.applyDisplayMetrics(to: tableView)
+        let displayChange = coordinator.applyDisplayMetrics(to: tableView)
 
-        if displayChanged {
-            tableView.reloadData()
-            coordinator.previousRowCount = rows.count
-        } else if workspaceChanged || newToken != oldToken {
+        if workspaceChanged || newToken != oldToken {
             let newCount = rows.count
             if !workspaceChanged,
                isAppendOnly,
@@ -139,6 +136,8 @@ struct RequestTableView: NSViewRepresentable {
                 tableView.reloadData()
             }
             coordinator.previousRowCount = newCount
+        } else if displayChange?.reloadVisibleRows == true {
+            coordinator.reloadVisibleRows(in: tableView)
         }
 
         if !coordinator.hasAutoSizedColumns, rows.count > 10 {
@@ -196,7 +195,7 @@ struct RequestTableView: NSViewRepresentable {
             ColumnSpec(id: "row", title: String(localized: "ID"), width: 46, minWidth: 36),
             ColumnSpec(id: "url", title: String(localized: "URL"), width: 300, minWidth: 200),
             ColumnSpec(id: "client", title: String(localized: "Client"), width: 120, minWidth: 60),
-            ColumnSpec(id: "method", title: String(localized: "Method"), width: 70, minWidth: 55),
+            ColumnSpec(id: "method", title: String(localized: "Method"), width: 82, minWidth: 72),
             ColumnSpec(id: "state", title: String(localized: "Status"), width: 150, minWidth: 112),
             ColumnSpec(id: "code", title: String(localized: "Code"), width: 52, minWidth: 44),
             ColumnSpec(id: "time", title: String(localized: "Time"), width: 80, minWidth: 60),
@@ -244,6 +243,34 @@ private struct ColumnSpec {
     let minWidth: CGFloat
 }
 
+// MARK: - RequestTableAppliedMetrics
+
+private struct RequestTableAppliedMetrics: Equatable {
+    let rowHeight: CGFloat
+    let usesAlternatingRowBackgroundColors: Bool
+    let headerFontSize: CGFloat
+    let contentMetrics: RequestTableContentMetrics
+
+    init(metrics: AppUIDisplayMetrics) {
+        rowHeight = metrics.tableRowHeight
+        usesAlternatingRowBackgroundColors = metrics.settings.useAlternatingRowBackgroundColors
+        headerFontSize = metrics.secondaryFontSize
+        contentMetrics = RequestTableContentMetrics(metrics: metrics)
+    }
+}
+
+private struct RequestTableContentMetrics: Equatable {
+    let fontSize: CGFloat
+    let secondaryFontSize: CGFloat
+    let useMonospacedFont: Bool
+
+    init(metrics: AppUIDisplayMetrics) {
+        fontSize = metrics.fontSize
+        secondaryFontSize = metrics.secondaryFontSize
+        useMonospacedFont = metrics.settings.useMonospacedFont
+    }
+}
+
 // MARK: - RequestTableView.Coordinator
 
 extension RequestTableView {
@@ -269,6 +296,7 @@ extension RequestTableView {
         var lastRefreshToken: Int = 0
         var previousRowCount: Int = 0
         var lastAppliedDisplayMetrics: AppUIDisplayMetrics?
+        private var lastAppliedRequestTableMetrics: RequestTableAppliedMetrics?
 
         /// Guard flag to prevent feedback loops: when we programmatically update NSTableView
         /// selection from SwiftUI state, we suppress the delegate callback that would
@@ -287,20 +315,61 @@ extension RequestTableView {
             rows.count
         }
 
+        struct DisplayMetricsChange: Equatable {
+            let reloadVisibleRows: Bool
+            let autosizeContentColumns: Bool
+        }
+
         @discardableResult
-        func applyDisplayMetrics(to tableView: NSTableView) -> Bool {
+        func applyDisplayMetrics(to tableView: NSTableView) -> DisplayMetricsChange? {
             let metrics = parent.effectiveDisplayMetrics
-            guard lastAppliedDisplayMetrics != metrics else {
-                return false
+            let tableMetrics = RequestTableAppliedMetrics(metrics: metrics)
+            guard lastAppliedRequestTableMetrics != tableMetrics else {
+                lastAppliedDisplayMetrics = metrics
+                return nil
             }
+
+            let previousTableMetrics = lastAppliedRequestTableMetrics
             tableView.rowHeight = metrics.tableRowHeight
             tableView.usesAlternatingRowBackgroundColors = metrics.settings.useAlternatingRowBackgroundColors
             for column in tableView.tableColumns {
                 column.headerCell.font = .systemFont(ofSize: metrics.secondaryFontSize, weight: .medium)
             }
+            tableView.needsDisplay = true
+
             lastAppliedDisplayMetrics = metrics
-            hasAutoSizedColumns = false
-            return true
+            lastAppliedRequestTableMetrics = tableMetrics
+
+            let contentMetricsChanged = previousTableMetrics?.contentMetrics != tableMetrics.contentMetrics
+            let rowHeightChanged = previousTableMetrics?.rowHeight != tableMetrics.rowHeight
+            let reloadVisibleRows = previousTableMetrics == nil || contentMetricsChanged || rowHeightChanged
+            let autosizeContentColumns = previousTableMetrics == nil || contentMetricsChanged
+
+            if autosizeContentColumns {
+                hasAutoSizedColumns = false
+            }
+
+            return DisplayMetricsChange(
+                reloadVisibleRows: reloadVisibleRows,
+                autosizeContentColumns: autosizeContentColumns
+            )
+        }
+
+        func reloadVisibleRows(in tableView: NSTableView) {
+            let visibleRange = tableView.rows(in: tableView.visibleRect)
+            guard visibleRange.location != NSNotFound, visibleRange.length > 0 else {
+                return
+            }
+            let rowStart = max(0, visibleRange.location)
+            let rowEnd = min(rows.count, visibleRange.location + visibleRange.length)
+            guard rowStart < rowEnd else {
+                return
+            }
+
+            tableView.reloadData(
+                forRowIndexes: IndexSet(integersIn: rowStart ..< rowEnd),
+                columnIndexes: IndexSet(integersIn: 0 ..< tableView.numberOfColumns)
+            )
         }
 
         func tableView(_ tableView: NSTableView, sortDescriptorsDidChange oldDescriptors: [NSSortDescriptor]) {
@@ -1473,12 +1542,13 @@ extension RequestTableView {
             -> NSView
         {
             let cellID = NSUserInterfaceItemIdentifier("Cell_status")
-            let dotSize: CGFloat = 9
+            let dotSize = parent.effectiveDisplayMetrics.tableStatusDotSize
 
             if let existing = tableView.makeView(withIdentifier: cellID, owner: nil),
                let imageView = existing.subviews.first as? NSImageView
             {
                 imageView.contentTintColor = statusDotColor(for: row)
+                applyFixedSize(dotSize, to: imageView, in: existing)
                 return existing
             }
 
@@ -1493,12 +1563,7 @@ extension RequestTableView {
             }
             imageView.contentTintColor = statusDotColor(for: row)
             container.addSubview(imageView)
-            NSLayoutConstraint.activate([
-                imageView.centerXAnchor.constraint(equalTo: container.centerXAnchor),
-                imageView.centerYAnchor.constraint(equalTo: container.centerYAnchor),
-                imageView.widthAnchor.constraint(equalToConstant: dotSize),
-                imageView.heightAnchor.constraint(equalToConstant: dotSize),
-            ])
+            applyFixedSize(dotSize, to: imageView, in: container)
             return container
         }
 
@@ -1509,13 +1574,13 @@ extension RequestTableView {
             -> NSView
         {
             let cellID = NSUserInterfaceItemIdentifier("Cell_ssl")
-            let iconSize: CGFloat = 12
+            let iconSize = parent.effectiveDisplayMetrics.tableSSLIconSize
 
             if let existing = tableView.makeView(withIdentifier: cellID, owner: nil),
                let imageView = existing.subviews.first as? NSImageView
             {
                 configureSSLImageView(imageView, row: row)
-                centerSSLImageView(imageView, in: existing)
+                applyFixedSize(iconSize, to: imageView, in: existing)
                 return existing
             }
 
@@ -1523,10 +1588,9 @@ extension RequestTableView {
             container.identifier = cellID
 
             let imageView = NSImageView(frame: NSRect(x: 0, y: 0, width: iconSize, height: iconSize))
-            imageView.symbolConfiguration = NSImage.SymbolConfiguration(pointSize: parent.effectiveDisplayMetrics.secondaryFontSize, weight: .medium)
             configureSSLImageView(imageView, row: row)
             container.addSubview(imageView)
-            centerSSLImageView(imageView, in: container)
+            applyFixedSize(iconSize, to: imageView, in: container)
             return container
         }
 
@@ -1621,6 +1685,7 @@ extension RequestTableView {
         }
 
         private func configureSSLImageView(_ imageView: NSImageView, row: RequestListRow) {
+            let iconSize = parent.effectiveDisplayMetrics.tableSSLIconSize
             let symbolName: String
             let tintColor: NSColor
 
@@ -1636,31 +1701,47 @@ extension RequestTableView {
                 tintColor = .systemGreen
             }
 
+            imageView.symbolConfiguration = NSImage.SymbolConfiguration(pointSize: iconSize, weight: .medium)
+            imageView.imageScaling = .scaleProportionallyUpOrDown
             imageView.image = NSImage(systemSymbolName: symbolName, accessibilityDescription: nil)
             imageView.contentTintColor = tintColor
         }
 
-        private func centerSSLImageView(_ imageView: NSImageView, in container: NSView) {
+        private func applyFixedSize(_ size: CGFloat, to imageView: NSImageView, in container: NSView) {
             imageView.translatesAutoresizingMaskIntoConstraints = false
             NSLayoutConstraint.deactivate(container.constraints.filter { constraint in
                 constraint.firstItem as AnyObject? === imageView || constraint.secondItem as AnyObject? === imageView
             })
+            NSLayoutConstraint.deactivate(imageView.constraints.filter { constraint in
+                constraint.firstAttribute == .width || constraint.firstAttribute == .height
+            })
             NSLayoutConstraint.activate([
                 imageView.centerXAnchor.constraint(equalTo: container.centerXAnchor),
                 imageView.centerYAnchor.constraint(equalTo: container.centerYAnchor),
+                imageView.widthAnchor.constraint(equalToConstant: size),
+                imageView.heightAnchor.constraint(equalToConstant: size),
             ])
         }
 
         private func appIcon(for appName: String) -> NSImage? {
+            guard let source = appIconSource(for: appName),
+                  let icon = source.copy() as? NSImage else
+            {
+                return nil
+            }
+            let iconSize = parent.effectiveDisplayMetrics.tableClientIconSize
+            icon.size = NSSize(width: iconSize, height: iconSize)
+            return icon
+        }
+
+        private func appIconSource(for appName: String) -> NSImage? {
             if let cached = Self.appIconCache[appName] {
                 return cached
             }
-
             if let bundleID = Self.bundleIDByAppName[appName],
                let appURL = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleID)
             {
                 let icon = NSWorkspace.shared.icon(forFile: appURL.path)
-                icon.size = NSSize(width: 16, height: 16)
                 Self.appIconCache[appName] = icon
                 return icon
             }
@@ -1673,7 +1754,6 @@ extension RequestTableView {
             for path in appPaths {
                 if FileManager.default.fileExists(atPath: path) {
                     let icon = NSWorkspace.shared.icon(forFile: path)
-                    icon.size = NSSize(width: 16, height: 16)
                     Self.appIconCache[appName] = icon
                     return icon
                 }
@@ -1681,7 +1761,6 @@ extension RequestTableView {
 
             for app in NSWorkspace.shared.runningApplications {
                 if app.localizedName == appName, let icon = app.icon {
-                    icon.size = NSSize(width: 16, height: 16)
                     Self.appIconCache[appName] = icon
                     return icon
                 }
@@ -1697,7 +1776,7 @@ extension RequestTableView {
         )
             -> NSView
         {
-            let iconSize: CGFloat = 16
+            let iconSize = parent.effectiveDisplayMetrics.tableClientIconSize
             let gap: CGFloat = 4
             let rowHeight = parent.effectiveDisplayMetrics.tableRowHeight
             let iconY = (rowHeight - iconSize) / 2
@@ -1710,6 +1789,10 @@ extension RequestTableView {
                 let fallbackView = existing.subviews[1]
                 let nameLabel = existing.subviews[2] as? NSTextField
 
+                updateClientIconFrames(imageView: imageView, fallbackView: fallbackView, iconSize: iconSize, iconY: iconY)
+                if let nameLabel {
+                    updateClientNameConstraints(nameLabel, in: existing, iconSize: iconSize, gap: gap)
+                }
                 nameLabel?.stringValue = appName
                 nameLabel?.font = parent.effectiveDisplayMetrics.appKitFont()
                 if let icon = appIcon(for: appName) {
@@ -1740,7 +1823,7 @@ extension RequestTableView {
             fallbackView.wantsLayer = true
             fallbackView.layer?.cornerRadius = 4
             let initialsLabel = NSTextField(labelWithString: "")
-            initialsLabel.font = .systemFont(ofSize: 7, weight: .bold)
+            initialsLabel.font = .systemFont(ofSize: max(7, iconSize * 0.44), weight: .bold)
             initialsLabel.textColor = .white
             initialsLabel.alignment = .center
             initialsLabel.frame = NSRect(x: 0, y: 0, width: iconSize, height: iconSize)
@@ -1778,12 +1861,50 @@ extension RequestTableView {
             return container
         }
 
+        private func updateClientIconFrames(
+            imageView: NSImageView?,
+            fallbackView: NSView,
+            iconSize: CGFloat,
+            iconY: CGFloat
+        ) {
+            imageView?.frame = NSRect(x: 0, y: iconY, width: iconSize, height: iconSize)
+            fallbackView.frame = NSRect(x: 0, y: iconY, width: iconSize, height: iconSize)
+            fallbackView.layer?.cornerRadius = max(4, iconSize * 0.25)
+            if let initialsLabel = fallbackView.subviews.first as? NSTextField {
+                initialsLabel.frame = NSRect(x: 0, y: 0, width: iconSize, height: iconSize)
+                initialsLabel.font = .systemFont(ofSize: max(7, iconSize * 0.44), weight: .bold)
+            }
+        }
+
+        private func updateClientNameConstraints(
+            _ nameLabel: NSTextField,
+            in container: NSView,
+            iconSize: CGFloat,
+            gap: CGFloat
+        ) {
+            NSLayoutConstraint.deactivate(container.constraints.filter { constraint in
+                constraint.firstItem as AnyObject? === nameLabel || constraint.secondItem as AnyObject? === nameLabel
+            })
+            NSLayoutConstraint.activate([
+                nameLabel.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: iconSize + gap),
+                nameLabel.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -2),
+                nameLabel.centerYAnchor.constraint(equalTo: container.centerYAnchor),
+            ])
+        }
+
         private func makeCellView(identifier: NSUserInterfaceItemIdentifier) -> NSView {
             let container = NSView()
             container.identifier = identifier
 
             let field = NSTextField(labelWithString: "")
             field.lineBreakMode = .byTruncatingTail
+            field.cell?.lineBreakMode = .byTruncatingTail
+            field.maximumNumberOfLines = 1
+            field.cell?.wraps = false
+            if let textCell = field.cell as? NSTextFieldCell {
+                textCell.usesSingleLineMode = true
+                textCell.truncatesLastVisibleLine = true
+            }
             field.font = parent.effectiveDisplayMetrics.appKitFont()
             field.textColor = .labelColor
             field.isBordered = false
@@ -1806,6 +1927,17 @@ extension RequestTableView {
             row: Int,
             rowData: RequestListRow
         ) {
+            defer {
+                cell.lineBreakMode = .byTruncatingTail
+                cell.cell?.lineBreakMode = .byTruncatingTail
+                cell.maximumNumberOfLines = 1
+                cell.cell?.wraps = false
+                if let textCell = cell.cell as? NSTextFieldCell {
+                    textCell.usesSingleLineMode = true
+                    textCell.truncatesLastVisibleLine = true
+                }
+            }
+
             let metrics = parent.effectiveDisplayMetrics
             cell.stringValue = ""
             cell.textColor = .labelColor

--- a/Rockxy/Views/RequestList/StatusBarView.swift
+++ b/Rockxy/Views/RequestList/StatusBarView.swift
@@ -165,11 +165,11 @@ private struct FooterProxyOverridePopover: View {
     var body: some View {
         HStack(spacing: 8) {
             Image(systemName: "checkmark.circle.fill")
-                .font(.system(size: 14, weight: .semibold))
+                .font(.system(size: metrics.chromeIconFontSize, weight: .semibold))
                 .foregroundStyle(Color(nsColor: .systemGreen))
 
             Text(statusText)
-                .font(.system(size: 13))
+                .font(.system(size: metrics.chromeFontSize))
                 .foregroundStyle(Color(nsColor: .labelColor))
                 .lineLimit(1)
                 .truncationMode(.middle)
@@ -184,6 +184,8 @@ private struct FooterProxyOverridePopover: View {
         .padding(.vertical, 8)
         .frame(width: 660, alignment: .leading)
     }
+
+    @Environment(\.appUIDisplayMetrics) private var metrics
 
     private var statusText: String {
         String(localized: "System Proxy is Overridden by Rockxy (IP=\(proxyHost) Port=\(proxyPort)) (Toggle by: ⌥⌘O)")

--- a/Rockxy/Views/Settings/AppearanceSettingsTab.swift
+++ b/Rockxy/Views/Settings/AppearanceSettingsTab.swift
@@ -30,7 +30,7 @@ struct AppearanceSettingsTab: View {
                 .padding(.top, 12)
                 .padding(.bottom, 24)
         }
-        .appUIDisplayMetrics(AppUIDisplayMetrics(settings: settingsManager.settings.appUI))
+        .appUIDisplayMetrics(AppUIDisplayMetrics(settings: settingsManager.appUI))
     }
 
     // MARK: Private
@@ -38,11 +38,11 @@ struct AppearanceSettingsTab: View {
     private let settingsManager = AppSettingsManager.shared
 
     private var appUI: AppUISettings {
-        settingsManager.settings.appUI
+        settingsManager.appUI
     }
 
     private var appTheme: AppTheme {
-        settingsManager.settings.appTheme
+        settingsManager.appTheme
     }
 
     private var appUISection: some View {

--- a/Rockxy/Views/Settings/AppearanceSettingsTab.swift
+++ b/Rockxy/Views/Settings/AppearanceSettingsTab.swift
@@ -78,7 +78,7 @@ struct AppearanceSettingsTab: View {
                         .toggleStyle(.checkbox)
                 }
 
-                Text(String(localized: "Apply to all tabs in the Request and Response Panel and the main table."))
+                Text(String(localized: "Applies to the main table, inspector, and Developer Setup Hub."))
                     .font(.system(size: 11))
                     .foregroundStyle(.secondary)
                     .padding(.leading, 192)

--- a/Rockxy/Views/Settings/SettingsView.swift
+++ b/Rockxy/Views/Settings/SettingsView.swift
@@ -78,11 +78,9 @@ struct SettingsView: View {
                 .tag(RockxySettingsTab.advanced.rawValue)
         }
         .frame(width: 820, height: 600)
-        .appUIDisplayMetrics(AppUIDisplayMetrics(settings: settingsManager.settings.appUI))
     }
 
     // MARK: Private
 
     @AppStorage(RockxySettingsTab.defaultsKey) private var selectedTabID = RockxySettingsTab.general.rawValue
-    private let settingsManager = AppSettingsManager.shared
 }

--- a/Rockxy/Views/Sidebar/AddFavoriteView.swift
+++ b/Rockxy/Views/Sidebar/AddFavoriteView.swift
@@ -15,7 +15,7 @@ struct AddFavoriteView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             Text(String(localized: "Add favorite app or domain"))
-                .font(.system(size: 13, weight: .medium))
+                .font(.system(size: metrics.sidebarNavigationFontSize, weight: .medium))
                 .padding(.horizontal, 16)
                 .padding(.top, 14)
                 .padding(.bottom, 10)
@@ -32,7 +32,7 @@ struct AddFavoriteView: View {
             Divider()
 
             Text(String(localized: "Launch your app/domain to see it in the list"))
-                .font(.system(size: 11))
+                .font(.system(size: metrics.sidebarSecondaryFontSize))
                 .foregroundStyle(.secondary)
                 .padding(.horizontal, 16)
                 .padding(.vertical, 8)
@@ -53,6 +53,7 @@ struct AddFavoriteView: View {
 
     @State private var isAppsExpanded = true
     @State private var isDomainsExpanded = true
+    @Environment(\.appUIDisplayMetrics) private var metrics
 
     private var filteredApps: [AppCandidate] {
         let apps = buildAppCandidates()
@@ -85,20 +86,20 @@ struct AddFavoriteView: View {
     private var searchField: some View {
         HStack(spacing: 6) {
             Image(systemName: "magnifyingglass")
-                .font(.system(size: 12))
+                .font(.system(size: metrics.sidebarSecondaryFontSize))
                 .foregroundStyle(.secondary)
             TextField(
                 String(localized: "Search app or domain (\u{2318}\u{21E7}F)"),
                 text: $searchText
             )
             .textFieldStyle(.plain)
-            .font(.system(size: 13))
+            .font(.system(size: metrics.sidebarNavigationFontSize))
             if !searchText.isEmpty {
                 Button {
                     searchText = ""
                 } label: {
                     Image(systemName: "xmark.circle.fill")
-                        .font(.system(size: 11))
+                        .font(.system(size: metrics.sidebarBadgeFontSize))
                         .foregroundStyle(.secondary)
                 }
                 .buttonStyle(.borderless)
@@ -177,7 +178,7 @@ struct AddFavoriteView: View {
                 HStack(spacing: 4) {
                     Text(String(localized: "Select"))
                     Image(systemName: "chevron.down")
-                        .font(.system(size: 9))
+                        .font(.system(size: metrics.sidebarSectionHeaderFontSize))
                 }
             }
             .menuStyle(.borderlessButton)
@@ -207,17 +208,17 @@ struct AddFavoriteView: View {
         } label: {
             HStack(spacing: 6) {
                 Image(systemName: isExpanded.wrappedValue ? "chevron.down" : "chevron.right")
-                    .font(.system(size: 9, weight: .semibold))
+                    .font(.system(size: metrics.sidebarSectionHeaderFontSize, weight: .semibold))
                     .foregroundStyle(.secondary)
                     .frame(width: 10)
                 Image(systemName: icon)
-                    .font(.system(size: 12))
+                    .font(.system(size: metrics.sidebarSecondaryFontSize))
                     .foregroundStyle(.secondary)
                 Text(label)
-                    .font(.system(size: 13, weight: .medium))
+                    .font(.system(size: metrics.sidebarNavigationFontSize, weight: .medium))
                 Spacer()
                 Text("\(count)")
-                    .font(.system(size: 12).monospacedDigit())
+                    .font(.system(size: metrics.sidebarSecondaryFontSize).monospacedDigit())
                     .foregroundStyle(.secondary)
             }
             .padding(.horizontal, 16)
@@ -234,18 +235,19 @@ struct AddFavoriteView: View {
         } label: {
             HStack(spacing: 6) {
                 Image(systemName: "chevron.right")
-                    .font(.system(size: 8))
+                    .font(.system(size: metrics.sidebarSectionHeaderFontSize))
                     .foregroundStyle(.tertiary)
                     .frame(width: 10)
                 AppIconView(name: app.name)
                 Text(app.name)
-                    .font(.system(size: 13))
+                    .font(.system(size: metrics.sidebarNavigationFontSize))
                     .lineLimit(1)
                 Spacer()
             }
             .padding(.horizontal, 16)
             .padding(.leading, 12)
             .padding(.vertical, 4)
+            .frame(minHeight: metrics.sidebarRowHeight)
             .background(isSelected ? Color.accentColor.opacity(0.15) : Color.clear)
             .contentShape(Rectangle())
         }
@@ -259,25 +261,26 @@ struct AddFavoriteView: View {
         } label: {
             HStack(spacing: 6) {
                 Image(systemName: "chevron.right")
-                    .font(.system(size: 8))
+                    .font(.system(size: metrics.sidebarSectionHeaderFontSize))
                     .foregroundStyle(.tertiary)
                     .frame(width: 10)
                 Image(systemName: "globe")
-                    .font(.system(size: 12))
+                    .font(.system(size: metrics.sidebarSecondaryFontSize))
                     .foregroundStyle(.secondary)
                 Text(node.domain)
-                    .font(.system(size: 13))
+                    .font(.system(size: metrics.sidebarNavigationFontSize))
                     .lineLimit(1)
                 Spacer()
                 if node.requestCount > 0 {
                     Text("\(node.requestCount)")
-                        .font(.system(size: 12).monospacedDigit())
+                        .font(.system(size: metrics.sidebarSecondaryFontSize).monospacedDigit())
                         .foregroundStyle(.secondary)
                 }
             }
             .padding(.horizontal, 16)
             .padding(.leading, 12)
             .padding(.vertical, 4)
+            .frame(minHeight: metrics.sidebarRowHeight)
             .background(isSelected ? Color.accentColor.opacity(0.15) : Color.clear)
             .contentShape(Rectangle())
         }
@@ -334,15 +337,21 @@ private struct AppIconView: View {
     var body: some View {
         RoundedRectangle(cornerRadius: 5)
             .fill(gradient)
-            .frame(width: 20, height: 20)
+            .frame(width: iconSize, height: iconSize)
             .overlay {
                 Text(letter)
-                    .font(.system(size: 11, weight: .bold, design: .rounded))
+                    .font(.system(size: max(11, metrics.sidebarSecondaryFontSize), weight: .bold, design: .rounded))
                     .foregroundStyle(.white)
             }
     }
 
     // MARK: Private
+
+    @Environment(\.appUIDisplayMetrics) private var metrics
+
+    private var iconSize: CGFloat {
+        metrics.sidebarAppIconSize
+    }
 
     private var letter: String {
         String(name.prefix(1)).uppercased()

--- a/Rockxy/Views/Sidebar/SidebarView.swift
+++ b/Rockxy/Views/Sidebar/SidebarView.swift
@@ -18,12 +18,10 @@ private struct AppIconView: View {
                 .resizable()
                 .interpolation(.high)
                 .frame(width: iconSize, height: iconSize)
-                .id(iconSize)
         } else {
             RoundedRectangle(cornerRadius: 5)
                 .fill(gradient)
                 .frame(width: iconSize, height: iconSize)
-                .id(iconSize)
                 .overlay {
                     Text(letter)
                         .font(.system(size: max(11, metrics.sidebarSecondaryFontSize), weight: .bold, design: .rounded))
@@ -41,6 +39,13 @@ private struct AppIconView: View {
     }
 
     private static var iconCache: [String: NSImage] = [:]
+    private static var resizedIconCache: [IconCacheKey: NSImage] = [:]
+    private static var missingIconNames: Set<String> = []
+
+    private struct IconCacheKey: Hashable {
+        let name: String
+        let size: Int
+    }
 
     private static let bundleIDMap: [String: String] = [
         "Chrome": "com.google.Chrome",
@@ -71,16 +76,26 @@ private struct AppIconView: View {
     }
 
     private static func resolvedIcon(for name: String, size: CGFloat) -> NSImage? {
+        let cacheKey = IconCacheKey(name: name, size: Int(size.rounded()))
+        if let cached = resizedIconCache[cacheKey] {
+            return cached
+        }
         guard let source = resolveIconSource(for: name),
               let icon = source.copy() as? NSImage else
         {
             return nil
         }
         icon.size = NSSize(width: size, height: size)
+        resizedIconCache[cacheKey] = icon
         return icon
     }
 
     private static func resolveIconSource(for name: String) -> NSImage? {
+        guard !name.isEmpty,
+              !missingIconNames.contains(name) else
+        {
+            return nil
+        }
         if let cached = iconCache[name] {
             return cached
         }
@@ -108,6 +123,7 @@ private struct AppIconView: View {
             }
         }
 
+        missingIconNames.insert(name)
         return nil
     }
 }
@@ -165,10 +181,6 @@ struct SidebarView: View {
 
     private var appNodes: [AppInfo] {
         coordinator.appNodes
-    }
-
-    private var totalDomainCount: Int {
-        coordinator.domainTree.reduce(0) { $0 + $1.requestCount }
     }
 
     // MARK: - Sections
@@ -292,7 +304,7 @@ struct SidebarView: View {
                 }
             } label: {
                 Label(String(localized: "Domains"), systemImage: "globe")
-                    .badge(totalDomainCount)
+                    .badge(coordinator.totalDomainCount)
                     .tag(SidebarItem.allDomains)
                     .frame(minHeight: metrics.sidebarRowHeight)
                     .contentShape(Rectangle())

--- a/Rockxy/Views/Sidebar/SidebarView.swift
+++ b/Rockxy/Views/Sidebar/SidebarView.swift
@@ -13,23 +13,32 @@ private struct AppIconView: View {
     let name: String
 
     var body: some View {
-        if let icon = Self.resolveIcon(for: name) {
+        if let icon = Self.resolvedIcon(for: name, size: iconSize) {
             Image(nsImage: icon)
                 .resizable()
-                .frame(width: 20, height: 20)
+                .interpolation(.high)
+                .frame(width: iconSize, height: iconSize)
+                .id(iconSize)
         } else {
             RoundedRectangle(cornerRadius: 5)
                 .fill(gradient)
-                .frame(width: 20, height: 20)
+                .frame(width: iconSize, height: iconSize)
+                .id(iconSize)
                 .overlay {
                     Text(letter)
-                        .font(.system(size: 11, weight: .bold, design: .rounded))
+                        .font(.system(size: max(11, metrics.sidebarSecondaryFontSize), weight: .bold, design: .rounded))
                         .foregroundStyle(.white)
                 }
         }
     }
 
     // MARK: Private
+
+    @Environment(\.appUIDisplayMetrics) private var metrics
+
+    private var iconSize: CGFloat {
+        metrics.sidebarAppIconSize
+    }
 
     private static var iconCache: [String: NSImage] = [:]
 
@@ -61,7 +70,17 @@ private struct AppIconView: View {
         )
     }
 
-    private static func resolveIcon(for name: String) -> NSImage? {
+    private static func resolvedIcon(for name: String, size: CGFloat) -> NSImage? {
+        guard let source = resolveIconSource(for: name),
+              let icon = source.copy() as? NSImage else
+        {
+            return nil
+        }
+        icon.size = NSSize(width: size, height: size)
+        return icon
+    }
+
+    private static func resolveIconSource(for name: String) -> NSImage? {
         if let cached = iconCache[name] {
             return cached
         }
@@ -70,7 +89,6 @@ private struct AppIconView: View {
            let appURL = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleID)
         {
             let icon = NSWorkspace.shared.icon(forFile: appURL.path)
-            icon.size = NSSize(width: 20, height: 20)
             iconCache[name] = icon
             return icon
         }
@@ -78,7 +96,6 @@ private struct AppIconView: View {
         for path in ["/Applications/\(name).app", "/System/Applications/\(name).app"] {
             if FileManager.default.fileExists(atPath: path) {
                 let icon = NSWorkspace.shared.icon(forFile: path)
-                icon.size = NSSize(width: 20, height: 20)
                 iconCache[name] = icon
                 return icon
             }
@@ -86,7 +103,6 @@ private struct AppIconView: View {
 
         for app in NSWorkspace.shared.runningApplications {
             if app.localizedName == name, let icon = app.icon {
-                icon.size = NSSize(width: 20, height: 20)
                 iconCache[name] = icon
                 return icon
             }
@@ -110,6 +126,7 @@ struct SidebarView: View {
                 allSection
             }
             .listStyle(.sidebar)
+            .font(.system(size: metrics.sidebarNavigationFontSize))
 
             SidebarBottomBar(
                 filterText: $sidebarFilterText,
@@ -137,6 +154,7 @@ struct SidebarView: View {
     @State private var sidebarFilterText = ""
     @State private var isAddFavoritePresented = false
     @State private var expandedDomainNodeIDs: Set<String> = []
+    @Environment(\.appUIDisplayMetrics) private var metrics
 
     private var sidebarBinding: Binding<SidebarItem?> {
         Binding(
@@ -162,17 +180,22 @@ struct SidebarView: View {
                 if pinned.isEmpty {
                     Text(String(localized: "No pinned items"))
                         .foregroundStyle(.secondary)
-                        .font(.caption)
+                        .font(.system(size: metrics.sidebarSecondaryFontSize))
+                        .frame(minHeight: metrics.sidebarRowHeight, alignment: .center)
                 } else {
                     ForEach(pinned) { transaction in
                         Label {
                             Text(transaction.request.host + transaction.request.path)
+                                .font(sidebarNavigationFont)
                                 .lineLimit(1)
                         } icon: {
                             Image(systemName: "pin.fill")
+                                .font(sidebarIconFont)
                                 .foregroundStyle(.orange)
                         }
+                        .font(sidebarNavigationFont)
                         .tag(SidebarItem.pinnedTransaction(id: transaction.id))
+                        .frame(minHeight: metrics.sidebarRowHeight)
                         .contextMenu {
                             favoriteTransactionContextMenu(transaction, section: .pinned)
                         }
@@ -182,6 +205,7 @@ struct SidebarView: View {
                 Label(String(localized: "Pinned"), systemImage: "pin.fill")
                     .badge(coordinator.allPinnedTransactions.count)
                     .tag(SidebarItem.allPinned)
+                    .frame(minHeight: metrics.sidebarRowHeight)
                     .contentShape(Rectangle())
                     .onTapGesture { coordinator.selectSidebarItem(.allPinned) }
             }
@@ -191,16 +215,21 @@ struct SidebarView: View {
                 if saved.isEmpty {
                     Text(String(localized: "No saved items"))
                         .foregroundStyle(.secondary)
-                        .font(.caption)
+                        .font(.system(size: metrics.sidebarSecondaryFontSize))
+                        .frame(minHeight: metrics.sidebarRowHeight, alignment: .center)
                 } else {
                     ForEach(saved) { transaction in
                         Label {
                             Text(transaction.request.host + transaction.request.path)
+                                .font(sidebarNavigationFont)
                                 .lineLimit(1)
                         } icon: {
                             Image(systemName: "tray.full.fill")
+                                .font(sidebarIconFont)
                         }
+                        .font(sidebarNavigationFont)
                         .tag(SidebarItem.savedTransaction(id: transaction.id))
+                        .frame(minHeight: metrics.sidebarRowHeight)
                         .contextMenu {
                             favoriteTransactionContextMenu(transaction, section: .saved)
                         }
@@ -210,6 +239,7 @@ struct SidebarView: View {
                 Label(String(localized: "Saved"), systemImage: "tray.full.fill")
                     .badge(coordinator.allSavedTransactions.count)
                     .tag(SidebarItem.allSaved)
+                    .frame(minHeight: metrics.sidebarRowHeight)
                     .contentShape(Rectangle())
                     .onTapGesture { coordinator.selectSidebarItem(.allSaved) }
             }
@@ -220,6 +250,7 @@ struct SidebarView: View {
         } header: {
             Text(String(localized: "Favorites"))
                 .foregroundStyle(Theme.Sidebar.favoritesHeader)
+                .font(.system(size: metrics.sidebarSectionHeaderFontSize, weight: .semibold))
         }
         .headerProminence(.increased)
     }
@@ -235,11 +266,14 @@ struct SidebarView: View {
                     } label: {
                         Label {
                             Text(app.name)
+                                .font(sidebarNavigationFont)
                         } icon: {
                             AppIconView(name: app.name)
                         }
+                        .font(sidebarNavigationFont)
                         .badge(app.requestCount)
                         .tag(SidebarItem.app(name: app.name, bundleId: nil))
+                        .frame(minHeight: metrics.sidebarRowHeight)
                         .contextMenu { appContextMenu(app) }
                     }
                 }
@@ -247,6 +281,7 @@ struct SidebarView: View {
                 Label(String(localized: "Apps"), systemImage: "square.stack.3d.up.fill")
                     .badge(appNodes.count)
                     .tag(SidebarItem.allApps)
+                    .frame(minHeight: metrics.sidebarRowHeight)
                     .contentShape(Rectangle())
                     .onTapGesture { coordinator.selectSidebarItem(.allApps) }
             }
@@ -259,12 +294,14 @@ struct SidebarView: View {
                 Label(String(localized: "Domains"), systemImage: "globe")
                     .badge(totalDomainCount)
                     .tag(SidebarItem.allDomains)
+                    .frame(minHeight: metrics.sidebarRowHeight)
                     .contentShape(Rectangle())
                     .onTapGesture { coordinator.selectSidebarItem(.allDomains) }
             }
         } header: {
             Text(String(localized: "All"))
                 .foregroundStyle(Theme.Sidebar.sectionHeader)
+                .font(.system(size: metrics.sidebarSectionHeaderFontSize, weight: .semibold))
         }
         .headerProminence(.increased)
     }
@@ -276,33 +313,44 @@ struct SidebarView: View {
             Label {
                 HStack(spacing: 4) {
                     Text(domain)
+                        .font(sidebarNavigationFont)
                     if coordinator.isSSLProxyingEnabled(for: domain) {
                         Image(systemName: "lock.shield.fill")
-                            .font(.caption2)
+                            .font(.system(size: metrics.sidebarBadgeFontSize))
                             .foregroundStyle(.green)
                     }
                 }
             } icon: {
                 Image(systemName: "globe")
+                    .font(sidebarIconFont)
             }
+            .font(sidebarNavigationFont)
             .tag(item)
+            .frame(minHeight: metrics.sidebarRowHeight)
             .contextMenu { domainContextMenu(domain) }
         case let .domainPath(domain, pathPrefix):
             Label {
                 Text("\(domain)\(pathPrefix)")
+                    .font(sidebarNavigationFont)
                     .lineLimit(1)
             } icon: {
                 Image(systemName: "link")
+                    .font(sidebarIconFont)
             }
+            .font(sidebarNavigationFont)
             .tag(item)
+            .frame(minHeight: metrics.sidebarRowHeight)
             .contextMenu { domainContextMenu(domain, pathPrefix: pathPrefix) }
         case let .app(name, _):
             Label {
                 Text(name)
+                    .font(sidebarNavigationFont)
             } icon: {
                 AppIconView(name: name)
             }
+            .font(sidebarNavigationFont)
             .tag(item)
+            .frame(minHeight: metrics.sidebarRowHeight)
             .contextMenu {
                 if let app = coordinator.appNodes.first(where: { $0.name == name }) {
                     appContextMenu(app)
@@ -347,30 +395,34 @@ struct SidebarView: View {
         Label {
             HStack(spacing: 5) {
                 Text(node.domain)
+                    .font(sidebarNavigationFont)
                     .foregroundStyle(node.kind == .path ? .secondary : .primary)
                     .lineLimit(1)
                     .truncationMode(.middle)
 
                 if coordinator.isSSLProxyingEnabled(for: node.selectionDomain), node.kind != .path {
                     Image(systemName: "lock.shield.fill")
-                        .font(.caption2)
+                        .font(.system(size: metrics.sidebarBadgeFontSize))
                         .foregroundStyle(.green)
                 }
 
                 if node.errorCount > 0 {
                     Label("\(node.errorCount)", systemImage: "exclamationmark.triangle.fill")
                         .labelStyle(.titleAndIcon)
-                        .font(.caption2)
+                        .font(.system(size: metrics.sidebarBadgeFontSize))
                         .foregroundStyle(.orange)
                         .help(String(localized: "\(node.errorCount) failed or error responses"))
                 }
             }
         } icon: {
             Image(systemName: domainIconName(for: node.kind))
+                .font(sidebarIconFont)
                 .foregroundStyle(node.kind == .path ? .secondary : .primary)
         }
+        .font(sidebarNavigationFont)
         .badge(node.requestCount)
         .tag(sidebarItem(for: node))
+        .frame(minHeight: metrics.sidebarRowHeight)
         .contextMenu { domainContextMenu(node.selectionDomain, pathPrefix: node.pathPrefix) }
         .help(domainHelpText(for: node))
     }
@@ -410,6 +462,14 @@ struct SidebarView: View {
             return "\(node.selectionDomain)\(pathPrefix)"
         }
         return node.selectionDomain
+    }
+
+    private var sidebarNavigationFont: Font {
+        .system(size: metrics.sidebarNavigationFontSize)
+    }
+
+    private var sidebarIconFont: Font {
+        .system(size: metrics.sidebarIconFontSize)
     }
 
     // MARK: - Context Menus

--- a/Rockxy/Views/Timeline/RequestTimelineView.swift
+++ b/Rockxy/Views/Timeline/RequestTimelineView.swift
@@ -55,7 +55,7 @@ struct RequestTimelineView: View {
                         .fill(color)
                         .frame(width: 12, height: 12)
                     Text(name)
-                        .font(.caption)
+                        .font(.system(size: metrics.secondaryFontSize))
                         .foregroundStyle(.secondary)
                 }
             }
@@ -101,7 +101,7 @@ struct RequestTimelineView: View {
                     let timeMs = fraction * maxDuration * 1_000
 
                     Text(formatMs(timeMs))
-                        .font(.system(size: 9, design: .monospaced))
+                        .font(.system(size: metrics.metadataFontSize, design: .monospaced))
                         .foregroundStyle(.tertiary)
                         .position(x: xOffset, y: 10)
                 }
@@ -142,11 +142,11 @@ struct RequestTimelineView: View {
     private func requestLabel(_ transaction: HTTPTransaction) -> some View {
         HStack(spacing: 4) {
             Text(transaction.request.method)
-                .font(.system(size: 10, weight: .bold, design: .monospaced))
+                .font(.system(size: metrics.metadataFontSize, weight: .bold, design: .monospaced))
                 .foregroundStyle(.secondary)
 
             Text(transaction.request.host + transaction.request.path)
-                .font(.system(size: 10, design: .monospaced))
+                .font(.system(size: metrics.metadataFontSize, design: .monospaced))
                 .foregroundStyle(.primary)
                 .lineLimit(1)
                 .truncationMode(.middle)
@@ -201,4 +201,6 @@ struct RequestTimelineView: View {
         }
         return String(format: "%.0fms", ms)
     }
+
+    @Environment(\.appUIDisplayMetrics) private var metrics
 }

--- a/Rockxy/Views/Toolbar/AdvancedFilterBar.swift
+++ b/Rockxy/Views/Toolbar/AdvancedFilterBar.swift
@@ -89,7 +89,7 @@ struct AdvancedFilterBar: View {
                 removeRule(at: index)
             } label: {
                 Image(systemName: "minus")
-                    .font(.system(size: 12, weight: .medium))
+                    .font(.system(size: metrics.controlFontSize, weight: .medium))
             }
             .buttonStyle(.bordered)
             .controlSize(.small)
@@ -98,7 +98,7 @@ struct AdvancedFilterBar: View {
                 addRule(after: index)
             } label: {
                 Image(systemName: "plus")
-                    .font(.system(size: 12, weight: .medium))
+                    .font(.system(size: metrics.controlFontSize, weight: .medium))
             }
             .buttonStyle(.bordered)
             .controlSize(.small)

--- a/Rockxy/Views/Toolbar/ProxyStatusIndicator.swift
+++ b/Rockxy/Views/Toolbar/ProxyStatusIndicator.swift
@@ -11,6 +11,7 @@ struct ProxyStatusIndicator: View {
     // MARK: Internal
 
     @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.appUIDisplayMetrics) private var metrics
 
     let displayState: ProxyDisplayState
     let listenAddress: String
@@ -29,19 +30,19 @@ struct ProxyStatusIndicator: View {
                     statusDot
 
                     Text(statusText)
-                        .font(.callout.weight(.medium))
+                        .font(.system(size: metrics.chromeFontSize, weight: .medium))
                         .foregroundStyle(.secondary)
                         .lineLimit(1)
 
                     if updateStatusSummary != nil {
                         Text("|")
-                            .font(.caption)
+                            .font(.system(size: metrics.badgeFontSize))
                             .foregroundStyle(Color(nsColor: .tertiaryLabelColor))
                     }
                 }
                 .padding(.leading, ProxyStatusChromeMetrics.horizontalPadding)
                 .padding(.trailing, updateStatusSummary == nil ? ProxyStatusChromeMetrics.horizontalPadding : 7)
-                .frame(height: ProxyStatusChromeMetrics.outerHeight)
+                .frame(height: metrics.chromeControlHeight)
                 .contentShape(Capsule(style: .continuous))
             }
             .buttonStyle(.plain)
@@ -50,10 +51,10 @@ struct ProxyStatusIndicator: View {
             if let updateStatusSummary {
                 updateStatus(updateStatusSummary)
                     .padding(.trailing, ProxyStatusChromeMetrics.horizontalPadding)
-                    .frame(height: ProxyStatusChromeMetrics.outerHeight)
+                    .frame(height: metrics.chromeControlHeight)
             }
         }
-        .frame(height: ProxyStatusChromeMetrics.outerHeight)
+        .frame(height: metrics.chromeControlHeight)
         .contentShape(Rectangle())
         .popover(isPresented: $showPopover) {
             ProxyStatusPopover(
@@ -68,17 +69,14 @@ struct ProxyStatusIndicator: View {
     // MARK: Private
 
     private enum ProxyStatusChromeMetrics {
-        static let outerHeight: CGFloat = 32
-        static let updateBadgeHeight: CGFloat = 24
         static let horizontalPadding: CGFloat = 14
-        static let statusDotSize: CGFloat = 10
         static let strokeWidth: CGFloat = 0.75
     }
 
     private var statusDot: some View {
         Circle()
             .fill(statusColor)
-            .frame(width: ProxyStatusChromeMetrics.statusDotSize, height: ProxyStatusChromeMetrics.statusDotSize)
+            .frame(width: metrics.chromeStatusDotSize, height: metrics.chromeStatusDotSize)
             .shadow(
                 color: statusShadowColor,
                 radius: 4,
@@ -150,11 +148,11 @@ struct ProxyStatusIndicator: View {
 
     private func updateBadge(_ title: String) -> some View {
         Text(title)
-            .font(.system(size: 13, weight: .semibold))
+            .font(.system(size: metrics.chromeBadgeFontSize, weight: .semibold))
             .foregroundStyle(.white)
             .lineLimit(1)
             .padding(.horizontal, 9)
-            .frame(height: ProxyStatusChromeMetrics.updateBadgeHeight)
+            .frame(height: metrics.chromeBadgeHeight)
             .background {
                 Capsule(style: .continuous).fill(updateBadgeBackground)
             }

--- a/Rockxy/Views/Toolbar/ProxyStatusPopover.swift
+++ b/Rockxy/Views/Toolbar/ProxyStatusPopover.swift
@@ -22,16 +22,16 @@ struct ProxyStatusPopover: View {
 
             HStack(spacing: 4) {
                 Text(String(localized: "Proxy Port:"))
-                    .font(.system(size: 13))
+                    .font(.system(size: metrics.chromeFontSize))
                     .foregroundStyle(.secondary)
                 Text("\(port)")
-                    .font(.system(size: 13, weight: .medium, design: .monospaced))
+                    .font(.system(size: metrics.chromeFontSize, weight: .medium, design: .monospaced))
                 Button {
                     openWindow(id: "advancedProxySettings")
                     showPopover = false
                 } label: {
                     Image(systemName: "pencil")
-                        .font(.system(size: 11))
+                        .font(.system(size: metrics.badgeFontSize))
                         .foregroundStyle(.secondary)
                 }
                 .buttonStyle(.plain)
@@ -55,14 +55,15 @@ struct ProxyStatusPopover: View {
     // MARK: Private
 
     @Environment(\.openWindow) private var openWindow
+    @Environment(\.appUIDisplayMetrics) private var metrics
 
     private func infoRow(label: String, value: String) -> some View {
         HStack(spacing: 4) {
             Text(label)
-                .font(.system(size: 13))
+                .font(.system(size: metrics.chromeFontSize))
                 .foregroundStyle(.secondary)
             Text(value)
-                .font(.system(size: 13, weight: .medium, design: .monospaced))
+                .font(.system(size: metrics.chromeFontSize, weight: .medium, design: .monospaced))
         }
     }
 }

--- a/Rockxy/Views/Toolbar/SystemProxyWarningBanner.swift
+++ b/Rockxy/Views/Toolbar/SystemProxyWarningBanner.swift
@@ -16,16 +16,17 @@ struct SystemProxyWarningBanner: View {
         HStack(spacing: 8) {
             Image(systemName: "exclamationmark.triangle.fill")
                 .foregroundStyle(.orange)
-                .font(.system(size: 13))
+                .font(.system(size: metrics.chromeIconFontSize))
 
             Text(message)
-                .font(.system(size: 12))
+                .font(.system(size: metrics.chromeSecondaryFontSize))
                 .foregroundStyle(.secondary)
 
             Spacer()
 
             if let primaryActionTitle, let onPrimaryAction {
                 Button(primaryActionTitle, action: onPrimaryAction)
+                    .font(.system(size: metrics.chromeBadgeFontSize))
                     .buttonStyle(.bordered)
                     .controlSize(.small)
             }
@@ -35,7 +36,7 @@ struct SystemProxyWarningBanner: View {
                     onDismiss()
                 } label: {
                     Image(systemName: "xmark")
-                        .font(.system(size: 10, weight: .semibold))
+                        .font(.system(size: metrics.badgeFontSize, weight: .semibold))
                         .foregroundStyle(.secondary)
                 }
                 .buttonStyle(.plain)
@@ -48,4 +49,6 @@ struct SystemProxyWarningBanner: View {
             Divider()
         }
     }
+
+    @Environment(\.appUIDisplayMetrics) private var metrics
 }

--- a/RockxyTests/Core/Storage/StorageTests.swift
+++ b/RockxyTests/Core/Storage/StorageTests.swift
@@ -203,6 +203,63 @@ struct AppSettingsStorageTests {
         #expect(loaded.appUI.tabWidth == AppUISettings.defaultTabWidth)
     }
 
+    @Test("appearance persistence updates only appearance values")
+    func appearancePersistenceUpdatesOnlyAppearanceValues() {
+        let cleanup = installSettingsTestGuard()
+        defer { cleanup() }
+
+        var settings = AppSettings()
+        settings.proxyPort = 8_181
+        settings.recordOnLaunch = false
+        settings.githubGistAskBeforePublishing = false
+        AppSettingsStorage.save(settings)
+
+        var appUI = AppUISettings.default
+        appUI.fontSize = 20
+        appUI.tabWidth = 4
+        appUI.useMonospacedFont = true
+        AppSettingsStorage.saveAppearance(appTheme: .dark, appUI: appUI)
+
+        let loaded = AppSettingsStorage.load()
+
+        #expect(loaded.proxyPort == 8_181)
+        #expect(loaded.recordOnLaunch == false)
+        #expect(loaded.githubGistAskBeforePublishing == false)
+        #expect(loaded.appTheme == .dark)
+        #expect(loaded.appUI.fontSize == 20)
+        #expect(loaded.appUI.tabWidth == 4)
+        #expect(loaded.appUI.useMonospacedFont == true)
+    }
+
+    @MainActor
+    @Test("appearance manager split state stays coherent with settings snapshot")
+    func appearanceManagerSplitStateStaysCoherentWithSettingsSnapshot() {
+        let cleanup = installSettingsTestGuard()
+        let originalSettings = AppSettingsManager.shared.settings
+        defer {
+            AppSettingsManager.shared.settings = originalSettings
+            cleanup()
+        }
+
+        var settings = AppSettings()
+        settings.appTheme = .light
+        settings.appUI.fontSize = 12
+        AppSettingsManager.shared.settings = settings
+
+        #expect(AppSettingsManager.shared.appTheme == .light)
+        #expect(AppSettingsManager.shared.appUI.fontSize == 12)
+
+        var updatedUI = AppSettingsManager.shared.appUI
+        updatedUI.fontSize = 20
+        AppSettingsManager.shared.updateAppUI(updatedUI)
+        AppSettingsManager.shared.updateAppTheme(.dark)
+
+        #expect(AppSettingsManager.shared.appUI.fontSize == 20)
+        #expect(AppSettingsManager.shared.settings.appUI.fontSize == 20)
+        #expect(AppSettingsManager.shared.appTheme == .dark)
+        #expect(AppSettingsManager.shared.settings.appTheme == .dark)
+    }
+
     @MainActor
     @Test("restore appearance defaults resets only appearance values")
     func restoreAppearanceDefaults() {

--- a/RockxyTests/Core/Storage/StorageTests.swift
+++ b/RockxyTests/Core/Storage/StorageTests.swift
@@ -158,7 +158,32 @@ struct AppSettingsStorageTests {
         #expect(defaultSettings.autoSelectPort == true)
         #expect(defaultSettings.appTheme == .system)
         #expect(defaultSettings.appUI == .default)
+        #expect(defaultSettings.appUI.fontSize == 13)
         #expect(defaultSettings.lastExportedRootCAPath == nil)
+    }
+
+    @Test("missing appearance font size key loads new readable default")
+    func missingAppearanceFontSizeKeyLoadsDefault() {
+        let cleanup = installSettingsTestGuard()
+        defer { cleanup() }
+
+        UserDefaults.standard.removeObject(forKey: RockxyIdentity.current.defaultsKey("appearance.fontSize"))
+
+        let loaded = AppSettingsStorage.load()
+
+        #expect(loaded.appUI.fontSize == 13)
+    }
+
+    @Test("explicit compact appearance font size is respected")
+    func explicitCompactAppearanceFontSizeIsRespected() {
+        let cleanup = installSettingsTestGuard()
+        defer { cleanup() }
+
+        UserDefaults.standard.set(12, forKey: RockxyIdentity.current.defaultsKey("appearance.fontSize"))
+
+        let loaded = AppSettingsStorage.load()
+
+        #expect(loaded.appUI.fontSize == 12)
     }
 
     @Test("appearance settings reject invalid stored menu values")
@@ -207,6 +232,7 @@ struct AppSettingsStorageTests {
         #expect(AppSettingsManager.shared.settings.proxyPort == 8_181)
         #expect(AppSettingsManager.shared.settings.appTheme == .system)
         #expect(AppSettingsManager.shared.settings.appUI == .default)
+        #expect(AppSettingsManager.shared.settings.appUI.fontSize == 13)
     }
 
     // MARK: Private

--- a/RockxyTests/Views/Inspector/InspectorTextEditorSettingsTests.swift
+++ b/RockxyTests/Views/Inspector/InspectorTextEditorSettingsTests.swift
@@ -76,6 +76,53 @@ struct InspectorTextEditorSettingsTests {
         #expect(textView.layoutManager?.showsControlCharacters == true)
     }
 
+    @Test("Inspector editor style-only update preserves content selection and scroll without highlighting")
+    func styleOnlyUpdatePreservesEditorStateWithoutHighlighting() throws {
+        let text = (0 ..< 300).map { "line \($0): alpha beta gamma" }.joined(separator: "\n")
+        let scrollView = makeEditorScrollView(text: text)
+        let textView = try #require(scrollView.documentView as? NSTextView)
+        textView.frame.size.height = 4_000
+        textView.setSelectedRange(NSRange(location: 20, length: 8))
+        let visibleOrigin = NSPoint(x: 0, y: 120)
+        scrollView.contentView.scroll(to: visibleOrigin)
+        scrollView.reflectScrolledClipView(scrollView.contentView)
+
+        let coordinator = InspectorBodyTextEditor.Coordinator()
+        coordinator.lastEditorSettings = InspectorTextEditorSettings(fontSize: 13)
+        coordinator.lastHighlightIdentity = InspectorHighlightContext.empty.identity
+        let editor = InspectorBodyTextEditor(
+            text: text,
+            editorSettings: InspectorTextEditorSettings(fontSize: 20, useMonospacedFont: true)
+        )
+
+        editor.applyUpdate(to: scrollView, coordinator: coordinator)
+
+        let font = try #require(textView.textStorage?.attribute(.font, at: 0, effectiveRange: nil) as? NSFont)
+        #expect(textView.string == text)
+        #expect(textView.selectedRange() == NSRange(location: 20, length: 8))
+        #expect(scrollView.contentView.bounds.origin.y == visibleOrigin.y)
+        #expect(font.pointSize == 20)
+        #expect(font.fontDescriptor.symbolicTraits.contains(.monoSpace))
+        #expect(coordinator.highlightTask == nil)
+        #expect(coordinator.lastEditorSettings == InspectorTextEditorSettings(fontSize: 20, useMonospacedFont: true))
+    }
+
+    @Test("Inspector editor no-op update does not schedule highlighting")
+    func noOpUpdateDoesNotScheduleHighlighting() throws {
+        let text = "alpha beta"
+        let scrollView = makeEditorScrollView(text: text)
+        let coordinator = InspectorBodyTextEditor.Coordinator()
+        let settings = InspectorTextEditorSettings(fontSize: 13)
+        coordinator.lastEditorSettings = settings
+        coordinator.lastHighlightIdentity = InspectorHighlightContext.empty.identity
+
+        InspectorBodyTextEditor(text: text, editorSettings: settings)
+            .applyUpdate(to: scrollView, coordinator: coordinator)
+
+        #expect(coordinator.highlightTask == nil)
+        #expect(coordinator.lastEditorSettings == settings)
+    }
+
     @Test("Inspector editor keeps ruler and wrapped text contained inside the scroll view")
     func editorRulerAndWrappedTextStayContained() throws {
         let scrollView = makeEditorScrollView(text: "GET /very/long/request/path HTTP/1.1")

--- a/RockxyTests/Views/Inspector/InspectorTextEditorSettingsTests.swift
+++ b/RockxyTests/Views/Inspector/InspectorTextEditorSettingsTests.swift
@@ -76,6 +76,25 @@ struct InspectorTextEditorSettingsTests {
         #expect(textView.layoutManager?.showsControlCharacters == true)
     }
 
+    @Test("Inspector editor keeps ruler and wrapped text contained inside the scroll view")
+    func editorRulerAndWrappedTextStayContained() throws {
+        let scrollView = makeEditorScrollView(text: "GET /very/long/request/path HTTP/1.1")
+        let textView = try #require(scrollView.documentView as? NSTextView)
+        let ruler = ScriptCodeEditorRulerView(textView: textView)
+        scrollView.verticalRulerView = ruler
+        scrollView.hasVerticalRuler = true
+        scrollView.rulersVisible = true
+
+        InspectorBodyTextEditor.applyEditorSettings(InspectorTextEditorSettings(fontSize: 22, wordWrap: true), to: scrollView)
+
+        #expect(scrollView.clipsToBounds == true)
+        #expect(scrollView.contentView.clipsToBounds == true)
+        #expect(textView.clipsToBounds == true)
+        #expect(scrollView.verticalRulerView?.frame.maxX ?? 0 <= scrollView.bounds.maxX)
+        #expect(textView.frame.width <= scrollView.contentView.bounds.width + 0.5)
+        #expect(textView.textContainer?.containerSize.width == scrollView.contentView.bounds.width)
+    }
+
     private func makeEditorScrollView() -> NSScrollView {
         makeEditorScrollView(text: "")
     }

--- a/RockxyTests/Views/RequestList/RequestTableSelectionScrollTests.swift
+++ b/RockxyTests/Views/RequestList/RequestTableSelectionScrollTests.swift
@@ -289,6 +289,94 @@ struct RequestTableSelectionScrollTests {
         #expect(tableView.usesAlternatingRowBackgroundColors == false)
     }
 
+    @Test("Request table font metric changes reload visible rows without rescheduling autosize")
+    func requestTableFontMetricChangesReloadVisibleRowsWithoutReschedulingAutosize() {
+        var selectedIDs = Set<UUID>()
+        let parent = RequestTableView(
+            workspaceID: UUID(),
+            rows: [],
+            refreshToken: 0,
+            isAppendOnly: false,
+            displayMetricsOverride: AppUIDisplayMetrics(settings: .default),
+            selectedIDs: Binding(
+                get: { selectedIDs },
+                set: { selectedIDs = $0 }
+            )
+        )
+        let coordinator = RequestTableView.Coordinator(parent: parent)
+        let tableView = makeTableView(rowCount: 1, coordinator: coordinator)
+        _ = coordinator.applyDisplayMetrics(to: tableView)
+
+        var appUI = AppUISettings.default
+        appUI.fontSize = 20
+        coordinator.parent = RequestTableView(
+            workspaceID: UUID(),
+            rows: [],
+            refreshToken: 0,
+            isAppendOnly: false,
+            displayMetricsOverride: AppUIDisplayMetrics(settings: appUI),
+            selectedIDs: Binding(
+                get: { selectedIDs },
+                set: { selectedIDs = $0 }
+            )
+        )
+
+        let change = coordinator.applyDisplayMetrics(to: tableView)
+
+        #expect(change?.reloadVisibleRows == true)
+        #expect(change?.contentMetricsChanged == true)
+        #expect(change?.rowHeightChanged == true)
+        #expect(change?.autosizeContentColumns == false)
+    }
+
+    @Test("Request table row-height metric changes preserve top visible row anchor")
+    func requestTableRowHeightChangesPreserveTopVisibleRowAnchor() throws {
+        var selectedIDs = Set<UUID>()
+        let rows = TestFixtures.makeBulkTransactions(count: 80).map {
+            RequestListRow(from: $0, sslState: .insecure)
+        }
+        var appUI = AppUISettings.default
+        let parent = RequestTableView(
+            workspaceID: UUID(),
+            rows: rows,
+            refreshToken: 0,
+            isAppendOnly: false,
+            displayMetricsOverride: AppUIDisplayMetrics(settings: appUI),
+            selectedIDs: Binding(
+                get: { selectedIDs },
+                set: { selectedIDs = $0 }
+            )
+        )
+        let coordinator = RequestTableView.Coordinator(parent: parent)
+        coordinator.rows = rows
+        let tableView = makeTableView(rowCount: rows.count, coordinator: coordinator)
+        let scrollView = makeScrollView(documentView: tableView)
+        _ = coordinator.applyDisplayMetrics(to: tableView)
+        tableView.reloadData()
+        tableView.frame.size.height = CGFloat(rows.count) * tableView.rowHeight
+
+        tableView.scrollRowToVisible(25)
+        let anchor = try #require(coordinator.makeScrollAnchor(in: tableView))
+
+        appUI.fontSize = 20
+        coordinator.parent = RequestTableView(
+            workspaceID: UUID(),
+            rows: rows,
+            refreshToken: 1,
+            isAppendOnly: false,
+            displayMetricsOverride: AppUIDisplayMetrics(settings: appUI),
+            selectedIDs: Binding(
+                get: { selectedIDs },
+                set: { selectedIDs = $0 }
+            )
+        )
+        _ = coordinator.applyDisplayMetrics(to: tableView)
+        tableView.frame.size.height = CGFloat(rows.count) * tableView.rowHeight
+        coordinator.restoreScrollAnchor(anchor, in: tableView)
+
+        #expect(tableView.rows(in: scrollView.contentView.bounds).location == anchor.row)
+    }
+
     @Test("Request table scales row height after default size")
     func requestTableScalesRowHeightAfterDefaultSize() {
         var selectedIDs = Set<UUID>()
@@ -539,13 +627,16 @@ struct RequestTableSelectionScrollTests {
 
         #expect(fixedConstraintConstant(.width, for: statusImageView) == expected.tableStatusDotSize)
         #expect(fixedConstraintConstant(.height, for: statusImageView) == expected.tableStatusDotSize)
+        #expect(fixedConstraintCount(for: statusImageView) == 2)
         #expect(fixedConstraintConstant(.width, for: sslImageView) == expected.tableSSLIconSize)
         #expect(fixedConstraintConstant(.height, for: sslImageView) == expected.tableSSLIconSize)
+        #expect(fixedConstraintCount(for: sslImageView) == 2)
         #expect(clientImageView.frame.size.width == expected.tableClientIconSize)
         #expect(clientImageView.frame.size.height == expected.tableClientIconSize)
         #expect(fallbackView.frame.size.width == expected.tableClientIconSize)
         #expect(fallbackView.frame.size.height == expected.tableClientIconSize)
         #expect(leadingConstraintConstant(for: nameLabel, in: clientView) == expected.tableClientIconSize + 4)
+        #expect(leadingConstraintCount(for: nameLabel, in: clientView) == 1)
     }
 
     private func makeScrollView(documentView: NSTableView) -> NSScrollView {
@@ -627,11 +718,27 @@ struct RequestTableSelectionScrollTests {
         }?.constant
     }
 
+    private func fixedConstraintCount(for imageView: NSImageView) -> Int {
+        imageView.constraints.filter { constraint in
+            constraint.firstItem as AnyObject? === imageView
+                && constraint.secondItem == nil
+                && (constraint.firstAttribute == .width || constraint.firstAttribute == .height)
+        }.count
+    }
+
     private func leadingConstraintConstant(for textField: NSTextField, in container: NSView) -> CGFloat? {
         container.constraints.first { constraint in
             constraint.firstItem as AnyObject? === textField
                 && constraint.secondItem as AnyObject? === container
                 && constraint.firstAttribute == .leading
         }?.constant
+    }
+
+    private func leadingConstraintCount(for textField: NSTextField, in container: NSView) -> Int {
+        container.constraints.filter { constraint in
+            constraint.firstItem as AnyObject? === textField
+                && constraint.secondItem as AnyObject? === container
+                && constraint.firstAttribute == .leading
+        }.count
     }
 }

--- a/RockxyTests/Views/RequestList/RequestTableSelectionScrollTests.swift
+++ b/RockxyTests/Views/RequestList/RequestTableSelectionScrollTests.swift
@@ -21,19 +21,23 @@ struct RequestTableSelectionScrollTests {
             tableStatusDot: CGFloat,
             tableSSLIcon: CGFloat,
             tableClientIcon: CGFloat,
+            chromeFont: CGFloat,
+            chromeDot: CGFloat,
+            chromeControl: CGFloat,
+            workspaceTab: CGFloat,
             sidebarRow: CGFloat,
             row: CGFloat,
             status: CGFloat,
             filter: CGFloat,
             tab: CGFloat
         )] = [
-            (10, 11, 9, 10, 10, 11, 10, 10, 10, 20, 8, 10, 14, 24, 26, 34, 26, 22),
-            (11, 11, 10, 10, 10, 11, 10, 10, 10, 20, 8, 10, 14, 24, 27, 34, 26, 22),
-            (12, 11, 11, 10, 10, 12, 11, 10, 10, 20, 9, 11, 15, 24, 28, 34, 26, 22),
-            (13, 12, 12, 11, 10, 13, 12, 11, 11, 20, 10, 12, 16, 25, 28, 35, 27, 23),
-            (14, 13, 13, 12, 11, 14, 13, 12, 12, 21, 11, 13, 17, 26, 30, 36, 28, 24),
-            (20, 19, 19, 18, 17, 20, 19, 18, 18, 27, 12, 16, 18, 32, 36, 42, 34, 30),
-            (28, 27, 27, 26, 25, 28, 27, 26, 26, 32, 12, 16, 18, 40, 44, 50, 42, 38),
+            (10, 11, 9, 10, 10, 11, 10, 10, 10, 20, 8, 10, 14, 11, 9, 32, 13, 24, 26, 34, 26, 22),
+            (11, 11, 10, 10, 10, 11, 10, 10, 10, 20, 8, 10, 14, 11, 9, 32, 13, 24, 27, 34, 26, 22),
+            (12, 11, 11, 10, 10, 12, 11, 10, 10, 20, 9, 11, 15, 11, 9, 32, 13, 24, 28, 34, 26, 22),
+            (13, 12, 12, 11, 10, 13, 12, 11, 11, 20, 10, 12, 16, 12, 10, 32, 13, 25, 28, 35, 27, 23),
+            (14, 13, 13, 12, 11, 14, 13, 12, 12, 21, 11, 13, 17, 13, 11, 32, 13, 26, 30, 36, 28, 24),
+            (20, 19, 19, 18, 17, 20, 19, 18, 18, 27, 12, 16, 18, 19, 14, 35, 18, 32, 36, 42, 34, 30),
+            (28, 27, 27, 26, 25, 28, 27, 26, 26, 32, 12, 16, 18, 27, 14, 43, 18, 40, 44, 50, 42, 38),
         ]
 
         for item in cases {
@@ -56,6 +60,11 @@ struct RequestTableSelectionScrollTests {
             #expect(metrics.tableStatusDotSize == item.tableStatusDot)
             #expect(metrics.tableSSLIconSize == item.tableSSLIcon)
             #expect(metrics.tableClientIconSize == item.tableClientIcon)
+            #expect(metrics.chromeFontSize == item.chromeFont)
+            #expect(metrics.chromeSecondaryFontSize == item.secondary)
+            #expect(metrics.chromeStatusDotSize == item.chromeDot)
+            #expect(metrics.chromeControlHeight == item.chromeControl)
+            #expect(metrics.workspaceTabFontSize == item.workspaceTab)
             #expect(metrics.sidebarRowHeight == item.sidebarRow)
             #expect(metrics.tableRowHeight == item.row)
             #expect(metrics.statusBarHeight == item.status)
@@ -637,6 +646,101 @@ struct RequestTableSelectionScrollTests {
         #expect(fallbackView.frame.size.height == expected.tableClientIconSize)
         #expect(leadingConstraintConstant(for: nameLabel, in: clientView) == expected.tableClientIconSize + 4)
         #expect(leadingConstraintCount(for: nameLabel, in: clientView) == 1)
+    }
+
+    @Test("Request table visible metric refresh converges after rapid large-small jumps")
+    func requestTableVisibleMetricRefreshConvergesAfterRapidJumps() async throws {
+        var selectedIDs = Set<UUID>()
+        var appUI = AppUISettings()
+        appUI.fontSize = 13
+        let transaction = TestFixtures.makeTransaction(method: "CONNECT", url: "https://example.com:443")
+        transaction.clientApp = "Example Client"
+        let rows = [RequestListRow(from: transaction, sslState: .secureIntercepted)]
+        let parent = RequestTableView(
+            workspaceID: UUID(),
+            rows: rows,
+            refreshToken: 0,
+            isAppendOnly: false,
+            displayMetricsOverride: AppUIDisplayMetrics(settings: appUI),
+            selectedIDs: Binding(
+                get: { selectedIDs },
+                set: { selectedIDs = $0 }
+            )
+        )
+        let coordinator = RequestTableView.Coordinator(parent: parent)
+        coordinator.rows = rows
+        let tableView = makeTableView(rowCount: rows.count, coordinator: coordinator, columns: ["status", "ssl", "client"])
+        _ = makeScrollView(documentView: tableView)
+
+        for fontSize in [13, 28, 10, 28, 10] {
+            appUI.fontSize = fontSize
+            coordinator.parent = RequestTableView(
+                workspaceID: UUID(),
+                rows: rows,
+                refreshToken: fontSize,
+                isAppendOnly: false,
+                displayMetricsOverride: AppUIDisplayMetrics(settings: appUI),
+                selectedIDs: Binding(
+                    get: { selectedIDs },
+                    set: { selectedIDs = $0 }
+                )
+            )
+            _ = coordinator.applyDisplayMetrics(to: tableView)
+            coordinator.reloadVisibleRows(in: tableView)
+            coordinator.scheduleVisibleMetricsRefresh(in: tableView, preserving: nil)
+        }
+
+        await Task.yield()
+
+        let expected = AppUIDisplayMetrics(settings: appUI)
+        let statusView = try #require(tableView.view(atColumn: 0, row: 0, makeIfNecessary: true))
+        let statusImageView = try #require(statusView.subviews.first as? NSImageView)
+        let sslView = try #require(tableView.view(atColumn: 1, row: 0, makeIfNecessary: true))
+        let sslImageView = try #require(sslView.subviews.first as? NSImageView)
+        let clientView = try #require(tableView.view(atColumn: 2, row: 0, makeIfNecessary: true))
+        let clientImageView = try #require(clientView.subviews.first as? NSImageView)
+        let fallbackView = clientView.subviews[1]
+        let nameLabel = try #require(clientView.subviews[2] as? NSTextField)
+
+        #expect(fixedConstraintConstant(.width, for: statusImageView) == expected.tableStatusDotSize)
+        #expect(fixedConstraintConstant(.height, for: statusImageView) == expected.tableStatusDotSize)
+        #expect(fixedConstraintConstant(.width, for: sslImageView) == expected.tableSSLIconSize)
+        #expect(fixedConstraintConstant(.height, for: sslImageView) == expected.tableSSLIconSize)
+        #expect(clientImageView.frame.size.width == expected.tableClientIconSize)
+        #expect(clientImageView.frame.size.height == expected.tableClientIconSize)
+        #expect(fallbackView.frame.size.width == expected.tableClientIconSize)
+        #expect(fallbackView.frame.size.height == expected.tableClientIconSize)
+        #expect(leadingConstraintConstant(for: nameLabel, in: clientView) == expected.tableClientIconSize + 4)
+    }
+
+    @Test("Request table reapplies header font to custom columns after appearance changes")
+    func requestTableHeaderMetricsApplyToCustomColumns() throws {
+        var selectedIDs = Set<UUID>()
+        var appUI = AppUISettings()
+        appUI.fontSize = 28
+        let parent = RequestTableView(
+            workspaceID: UUID(),
+            rows: [],
+            refreshToken: 0,
+            isAppendOnly: false,
+            displayMetricsOverride: AppUIDisplayMetrics(settings: appUI),
+            selectedIDs: Binding(
+                get: { selectedIDs },
+                set: { selectedIDs = $0 }
+            )
+        )
+        let coordinator = RequestTableView.Coordinator(parent: parent)
+        let tableView = makeTableView(rowCount: 1, coordinator: coordinator, columns: ["url"])
+        let customColumn = NSTableColumn(identifier: NSUserInterfaceItemIdentifier("reqHeader.X-Test"))
+        tableView.addTableColumn(customColumn)
+
+        _ = coordinator.applyDisplayMetrics(to: tableView)
+        coordinator.applyHeaderMetrics(to: tableView)
+
+        let expected = AppUIDisplayMetrics(settings: appUI).secondaryFontSize
+        let customHeaderFont = try #require(customColumn.headerCell.font)
+
+        #expect(customHeaderFont.pointSize == expected)
     }
 
     private func makeScrollView(documentView: NSTableView) -> NSScrollView {

--- a/RockxyTests/Views/RequestList/RequestTableSelectionScrollTests.swift
+++ b/RockxyTests/Views/RequestList/RequestTableSelectionScrollTests.swift
@@ -5,6 +5,121 @@ import Testing
 
 @MainActor
 struct RequestTableSelectionScrollTests {
+    @Test("Appearance display metrics keep default request table density")
+    func appearanceDisplayMetricsKeepDefaultRequestTableDensity() {
+        let cases: [(
+            fontSize: Int,
+            control: CGFloat,
+            secondary: CGFloat,
+            metadata: CGFloat,
+            badge: CGFloat,
+            sidebarNavigation: CGFloat,
+            sidebarSecondary: CGFloat,
+            sidebarSection: CGFloat,
+            sidebarBadge: CGFloat,
+            sidebarAppIcon: CGFloat,
+            tableStatusDot: CGFloat,
+            tableSSLIcon: CGFloat,
+            tableClientIcon: CGFloat,
+            sidebarRow: CGFloat,
+            row: CGFloat,
+            status: CGFloat,
+            filter: CGFloat,
+            tab: CGFloat
+        )] = [
+            (10, 11, 9, 10, 10, 11, 10, 10, 10, 20, 8, 10, 14, 24, 26, 34, 26, 22),
+            (11, 11, 10, 10, 10, 11, 10, 10, 10, 20, 8, 10, 14, 24, 27, 34, 26, 22),
+            (12, 11, 11, 10, 10, 12, 11, 10, 10, 20, 9, 11, 15, 24, 28, 34, 26, 22),
+            (13, 12, 12, 11, 10, 13, 12, 11, 11, 20, 10, 12, 16, 25, 28, 35, 27, 23),
+            (14, 13, 13, 12, 11, 14, 13, 12, 12, 21, 11, 13, 17, 26, 30, 36, 28, 24),
+            (20, 19, 19, 18, 17, 20, 19, 18, 18, 27, 12, 16, 18, 32, 36, 42, 34, 30),
+            (28, 27, 27, 26, 25, 28, 27, 26, 26, 32, 12, 16, 18, 40, 44, 50, 42, 38),
+        ]
+
+        for item in cases {
+            var appUI = AppUISettings()
+            appUI.fontSize = item.fontSize
+            let metrics = AppUIDisplayMetrics(settings: appUI)
+
+            #expect(metrics.fontSize == CGFloat(item.fontSize))
+            #expect(metrics.primaryFontSize == CGFloat(item.fontSize))
+            #expect(metrics.controlFontSize == item.control)
+            #expect(metrics.secondaryFontSize == item.secondary)
+            #expect(metrics.metadataFontSize == item.metadata)
+            #expect(metrics.badgeFontSize == item.badge)
+            #expect(metrics.monospacedContentFontSize == CGFloat(item.fontSize))
+            #expect(metrics.sidebarNavigationFontSize == item.sidebarNavigation)
+            #expect(metrics.sidebarSecondaryFontSize == item.sidebarSecondary)
+            #expect(metrics.sidebarSectionHeaderFontSize == item.sidebarSection)
+            #expect(metrics.sidebarBadgeFontSize == item.sidebarBadge)
+            #expect(metrics.sidebarAppIconSize == item.sidebarAppIcon)
+            #expect(metrics.tableStatusDotSize == item.tableStatusDot)
+            #expect(metrics.tableSSLIconSize == item.tableSSLIcon)
+            #expect(metrics.tableClientIconSize == item.tableClientIcon)
+            #expect(metrics.sidebarRowHeight == item.sidebarRow)
+            #expect(metrics.tableRowHeight == item.row)
+            #expect(metrics.statusBarHeight == item.status)
+            #expect(metrics.filterBarHeight == item.filter)
+            #expect(metrics.inspectorTabHeight == item.tab)
+        }
+    }
+
+    @Test("Developer Setup display metrics derive from Appearance font size")
+    func developerSetupDisplayMetricsDeriveFromAppearanceFontSize() {
+        let cases: [(
+            fontSize: Int,
+            title: CGFloat,
+            sectionTitle: CGFloat,
+            body: CGFloat,
+            secondary: CGFloat,
+            metadata: CGFloat,
+            badge: CGFloat,
+            snippet: CGFloat,
+            sidebarRow: CGFloat,
+            cardMinimum: CGFloat
+        )] = [
+            (10, 15, 13, 10, 11, 10, 10, 10, 36, 82),
+            (11, 16, 13, 11, 11, 10, 10, 11, 36, 82),
+            (12, 17, 13, 12, 11, 10, 10, 12, 36, 82),
+            (13, 18, 14, 13, 12, 11, 10, 13, 37, 82),
+            (14, 19, 15, 14, 13, 12, 11, 14, 38, 82),
+            (20, 25, 21, 20, 19, 18, 17, 20, 44, 88),
+            (28, 33, 29, 28, 27, 26, 25, 28, 52, 96),
+        ]
+
+        for item in cases {
+            var appUI = AppUISettings()
+            appUI.fontSize = item.fontSize
+            let metrics = DeveloperSetupDisplayMetrics(appMetrics: AppUIDisplayMetrics(settings: appUI))
+
+            #expect(metrics.titleFontSize == item.title)
+            #expect(metrics.sectionTitleFontSize == item.sectionTitle)
+            #expect(metrics.bodyFontSize == item.body)
+            #expect(metrics.secondaryFontSize == item.secondary)
+            #expect(metrics.metadataFontSize == item.metadata)
+            #expect(metrics.badgeFontSize == item.badge)
+            #expect(metrics.snippetFontSize == item.snippet)
+            #expect(metrics.sidebarRowHeight == item.sidebarRow)
+            #expect(metrics.cardMinimumHeight == item.cardMinimum)
+        }
+    }
+
+    @Test("Inspector tab metrics use scalable control text without growing default table density")
+    func inspectorTabMetricsUseScalableControlText() {
+        var appUI = AppUISettings()
+        appUI.fontSize = AppUISettings.defaultFontSize
+        let defaultMetrics = AppUIDisplayMetrics(settings: appUI)
+        appUI.fontSize = 20
+        let largeMetrics = AppUIDisplayMetrics(settings: appUI)
+
+        #expect(defaultMetrics.controlFontSize == 12)
+        #expect(defaultMetrics.inspectorTabHeight == 23)
+        #expect(defaultMetrics.tableRowHeight == 28)
+        #expect(largeMetrics.controlFontSize == 19)
+        #expect(largeMetrics.inspectorTabHeight == 30)
+        #expect(largeMetrics.tableRowHeight == 36)
+    }
+
     @Test("Replaying unchanged selection preserves table scroll position")
     func unchangedSelectionReplayPreservesScrollPosition() {
         var selectedIDs = Set<UUID>()
@@ -43,6 +158,29 @@ struct RequestTableSelectionScrollTests {
         #expect(scrollView.contentView.bounds.origin.y == preservedOrigin.y)
     }
 
+    @Test("Request table default font keeps dense row height")
+    func requestTableDefaultFontKeepsDenseRowHeight() {
+        var selectedIDs = Set<UUID>()
+        let parent = RequestTableView(
+            workspaceID: UUID(),
+            rows: [],
+            refreshToken: 0,
+            isAppendOnly: false,
+            displayMetricsOverride: AppUIDisplayMetrics(settings: .default),
+            selectedIDs: Binding(
+                get: { selectedIDs },
+                set: { selectedIDs = $0 }
+            )
+        )
+        let coordinator = RequestTableView.Coordinator(parent: parent)
+        let tableView = makeTableView(rowCount: 1, coordinator: coordinator)
+
+        coordinator.applyDisplayMetrics(to: tableView)
+
+        #expect(AppUISettings.defaultFontSize == 13)
+        #expect(tableView.rowHeight == 28)
+    }
+
     @Test("Request table applies appearance display metrics")
     func requestTableAppliesAppearanceDisplayMetrics() {
         var selectedIDs = Set<UUID>()
@@ -69,6 +207,347 @@ struct RequestTableSelectionScrollTests {
         #expect(tableView.usesAlternatingRowBackgroundColors == false)
     }
 
+    @Test("Request table ignores inspector-only appearance options")
+    func requestTableIgnoresInspectorOnlyAppearanceOptions() {
+        var selectedIDs = Set<UUID>()
+        let parent = RequestTableView(
+            workspaceID: UUID(),
+            rows: [],
+            refreshToken: 0,
+            isAppendOnly: false,
+            displayMetricsOverride: AppUIDisplayMetrics(settings: .default),
+            selectedIDs: Binding(
+                get: { selectedIDs },
+                set: { selectedIDs = $0 }
+            )
+        )
+        let coordinator = RequestTableView.Coordinator(parent: parent)
+        let tableView = makeTableView(rowCount: 1, coordinator: coordinator)
+
+        let firstChange = coordinator.applyDisplayMetrics(to: tableView)
+
+        var inspectorOnlyAppUI = AppUISettings.default
+        inspectorOnlyAppUI.bodyWordWrap.toggle()
+        inspectorOnlyAppUI.bodyShowInvisibles.toggle()
+        inspectorOnlyAppUI.bodyShowMinimap.toggle()
+        inspectorOnlyAppUI.bodyScrollBeyondLastLine.toggle()
+        coordinator.parent = RequestTableView(
+            workspaceID: UUID(),
+            rows: [],
+            refreshToken: 0,
+            isAppendOnly: false,
+            displayMetricsOverride: AppUIDisplayMetrics(settings: inspectorOnlyAppUI),
+            selectedIDs: Binding(
+                get: { selectedIDs },
+                set: { selectedIDs = $0 }
+            )
+        )
+
+        let secondChange = coordinator.applyDisplayMetrics(to: tableView)
+
+        #expect(firstChange?.reloadVisibleRows == true)
+        #expect(firstChange?.autosizeContentColumns == true)
+        #expect(secondChange == nil)
+    }
+
+    @Test("Request table alternating-row option avoids content autosize")
+    func requestTableAlternatingRowOptionAvoidsContentAutosize() {
+        var selectedIDs = Set<UUID>()
+        let parent = RequestTableView(
+            workspaceID: UUID(),
+            rows: [],
+            refreshToken: 0,
+            isAppendOnly: false,
+            displayMetricsOverride: AppUIDisplayMetrics(settings: .default),
+            selectedIDs: Binding(
+                get: { selectedIDs },
+                set: { selectedIDs = $0 }
+            )
+        )
+        let coordinator = RequestTableView.Coordinator(parent: parent)
+        let tableView = makeTableView(rowCount: 1, coordinator: coordinator)
+        _ = coordinator.applyDisplayMetrics(to: tableView)
+
+        var appUI = AppUISettings.default
+        appUI.useAlternatingRowBackgroundColors = false
+        coordinator.parent = RequestTableView(
+            workspaceID: UUID(),
+            rows: [],
+            refreshToken: 0,
+            isAppendOnly: false,
+            displayMetricsOverride: AppUIDisplayMetrics(settings: appUI),
+            selectedIDs: Binding(
+                get: { selectedIDs },
+                set: { selectedIDs = $0 }
+            )
+        )
+
+        let change = coordinator.applyDisplayMetrics(to: tableView)
+
+        #expect(change?.reloadVisibleRows == false)
+        #expect(change?.autosizeContentColumns == false)
+        #expect(tableView.usesAlternatingRowBackgroundColors == false)
+    }
+
+    @Test("Request table scales row height after default size")
+    func requestTableScalesRowHeightAfterDefaultSize() {
+        var selectedIDs = Set<UUID>()
+        var appUI = AppUISettings()
+        appUI.fontSize = 14
+        let parent = RequestTableView(
+            workspaceID: UUID(),
+            rows: [],
+            refreshToken: 0,
+            isAppendOnly: false,
+            displayMetricsOverride: AppUIDisplayMetrics(settings: appUI),
+            selectedIDs: Binding(
+                get: { selectedIDs },
+                set: { selectedIDs = $0 }
+            )
+        )
+        let coordinator = RequestTableView.Coordinator(parent: parent)
+        let tableView = makeTableView(rowCount: 1, coordinator: coordinator)
+
+        coordinator.applyDisplayMetrics(to: tableView)
+
+        #expect(tableView.rowHeight == 30)
+    }
+
+    @Test("Applying request table metrics preserves column widths")
+    func applyingRequestTableMetricsPreservesColumnWidths() {
+        var selectedIDs = Set<UUID>()
+        let parent = RequestTableView(
+            workspaceID: UUID(),
+            rows: [],
+            refreshToken: 0,
+            isAppendOnly: false,
+            displayMetricsOverride: AppUIDisplayMetrics(settings: .default),
+            selectedIDs: Binding(
+                get: { selectedIDs },
+                set: { selectedIDs = $0 }
+            )
+        )
+        let coordinator = RequestTableView.Coordinator(parent: parent)
+        let tableView = makeTableView(rowCount: 1, coordinator: coordinator)
+        tableView.tableColumns[0].width = 333
+
+        coordinator.applyDisplayMetrics(to: tableView)
+
+        #expect(tableView.tableColumns[0].width == 333)
+    }
+
+    @Test("Request table size-to-fit measures with active metrics without mutating columns")
+    func requestTableSizeToFitMeasuresWithActiveMetricsWithoutMutatingColumns() {
+        let compactWidth = measuredURLWidth(fontSize: 12)
+        let largeWidth = measuredURLWidth(fontSize: 20)
+
+        #expect(largeWidth > compactWidth)
+    }
+
+    @Test("Method column sizing accounts for CONNECT at default font")
+    func methodColumnSizingAccountsForConnectAtDefaultFont() {
+        var selectedIDs = Set<UUID>()
+        let rows = [
+            TestFixtures.makeTransaction(method: "CONNECT", url: "https://example.com:443"),
+        ].map {
+            RequestListRow(from: $0, sslState: .secureTunneled)
+        }
+        let parent = RequestTableView(
+            workspaceID: UUID(),
+            rows: rows,
+            refreshToken: 0,
+            isAppendOnly: false,
+            displayMetricsOverride: AppUIDisplayMetrics(settings: .default),
+            selectedIDs: Binding(
+                get: { selectedIDs },
+                set: { selectedIDs = $0 }
+            )
+        )
+        let coordinator = RequestTableView.Coordinator(parent: parent)
+        coordinator.rows = rows
+        let tableView = makeTableView(rowCount: rows.count, coordinator: coordinator, columns: ["method"])
+
+        let measuredWidth = coordinator.tableView(tableView, sizeToFitWidthOfColumn: 0)
+        let cellView = coordinator.tableView(tableView, viewFor: tableView.tableColumns[0], row: 0)
+        let textField = cellView?.subviews.first as? NSTextField
+
+        #expect(measuredWidth <= 82)
+        #expect(textField?.stringValue == "CONNECT")
+        #expect(textField?.maximumNumberOfLines == 1)
+        #expect(textField?.cell?.wraps == false)
+        #expect((textField?.cell as? NSTextFieldCell)?.usesSingleLineMode == true)
+        #expect((textField?.cell as? NSTextFieldCell)?.truncatesLastVisibleLine == true)
+    }
+
+    @Test("Request table SSL icon constraints shrink after large-to-small metric changes")
+    func requestTableSSLIconConstraintsShrinkAfterLargeToSmallMetricChanges() throws {
+        var selectedIDs = Set<UUID>()
+        var appUI = AppUISettings()
+        appUI.fontSize = 28
+        let rows = [
+            TestFixtures.makeTransaction(method: "CONNECT", url: "https://example.com:443"),
+        ].map {
+            RequestListRow(from: $0, sslState: .secureIntercepted)
+        }
+        let parent = RequestTableView(
+            workspaceID: UUID(),
+            rows: rows,
+            refreshToken: 0,
+            isAppendOnly: false,
+            displayMetricsOverride: AppUIDisplayMetrics(settings: appUI),
+            selectedIDs: Binding(
+                get: { selectedIDs },
+                set: { selectedIDs = $0 }
+            )
+        )
+        let coordinator = RequestTableView.Coordinator(parent: parent)
+        coordinator.rows = rows
+        let tableView = makeTableView(rowCount: rows.count, coordinator: coordinator, columns: ["ssl"])
+        _ = coordinator.applyDisplayMetrics(to: tableView)
+
+        _ = tableView.view(atColumn: 0, row: 0, makeIfNecessary: true)
+
+        appUI.fontSize = 10
+        coordinator.parent = RequestTableView(
+            workspaceID: UUID(),
+            rows: rows,
+            refreshToken: 1,
+            isAppendOnly: false,
+            displayMetricsOverride: AppUIDisplayMetrics(settings: appUI),
+            selectedIDs: Binding(
+                get: { selectedIDs },
+                set: { selectedIDs = $0 }
+            )
+        )
+        _ = coordinator.applyDisplayMetrics(to: tableView)
+        tableView.reloadData()
+
+        let smallView = try #require(tableView.view(atColumn: 0, row: 0, makeIfNecessary: true))
+        let imageView = try #require(smallView.subviews.first as? NSImageView)
+        let expected = AppUIDisplayMetrics(settings: appUI).tableSSLIconSize
+
+        #expect(fixedConstraintConstant(.width, for: imageView) == expected)
+        #expect(fixedConstraintConstant(.height, for: imageView) == expected)
+    }
+
+    @Test("Request table client app icon frame shrinks after large-to-small metric changes")
+    func requestTableClientIconFrameShrinksAfterLargeToSmallMetricChanges() throws {
+        var selectedIDs = Set<UUID>()
+        var appUI = AppUISettings()
+        appUI.fontSize = 28
+        let transaction = TestFixtures.makeTransaction()
+        transaction.clientApp = "Example Client"
+        let rows = [RequestListRow(from: transaction, sslState: .insecure)]
+        let parent = RequestTableView(
+            workspaceID: UUID(),
+            rows: rows,
+            refreshToken: 0,
+            isAppendOnly: false,
+            displayMetricsOverride: AppUIDisplayMetrics(settings: appUI),
+            selectedIDs: Binding(
+                get: { selectedIDs },
+                set: { selectedIDs = $0 }
+            )
+        )
+        let coordinator = RequestTableView.Coordinator(parent: parent)
+        coordinator.rows = rows
+        let tableView = makeTableView(rowCount: rows.count, coordinator: coordinator, columns: ["client"])
+        _ = coordinator.applyDisplayMetrics(to: tableView)
+
+        _ = tableView.view(atColumn: 0, row: 0, makeIfNecessary: true)
+
+        appUI.fontSize = 10
+        coordinator.parent = RequestTableView(
+            workspaceID: UUID(),
+            rows: rows,
+            refreshToken: 1,
+            isAppendOnly: false,
+            displayMetricsOverride: AppUIDisplayMetrics(settings: appUI),
+            selectedIDs: Binding(
+                get: { selectedIDs },
+                set: { selectedIDs = $0 }
+            )
+        )
+        _ = coordinator.applyDisplayMetrics(to: tableView)
+        tableView.reloadData()
+
+        let smallView = try #require(tableView.view(atColumn: 0, row: 0, makeIfNecessary: true))
+        let imageView = try #require(smallView.subviews.first as? NSImageView)
+        let fallbackView = smallView.subviews[1]
+        let nameLabel = try #require(smallView.subviews[2] as? NSTextField)
+        let expected = AppUIDisplayMetrics(settings: appUI).tableClientIconSize
+
+        #expect(imageView.frame.size.width == expected)
+        #expect(imageView.frame.size.height == expected)
+        #expect(fallbackView.frame.size.width == expected)
+        #expect(fallbackView.frame.size.height == expected)
+        #expect(leadingConstraintConstant(for: nameLabel, in: smallView) == expected + 4)
+    }
+
+    @Test("Request table status, SSL, and client icons remain consistent after repeated metric changes")
+    func requestTableIconsRemainConsistentAfterRepeatedMetricChanges() throws {
+        var selectedIDs = Set<UUID>()
+        var appUI = AppUISettings()
+        appUI.fontSize = 10
+        let transaction = TestFixtures.makeTransaction(method: "CONNECT", url: "https://example.com:443")
+        transaction.clientApp = "Example Client"
+        let rows = [RequestListRow(from: transaction, sslState: .secureIntercepted)]
+        let parent = RequestTableView(
+            workspaceID: UUID(),
+            rows: rows,
+            refreshToken: 0,
+            isAppendOnly: false,
+            displayMetricsOverride: AppUIDisplayMetrics(settings: appUI),
+            selectedIDs: Binding(
+                get: { selectedIDs },
+                set: { selectedIDs = $0 }
+            )
+        )
+        let coordinator = RequestTableView.Coordinator(parent: parent)
+        coordinator.rows = rows
+        let tableView = makeTableView(rowCount: rows.count, coordinator: coordinator, columns: ["status", "ssl", "client"])
+
+        for fontSize in [10, 28, 10, 28, 10] {
+            appUI.fontSize = fontSize
+            coordinator.parent = RequestTableView(
+                workspaceID: UUID(),
+                rows: rows,
+                refreshToken: fontSize,
+                isAppendOnly: false,
+                displayMetricsOverride: AppUIDisplayMetrics(settings: appUI),
+                selectedIDs: Binding(
+                    get: { selectedIDs },
+                    set: { selectedIDs = $0 }
+                )
+            )
+            _ = coordinator.applyDisplayMetrics(to: tableView)
+            tableView.reloadData()
+            for column in 0 ..< tableView.numberOfColumns {
+                _ = tableView.view(atColumn: column, row: 0, makeIfNecessary: true)
+            }
+        }
+
+        let expected = AppUIDisplayMetrics(settings: appUI)
+        let statusView = try #require(tableView.view(atColumn: 0, row: 0, makeIfNecessary: true))
+        let statusImageView = try #require(statusView.subviews.first as? NSImageView)
+        let sslView = try #require(tableView.view(atColumn: 1, row: 0, makeIfNecessary: true))
+        let sslImageView = try #require(sslView.subviews.first as? NSImageView)
+        let clientView = try #require(tableView.view(atColumn: 2, row: 0, makeIfNecessary: true))
+        let clientImageView = try #require(clientView.subviews.first as? NSImageView)
+        let fallbackView = clientView.subviews[1]
+        let nameLabel = try #require(clientView.subviews[2] as? NSTextField)
+
+        #expect(fixedConstraintConstant(.width, for: statusImageView) == expected.tableStatusDotSize)
+        #expect(fixedConstraintConstant(.height, for: statusImageView) == expected.tableStatusDotSize)
+        #expect(fixedConstraintConstant(.width, for: sslImageView) == expected.tableSSLIconSize)
+        #expect(fixedConstraintConstant(.height, for: sslImageView) == expected.tableSSLIconSize)
+        #expect(clientImageView.frame.size.width == expected.tableClientIconSize)
+        #expect(clientImageView.frame.size.height == expected.tableClientIconSize)
+        #expect(fallbackView.frame.size.width == expected.tableClientIconSize)
+        #expect(fallbackView.frame.size.height == expected.tableClientIconSize)
+        #expect(leadingConstraintConstant(for: nameLabel, in: clientView) == expected.tableClientIconSize + 4)
+    }
+
     private func makeScrollView(documentView: NSTableView) -> NSScrollView {
         let scrollView = NSScrollView(frame: NSRect(x: 0, y: 0, width: 480, height: 120))
         scrollView.hasVerticalScroller = true
@@ -78,7 +557,8 @@ struct RequestTableSelectionScrollTests {
 
     private func makeTableView(
         rowCount: Int,
-        coordinator: RequestTableView.Coordinator
+        coordinator: RequestTableView.Coordinator,
+        columns: [String] = ["url"]
     )
         -> NSTableView
     {
@@ -87,11 +567,71 @@ struct RequestTableSelectionScrollTests {
         )
         tableView.rowHeight = 28
         tableView.intercellSpacing = .zero
-        tableView.addTableColumn(NSTableColumn(identifier: NSUserInterfaceItemIdentifier("url")))
+        for column in columns {
+            tableView.addTableColumn(NSTableColumn(identifier: NSUserInterfaceItemIdentifier(column)))
+        }
         tableView.dataSource = coordinator
         tableView.delegate = coordinator
         coordinator.tableView = tableView
         tableView.reloadData()
         return tableView
+    }
+
+    private func measuredURLWidth(fontSize: Int) -> CGFloat {
+        var selectedIDs = Set<UUID>()
+        var appUI = AppUISettings()
+        appUI.fontSize = fontSize
+        let rows = [
+            TestFixtures.makeTransaction(
+                url: "https://example.com/api/v1/workspaces/current/traffic/transactions?include=metadata"
+            ),
+        ].map {
+            RequestListRow(from: $0, sslState: .insecure)
+        }
+        let parent = RequestTableView(
+            workspaceID: UUID(),
+            rows: rows,
+            refreshToken: 0,
+            isAppendOnly: false,
+            displayMetricsOverride: AppUIDisplayMetrics(settings: appUI),
+            selectedIDs: Binding(
+                get: { selectedIDs },
+                set: { selectedIDs = $0 }
+            )
+        )
+        let coordinator = RequestTableView.Coordinator(parent: parent)
+        coordinator.rows = rows
+        let tableView = makeTableView(rowCount: rows.count, coordinator: coordinator)
+        let durationColumn = NSTableColumn(identifier: NSUserInterfaceItemIdentifier("duration"))
+        durationColumn.width = 70
+        tableView.addTableColumn(durationColumn)
+        tableView.tableColumns[0].width = 222
+
+        let measuredWidth = coordinator.tableView(tableView, sizeToFitWidthOfColumn: 0)
+
+        #expect(tableView.tableColumns[0].width == 222)
+        #expect(tableView.tableColumns[1].width == 70)
+        return measuredWidth
+    }
+
+    private func fixedConstraintConstant(
+        _ attribute: NSLayoutConstraint.Attribute,
+        for imageView: NSImageView
+    )
+        -> CGFloat?
+    {
+        imageView.constraints.first { constraint in
+            constraint.firstItem as AnyObject? === imageView
+                && constraint.secondItem == nil
+                && constraint.firstAttribute == attribute
+        }?.constant
+    }
+
+    private func leadingConstraintConstant(for textField: NSTextField, in container: NSView) -> CGFloat? {
+        container.constraints.first { constraint in
+            constraint.firstItem as AnyObject? === textField
+                && constraint.secondItem as AnyObject? === container
+                && constraint.firstAttribute == .leading
+        }?.constant
     }
 }


### PR DESCRIPTION
## Summary

- Promote the Appearance scanability and scaling stability improvements from `develop` to `main`.
- Includes the merged work from PR #122 for the main request table, inspector, Developer Setup Hub, sidebar, toolbar/status chrome, and AppKit-owned workspace surfaces.
- Preserves request-table density and saved column behavior while improving readability and rapid font-size change stability.

## Included Changes

- Default Appearance font size now follows the macOS regular text baseline while keeping dense choices available.
- Appearance metrics propagate through primary traffic content, inspector panes, Developer Setup screens, sidebar rows, toolbar/status chrome, and request-table cells.
- Rapid font-size jumps now converge consistently for visible rows, headers, SSL/client/sidebar icons, and chrome text.
- Appearance persistence and update paths avoid unnecessary settings churn.
- Inspector text editor and request-table update paths avoid avoidable restyling/reload work.

## Validation

- `git diff --check`
- Focused storage, inspector editor, and request-table tests
- `xcodebuild -project Rockxy.xcodeproj -scheme Rockxy -configuration Debug build`
- `xcodebuild -project Rockxy.xcodeproj -scheme Rockxy -destination 'platform=macOS' test`

Not run locally:

- `swiftlint lint --strict` because `swiftlint` is not installed in this environment.

Refs #119

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented dynamic display metrics system for responsive typography across the entire UI.

* **Improvements**
  * Increased default font size to 13pt for better readability.
  * Enhanced appearance change notifications for improved settings synchronization.
  * Optimized sidebar favorites caching for faster performance.
  * Improved layout consistency and constraint handling throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->