### PR TITLE
fix: improve issue 119 readability and Firefox response body inspection

### DIFF
--- a/Rockxy/Core/Utilities/BodyDecoder.swift
+++ b/Rockxy/Core/Utilities/BodyDecoder.swift
@@ -10,9 +10,28 @@ enum BodyDecoder {
     // MARK: Internal
 
     static func decode(_ data: Data, encoding: String?) -> Data {
-        guard let encoding = encoding?.lowercased() else {
+        guard let encoding else {
             return data
         }
+        let encodings = encoding
+            .split(separator: ",")
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() }
+            .filter { !$0.isEmpty }
+        guard !encodings.isEmpty else {
+            return data
+        }
+        return encodings.reversed().reduce(data) { body, encoding in
+            decodeSingle(body, encoding: encoding)
+        }
+    }
+
+    // MARK: Private
+
+    private static let logger = Logger(subsystem: RockxyIdentity.current.logSubsystem, category: "BodyDecoder")
+
+    private static let maxDecompressedSize = 50 * 1_024 * 1_024 // 50MB
+
+    private static func decodeSingle(_ data: Data, encoding: String) -> Data {
         switch encoding {
         case "gzip":
             return decompressGzip(data) ?? data
@@ -24,12 +43,6 @@ enum BodyDecoder {
             return data
         }
     }
-
-    // MARK: Private
-
-    private static let logger = Logger(subsystem: RockxyIdentity.current.logSubsystem, category: "BodyDecoder")
-
-    private static let maxDecompressedSize = 50 * 1_024 * 1_024 // 50MB
 
     private static func decompressGzip(_ data: Data) -> Data? {
         guard data.count >= 18 else {

--- a/Rockxy/Models/UI/AppUIDisplayMetrics.swift
+++ b/Rockxy/Models/UI/AppUIDisplayMetrics.swift
@@ -358,6 +358,15 @@ struct ToolWindowDisplayMetrics: Equatable {
         max(24, bodyFontSize + 12)
     }
 
+    var codeEditorSettings: InspectorTextEditorSettings {
+        InspectorTextEditorSettings(
+            fontSize: Int(appMetrics.primaryFontSize),
+            tabWidth: appMetrics.settings.tabWidth,
+            useMonospacedFont: true,
+            wordWrap: false
+        )
+    }
+
     var footerButtonWidth: CGFloat {
         max(100, bodyFontSize + 88)
     }

--- a/Rockxy/Views/Breakpoint/BreakpointEditorView.swift
+++ b/Rockxy/Views/Breakpoint/BreakpointEditorView.swift
@@ -292,7 +292,7 @@ struct BreakpointEditorView: View {
             MapLocalHTTPMessageEditor(text: Binding(
                 get: { rawMessage },
                 set: { updateRawMessage($0, itemId: itemId) }
-            ))
+            ), editorSettings: toolMetrics.codeEditorSettings)
             .overlay(Rectangle().stroke(Color(nsColor: .separatorColor).opacity(0.35)))
             .padding(.horizontal, 12)
             .padding(.bottom, 12)

--- a/Rockxy/Views/Breakpoint/BreakpointTemplateWindowView.swift
+++ b/Rockxy/Views/Breakpoint/BreakpointTemplateWindowView.swift
@@ -209,7 +209,7 @@ struct BreakpointTemplateWindowView: View {
             MapLocalHTTPMessageEditor(text: Binding(
                 get: { template.rawMessage },
                 set: { store.updateSelected(rawMessage: $0) }
-            ))
+            ), editorSettings: toolMetrics.codeEditorSettings)
             .frame(minHeight: 382)
             .overlay(Rectangle().stroke(Color(nsColor: .separatorColor).opacity(0.45)))
         }

--- a/Rockxy/Views/Inspector/BodyInspectorView.swift
+++ b/Rockxy/Views/Inspector/BodyInspectorView.swift
@@ -7,9 +7,10 @@ struct BodyInspectorView: View {
     var highlightContext: InspectorHighlightContext = .empty
 
     var body: some View {
-        if let body = transaction.response?.body {
+        let snapshot = InspectorTransactionSnapshot(transaction: transaction)
+        if let body = snapshot.response?.displayBody {
             AsyncInspectorTextEditor(
-                renderID: "\(transaction.id.uuidString)-legacy-body-\(body.count)",
+                renderID: "\(transaction.id.uuidString)-legacy-body-\(snapshot.response?.body?.count ?? 0)-\(body.count)",
                 highlightContext: highlightContext
             ) {
                 InspectorPayloadFormatter.requestBodyText(body)

--- a/Rockxy/Views/Inspector/InspectorBodyTextEditor.swift
+++ b/Rockxy/Views/Inspector/InspectorBodyTextEditor.swift
@@ -369,6 +369,13 @@ struct InspectorBodyTextEditor: NSViewRepresentable {
         textView.layoutManager?.showsInvisibleCharacters = editorSettings.showInvisibles
         textView.layoutManager?.showsControlCharacters = editorSettings.showInvisibles
 
+        if let ruler = scrollView.verticalRulerView as? ScriptCodeEditorRulerView {
+            ruler.applyEditorSettings(editorSettings)
+        } else {
+            scrollView.verticalRulerView?.needsDisplay = true
+        }
+        scrollView.tile()
+
         if editorSettings.wordWrap {
             textView.frame.size.width = max(scrollView.contentView.bounds.width, 1)
             textView.textContainer?.containerSize = NSSize(
@@ -385,7 +392,6 @@ struct InspectorBodyTextEditor: NSViewRepresentable {
             textView.textContainer?.widthTracksTextView = false
         }
         scrollView.tile()
-        scrollView.verticalRulerView?.needsDisplay = true
         applyTextStorageSettings(editorSettings, to: textView)
         textView.layoutManager?.invalidateLayout(forCharacterRange: NSRange(location: 0, length: textView.string.utf16.count), actualCharacterRange: nil)
         textView.needsDisplay = true

--- a/Rockxy/Views/Inspector/InspectorBodyTextEditor.swift
+++ b/Rockxy/Views/Inspector/InspectorBodyTextEditor.swift
@@ -775,6 +775,7 @@ struct InspectorResponseSnapshot: Sendable {
     let statusMessage: String
     let headers: [InspectorHeaderSnapshot]
     let body: Data?
+    let displayBody: Data?
     let contentType: ContentType?
 
     init(response: HTTPResponseData) {
@@ -782,7 +783,18 @@ struct InspectorResponseSnapshot: Sendable {
         statusMessage = response.statusMessage
         headers = response.headers.map(InspectorHeaderSnapshot.init(header:))
         body = response.body
+        displayBody = Self.decodedDisplayBody(
+            response.body,
+            contentEncoding: response.headers.first { $0.name.lowercased() == "content-encoding" }?.value
+        )
         contentType = response.contentType
+    }
+
+    private static func decodedDisplayBody(_ body: Data?, contentEncoding: String?) -> Data? {
+        guard let body else {
+            return nil
+        }
+        return BodyDecoder.decode(body, encoding: contentEncoding)
     }
 }
 
@@ -823,7 +835,7 @@ enum InspectorPayloadFormatter {
             raw += "\(header.name): \(header.value)\r\n"
         }
         raw += "\r\n"
-        if let body = response.body, let bodyString = String(data: body, encoding: .utf8) {
+        if let body = response.displayBody, let bodyString = String(data: body, encoding: .utf8) {
             raw += bodyString
         }
         return raw

--- a/Rockxy/Views/Inspector/PreviewTabContentView.swift
+++ b/Rockxy/Views/Inspector/PreviewTabContentView.swift
@@ -26,7 +26,7 @@ struct PreviewTabContentView: View {
 
     @ViewBuilder
     private func jsonTreePreview(snapshot: InspectorTransactionSnapshot) -> some View {
-        if let data = tab.panel == .request ? snapshot.request.body : snapshot.response?.body {
+        if let data = tab.panel == .request ? snapshot.request.body : snapshot.response?.displayBody {
             JSONTreeView(data: data)
                 .id("\(snapshot.id.uuidString)-\(tab.id.uuidString)")
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
@@ -41,10 +41,12 @@ struct PreviewTabContentView: View {
     }
 
     private func renderID(snapshot: InspectorTransactionSnapshot) -> String {
-        let bodyCount = tab.panel == .request
-            ? snapshot.request.body?.count ?? 0
-            : snapshot.response?.body?.count ?? 0
-        return "\(snapshot.id.uuidString)-\(tab.id.uuidString)-\(tab.renderMode.rawValue)-\(beautify)-\(bodyCount)"
+        let bodyCounts = if tab.panel == .request {
+            "\(snapshot.request.body?.count ?? 0)"
+        } else {
+            "\(snapshot.response?.body?.count ?? 0)-\(snapshot.response?.displayBody?.count ?? 0)"
+        }
+        return "\(snapshot.id.uuidString)-\(tab.id.uuidString)-\(tab.renderMode.rawValue)-\(beautify)-\(bodyCounts)"
     }
 
     nonisolated private static func renderPreview(
@@ -66,7 +68,7 @@ struct PreviewTabContentView: View {
             }
         }
 
-        let bodyData = tab.panel == .request ? snapshot.request.body : snapshot.response?.body
+        let bodyData = Self.previewBodyData(tab: tab, snapshot: snapshot)
         switch PreviewRenderer.render(body: bodyData, mode: tab.renderMode, beautify: beautify) {
         case let .text(text):
             return .text(text)
@@ -78,6 +80,18 @@ struct PreviewTabContentView: View {
             return .imageData(data)
         case let .empty(reason):
             return .empty(reason: reason)
+        }
+    }
+
+    nonisolated private static func previewBodyData(
+        tab: PreviewTab,
+        snapshot: InspectorTransactionSnapshot
+    ) -> Data? {
+        switch tab.panel {
+        case .request:
+            snapshot.request.body
+        case .response:
+            tab.renderMode == .hex ? snapshot.response?.body : snapshot.response?.displayBody
         }
     }
 }

--- a/Rockxy/Views/Inspector/RawInspectorView.swift
+++ b/Rockxy/Views/Inspector/RawInspectorView.swift
@@ -11,7 +11,7 @@ struct RawInspectorView: View {
     var body: some View {
         let snapshot = InspectorTransactionSnapshot(transaction: transaction)
         AsyncInspectorTextEditor(
-            renderID: "\(snapshot.id.uuidString)-full-raw-\(snapshot.response?.body?.count ?? 0)",
+            renderID: "\(snapshot.id.uuidString)-full-raw-\(snapshot.response?.body?.count ?? 0)-\(snapshot.response?.displayBody?.count ?? 0)",
             highlightContext: highlightContext
         ) {
             var text = InspectorPayloadFormatter.rawRequest(snapshot.request)

--- a/Rockxy/Views/Inspector/ResponseInspectorView.swift
+++ b/Rockxy/Views/Inspector/ResponseInspectorView.swift
@@ -349,16 +349,17 @@ struct ResponseInspectorView: View {
 
     @ViewBuilder
     private func responseBodyView(response: HTTPResponseData) -> some View {
+        let snapshot = InspectorResponseSnapshot(response: response)
         if bodyDisplayMode == .raw {
             responseRawView()
-        } else if let body = response.body, !body.isEmpty {
+        } else if let body = responseBody(for: bodyDisplayMode, snapshot: snapshot), !body.isEmpty {
             switch bodyDisplayMode {
             case .tree:
                 JSONTreeView(data: body)
                     .id(transaction.id)
                     .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
             case .json:
-                responseCodeEditor(for: body, response: response)
+                responseCodeEditor(for: body)
             case .raw:
                 responseRawView()
             case .hex:
@@ -382,11 +383,22 @@ struct ResponseInspectorView: View {
         }
     }
 
+    private func responseBody(for mode: ResponseBodyDisplayMode, snapshot: InspectorResponseSnapshot) -> Data? {
+        switch mode {
+        case .hex:
+            snapshot.body
+        case .tree,
+             .json,
+             .raw:
+            snapshot.displayBody
+        }
+    }
+
     @ViewBuilder
     private func responseRawView() -> some View {
         let snapshot = InspectorTransactionSnapshot(transaction: transaction)
         AsyncInspectorTextEditor(
-            renderID: "\(snapshot.id.uuidString)-response-raw-\(snapshot.response?.body?.count ?? 0)",
+            renderID: "\(snapshot.id.uuidString)-response-raw-\(snapshot.response?.body?.count ?? 0)-\(snapshot.response?.displayBody?.count ?? 0)",
             highlightContext: highlightContext
         ) {
             if let text = InspectorPayloadFormatter.rawResponse(snapshot.response) {
@@ -401,7 +413,7 @@ struct ResponseInspectorView: View {
     }
 
     @ViewBuilder
-    private func responseCodeEditor(for body: Data, response _: HTTPResponseData) -> some View {
+    private func responseCodeEditor(for body: Data) -> some View {
         let sortedKeys = sortJSONKeys
         AsyncInspectorTextEditor(
             renderID: "\(transaction.id.uuidString)-response-json-\(sortedKeys)-\(body.count)",
@@ -518,7 +530,10 @@ struct ResponseInspectorView: View {
         }
     }
 
-    private func bodyDisplayText(for body: Data, response _: HTTPResponseData) -> String? {
+    private func bodyDisplayText(for response: HTTPResponseData) -> String? {
+        guard let body = InspectorResponseSnapshot(response: response).displayBody else {
+            return nil
+        }
         if let pretty = prettyJSONString(from: body, sortedKeys: sortJSONKeys)
         {
             return pretty
@@ -550,7 +565,7 @@ struct ResponseInspectorView: View {
             let url = directory
                 .appendingPathComponent(transaction.id.uuidString)
                 .appendingPathExtension(responseBodyFileExtension())
-            let data = bodyDisplayText(for: body, response: response)
+            let data = bodyDisplayText(for: response)
                 .map { Data($0.utf8) } ?? body
             try data.write(to: url, options: .atomic)
             return url
@@ -595,7 +610,7 @@ struct ResponseInspectorView: View {
         {
             return
         }
-        let text = bodyDisplayText(for: body, response: response) ?? SizeFormatter.format(bytes: body.count)
+        let text = bodyDisplayText(for: response) ?? SizeFormatter.format(bytes: body.count)
         NSPasteboard.general.clearContents()
         NSPasteboard.general.setString(text, forType: .string)
     }

--- a/Rockxy/Views/Rules/MapLocalHTTPMessageEditor.swift
+++ b/Rockxy/Views/Rules/MapLocalHTTPMessageEditor.swift
@@ -7,8 +7,9 @@ struct MapLocalHTTPMessageEditor: NSViewRepresentable {
     final class Coordinator: NSObject, NSTextViewDelegate {
         // MARK: Lifecycle
 
-        init(text: Binding<String>) {
+        init(text: Binding<String>, editorSettings: InspectorTextEditorSettings) {
             self.text = text
+            self.editorSettings = editorSettings
         }
 
         deinit {
@@ -18,6 +19,7 @@ struct MapLocalHTTPMessageEditor: NSViewRepresentable {
         // MARK: Internal
 
         var isProgrammaticChange = false
+        var editorSettings: InspectorTextEditorSettings
         var highlightTask: Task<Void, Never>?
 
         func textDidChange(_ notification: Notification) {
@@ -29,12 +31,17 @@ struct MapLocalHTTPMessageEditor: NSViewRepresentable {
             }
             text.wrappedValue = textView.string
             (scrollView.verticalRulerView as? ScriptCodeEditorRulerView)?.invalidateLineNumbers()
-            scheduleHighlight(text: textView.string, in: scrollView)
+            scheduleHighlight(text: textView.string, editorSettings: editorSettings, in: scrollView)
         }
 
         @MainActor
-        func scheduleHighlight(text: String, in scrollView: NSScrollView) {
+        func scheduleHighlight(
+            text: String,
+            editorSettings: InspectorTextEditorSettings,
+            in scrollView: NSScrollView
+        ) {
             highlightTask?.cancel()
+            self.editorSettings = editorSettings
             highlightTask = Task { [weak self, weak scrollView] in
                 let spans = await Task.detached(priority: .utility) {
                     Self.highlightSpans(for: text)
@@ -50,14 +57,14 @@ struct MapLocalHTTPMessageEditor: NSViewRepresentable {
                 }
 
                 let selectedRange = textView.selectedRange()
-                let attributed = Self.baseAttributedString(text)
+                let attributed = Self.baseAttributedString(text, editorSettings: editorSettings)
                 for span in spans where NSMaxRange(span.range) <= attributed.length {
                     attributed.addAttribute(.foregroundColor, value: span.role.color, range: span.range)
                 }
                 isProgrammaticChange = true
                 textView.textStorage?.setAttributedString(attributed)
                 textView.setSelectedRange(Self.clamped(range: selectedRange, length: attributed.length))
-                textView.typingAttributes = Self.typingAttributes
+                textView.typingAttributes = Self.typingAttributes(editorSettings: editorSettings)
                 isProgrammaticChange = false
                 (scrollView.verticalRulerView as? ScriptCodeEditorRulerView)?.invalidateLineNumbers()
             }
@@ -76,18 +83,28 @@ struct MapLocalHTTPMessageEditor: NSViewRepresentable {
 
         private var text: Binding<String>
 
-        private static let editorFont = NSFont.monospacedSystemFont(ofSize: 12, weight: .regular)
-
-        private static var typingAttributes: [NSAttributedString.Key: Any] {
+        static func typingAttributes(editorSettings: InspectorTextEditorSettings) -> [NSAttributedString.Key: Any] {
             [
-                .font: editorFont,
+                .font: editorSettings.appKitFont,
                 .foregroundColor: NSColor.textColor,
                 .backgroundColor: NSColor.textBackgroundColor,
+                .paragraphStyle: paragraphStyle(for: editorSettings),
             ]
         }
 
-        private static func baseAttributedString(_ text: String) -> NSMutableAttributedString {
-            NSMutableAttributedString(string: text, attributes: typingAttributes)
+        private static func baseAttributedString(
+            _ text: String,
+            editorSettings: InspectorTextEditorSettings
+        )
+            -> NSMutableAttributedString
+        {
+            NSMutableAttributedString(string: text, attributes: typingAttributes(editorSettings: editorSettings))
+        }
+
+        private static func paragraphStyle(for editorSettings: InspectorTextEditorSettings) -> NSParagraphStyle {
+            let style = NSMutableParagraphStyle()
+            style.defaultTabInterval = editorSettings.tabInterval
+            return style
         }
 
         nonisolated private static func highlightSpans(for text: String) -> [HighlightSpan] {
@@ -178,9 +195,10 @@ struct MapLocalHTTPMessageEditor: NSViewRepresentable {
     }
 
     @Binding var text: String
+    var editorSettings = InspectorTextEditorSettings(useMonospacedFont: true, wordWrap: false)
 
     func makeCoordinator() -> Coordinator {
-        Coordinator(text: $text)
+        Coordinator(text: $text, editorSettings: editorSettings)
     }
 
     func makeNSView(context: Context) -> NSScrollView {
@@ -194,10 +212,22 @@ struct MapLocalHTTPMessageEditor: NSViewRepresentable {
         guard let textView = nsView.documentView as? NSTextView else {
             return
         }
+        let settingsChanged = context.coordinator.editorSettings != editorSettings
         if textView.string != text {
             let selectedRange = textView.selectedRange()
+            let visibleOrigin = nsView.contentView.bounds.origin
             apply(text, to: nsView, coordinator: context.coordinator)
             textView.setSelectedRange(Coordinator.clamped(range: selectedRange, length: (text as NSString).length))
+            nsView.contentView.scroll(to: visibleOrigin)
+            nsView.reflectScrolledClipView(nsView.contentView)
+        } else if settingsChanged {
+            let selectedRange = textView.selectedRange()
+            let visibleOrigin = nsView.contentView.bounds.origin
+            applyEditorSettings(to: nsView)
+            context.coordinator.scheduleHighlight(text: text, editorSettings: editorSettings, in: nsView)
+            textView.setSelectedRange(Coordinator.clamped(range: selectedRange, length: (text as NSString).length))
+            nsView.contentView.scroll(to: visibleOrigin)
+            nsView.reflectScrolledClipView(nsView.contentView)
         }
     }
 
@@ -226,7 +256,7 @@ struct MapLocalHTTPMessageEditor: NSViewRepresentable {
         textView.isAutomaticDashSubstitutionEnabled = false
         textView.isAutomaticTextReplacementEnabled = false
         textView.isAutomaticSpellingCorrectionEnabled = false
-        textView.font = .monospacedSystemFont(ofSize: 12, weight: .regular)
+        textView.font = editorSettings.appKitFont
         textView.textColor = .textColor
         textView.backgroundColor = .textBackgroundColor
         textView.textContainerInset = NSSize(width: 8, height: 7)
@@ -243,7 +273,7 @@ struct MapLocalHTTPMessageEditor: NSViewRepresentable {
         textView.delegate = coordinator
 
         let ruler = ScriptCodeEditorRulerView(textView: textView)
-        ruler.ruleThickness = 46
+        ruler.applyEditorSettings(editorSettings)
         scrollView.verticalRulerView = ruler
         scrollView.hasVerticalRuler = true
         scrollView.rulersVisible = true
@@ -255,11 +285,22 @@ struct MapLocalHTTPMessageEditor: NSViewRepresentable {
         }
         coordinator.isProgrammaticChange = true
         textView.string = text
-        textView.font = .monospacedSystemFont(ofSize: 12, weight: .regular)
+        textView.font = editorSettings.appKitFont
         textView.textColor = .textColor
         textView.backgroundColor = .textBackgroundColor
         coordinator.isProgrammaticChange = false
-        coordinator.scheduleHighlight(text: text, in: scrollView)
+        applyEditorSettings(to: scrollView)
+        coordinator.scheduleHighlight(text: text, editorSettings: editorSettings, in: scrollView)
         (scrollView.verticalRulerView as? ScriptCodeEditorRulerView)?.invalidateLineNumbers()
+    }
+
+    private func applyEditorSettings(to scrollView: NSScrollView) {
+        guard let textView = scrollView.documentView as? NSTextView else {
+            return
+        }
+        textView.font = editorSettings.appKitFont
+        textView.typingAttributes = Coordinator.typingAttributes(editorSettings: editorSettings)
+        textView.textContainerInset = NSSize(width: 8, height: 7)
+        (scrollView.verticalRulerView as? ScriptCodeEditorRulerView)?.applyEditorSettings(editorSettings)
     }
 }

--- a/Rockxy/Views/Rules/MapLocalWindowView.swift
+++ b/Rockxy/Views/Rules/MapLocalWindowView.swift
@@ -1109,7 +1109,7 @@ struct MapLocalEditorWindowView: View {
                     .foregroundStyle(.secondary)
             }
 
-            MapLocalHTTPMessageEditor(text: $viewModel.httpMessageText)
+            MapLocalHTTPMessageEditor(text: $viewModel.httpMessageText, editorSettings: toolMetrics.codeEditorSettings)
                 .frame(minHeight: 238)
                 .clipped()
                 .overlay(Rectangle().stroke(Color(nsColor: .separatorColor).opacity(0.35)))

--- a/Rockxy/Views/Scripting/ScriptCodeEditor.swift
+++ b/Rockxy/Views/Scripting/ScriptCodeEditor.swift
@@ -3,19 +3,20 @@ import SwiftUI
 
 // MARK: - ScriptCodeEditor
 
-/// NSTextView-backed code editor with a line-number ruler. Monospaced 13pt,
-/// find-bar enabled, automatic substitutions disabled so JS syntax characters
-/// aren't mangled. Used by `ScriptEditorWindowView`.
+/// NSTextView-backed code editor with a line-number ruler, find-bar support,
+/// and disabled substitutions so JS syntax characters are not mangled.
 struct ScriptCodeEditor: NSViewRepresentable {
     final class Coordinator: NSObject, NSTextViewDelegate {
         // MARK: Lifecycle
 
-        init(text: Binding<String>) {
+        init(text: Binding<String>, editorSettings: InspectorTextEditorSettings) {
             self.text = text
+            self.editorSettings = editorSettings
         }
 
         // MARK: Internal
 
+        var editorSettings: InspectorTextEditorSettings
         var highlightTask: Task<Void, Never>?
 
         deinit {
@@ -28,13 +29,18 @@ struct ScriptCodeEditor: NSViewRepresentable {
             }
             text.wrappedValue = textView.string
             if let scrollView = textView.enclosingScrollView {
-                scheduleHighlight(text: textView.string, in: scrollView)
+                scheduleHighlight(text: textView.string, editorSettings: editorSettings, in: scrollView)
             }
         }
 
         @MainActor
-        func scheduleHighlight(text: String, in scrollView: NSScrollView) {
+        func scheduleHighlight(
+            text: String,
+            editorSettings: InspectorTextEditorSettings,
+            in scrollView: NSScrollView
+        ) {
             highlightTask?.cancel()
+            self.editorSettings = editorSettings
 
             highlightTask = Task { [weak scrollView] in
                 let spans = await Task.detached(priority: .utility) {
@@ -50,11 +56,15 @@ struct ScriptCodeEditor: NSViewRepresentable {
                 }
 
                 let selectedRange = textView.selectedRange()
-                let highlighted = ScriptCodeHighlighting.highlightedString(text, spans: spans)
+                let highlighted = ScriptCodeHighlighting.highlightedString(
+                    text,
+                    spans: spans,
+                    editorSettings: editorSettings
+                )
                 textView.undoManager?.disableUndoRegistration()
                 textView.textStorage?.setAttributedString(highlighted)
                 textView.undoManager?.enableUndoRegistration()
-                textView.typingAttributes = ScriptCodeHighlighting.baseAttributes
+                textView.typingAttributes = ScriptCodeHighlighting.baseAttributes(editorSettings: editorSettings)
                 textView.setSelectedRange(ScriptCodeEditorRulerLayout.clamped(
                     range: selectedRange,
                     length: highlighted.length
@@ -69,6 +79,7 @@ struct ScriptCodeEditor: NSViewRepresentable {
     }
 
     @Binding var text: String
+    var editorSettings = InspectorTextEditorSettings(useMonospacedFont: true, wordWrap: false)
 
     func makeNSView(context: Context) -> NSScrollView {
         let scrollView = NSScrollView()
@@ -92,7 +103,7 @@ struct ScriptCodeEditor: NSViewRepresentable {
         textView.isAutomaticDashSubstitutionEnabled = false
         textView.isAutomaticTextReplacementEnabled = false
         textView.isAutomaticSpellingCorrectionEnabled = false
-        textView.font = ScriptCodeHighlighting.font
+        textView.font = editorSettings.appKitFont
         textView.textColor = .textColor
         textView.backgroundColor = .textBackgroundColor
         textView.textContainerInset = NSSize(width: 8, height: 6)
@@ -111,7 +122,7 @@ struct ScriptCodeEditor: NSViewRepresentable {
             height: CGFloat.greatestFiniteMagnitude
         )
         textView.textContainer?.widthTracksTextView = false
-        textView.typingAttributes = ScriptCodeHighlighting.baseAttributes
+        textView.typingAttributes = ScriptCodeHighlighting.baseAttributes(editorSettings: editorSettings)
         textView.delegate = context.coordinator
         scrollView.drawsBackground = true
         scrollView.backgroundColor = .textBackgroundColor
@@ -121,12 +132,14 @@ struct ScriptCodeEditor: NSViewRepresentable {
         scrollView.documentView = textView
 
         let ruler = ScriptCodeEditorRulerView(textView: textView)
+        ruler.applyEditorSettings(editorSettings)
         scrollView.verticalRulerView = ruler
         scrollView.hasVerticalRuler = true
         scrollView.rulersVisible = true
 
         textView.string = text
-        context.coordinator.scheduleHighlight(text: text, in: scrollView)
+        applyEditorSettings(to: scrollView)
+        context.coordinator.scheduleHighlight(text: text, editorSettings: editorSettings, in: scrollView)
         return scrollView
     }
 
@@ -134,15 +147,38 @@ struct ScriptCodeEditor: NSViewRepresentable {
         guard let textView = nsView.documentView as? NSTextView else {
             return
         }
+        let settingsChanged = context.coordinator.editorSettings != editorSettings
         if textView.string != text {
             textView.string = text
-            context.coordinator.scheduleHighlight(text: text, in: nsView)
+            applyEditorSettings(to: nsView)
+            context.coordinator.scheduleHighlight(text: text, editorSettings: editorSettings, in: nsView)
             (nsView.verticalRulerView as? ScriptCodeEditorRulerView)?.invalidateLineNumbers()
+        } else if settingsChanged {
+            let selectedRange = textView.selectedRange()
+            let visibleOrigin = nsView.contentView.bounds.origin
+            applyEditorSettings(to: nsView)
+            context.coordinator.scheduleHighlight(text: text, editorSettings: editorSettings, in: nsView)
+            textView.setSelectedRange(ScriptCodeEditorRulerLayout.clamped(
+                range: selectedRange,
+                length: (text as NSString).length
+            ))
+            nsView.contentView.scroll(to: visibleOrigin)
+            nsView.reflectScrolledClipView(nsView.contentView)
         }
     }
 
     func makeCoordinator() -> Coordinator {
-        Coordinator(text: $text)
+        Coordinator(text: $text, editorSettings: editorSettings)
+    }
+
+    private func applyEditorSettings(to scrollView: NSScrollView) {
+        guard let textView = scrollView.documentView as? NSTextView else {
+            return
+        }
+        textView.font = editorSettings.appKitFont
+        textView.typingAttributes = ScriptCodeHighlighting.baseAttributes(editorSettings: editorSettings)
+        textView.textContainerInset = NSSize(width: 8, height: 6)
+        (scrollView.verticalRulerView as? ScriptCodeEditorRulerView)?.applyEditorSettings(editorSettings)
     }
 }
 
@@ -296,24 +332,35 @@ enum ScriptCodeHighlighting {
     }
 
     @MainActor
-    static let font = NSFont.monospacedSystemFont(ofSize: 13, weight: .regular)
-
-    @MainActor
-    static var baseAttributes: [NSAttributedString.Key: Any] {
+    static func baseAttributes(editorSettings: InspectorTextEditorSettings) -> [NSAttributedString.Key: Any] {
         [
-            .font: font,
+            .font: editorSettings.appKitFont,
             .foregroundColor: NSColor.textColor,
             .backgroundColor: NSColor.textBackgroundColor,
+            .paragraphStyle: paragraphStyle(for: editorSettings),
         ]
     }
 
     @MainActor
-    static func highlightedString(_ text: String, spans: [Span]) -> NSMutableAttributedString {
-        let attributed = NSMutableAttributedString(string: text, attributes: baseAttributes)
+    static func highlightedString(
+        _ text: String,
+        spans: [Span],
+        editorSettings: InspectorTextEditorSettings
+    )
+        -> NSMutableAttributedString
+    {
+        let attributed = NSMutableAttributedString(string: text, attributes: baseAttributes(editorSettings: editorSettings))
         for span in spans where NSMaxRange(span.range) <= attributed.length {
             attributed.addAttribute(.foregroundColor, value: span.role.color, range: span.range)
         }
         return attributed
+    }
+
+    @MainActor
+    private static func paragraphStyle(for editorSettings: InspectorTextEditorSettings) -> NSParagraphStyle {
+        let style = NSMutableParagraphStyle()
+        style.defaultTabInterval = editorSettings.tabInterval
+        return style
     }
 
     nonisolated static func spans(for text: String) -> [Span] {
@@ -404,6 +451,13 @@ final class ScriptCodeEditorRulerView: NSRulerView {
 
     // MARK: Internal
 
+    func applyEditorSettings(_ editorSettings: InspectorTextEditorSettings) {
+        lineNumberFont = Self.lineNumberFont(for: editorSettings)
+        ruleThickness = Self.ruleThickness(for: lineNumberFont)
+        needsDisplay = true
+        setNeedsDisplay(bounds)
+    }
+
     override func drawHashMarksAndLabels(in rect: NSRect) {
         let dirtyRect = bounds.intersection(rect)
         NSColor.textBackgroundColor.setFill()
@@ -432,7 +486,7 @@ final class ScriptCodeEditorRulerView: NSRulerView {
         let visibleGlyphRange = layoutManager.glyphRange(forBoundingRect: visibleRect, in: textContainer)
 
         let attrs: [NSAttributedString.Key: Any] = [
-            .font: NSFont.monospacedDigitSystemFont(ofSize: 11, weight: .regular),
+            .font: lineNumberFont,
             .foregroundColor: NSColor.secondaryLabelColor,
         ]
 
@@ -488,6 +542,17 @@ final class ScriptCodeEditorRulerView: NSRulerView {
     // MARK: Private
 
     private weak var textView: NSTextView?
+    private var lineNumberFont = NSFont.monospacedDigitSystemFont(ofSize: 11, weight: .regular)
+
+    private static func lineNumberFont(for editorSettings: InspectorTextEditorSettings) -> NSFont {
+        .monospacedDigitSystemFont(ofSize: max(10, editorSettings.cgFontSize - 2), weight: .regular)
+    }
+
+    private static func ruleThickness(for font: NSFont) -> CGFloat {
+        let sample = "99999" as NSString
+        let width = sample.size(withAttributes: [.font: font]).width
+        return max(40, ceil(width + 12))
+    }
 }
 
 // MARK: - ScriptCodeEditorRulerLayout

--- a/Rockxy/Views/Scripting/ScriptEditorWindowView.swift
+++ b/Rockxy/Views/Scripting/ScriptEditorWindowView.swift
@@ -198,7 +198,7 @@ struct ScriptEditorWindowView: View {
                     .zIndex(1)
                 Divider()
                     .zIndex(1)
-                ScriptCodeEditor(text: $viewModel.code)
+                ScriptCodeEditor(text: $viewModel.code, editorSettings: toolMetrics.codeEditorSettings)
                     .clipped()
                     .zIndex(0)
             }

--- a/RockxyTests/Core/Utilities/BodyDecoderTests.swift
+++ b/RockxyTests/Core/Utilities/BodyDecoderTests.swift
@@ -32,6 +32,17 @@ struct BodyDecoderTests {
         #expect(result == original)
     }
 
+    @Test("Encoding names are normalized before decompression")
+    func encodingNameNormalization() throws {
+        let original = "Encoding names should ignore case and whitespace."
+        let originalData = try #require(original.data(using: .utf8))
+        let compressed = try #require(deflateCompress(originalData))
+
+        let decompressed = BodyDecoder.decode(compressed, encoding: " Deflate ")
+
+        #expect(String(data: decompressed, encoding: .utf8) == original)
+    }
+
     @Test("Deflate decompression restores compressed data")
     func deflateDecompression() throws {
         let original = "This is a test string for deflate compression. Repeated words help compression work better. Test test test."

--- a/RockxyTests/ViewModels/ScriptingViewModelTests.swift
+++ b/RockxyTests/ViewModels/ScriptingViewModelTests.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 @testable import Rockxy
 import Testing
@@ -96,6 +97,16 @@ struct ScriptingViewModelTests {
         #expect(spans.contains { $0.role == .string })
         #expect(spans.contains { $0.role == .comment })
         #expect(spans.contains { $0.role == .punctuation })
+    }
+
+    @Test("Script code highlighting uses supplied editor font size")
+    func scriptCodeHighlightingUsesEditorFontSize() throws {
+        let settings = InspectorTextEditorSettings(fontSize: 20, tabWidth: 4, useMonospacedFont: true)
+        let highlighted = ScriptCodeHighlighting.highlightedString("const value = 1", spans: [], editorSettings: settings)
+        let font = try #require(highlighted.attribute(.font, at: 0, effectiveRange: nil) as? NSFont)
+
+        #expect(font.pointSize == 20)
+        #expect(font.fontDescriptor.symbolicTraits.contains(.monoSpace))
     }
 
     @Test("Method enum round-trips via persistedValue")

--- a/RockxyTests/Views/Inspector/InspectorRoutingTests.swift
+++ b/RockxyTests/Views/Inspector/InspectorRoutingTests.swift
@@ -1,3 +1,4 @@
+import Compression
 import Foundation
 @testable import Rockxy
 import Testing
@@ -35,6 +36,120 @@ struct InspectorRoutingTests {
         let transaction = TestFixtures.makeWebSocketTransaction()
         #expect(transaction.response != nil)
         #expect(transaction.response?.statusCode == 101)
+    }
+
+    @Test("Inspector response snapshot decodes Brotli display body without mutating original bytes")
+    func inspectorResponseSnapshotDecodesBrotliDisplayBody() throws {
+        let html = "<html><body>Example Domain</body></html>"
+        let compressed = try #require(compress(Data(html.utf8), algorithm: COMPRESSION_BROTLI))
+        let response = HTTPResponseData(
+            statusCode: 200,
+            statusMessage: "OK",
+            headers: [
+                HTTPHeader(name: "Content-Type", value: "text/html"),
+                HTTPHeader(name: "Content-Encoding", value: "br"),
+            ],
+            body: compressed,
+            contentType: .html
+        )
+
+        let snapshot = InspectorResponseSnapshot(response: response)
+
+        #expect(snapshot.body == compressed)
+        #expect(String(data: try #require(snapshot.displayBody), encoding: .utf8) == html)
+        #expect(InspectorPayloadFormatter.responseDisplayText(body: try #require(snapshot.displayBody), sortedKeys: false) == html)
+    }
+
+    @Test("Raw response text uses decoded gzip body while preserving headers")
+    func rawResponseTextUsesDecodedGzipBody() throws {
+        let text = "compressed response text"
+        let originalData = Data(text.utf8)
+        let compressed = try #require(compress(originalData, algorithm: COMPRESSION_ZLIB))
+        let gzipData = wrapInGzip(compressed, originalData: originalData)
+        let response = HTTPResponseData(
+            statusCode: 200,
+            statusMessage: "OK",
+            headers: [
+                HTTPHeader(name: "Content-Type", value: "text/plain"),
+                HTTPHeader(name: "Content-Encoding", value: "gzip"),
+            ],
+            body: gzipData,
+            contentType: .text
+        )
+
+        let raw = try #require(InspectorPayloadFormatter.rawResponse(InspectorResponseSnapshot(response: response)))
+
+        #expect(raw.contains("Content-Encoding: gzip"))
+        #expect(raw.contains(text))
+        #expect(InspectorResponseSnapshot(response: response).body == gzipData)
+    }
+
+    @Test("Decoded JSON display body feeds JSON preview rendering")
+    func decodedJSONDisplayBodyFeedsPreviewRendering() throws {
+        let json = #"{"name":"Rockxy","ok":true}"#
+        let compressed = try #require(compress(Data(json.utf8), algorithm: COMPRESSION_BROTLI))
+        let response = HTTPResponseData(
+            statusCode: 200,
+            statusMessage: "OK",
+            headers: [
+                HTTPHeader(name: "Content-Type", value: "application/json"),
+                HTTPHeader(name: "Content-Encoding", value: "br"),
+            ],
+            body: compressed,
+            contentType: .json
+        )
+        let body = try #require(InspectorResponseSnapshot(response: response).displayBody)
+
+        if case let .text(text) = PreviewRenderer.render(body: body, mode: .json) {
+            #expect(text.contains(#""name" : "Rockxy""#))
+        } else {
+            Issue.record("Expected decoded JSON text preview")
+        }
+
+        if case let .json(object) = PreviewRenderer.render(body: body, mode: .jsonTree),
+           let dict = object as? [String: Any] {
+            #expect(dict["name"] as? String == "Rockxy")
+        } else {
+            Issue.record("Expected decoded JSON tree preview")
+        }
+    }
+
+    @Test("Invalid and unsupported response encodings fall back to original body")
+    func unsupportedResponseEncodingsFallBackToOriginalBody() throws {
+        let invalidCompressedBody = Data([0x00, 0x01, 0x02, 0x03])
+        let invalidResponse = HTTPResponseData(
+            statusCode: 200,
+            statusMessage: "OK",
+            headers: [HTTPHeader(name: "Content-Encoding", value: "br")],
+            body: invalidCompressedBody
+        )
+        let unsupportedBody = Data("zstd bytes stay opaque".utf8)
+        let unsupportedResponse = HTTPResponseData(
+            statusCode: 200,
+            statusMessage: "OK",
+            headers: [HTTPHeader(name: "Content-Encoding", value: "zstd")],
+            body: unsupportedBody
+        )
+
+        #expect(InspectorResponseSnapshot(response: invalidResponse).displayBody == invalidCompressedBody)
+        #expect(InspectorResponseSnapshot(response: unsupportedResponse).displayBody == unsupportedBody)
+    }
+
+    @Test("Inspector snapshot preserves original bytes for wire-fidelity renderers")
+    func inspectorSnapshotPreservesOriginalBytesForWireFidelityRenderers() throws {
+        let text = "wire bytes should stay compressed"
+        let compressed = try #require(compress(Data(text.utf8), algorithm: COMPRESSION_BROTLI))
+        let response = HTTPResponseData(
+            statusCode: 200,
+            statusMessage: "OK",
+            headers: [HTTPHeader(name: "Content-Encoding", value: "br")],
+            body: compressed
+        )
+        let snapshot = InspectorResponseSnapshot(response: response)
+
+        #expect(snapshot.body == compressed)
+        #expect(snapshot.displayBody != compressed)
+        #expect(PreviewRenderer.formatHexDump(try #require(snapshot.body)) == PreviewRenderer.formatHexDump(compressed))
     }
 
     @Test("WebSocket transaction preserves HTTP request for upgrade headers")
@@ -211,6 +326,64 @@ struct InspectorRoutingTests {
 
         #expect(prompt?.primaryAction == .installCertificate)
         #expect(prompt?.secondaryAction == nil)
+    }
+
+    // MARK: - Compression Helpers
+
+    private func compress(_ input: Data, algorithm: compression_algorithm) -> Data? {
+        let capacity = max(input.count * 4, 1_024)
+        let destBuffer = UnsafeMutablePointer<UInt8>.allocate(capacity: capacity)
+        defer { destBuffer.deallocate() }
+        let compressedSize = input.withUnsafeBytes { srcPtr -> Int in
+            guard let base = srcPtr.baseAddress else {
+                return 0
+            }
+            return compression_encode_buffer(
+                destBuffer,
+                capacity,
+                base.assumingMemoryBound(to: UInt8.self),
+                input.count,
+                nil,
+                algorithm
+            )
+        }
+        guard compressedSize > 0 else {
+            return nil
+        }
+        return Data(bytes: destBuffer, count: compressedSize)
+    }
+
+    private func wrapInGzip(_ deflatedData: Data, originalData: Data) -> Data {
+        var gzip = Data()
+        gzip.append(contentsOf: [0x1F, 0x8B, 0x08, 0x00])
+        gzip.append(contentsOf: [0x00, 0x00, 0x00, 0x00])
+        gzip.append(contentsOf: [0x00, 0x03])
+        gzip.append(deflatedData)
+
+        var crc: UInt32 = 0
+        originalData.withUnsafeBytes { ptr in
+            crc = Self.crc32(ptr)
+        }
+        withUnsafeBytes(of: crc.littleEndian) { gzip.append(contentsOf: $0) }
+
+        let size = UInt32(originalData.count & 0xFFFF_FFFF)
+        withUnsafeBytes(of: size.littleEndian) { gzip.append(contentsOf: $0) }
+        return gzip
+    }
+
+    private static func crc32(_ buffer: UnsafeRawBufferPointer) -> UInt32 {
+        var crc: UInt32 = 0xFFFF_FFFF
+        for byte in buffer {
+            crc ^= UInt32(byte)
+            for _ in 0 ..< 8 {
+                if crc & 1 != 0 {
+                    crc = (crc >> 1) ^ 0xEDB8_8320
+                } else {
+                    crc >>= 1
+                }
+            }
+        }
+        return crc ^ 0xFFFF_FFFF
     }
 
     @Test("CONNECT tunnel with existing SSL rule shows disable guidance")

--- a/RockxyTests/Views/Inspector/ScriptCodeEditorRulerLayoutTests.swift
+++ b/RockxyTests/Views/Inspector/ScriptCodeEditorRulerLayoutTests.swift
@@ -51,4 +51,16 @@ struct ScriptCodeEditorRulerLayoutTests {
 
         #expect(x == 18)
     }
+
+    @Test("Ruler gutter scales with editor font size")
+    @MainActor
+    func rulerGutterScalesWithEditorFontSize() {
+        let textView = NSTextView()
+        let ruler = ScriptCodeEditorRulerView(textView: textView)
+        let defaultThickness = ruler.ruleThickness
+
+        ruler.applyEditorSettings(InspectorTextEditorSettings(fontSize: 28, useMonospacedFont: true))
+
+        #expect(ruler.ruleThickness > defaultThickness)
+    }
 }

--- a/RockxyTests/Views/ToolWindowReadabilityTests.swift
+++ b/RockxyTests/Views/ToolWindowReadabilityTests.swift
@@ -1,3 +1,4 @@
+import AppKit
 import CoreGraphics
 import Foundation
 @testable import Rockxy
@@ -46,6 +47,20 @@ struct ToolWindowReadabilityTests {
             #expect(metrics.menuWidth(90) >= 90)
             #expect(metrics.fieldWidth(200) >= 200)
         }
+    }
+
+    @Test("Tool window code editor settings follow Appearance font size")
+    func codeEditorSettingsFollowAppearanceFontSize() {
+        var appUI = AppUISettings()
+        appUI.fontSize = 20
+        appUI.tabWidth = 4
+        let metrics = ToolWindowDisplayMetrics(appMetrics: AppUIDisplayMetrics(settings: appUI))
+
+        #expect(metrics.codeEditorSettings.fontSize == 20)
+        #expect(metrics.codeEditorSettings.tabWidth == 4)
+        #expect(metrics.codeEditorSettings.useMonospacedFont == true)
+        #expect(metrics.codeEditorSettings.wordWrap == false)
+        #expect(metrics.codeEditorSettings.appKitFont.pointSize == 20)
     }
 
     @Test("Settings display metrics derive from Appearance font size")

--- a/docs/setup-guides/browsers-and-api-clients.mdx
+++ b/docs/setup-guides/browsers-and-api-clients.mdx
@@ -27,9 +27,13 @@ Firefox is the most common example of a browser that needs extra care.
 
 Check:
 
-- proxy settings inside Firefox,
-- browser-specific certificate behavior,
+- whether you are using Rockxy's prepared Firefox profile or manually editing your normal profile,
+- proxy settings inside Firefox when using manual setup,
+- browser-specific certificate trust behavior,
+- SSL Proxying scope for the domain you want to inspect,
 - and whether you restarted Firefox after trust changes.
+
+If you manually edit your normal Firefox profile, switch it back to **No proxy** when you finish debugging. Rockxy can restore macOS system proxy settings that Rockxy changes, but it cannot automatically revert Firefox profile preferences that you changed manually.
 
 ## Postman and Insomnia
 

--- a/docs/setup-guides/firefox.mdx
+++ b/docs/setup-guides/firefox.mdx
@@ -10,14 +10,127 @@ Firefox is a common case where browser traffic needs app-specific setup instead 
 ## Support in Rockxy
 
 - Manual setup available
-- No automation entry point today
+- Prepared Firefox profile available from Developer Setup
 - Validation-backed setup
 
 ## What Rockxy currently provides
 
 - Firefox proxy settings guidance
+- a prepared Firefox profile with Rockxy proxy preferences scoped to that profile
 - browser authority-store certificate guidance
 - a cURL preflight path before you touch the browser setup
+
+## Recommended workflow
+
+For normal debugging, start with the prepared Firefox profile from Rockxy:
+
+1. Start Rockxy capture.
+2. Open **Tools → Debug My App…**.
+3. Select **Firefox**.
+4. Open **Automatic Setup**.
+5. In **Web Browsers**, choose **Firefox…**.
+6. Click **Open Browser…**.
+7. Open one simple HTTPS page, such as `https://example.com/`.
+
+The prepared profile is launched with Rockxy proxy preferences scoped to that profile. Your normal Firefox profile does not need to be changed back and forth.
+
+Firefox may still require the Rockxy root certificate in its own certificate store. If HTTPS pages fail or Rockxy only shows CONNECT tunnels, complete the certificate steps below.
+
+## Manual Firefox setup
+
+Use this when you want to configure your normal Firefox profile directly.
+
+1. Start Rockxy capture and note the active proxy address in the Rockxy toolbar, for example `127.0.0.1:9090`.
+2. In Firefox, open **Settings → Network Settings**.
+3. Select **Manual proxy configuration**.
+4. Set:
+   - **HTTP Proxy**: `127.0.0.1`
+   - **Port**: the active Rockxy proxy port
+   - enable **Also use this proxy for HTTPS**
+5. Leave **No proxy for** with local addresses such as `localhost`, `127.0.0.1`, and `::1`.
+6. Click **OK**.
+
+After this, Firefox traffic should reach Rockxy. If you only see `CONNECT` rows, the proxy path is working but HTTPS is not yet decrypted.
+
+## Import the Rockxy root CA into Firefox
+
+Firefox can use its own certificate store, so macOS Keychain trust is not always enough.
+
+1. Export or locate the Rockxy root certificate from Rockxy.
+2. In Firefox, open **Settings → Privacy & Security → Certificates**.
+3. Click **View Certificates**.
+4. Open the **Authorities** tab.
+5. Click **Import…** and select the Rockxy root certificate.
+6. Enable **Trust this CA to identify websites**.
+7. Confirm the dialog and restart Firefox.
+
+If the Rockxy certificate already appears under **Authorities**, select it and use **Edit Trust…** to confirm **Trust this CA to identify websites** is enabled.
+
+## Enable HTTPS inspection for a domain
+
+Seeing a successful `CONNECT` request is normal for HTTPS proxying. It means Firefox created a tunnel to the target host.
+
+To inspect the real HTTPS requests inside that tunnel:
+
+1. In Rockxy, open **Tools → SSL Proxying List…**.
+2. Make sure **Enable SSL Proxying Tool** is on.
+3. Add the domain you want to inspect to the **Include List**, for example `example.com`.
+4. Reload the page in Firefox.
+5. Select the decrypted `GET`, `POST`, or other HTTP row in Rockxy, not only the `CONNECT` row.
+
+For broad temporary testing, you can add `*` to the Include List, but for day-to-day debugging it is better to allow only the domain you are working on. That keeps the request list cleaner and avoids decrypting unrelated background traffic.
+
+## Expected results
+
+For a test page such as `https://example.com/`, a working setup usually shows:
+
+- an initial `CONNECT example.com:443` row,
+- then one or more decrypted HTTPS rows such as `GET https://example.com/`,
+- readable request headers,
+- readable response headers and body when the response is text, HTML, JSON, XML, or another supported text format.
+
+Some response bodies are compressed by the server with `Content-Encoding` such as `gzip`, `deflate`, or `br`. Rockxy keeps the original captured bytes for wire-level views and export, while readable inspector views decode supported encodings for display.
+
+This means:
+
+- **Body**, **Raw**, **JSON**, **Tree**, and HTML/text preview views should show readable content when decoding succeeds.
+- **Hex** and exported response-body files preserve the original captured bytes.
+- Unsupported encodings may still appear as binary until Rockxy supports that encoding.
+
+## Manual proxy cleanup
+
+If you manually set `HTTP Proxy: 127.0.0.1` in your normal Firefox profile, Firefox stores that setting inside the browser profile. Rockxy can restore macOS system proxy settings that Rockxy changes, but it cannot automatically revert a manual Firefox preference after you quit Rockxy.
+
+When you finish a manual Firefox debugging session, change Firefox back to **No proxy** if you want that profile to browse normally without Rockxy running.
+
+For a scoped workflow, use Rockxy's Developer Setup Firefox profile instead. That profile is launched with Rockxy proxy preferences already written for the debugging session, so your normal Firefox profile does not need to be changed back and forth.
+
+## Troubleshooting checklist
+
+### Firefox cannot load pages after Rockxy quits
+
+If you configured your normal Firefox profile manually, switch Firefox back to **No proxy** in **Settings → Network Settings**.
+
+### Rockxy shows CONNECT only
+
+Check these items:
+
+- Firefox is using manual proxy configuration with **Also use this proxy for HTTPS** enabled.
+- The port matches the active Rockxy proxy port.
+- The Rockxy root CA is imported into Firefox **Authorities**.
+- **Trust this CA to identify websites** is enabled.
+- The target domain is enabled in Rockxy's **SSL Proxying List**.
+- Firefox has been restarted after changing certificate trust.
+
+### The request appears, but the body is still binary
+
+Check the selected row first. A `CONNECT` row is only the tunnel handshake and does not contain the decrypted response body. Select the decrypted `GET` or `POST` row instead.
+
+If the selected row is already decrypted, the response may be binary or compressed with an encoding Rockxy does not decode yet. Use **Headers** to check `Content-Type` and `Content-Encoding`, and use **Hex** when you need the original captured bytes.
+
+### Firefox shows certificate warnings
+
+Re-check the Firefox authority store. Firefox may not use the same trust path as macOS Keychain, so the Rockxy root certificate must be trusted inside Firefox itself.
 
 ## Related pages
 


### PR DESCRIPTION
## Summary

- Scale code editors and HTTP message editors with Rockxy Appearance font settings so script, map-local, and breakpoint code input surfaces stay readable.
- Decode supported compressed response bodies for readable inspector views while preserving original captured bytes for Hex and export paths.
- Expand Firefox setup docs with prepared profile guidance, manual proxy cleanup, certificate trust, SSL Proxying, and response-body troubleshooting.

## Root Cause

Issue #119 uncovered two remaining readability/debugging gaps after the initial UI pass:

- Code-input surfaces still used fixed compact AppKit font sizes instead of the shared Appearance metrics.
- Compressed HTTPS responses could be captured correctly but displayed as binary in readable inspector views because the display path did not decode supported `Content-Encoding` values before rendering text/HTML/JSON.

## Validation

```bash
xcodebuild -project Rockxy.xcodeproj -scheme Rockxy -destination 'platform=macOS' test \
  -only-testing:RockxyTests/ToolWindowReadabilityTests \
  -only-testing:RockxyTests/ScriptingViewModelTests \
  -only-testing:RockxyTests/ScriptCodeEditorRulerLayoutTests \
  -only-testing:RockxyTests/InspectorTextEditorSettingsTests \
  -only-testing:RockxyTests/Views/Inspector \
  -only-testing:RockxyTests/Core/Utilities/BodyDecoderTests \
  -only-testing:RockxyTests/Core/Utilities/PreviewRendererTests \
  -quiet
```

```bash
git diff --check
```

Refs #119
