### PR TITLE
docs: align React Native setup guide with the public manual/hybrid implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -241,7 +241,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
-- Developer Setup Hub now includes Flutter and React Native mobile setup flows, with licensed Android automation for supported workflows.
+- Developer Setup Hub now includes Flutter and React Native mobile setup flows, with manual/hybrid setup guidance for React Native.
 - Favorite request context menus now include richer actions, including opening favorites in new tabs.
 - Developer Setup Hub can now be opened directly from the toolbar.
 

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -243,7 +243,7 @@ rss: true
 <Update label="April 2026" description="v0.15.0">
   ### Added
 
-  - Developer Setup Hub now includes Flutter and React Native mobile setup flows, with licensed Android automation for supported workflows.
+  - Developer Setup Hub now includes Flutter and React Native mobile setup flows, with manual/hybrid setup guidance for React Native.
   - Favorite request context menus now include richer actions, including opening favorites in new tabs.
   - Developer Setup Hub can now be opened directly from the toolbar.
 

--- a/docs/getting-started/developer-setup-hub.mdx
+++ b/docs/getting-started/developer-setup-hub.mdx
@@ -170,7 +170,7 @@ That is not incomplete documentation. It is the product being explicit about whe
 
 Developer Setup Hub itself is not a Pro-only feature.
 
-The current paid addition in this area is the in-app **React Native Android Setup** automation workflow for supported Android targets. Without Pro, the manual setup path remains available.
+React Native setup currently ships as a manual/hybrid guide: fetch probe, Android debug network-security-config XML guidance, and the Metro checklist. A guided React Native Android automation flow is planned as a future Pro extension, but it is not shipping today; the manual setup path remains available.
 
 For the full license breakdown, see [Pro Features](/features/pro-features) and [License Management](/features/license-management).
 

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -96,7 +96,7 @@ Use native session files when you want to preserve Rockxy-specific context, or H
 - Inspect HTTPS traffic from apps, devices, and local runtimes
 - Replay, modify, compare, and export API traffic without leaving your machine
 - Local-first developer tooling with no account requirement
-- Optional Pro upgrade for unlimited caps, Advanced Diff, and React Native Android automation
+- Optional Pro upgrade for unlimited caps and Advanced Diff
 
 ## System Requirements
 

--- a/docs/setup-guides/react-native.mdx
+++ b/docs/setup-guides/react-native.mdx
@@ -10,7 +10,7 @@ React Native traffic still runs through the underlying iOS or Android network st
 ## Support in Rockxy
 
 - Manual setup available
-- Pro automation exists for the React Native Android workflow
+- Manual/hybrid debug-build setup only; no React Native Android automation ships
 - Certificate sharing support available
 
 ## What Rockxy currently provides
@@ -27,6 +27,6 @@ React Native traffic still runs through the underlying iOS or Android network st
     Return to the frameworks hub.
   </Card>
   <Card title="Pro Features" icon="sparkles" href="/features/pro-features">
-    See how React Native Android automation fits into Rockxy Pro.
+    Review the broader Rockxy Pro model and planned extensions.
   </Card>
 </CardGroup>

--- a/docs/troubleshooting/faq.mdx
+++ b/docs/troubleshooting/faq.mdx
@@ -27,7 +27,7 @@ Use HAR for cross-tool sharing. Use Rockxy's native session format when you want
 
 ## What does Rockxy Pro include today?
 
-Rockxy Pro currently unlocks unlimited usage caps, Advanced Diff, and the React Native Android automation workflow in Developer Setup Hub. Community keeps the core capture, inspection, replay, rules, sessions, and manual setup flows.
+Rockxy Pro currently unlocks unlimited usage caps and Advanced Diff. React Native Android automation is planned, not shipping. Community keeps the core capture, inspection, replay, rules, sessions, and manual setup flows.
 
 ## What does a perpetual Rockxy Pro license mean?
 


### PR DESCRIPTION
<!-- Please target the `develop` branch for all pull requests. -->

## Description
<!-- What does this PR do? Why is this change needed? -->

Public docs claim React Native ships a Pro Android automation workflow, but the shipped implementation sets React Native to `automationSupport: .none` in `Rockxy/Models/UI/DeveloperSetupCatalog.swift` — it is manual/hybrid only (fetch probe, Android debug `network-security-config` XML guidance, Metro checklist). This aligns the docs with that behavior and removes the unsupported automation claims that contradicted it across the public pages, matching the acceptance criteria in #76. A guided React Native Android automation flow is left documented as a planned (not-shipping) Pro extension, consistent with `docs/features/pro-features.mdx`.

## Changes
<!-- List the key changes in this PR. -->

- `docs/setup-guides/react-native.mdx`: replace the "Pro automation exists" bullet with manual/hybrid-only wording and reword the Pro Features card so it no longer asserts RN Android automation ships.
- `docs/getting-started/developer-setup-hub.mdx`, `docs/troubleshooting/faq.mdx`, `docs/index.mdx`: drop the current-feature RN Android automation claims; describe it as manual/hybrid with automation planned, not shipping.
- `docs/changelog.mdx` and root `CHANGELOG.md` (v0.15.0): drop the "licensed Android automation" claim while keeping the added Flutter/React Native mobile setup flows.

## Checklist

- [ ] Tests added or updated
- [x] `CHANGELOG.md` updated under `[Unreleased]` (skip for unreleased-only fixes)
- [x] Docs updated in `docs/` if the change affects user-facing behavior
- [ ] User-facing strings localized with `String(localized:)`
- [ ] No SwiftLint / SwiftFormat violations (`swiftlint lint --strict && swiftformat .`)
- [ ] If this PR touches helper packaging, release scripts, or platform compatibility claims, Intel + Apple Silicon validation was updated or re-run

## CLA

This project requires a signed [Contributor License Agreement](CLA.md).
If this is your first contribution, the CLA Assistant bot will comment on this PR
with instructions. You must sign the CLA before your PR can be merged.

Fixes #76
