### PR TITLE
Fix launch readiness crash from blocking proxy probes

### DIFF
--- a/Rockxy/Core/Detection/GRPCDetector.swift
+++ b/Rockxy/Core/Detection/GRPCDetector.swift
@@ -1,0 +1,172 @@
+import Foundation
+
+// MARK: - GRPCDetector
+
+nonisolated enum GRPCDetector {
+    // MARK: Internal
+
+    static func isGRPC(transaction: HTTPTransaction) -> Bool {
+        isGRPC(
+            request: transaction.request,
+            response: transaction.response
+        )
+    }
+
+    static func isGRPC(request: HTTPRequestData, response: HTTPResponseData?) -> Bool {
+        if isGRPCContentType(headerValue(named: "content-type", in: request.headers))
+            || isGRPCContentType(headerValue(named: "content-type", in: response?.headers ?? []))
+        {
+            return true
+        }
+
+        let hasGRPCTrailers = headerValue(named: "grpc-status", in: response?.headers ?? []) != nil
+            || headerValue(named: "grpc-message", in: response?.headers ?? []) != nil
+        return hasGRPCTrailers && looksLikeGRPCMethodPath(request.path)
+    }
+
+    static func detect(
+        request: HTTPRequestData,
+        response: HTTPResponseData?,
+        timingInfo: TimingInfo?,
+        measuredDuration: TimeInterval?
+    )
+        -> GRPCInspection?
+    {
+        guard isGRPC(request: request, response: response) else {
+            return nil
+        }
+
+        let method = parseMethodPath(request.path)
+        return GRPCInspection(
+            serviceName: method?.service,
+            methodName: method?.method,
+            fullMethodPath: method?.fullPath ?? request.path,
+            requestContentType: headerValue(named: "content-type", in: request.headers),
+            responseContentType: headerValue(named: "content-type", in: response?.headers ?? []),
+            requestEncoding: headerValue(named: "grpc-encoding", in: request.headers),
+            responseEncoding: headerValue(named: "grpc-encoding", in: response?.headers ?? []),
+            httpStatusCode: response?.statusCode,
+            httpStatusMessage: response?.statusMessage,
+            grpcStatus: headerValue(named: "grpc-status", in: response?.headers ?? []),
+            grpcMessage: headerValue(named: "grpc-message", in: response?.headers ?? []),
+            grpcStatusDetails: headerValue(named: "grpc-status-details-bin", in: response?.headers ?? []),
+            duration: timingInfo?.totalDuration ?? measuredDuration,
+            requestFrames: parseFrames(
+                request.body,
+                direction: .request
+            ),
+            responseFrames: parseFrames(
+                response?.body,
+                direction: .response
+            )
+        )
+    }
+
+    static func parseFrames(_ body: Data?, direction: GRPCMessageDirection) -> [GRPCMessageFrame] {
+        guard let body, !body.isEmpty else {
+            return []
+        }
+
+        var frames: [GRPCMessageFrame] = []
+        var offset = body.startIndex
+        var frameIndex = 1
+
+        while offset < body.endIndex {
+            let remaining = body.distance(from: offset, to: body.endIndex)
+            let frameOffset = body.distance(from: body.startIndex, to: offset)
+            guard remaining >= 5 else {
+                frames.append(GRPCMessageFrame(
+                    id: "\(direction.rawValue)-\(frameIndex)",
+                    direction: direction,
+                    index: frameIndex,
+                    offset: frameOffset,
+                    compressedFlag: nil,
+                    declaredLength: nil,
+                    payload: Data(body[offset ..< body.endIndex]),
+                    status: .incompleteHeader(remainingBytes: remaining),
+                    heuristicTree: nil
+                ))
+                break
+            }
+
+            let compressedFlag = body[offset]
+            let lengthStart = body.index(after: offset)
+            let lengthEnd = body.index(lengthStart, offsetBy: 4)
+            let declaredLength = body[lengthStart ..< lengthEnd].reduce(0) { partial, byte in
+                (partial << 8) | Int(byte)
+            }
+            let payloadStart = lengthEnd
+            let availablePayloadBytes = body.distance(from: payloadStart, to: body.endIndex)
+            let payloadLength = min(declaredLength, availablePayloadBytes)
+            let payloadEnd = body.index(payloadStart, offsetBy: payloadLength)
+            let payload = Data(body[payloadStart ..< payloadEnd])
+
+            let status: GRPCFrameParseStatus
+            if compressedFlag != 0, compressedFlag != 1 {
+                status = .unsupportedCompressionFlag(compressedFlag)
+            } else if availablePayloadBytes < declaredLength {
+                status = .truncatedPayload(expectedBytes: declaredLength, actualBytes: availablePayloadBytes)
+            } else {
+                status = .complete
+            }
+
+            let tree = compressedFlag == 0 && status == .complete
+                ? ProtobufHeuristicDecoder.decode(payload)
+                : nil
+
+            frames.append(GRPCMessageFrame(
+                id: "\(direction.rawValue)-\(frameIndex)",
+                direction: direction,
+                index: frameIndex,
+                offset: frameOffset,
+                compressedFlag: compressedFlag,
+                declaredLength: declaredLength,
+                payload: payload,
+                status: status,
+                heuristicTree: tree
+            ))
+
+            if availablePayloadBytes < declaredLength {
+                break
+            }
+            offset = payloadEnd
+            frameIndex += 1
+        }
+
+        return frames
+    }
+
+    // MARK: Private
+
+    private static func isGRPCContentType(_ rawValue: String?) -> Bool {
+        guard let rawValue else {
+            return false
+        }
+        let mediaType = rawValue
+            .split(separator: ";", maxSplits: 1)
+            .first?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased() ?? rawValue.lowercased()
+        return mediaType == "application/grpc"
+            || mediaType.hasPrefix("application/grpc+")
+            || mediaType == "application/grpc-web"
+            || mediaType.hasPrefix("application/grpc-web+")
+    }
+
+    private static func parseMethodPath(_ path: String) -> (service: String, method: String, fullPath: String)? {
+        let trimmed = path.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        let parts = trimmed.split(separator: "/", maxSplits: 1).map(String.init)
+        guard parts.count == 2, !parts[0].isEmpty, !parts[1].isEmpty else {
+            return nil
+        }
+        return (parts[0], parts[1], "/\(parts[0])/\(parts[1])")
+    }
+
+    private static func looksLikeGRPCMethodPath(_ path: String) -> Bool {
+        parseMethodPath(path) != nil
+    }
+
+    private static func headerValue(named name: String, in headers: [HTTPHeader]) -> String? {
+        headers.first { $0.name.caseInsensitiveCompare(name) == .orderedSame }?.value
+    }
+}

--- a/Rockxy/Core/LogEngine/ProcessLogSource.swift
+++ b/Rockxy/Core/LogEngine/ProcessLogSource.swift
@@ -96,11 +96,13 @@ enum ProcessLogSource {
             }
         }
 
-        let monitorTask = Task {
+        let monitorTask = Task.detached(priority: .utility) {
             process.waitUntilExit()
 
-            stdoutPipe.fileHandleForReading.readabilityHandler = nil
-            stderrPipe.fileHandleForReading.readabilityHandler = nil
+            await MainActor.run {
+                stdoutPipe.fileHandleForReading.readabilityHandler = nil
+                stderrPipe.fileHandleForReading.readabilityHandler = nil
+            }
 
             Self.logger.info("Process \(executablePath) (PID \(pid)) exited with code \(process.terminationStatus)")
         }

--- a/Rockxy/Core/Plugins/ProtobufDecoder/ProtobufDecodedTree.swift
+++ b/Rockxy/Core/Plugins/ProtobufDecoder/ProtobufDecodedTree.swift
@@ -2,13 +2,13 @@ import Foundation
 
 // MARK: - ProtobufDecodedTree
 
-struct ProtobufDecodedTree: Codable, Equatable {
+struct ProtobufDecodedTree: Codable, Equatable, Sendable {
     let fields: [ProtobufDecodedField]
 }
 
 // MARK: - ProtobufDecodedField
 
-struct ProtobufDecodedField: Codable, Equatable, Identifiable {
+struct ProtobufDecodedField: Codable, Equatable, Identifiable, Sendable {
     // MARK: Lifecycle
 
     init(
@@ -36,7 +36,7 @@ struct ProtobufDecodedField: Codable, Equatable, Identifiable {
 
 // MARK: - ProtobufDecodedValue
 
-enum ProtobufDecodedValue: Codable, Equatable {
+enum ProtobufDecodedValue: Codable, Equatable, Sendable {
     case varint(UInt64)
     case fixed64(UInt64)
     case fixed32(UInt32)

--- a/Rockxy/Core/Plugins/ProtobufDecoder/ProtobufWireType.swift
+++ b/Rockxy/Core/Plugins/ProtobufDecoder/ProtobufWireType.swift
@@ -2,7 +2,7 @@ import Foundation
 
 // MARK: - ProtobufWireType
 
-enum ProtobufWireType: Int, Codable, CaseIterable {
+enum ProtobufWireType: Int, Codable, CaseIterable, Sendable {
     case varint = 0
     case fixed64 = 1
     case lengthDelimited = 2

--- a/Rockxy/Core/Services/ReadinessCoordinator.swift
+++ b/Rockxy/Core/Services/ReadinessCoordinator.swift
@@ -251,7 +251,7 @@ final class ReadinessCoordinator {
     func refresh() async {
         await refreshCertState()
         refreshHelperState()
-        refreshProxyMode(isEnabled: SystemProxyManager.shared.isSystemProxyEnabled())
+        refreshProxyMode(isEnabled: await systemProxyEnabledProbe())
         recomputeWarning()
     }
 
@@ -261,7 +261,7 @@ final class ReadinessCoordinator {
         await HelperManager.shared.checkStatus()
         await refreshCertState(performValidation: true)
         refreshHelperState()
-        refreshProxyMode(isEnabled: SystemProxyManager.shared.isSystemProxyEnabled())
+        refreshProxyMode(isEnabled: await systemProxyEnabledProbe())
         recomputeWarning()
         Self.logger.debug("ReadinessCoordinator deep-refreshed all state")
     }
@@ -304,6 +304,18 @@ final class ReadinessCoordinator {
         recomputeWarning()
     }
 
+    #if DEBUG
+    func injectSystemProxyEnabledProbeForTests(_ probe: @escaping () async -> Bool) {
+        systemProxyEnabledProbe = probe
+    }
+
+    func resetSystemProxyEnabledProbeForTests() {
+        systemProxyEnabledProbe = {
+            await SystemProxyManager.shared.isSystemProxyEnabledAsync()
+        }
+    }
+    #endif
+
     // MARK: Private
 
     private static let logger = Logger(subsystem: RockxyIdentity.current.logSubsystem, category: "ReadinessCoordinator")
@@ -317,6 +329,9 @@ final class ReadinessCoordinator {
     private let activationRefreshClock = ContinuousClock()
     private var isActivationRefreshInFlight = false
     private var lastActivationRefreshFinishedAt: ContinuousClock.Instant?
+    private var systemProxyEnabledProbe: () async -> Bool = {
+        await SystemProxyManager.shared.isSystemProxyEnabledAsync()
+    }
 
     // MARK: - State Refresh
 

--- a/Rockxy/Core/TrafficCapture/SystemProxyManager.swift
+++ b/Rockxy/Core/TrafficCapture/SystemProxyManager.swift
@@ -375,7 +375,7 @@ final class SystemProxyManager: @unchecked Sendable {
         NotificationCenter.default.post(name: .systemProxyDidChange, object: nil, userInfo: ["enabled": false])
     }
 
-    func isSystemProxyEnabled() -> Bool {
+    private func isSystemProxyEnabled() -> Bool {
         guard let service = try? detectPrimaryNetworkService() else {
             return false
         }
@@ -394,6 +394,12 @@ final class SystemProxyManager: @unchecked Sendable {
         }
 
         return false
+    }
+
+    func isSystemProxyEnabledAsync() async -> Bool {
+        await Task.detached(priority: .utility) {
+            self.isSystemProxyEnabled()
+        }.value
     }
 
     // MARK: - Bypass Domain Management

--- a/Rockxy/Models/Network/ContentType.swift
+++ b/Rockxy/Models/Network/ContentType.swift
@@ -46,7 +46,14 @@ enum ContentType: String, Sendable {
         if mediaType == "multipart/form-data" {
             return .multipartForm
         }
-        if mediaType == "application/grpc" || mediaType == "application/protobuf" {
+        if mediaType == "application/grpc"
+            || mediaType.hasPrefix("application/grpc+")
+            || mediaType == "application/grpc-web"
+            || mediaType.hasPrefix("application/grpc-web+")
+            || mediaType == "application/protobuf"
+            || mediaType == "application/x-protobuf"
+            || mediaType.hasSuffix("+proto")
+        {
             return .protobuf
         }
         if mediaType.hasPrefix("text/") {

--- a/Rockxy/Models/Network/GRPCInfo.swift
+++ b/Rockxy/Models/Network/GRPCInfo.swift
@@ -1,0 +1,65 @@
+import Foundation
+
+// MARK: - GRPCInspection
+
+/// Derived gRPC inspection model for HTTP transactions. This is intentionally computed
+/// from captured request/response data so first-class inspection does not require a
+/// persistence migration while schema-backed decoding remains an explicit future seam.
+struct GRPCInspection: Equatable, Sendable {
+    let serviceName: String?
+    let methodName: String?
+    let fullMethodPath: String?
+    let requestContentType: String?
+    let responseContentType: String?
+    let requestEncoding: String?
+    let responseEncoding: String?
+    let httpStatusCode: Int?
+    let httpStatusMessage: String?
+    let grpcStatus: String?
+    let grpcMessage: String?
+    let grpcStatusDetails: String?
+    let duration: TimeInterval?
+    let requestFrames: [GRPCMessageFrame]
+    let responseFrames: [GRPCMessageFrame]
+
+    var frames: [GRPCMessageFrame] {
+        requestFrames + responseFrames
+    }
+}
+
+// MARK: - GRPCMessageFrame
+
+struct GRPCMessageFrame: Identifiable, Equatable, Sendable {
+    let id: String
+    let direction: GRPCMessageDirection
+    let index: Int
+    let offset: Int
+    let compressedFlag: UInt8?
+    let declaredLength: Int?
+    let payload: Data
+    let status: GRPCFrameParseStatus
+    let heuristicTree: ProtobufDecodedTree?
+
+    var isCompressed: Bool {
+        guard let compressedFlag else {
+            return false
+        }
+        return compressedFlag != 0
+    }
+}
+
+// MARK: - GRPCMessageDirection
+
+enum GRPCMessageDirection: String, Equatable, Sendable {
+    case request
+    case response
+}
+
+// MARK: - GRPCFrameParseStatus
+
+enum GRPCFrameParseStatus: Equatable, Sendable {
+    case complete
+    case incompleteHeader(remainingBytes: Int)
+    case truncatedPayload(expectedBytes: Int, actualBytes: Int)
+    case unsupportedCompressionFlag(UInt8)
+}

--- a/Rockxy/Models/Network/TimingInfo.swift
+++ b/Rockxy/Models/Network/TimingInfo.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// Breakdown of an HTTP request's timing phases, measured by the proxy pipeline.
 /// Used to render the waterfall chart in the timeline inspector.
-struct TimingInfo {
+struct TimingInfo: Sendable {
     let dnsLookup: TimeInterval
     let tcpConnection: TimeInterval
     let tlsHandshake: TimeInterval

--- a/Rockxy/Models/UI/DeveloperSetupRuntimeTooling.swift
+++ b/Rockxy/Models/UI/DeveloperSetupRuntimeTooling.swift
@@ -92,6 +92,12 @@ enum DeveloperSetupRuntimeTooling {
         }
     }
 
+    static func readinessAsync(for targetID: SetupTarget.ID) async -> SetupRuntimeReadiness {
+        await Task.detached(priority: .utility) {
+            readiness(for: targetID)
+        }.value
+    }
+
     static func javaTool(named name: String) -> URL? {
         let fileManager = FileManager.default
 

--- a/Rockxy/Models/UI/ProtocolFilter.swift
+++ b/Rockxy/Models/UI/ProtocolFilter.swift
@@ -13,6 +13,7 @@ enum ProtocolFilter: String, CaseIterable, Hashable {
     case js
     case css
     case graphql
+    case grpc
     case document
     case media
     case form
@@ -27,7 +28,7 @@ enum ProtocolFilter: String, CaseIterable, Hashable {
     // MARK: Internal
 
     static var contentFilters: [ProtocolFilter] {
-        [.all, .http, .https, .websocket, .json, .xml, .js, .css, .graphql, .document, .media, .form, .font, .other]
+        [.all, .http, .https, .websocket, .json, .xml, .js, .css, .graphql, .grpc, .document, .media, .form, .font, .other]
     }
 
     static var statusFilters: [ProtocolFilter] {
@@ -45,6 +46,7 @@ enum ProtocolFilter: String, CaseIterable, Hashable {
         case .js: "JS"
         case .css: "CSS"
         case .graphql: "GraphQL"
+        case .grpc: "gRPC"
         case .document: "Document"
         case .media: "Media"
         case .form: "Form"
@@ -91,6 +93,8 @@ enum ProtocolFilter: String, CaseIterable, Hashable {
             return contentTypeHeader(for: transaction).contains("css")
         case .graphql:
             return transaction.graphQLInfo != nil
+        case .grpc:
+            return GRPCDetector.isGRPC(transaction: transaction)
         case .document:
             return transaction.response?.contentType == .html
         case .media:
@@ -100,7 +104,7 @@ enum ProtocolFilter: String, CaseIterable, Hashable {
         case .font:
             return isFontContent(for: transaction)
         case .other:
-            let known: Set<ContentType> = [.json, .xml, .html, .image, .form, .multipartForm, .text]
+            let known: Set<ContentType> = [.json, .xml, .html, .image, .form, .multipartForm, .protobuf, .text]
             guard let respType = transaction.response?.contentType else {
                 return true
             }

--- a/Rockxy/RockxyApp.swift
+++ b/Rockxy/RockxyApp.swift
@@ -405,7 +405,7 @@ private struct MainWindowContent: View {
                     let certInstalled = await CertificateManager.shared.isRootCAInstalled()
                     let certTrusted = await CertificateManager.shared.isRootCATrusted()
                     let helperOK = HelperManager.shared.status == .installedCompatible
-                    let proxyOK = SystemProxyManager.shared.isSystemProxyEnabled()
+                    let proxyOK = await SystemProxyManager.shared.isSystemProxyEnabledAsync()
                     if certInstalled, certTrusted, helperOK, proxyOK {
                         onboardingCompletedOnce = true
                     }

--- a/Rockxy/ViewModels/DeveloperSetupViewModel.swift
+++ b/Rockxy/ViewModels/DeveloperSetupViewModel.swift
@@ -296,7 +296,7 @@ final class DeveloperSetupViewModel {
             return
         }
 
-        let runtimeReadiness = DeveloperSetupRuntimeTooling.readiness(for: originalTargetID)
+        let runtimeReadiness = await DeveloperSetupRuntimeTooling.readinessAsync(for: originalTargetID)
         let workflow = currentWorkflow
         let target = selectedTarget
 
@@ -344,7 +344,7 @@ final class DeveloperSetupViewModel {
         }
     }
 
-    func selectTarget(_ target: SetupTarget) {
+    func selectTarget(_ target: SetupTarget) async {
         if selectedTarget.id != target.id, snapshot.verificationState == .waitingForTraffic {
             cancelValidation(markCancelled: true)
         }
@@ -353,10 +353,7 @@ final class DeveloperSetupViewModel {
         selectedTarget = target
         selectedTab = .overview
         selectedSnippetID = defaultSnippetID(for: target.id)
-        let runtimeReadiness = DeveloperSetupRuntimeTooling.readiness(for: target.id)
         snapshot.supportStatus = target.supportStatus
-        snapshot.runtimeReady = runtimeReadiness.isSatisfied
-        snapshot.runtimeStatusNote = runtimeReadiness.note
         snapshot.selectedSnippetID = currentWorkflow.supportsSnippets ? selectedSnippetID : nil
         snapshot.matchedTransactionID = nil
         snapshot.matchedHost = nil
@@ -364,6 +361,15 @@ final class DeveloperSetupViewModel {
         snapshot.matchedPath = nil
         probeSession = nil
         Task { await probeServer.stop() }
+
+        let targetID = target.id
+        let runtimeReadiness = await DeveloperSetupRuntimeTooling.readinessAsync(for: targetID)
+        guard selectedTarget.id == targetID else {
+            return
+        }
+
+        snapshot.runtimeReady = runtimeReadiness.isSatisfied
+        snapshot.runtimeStatusNote = runtimeReadiness.note
         activeIssue = Self.validationIssue(for: target, snapshot: snapshot, workflow: currentWorkflow)
 
         if supportsValidation {

--- a/Rockxy/ViewModels/WelcomeViewModel.swift
+++ b/Rockxy/ViewModels/WelcomeViewModel.swift
@@ -171,6 +171,6 @@ final class WelcomeViewModel {
         certInstalled = readiness.certReadiness != .notGenerated
         certTrusted = readiness.canInterceptHTTPS
         applyHelperState(status: readiness.helperReadiness, signingIssue: readiness.helperSigningIssue)
-        systemProxyEnabled = SystemProxyManager.shared.isSystemProxyEnabled()
+        systemProxyEnabled = readiness.proxyMode != .unavailable
     }
 }

--- a/Rockxy/Views/DeveloperSetup/DeveloperSetupWindowView.swift
+++ b/Rockxy/Views/DeveloperSetup/DeveloperSetupWindowView.swift
@@ -120,8 +120,10 @@ struct DeveloperSetupWindowView: View {
               let target = SetupTarget.target(for: route.targetID) else {
             return
         }
-        viewModel.selectTarget(target)
-        viewModel.selectTab(route.tab)
+        Task { @MainActor in
+            await viewModel.selectTarget(target)
+            viewModel.selectTab(route.tab)
+        }
     }
 
     private var toolbar: some View {
@@ -189,8 +191,10 @@ struct DeveloperSetupWindowView: View {
                     viewModel.isPinned(target)
                 }
             ) { target in
-                viewModel.selectTarget(target)
-                refreshSnapshot()
+                Task { @MainActor in
+                    await viewModel.selectTarget(target)
+                    await viewModel.refreshSnapshot()
+                }
             } onTogglePinned: { target in
                 viewModel.togglePinned(target)
             }

--- a/Rockxy/Views/Inspector/GRPCInspectorView.swift
+++ b/Rockxy/Views/Inspector/GRPCInspectorView.swift
@@ -17,9 +17,9 @@ struct GRPCInspectorView: View {
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
             case .unsupported:
                 InspectorEmptyStateView(
-                    String(localized: "No gRPC Data"),
+                    String(localized: "Empty gRPC Data"),
                     systemImage: "point.3.connected.trianglepath.dotted",
-                    description: String(localized: "This transaction does not look like a gRPC exchange.")
+                    description: String(localized: "This transaction does not include gRPC metadata or length-prefixed messages.")
                 )
             case let .loaded(inspection):
                 inspectorContent(inspection)

--- a/Rockxy/Views/Inspector/GRPCInspectorView.swift
+++ b/Rockxy/Views/Inspector/GRPCInspectorView.swift
@@ -1,0 +1,460 @@
+import SwiftUI
+
+// MARK: - GRPCInspectorView
+
+/// gRPC-specific response inspector tab. It keeps the main inspector layout intact while
+/// surfacing method metadata, frame boundaries, trailers, and honest Protobuf fallback state.
+struct GRPCInspectorView: View {
+    // MARK: Internal
+
+    let transaction: HTTPTransaction
+
+    var body: some View {
+        Group {
+            switch inspectionState {
+            case .loading:
+                ProgressView()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            case .unsupported:
+                InspectorEmptyStateView(
+                    String(localized: "No gRPC Data"),
+                    systemImage: "point.3.connected.trianglepath.dotted",
+                    description: String(localized: "This transaction does not look like a gRPC exchange.")
+                )
+            case let .loaded(inspection):
+                inspectorContent(inspection)
+            }
+        }
+        .task(id: transaction.id) {
+            await loadInspection()
+        }
+    }
+
+    // MARK: Private
+
+    @State private var inspectionState: GRPCInspectionState = .loading
+    @State private var selectedFrameID: String?
+    @Environment(\.appUIDisplayMetrics) private var metrics
+    @Environment(\.openWindow) private var openWindow
+
+    private func inspectorContent(_ inspection: GRPCInspection) -> some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 12) {
+                callSummary(inspection)
+                messageFrames(inspection)
+                frameDetail(inspection)
+                metadataAndTrailers(inspection)
+                descriptorCallout(inspection)
+            }
+            .padding(12)
+            .frame(maxWidth: .infinity, alignment: .topLeading)
+        }
+        .background(Color(nsColor: .textBackgroundColor))
+    }
+
+    private func callSummary(_ inspection: GRPCInspection) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 6) {
+                badge(String(localized: "gRPC"), color: .blue)
+                badge(inspection.requestContentType ?? inspection.responseContentType ?? "application/grpc", color: .secondary)
+                badge(String(localized: "Schema: heuristic fallback"), color: .orange)
+                if let grpcStatus = inspection.grpcStatus {
+                    badge(String(localized: "grpc-status: \(grpcStatus)"), color: grpcStatus == "0" ? .green : .red)
+                }
+                Spacer(minLength: 0)
+            }
+
+            VStack(alignment: .leading, spacing: 3) {
+                Text(String(localized: "Service / method"))
+                    .font(.system(size: metrics.metadataFontSize, weight: .medium))
+                    .foregroundStyle(.secondary)
+                Text(methodTitle(inspection))
+                    .font(.system(size: metrics.primaryFontSize, weight: .semibold, design: .monospaced))
+                    .textSelection(.enabled)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+            }
+
+            HStack(spacing: 8) {
+                metric(String(localized: "HTTP"), value: httpStatusText(inspection), color: .green)
+                metric(String(localized: "Duration"), value: durationText(inspection), color: .primary)
+                metric(String(localized: "Messages"), value: "\(inspection.frames.count)", color: .primary)
+                metric(String(localized: "Payload"), value: SizeFormatter.format(bytes: totalPayloadBytes(inspection)), color: .primary)
+            }
+        }
+        .padding(12)
+        .background(Color(nsColor: .controlBackgroundColor).opacity(0.55))
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+        .overlay {
+            RoundedRectangle(cornerRadius: 8)
+                .stroke(Color(nsColor: .separatorColor), lineWidth: 0.5)
+        }
+    }
+
+    private func messageFrames(_ inspection: GRPCInspection) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 8) {
+                Text(String(localized: "Message Frames"))
+                    .font(.system(size: metrics.primaryFontSize, weight: .semibold))
+                badge(String(localized: "5-byte gRPC prefix visible"), color: .secondary)
+                Spacer(minLength: 0)
+            }
+
+            if inspection.frames.isEmpty {
+                InspectorEmptyStateView(
+                    String(localized: "No Message Frames"),
+                    systemImage: "shippingbox",
+                    description: String(localized: "Headers identify gRPC, but no length-prefixed messages were captured.")
+                )
+                .frame(minHeight: 120)
+            } else {
+                VStack(spacing: 0) {
+                    frameHeaderRow
+                    Divider()
+                    ForEach(inspection.frames) { frame in
+                        frameRow(frame)
+                        if frame.id != inspection.frames.last?.id {
+                            Divider()
+                        }
+                    }
+                }
+                .background(Color(nsColor: .textBackgroundColor))
+                .clipShape(RoundedRectangle(cornerRadius: 6))
+                .overlay {
+                    RoundedRectangle(cornerRadius: 6)
+                        .stroke(Color(nsColor: .separatorColor), lineWidth: 0.5)
+                }
+            }
+        }
+    }
+
+    private var frameHeaderRow: some View {
+        HStack(spacing: 0) {
+            headerCell("#", width: 44)
+            headerCell(String(localized: "Dir"), width: 86)
+            headerCell(String(localized: "Compressed"), width: 102)
+            headerCell(String(localized: "Bytes"), width: 72)
+            headerCell(String(localized: "Decode"), width: nil)
+        }
+        .background(Color(nsColor: .controlBackgroundColor))
+    }
+
+    private func frameRow(_ frame: GRPCMessageFrame) -> some View {
+        Button {
+            selectedFrameID = frame.id
+        } label: {
+            HStack(spacing: 0) {
+                frameCell("\(frame.index)", width: 44)
+                frameCell(frame.direction.displayName, width: 86, color: frame.direction == .request ? .blue : .green)
+                frameCell(frame.isCompressed ? String(localized: "Yes") : String(localized: "No"), width: 102)
+                frameCell(SizeFormatter.format(bytes: frame.payload.count), width: 72)
+                frameCell(decodeStateText(frame), width: nil, color: decodeStateColor(frame))
+            }
+            .contentShape(Rectangle())
+            .background(selectedFrameID == frame.id ? Color.accentColor.opacity(0.12) : Color.clear)
+        }
+        .buttonStyle(.plain)
+    }
+
+    @ViewBuilder
+    private func frameDetail(_ inspection: GRPCInspection) -> some View {
+        let frame = selectedFrame(in: inspection)
+        VStack(alignment: .leading, spacing: 8) {
+            Text(String(localized: "Decoded Payload"))
+                .font(.system(size: metrics.primaryFontSize, weight: .semibold))
+
+            if let frame {
+                HStack(spacing: 6) {
+                    badge(frame.direction.displayName, color: frame.direction == .request ? .blue : .green)
+                    badge(String(localized: "Frame #\(frame.index)"), color: .secondary)
+                    badge(frameStatusText(frame), color: frameStatusColor(frame))
+                    Spacer(minLength: 0)
+                }
+
+                if frame.isCompressed {
+                    InspectorEmptyStateView(
+                        String(localized: "Compressed Message"),
+                        systemImage: "archivebox",
+                        description: String(
+                            localized: "This gRPC message is compressed. Rockxy preserves the frame boundary but does not decode compressed message payloads yet."
+                        )
+                    )
+                    .frame(minHeight: 160)
+                } else if let tree = frame.heuristicTree {
+                    ProtobufTreeView(tree: tree)
+                        .frame(minHeight: 220)
+                        .clipShape(RoundedRectangle(cornerRadius: 6))
+                        .overlay {
+                            RoundedRectangle(cornerRadius: 6)
+                                .stroke(Color(nsColor: .separatorColor), lineWidth: 0.5)
+                        }
+                    Text(String(localized: "Schema needed for field names, message types, and enum labels."))
+                        .font(.system(size: metrics.secondaryFontSize))
+                        .foregroundStyle(.secondary)
+                } else {
+                    InspectorEmptyStateView(
+                        String(localized: "Raw Protobuf Payload"),
+                        systemImage: "doc.binary",
+                        description: String(
+                            localized: "Rockxy captured the gRPC frame, but heuristic Protobuf decoding could not infer a safe tree."
+                        )
+                    )
+                    .frame(minHeight: 160)
+                }
+            } else {
+                InspectorEmptyStateView(
+                    String(localized: "No Frame Selected"),
+                    systemImage: "shippingbox",
+                    description: String(localized: "Select a gRPC message frame to inspect its payload.")
+                )
+                .frame(minHeight: 160)
+            }
+        }
+    }
+
+    private func metadataAndTrailers(_ inspection: GRPCInspection) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(String(localized: "Metadata And Trailers"))
+                .font(.system(size: metrics.primaryFontSize, weight: .semibold))
+
+            VStack(spacing: 0) {
+                metadataRow(String(localized: "grpc-encoding"), value: inspection.responseEncoding ?? inspection.requestEncoding ?? "identity")
+                metadataRow(String(localized: "grpc-status"), value: inspection.grpcStatus ?? String(localized: "Not captured"))
+                metadataRow(String(localized: "grpc-message"), value: inspection.grpcMessage ?? String(localized: "Not captured"))
+                metadataRow(
+                    String(localized: "grpc-status-details-bin"),
+                    value: inspection.grpcStatusDetails ?? String(localized: "Not captured")
+                )
+            }
+            .background(Color(nsColor: .textBackgroundColor))
+            .clipShape(RoundedRectangle(cornerRadius: 6))
+            .overlay {
+                RoundedRectangle(cornerRadius: 6)
+                    .stroke(Color(nsColor: .separatorColor), lineWidth: 0.5)
+            }
+        }
+    }
+
+    private func descriptorCallout(_ inspection: GRPCInspection) -> some View {
+        HStack(spacing: 10) {
+            Image(systemName: "doc.badge.gearshape")
+                .foregroundStyle(.orange)
+            Text(descriptorCopy(inspection))
+                .font(.system(size: metrics.secondaryFontSize, weight: .medium))
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+            Spacer(minLength: 0)
+            Button(String(localized: "Add Descriptor...")) {
+                openWindow(id: "protobufSchemaList")
+            }
+            .controlSize(.small)
+        }
+        .padding(10)
+        .background(Color.orange.opacity(0.10))
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+        .overlay {
+            RoundedRectangle(cornerRadius: 8)
+                .stroke(Color.orange.opacity(0.35), lineWidth: 0.5)
+        }
+    }
+
+    private func loadInspection() async {
+        inspectionState = .loading
+        let request = transaction.request
+        let response = transaction.response
+        let timingInfo = transaction.timingInfo
+        let measuredDuration = transaction.measuredDuration
+        let inspection = await Task.detached {
+            GRPCDetector.detect(
+                request: request,
+                response: response,
+                timingInfo: timingInfo,
+                measuredDuration: measuredDuration
+            )
+        }.value
+
+        guard !Task.isCancelled else {
+            return
+        }
+
+        if let inspection {
+            inspectionState = .loaded(inspection)
+            if !inspection.frames.contains(where: { $0.id == selectedFrameID }) {
+                selectedFrameID = inspection.frames.first?.id
+            }
+        } else {
+            inspectionState = .unsupported
+            selectedFrameID = nil
+        }
+    }
+
+    private func selectedFrame(in inspection: GRPCInspection) -> GRPCMessageFrame? {
+        guard let selectedFrameID else {
+            return inspection.frames.first
+        }
+        return inspection.frames.first { $0.id == selectedFrameID } ?? inspection.frames.first
+    }
+
+    private func badge(_ text: String, color: Color) -> some View {
+        Text(text)
+            .font(.system(size: metrics.badgeFontSize, weight: .semibold))
+            .lineLimit(1)
+            .padding(.horizontal, 7)
+            .padding(.vertical, 3)
+            .background(color.opacity(0.12), in: Capsule())
+            .foregroundStyle(color)
+    }
+
+    private func metric(_ label: String, value: String, color: Color) -> some View {
+        VStack(alignment: .leading, spacing: 3) {
+            Text(label)
+                .font(.system(size: metrics.badgeFontSize, weight: .medium))
+                .foregroundStyle(.tertiary)
+            Text(value)
+                .font(.system(size: metrics.secondaryFontSize, weight: .medium, design: .monospaced))
+                .foregroundStyle(color)
+        }
+        .padding(.horizontal, 9)
+        .padding(.vertical, 7)
+        .background(Color(nsColor: .textBackgroundColor), in: RoundedRectangle(cornerRadius: 6))
+        .overlay {
+            RoundedRectangle(cornerRadius: 6)
+                .stroke(Color(nsColor: .separatorColor), lineWidth: 0.5)
+        }
+    }
+
+    private func headerCell(_ text: String, width: CGFloat?) -> some View {
+        Text(text)
+            .font(.system(size: metrics.metadataFontSize, weight: .semibold))
+            .foregroundStyle(.secondary)
+            .frame(width: width, alignment: .leading)
+            .frame(maxWidth: width == nil ? .infinity : nil, alignment: .leading)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 6)
+    }
+
+    private func frameCell(_ text: String, width: CGFloat?, color: Color = .secondary) -> some View {
+        Text(text)
+            .font(.system(size: metrics.metadataFontSize, design: .monospaced))
+            .foregroundStyle(color)
+            .lineLimit(1)
+            .truncationMode(.middle)
+            .frame(width: width, alignment: .leading)
+            .frame(maxWidth: width == nil ? .infinity : nil, alignment: .leading)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 6)
+    }
+
+    private func metadataRow(_ label: String, value: String) -> some View {
+        HStack(spacing: 0) {
+            Text(label)
+                .font(.system(size: metrics.metadataFontSize, weight: .semibold, design: .monospaced))
+                .foregroundStyle(.secondary)
+                .frame(width: 180, alignment: .leading)
+                .padding(.horizontal, 10)
+                .padding(.vertical, 6)
+            Divider()
+            Text(value)
+                .font(.system(size: metrics.metadataFontSize, design: .monospaced))
+                .textSelection(.enabled)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, 10)
+                .padding(.vertical, 6)
+        }
+    }
+
+    private func methodTitle(_ inspection: GRPCInspection) -> String {
+        if let serviceName = inspection.serviceName, let methodName = inspection.methodName {
+            return "\(serviceName) / \(methodName)"
+        }
+        return inspection.fullMethodPath ?? String(localized: "Unknown gRPC method")
+    }
+
+    private func httpStatusText(_ inspection: GRPCInspection) -> String {
+        guard let code = inspection.httpStatusCode else {
+            return String(localized: "No response")
+        }
+        return "\(code)"
+    }
+
+    private func durationText(_ inspection: GRPCInspection) -> String {
+        guard let duration = inspection.duration else {
+            return String(localized: "Unknown")
+        }
+        return String(format: "%.0f ms", duration * 1_000)
+    }
+
+    private func totalPayloadBytes(_ inspection: GRPCInspection) -> Int {
+        inspection.frames.reduce(0) { $0 + $1.payload.count }
+    }
+
+    private func decodeStateText(_ frame: GRPCMessageFrame) -> String {
+        guard frame.status == .complete else {
+            return frameStatusText(frame)
+        }
+        if frame.isCompressed {
+            return String(localized: "Compressed")
+        }
+        if frame.heuristicTree != nil {
+            return String(localized: "Heuristic tree")
+        }
+        return frameStatusText(frame)
+    }
+
+    private func decodeStateColor(_ frame: GRPCMessageFrame) -> Color {
+        if frame.heuristicTree != nil {
+            return .blue
+        }
+        return frameStatusColor(frame)
+    }
+
+    private func frameStatusText(_ frame: GRPCMessageFrame) -> String {
+        switch frame.status {
+        case .complete:
+            String(localized: "Raw bytes")
+        case let .incompleteHeader(remainingBytes):
+            String(localized: "Incomplete header · \(remainingBytes) bytes")
+        case let .truncatedPayload(expectedBytes, actualBytes):
+            String(localized: "Truncated · \(actualBytes)/\(expectedBytes) bytes")
+        case let .unsupportedCompressionFlag(flag):
+            String(localized: "Unknown compression flag \(flag)")
+        }
+    }
+
+    private func frameStatusColor(_ frame: GRPCMessageFrame) -> Color {
+        switch frame.status {
+        case .complete:
+            frame.isCompressed ? .orange : .secondary
+        case .incompleteHeader,
+             .truncatedPayload,
+             .unsupportedCompressionFlag:
+            .orange
+        }
+    }
+
+    private func descriptorCopy(_ inspection: GRPCInspection) -> String {
+        if let serviceName = inspection.serviceName, let methodName = inspection.methodName {
+            return String(
+                localized: "Add a descriptor to decode \(serviceName).\(methodName) with field names, message types, and enums."
+            )
+        }
+        return String(localized: "Add a descriptor to replace heuristic field numbers with schema-backed names.")
+    }
+}
+
+private enum GRPCInspectionState {
+    case loading
+    case unsupported
+    case loaded(GRPCInspection)
+}
+
+private extension GRPCMessageDirection {
+    var displayName: String {
+        switch self {
+        case .request:
+            String(localized: "Request")
+        case .response:
+            String(localized: "Response")
+        }
+    }
+}

--- a/Rockxy/Views/Inspector/ResponseInspectorView.swift
+++ b/Rockxy/Views/Inspector/ResponseInspectorView.swift
@@ -51,7 +51,7 @@ struct ResponseInspectorView: View {
     @Environment(\.appUIDisplayMetrics) private var metrics
 
     private var hasProtocolTab: Bool {
-        transaction.webSocketConnection != nil || transaction.graphQLInfo != nil || GRPCDetector.isGRPC(transaction: transaction)
+        true
     }
 
     private var httpsPromptModel: HTTPSInspectionPromptModel? {
@@ -148,15 +148,13 @@ struct ResponseInspectorView: View {
             }
         }
 
-        if GRPCDetector.isGRPC(transaction: transaction) {
-            InspectorTabButton(
-                title: "gRPC",
-                isActive: protocolTab == .grpc
-            ) {
-                selectionIntent = .protocolSpecific
-                protocolTab = .grpc
-                selectedPreviewTab = nil
-            }
+        InspectorTabButton(
+            title: "gRPC",
+            isActive: protocolTab == .grpc
+        ) {
+            selectionIntent = .protocolSpecific
+            protocolTab = .grpc
+            selectedPreviewTab = nil
         }
     }
 
@@ -799,7 +797,7 @@ enum ProtocolTabKind {
         case .graphql:
             transaction.graphQLInfo != nil
         case .grpc:
-            GRPCDetector.isGRPC(transaction: transaction)
+            true
         }
     }
 }

--- a/Rockxy/Views/Inspector/ResponseInspectorView.swift
+++ b/Rockxy/Views/Inspector/ResponseInspectorView.swift
@@ -51,7 +51,7 @@ struct ResponseInspectorView: View {
     @Environment(\.appUIDisplayMetrics) private var metrics
 
     private var hasProtocolTab: Bool {
-        true
+        transaction.webSocketConnection != nil || transaction.graphQLInfo != nil
     }
 
     private var httpsPromptModel: HTTPSInspectionPromptModel? {
@@ -97,6 +97,8 @@ struct ResponseInspectorView: View {
                     selectedTab = tab
                 }
             }
+
+            grpcTabButton
 
             if !previewTabStore.responseTabs.isEmpty {
                 Divider()
@@ -147,7 +149,9 @@ struct ResponseInspectorView: View {
                 selectedPreviewTab = nil
             }
         }
+    }
 
+    private var grpcTabButton: some View {
         InspectorTabButton(
             title: "gRPC",
             isActive: protocolTab == .grpc

--- a/Rockxy/Views/Inspector/ResponseInspectorView.swift
+++ b/Rockxy/Views/Inspector/ResponseInspectorView.swift
@@ -8,7 +8,7 @@ import SwiftUI
 /// Right half of the inspector split view. Provides tabbed access to response-side data:
 /// headers, body (with format picker), Set-Cookie headers, auth, and timing breakdown.
 /// Also supports optional body preview tabs from PreviewTabStore.
-/// Conditionally shows protocol-specific tabs (WebSocket, GraphQL) when the selected
+/// Conditionally shows protocol-specific tabs (WebSocket, GraphQL, gRPC) when the selected
 /// transaction has protocol-specific data.
 struct ResponseInspectorView: View {
     // MARK: Internal
@@ -78,6 +78,14 @@ struct ResponseInspectorView: View {
 
     private var inspectorTabBar: some View {
         InspectorTabStrip {
+            if hasProtocolTab {
+                protocolTabButtons
+
+                Divider()
+                    .frame(height: max(14, metrics.controlFontSize + 2))
+                    .padding(.horizontal, 4)
+            }
+
             ForEach(ResponseInspectorTab.allCases, id: \.self) { tab in
                 InspectorTabButton(
                     title: tab.displayName,
@@ -87,45 +95,6 @@ struct ResponseInspectorView: View {
                     protocolTab = nil
                     selectedPreviewTab = nil
                     selectedTab = tab
-                }
-            }
-
-            if hasProtocolTab {
-                Divider()
-                    .frame(height: max(14, metrics.controlFontSize + 2))
-                    .padding(.horizontal, 4)
-
-                if transaction.webSocketConnection != nil {
-                    InspectorTabButton(
-                        title: String(localized: "WebSocket"),
-                        isActive: protocolTab == .websocket
-                    ) {
-                        selectionIntent = .protocolSpecific
-                        protocolTab = .websocket
-                        selectedPreviewTab = nil
-                    }
-                }
-
-                if transaction.graphQLInfo != nil {
-                    InspectorTabButton(
-                        title: String(localized: "GraphQL"),
-                        isActive: protocolTab == .graphql
-                    ) {
-                        selectionIntent = .protocolSpecific
-                        protocolTab = .graphql
-                        selectedPreviewTab = nil
-                    }
-                }
-
-                if GRPCDetector.isGRPC(transaction: transaction) {
-                    InspectorTabButton(
-                        title: "gRPC",
-                        isActive: protocolTab == .grpc
-                    ) {
-                        selectionIntent = .protocolSpecific
-                        protocolTab = .grpc
-                        selectedPreviewTab = nil
-                    }
                 }
             }
 
@@ -153,6 +122,41 @@ struct ResponseInspectorView: View {
             previewTabMenuButton
         } trailingContent: {
             inspectorTrailingControls
+        }
+    }
+
+    @ViewBuilder private var protocolTabButtons: some View {
+        if transaction.webSocketConnection != nil {
+            InspectorTabButton(
+                title: String(localized: "WebSocket"),
+                isActive: protocolTab == .websocket
+            ) {
+                selectionIntent = .protocolSpecific
+                protocolTab = .websocket
+                selectedPreviewTab = nil
+            }
+        }
+
+        if transaction.graphQLInfo != nil {
+            InspectorTabButton(
+                title: String(localized: "GraphQL"),
+                isActive: protocolTab == .graphql
+            ) {
+                selectionIntent = .protocolSpecific
+                protocolTab = .graphql
+                selectedPreviewTab = nil
+            }
+        }
+
+        if GRPCDetector.isGRPC(transaction: transaction) {
+            InspectorTabButton(
+                title: "gRPC",
+                isActive: protocolTab == .grpc
+            ) {
+                selectionIntent = .protocolSpecific
+                protocolTab = .grpc
+                selectedPreviewTab = nil
+            }
         }
     }
 

--- a/Rockxy/Views/Inspector/ResponseInspectorView.swift
+++ b/Rockxy/Views/Inspector/ResponseInspectorView.swift
@@ -51,7 +51,7 @@ struct ResponseInspectorView: View {
     @Environment(\.appUIDisplayMetrics) private var metrics
 
     private var hasProtocolTab: Bool {
-        transaction.webSocketConnection != nil || transaction.graphQLInfo != nil
+        transaction.webSocketConnection != nil || transaction.graphQLInfo != nil || GRPCDetector.isGRPC(transaction: transaction)
     }
 
     private var httpsPromptModel: HTTPSInspectionPromptModel? {
@@ -113,6 +113,17 @@ struct ResponseInspectorView: View {
                     ) {
                         selectionIntent = .protocolSpecific
                         protocolTab = .graphql
+                        selectedPreviewTab = nil
+                    }
+                }
+
+                if GRPCDetector.isGRPC(transaction: transaction) {
+                    InspectorTabButton(
+                        title: "gRPC",
+                        isActive: protocolTab == .grpc
+                    ) {
+                        selectionIntent = .protocolSpecific
+                        protocolTab = .grpc
                         selectedPreviewTab = nil
                     }
                 }
@@ -291,6 +302,8 @@ struct ResponseInspectorView: View {
                     WebSocketInspectorView(transaction: transaction)
                 case .graphql:
                     GraphQLInspectorView(transaction: transaction)
+                case .grpc:
+                    GRPCInspectorView(transaction: transaction)
                 }
             } else if let previewTab = selectedPreviewTab,
                       previewTabStore.responseTabs.contains(where: { $0.id == previewTab.id })
@@ -757,6 +770,7 @@ struct HTTPSInspectionPromptModel: Equatable {
 enum ProtocolTabKind {
     case websocket
     case graphql
+    case grpc
 
     // MARK: Internal
 
@@ -768,6 +782,9 @@ enum ProtocolTabKind {
         if transaction.graphQLInfo != nil {
             return .graphql
         }
+        if GRPCDetector.isGRPC(transaction: transaction) {
+            return .grpc
+        }
         return nil
     }
 
@@ -777,6 +794,8 @@ enum ProtocolTabKind {
             transaction.webSocketConnection != nil
         case .graphql:
             transaction.graphQLInfo != nil
+        case .grpc:
+            GRPCDetector.isGRPC(transaction: transaction)
         }
     }
 }

--- a/RockxyTests/Core/Detection/DetectionTests.swift
+++ b/RockxyTests/Core/Detection/DetectionTests.swift
@@ -172,10 +172,71 @@ struct DetectionTests {
         #expect(result == .form)
     }
 
+    @Test("ContentTypeDetector detects gRPC and Protobuf media types")
+    func detectGRPCAndProtobuf() {
+        let grpc = [HTTPHeader(name: "Content-Type", value: "application/grpc+proto; charset=utf-8")]
+        let grpcWeb = [HTTPHeader(name: "Content-Type", value: "application/grpc-web+proto")]
+        let protobuf = [HTTPHeader(name: "Content-Type", value: "application/x-protobuf")]
+
+        #expect(ContentTypeDetector.detect(headers: grpc, body: nil) == .protobuf)
+        #expect(ContentTypeDetector.detect(headers: grpcWeb, body: nil) == .protobuf)
+        #expect(ContentTypeDetector.detect(headers: protobuf, body: nil) == .protobuf)
+    }
+
     @Test("ContentTypeDetector returns unknown for unrecognized type")
     func detectUnknown() {
         let headers = [HTTPHeader(name: "Content-Type", value: "application/octet-stream")]
         let result = ContentTypeDetector.detect(headers: headers, body: nil)
         #expect(result == .unknown)
+    }
+
+    // MARK: - GRPCDetector Tests
+
+    @Test("GRPCDetector detects method metadata and unary frames")
+    func detectGRPCUnaryFrames() throws {
+        let transaction = TestFixtures.makeGRPCTransaction()
+
+        let inspection = try #require(GRPCDetector.detect(
+            request: transaction.request,
+            response: transaction.response,
+            timingInfo: transaction.timingInfo,
+            measuredDuration: transaction.measuredDuration
+        ))
+
+        #expect(inspection.serviceName == "user.v1.UserService")
+        #expect(inspection.methodName == "GetProfile")
+        #expect(inspection.grpcStatus == "0")
+        #expect(inspection.requestFrames.count == 1)
+        #expect(inspection.responseFrames.count == 1)
+        #expect(inspection.requestFrames.first?.heuristicTree != nil)
+    }
+
+    @Test("GRPCDetector preserves streaming frame boundaries")
+    func detectGRPCStreamingFrames() throws {
+        let first = TestFixtures.grpcFrame(payload: Data([0x08, 0x01]))
+        let second = TestFixtures.grpcFrame(payload: Data([0x08, 0x02]))
+        let transaction = TestFixtures.makeGRPCTransaction(responseBody: first + second)
+
+        let inspection = try #require(GRPCDetector.detect(
+            request: transaction.request,
+            response: transaction.response,
+            timingInfo: nil,
+            measuredDuration: nil
+        ))
+
+        #expect(inspection.responseFrames.count == 2)
+        #expect(inspection.responseFrames.map(\.index) == [1, 2])
+        #expect(inspection.responseFrames.map(\.payload.count) == [2, 2])
+    }
+
+    @Test("GRPCDetector reports truncated payloads honestly")
+    func detectGRPCTruncatedPayload() throws {
+        let truncated = Data([0x00, 0x00, 0x00, 0x00, 0x04, 0x08])
+        let frames = GRPCDetector.parseFrames(truncated, direction: .response)
+        let frame = try #require(frames.first)
+
+        #expect(frames.count == 1)
+        #expect(frame.status == .truncatedPayload(expectedBytes: 4, actualBytes: 1))
+        #expect(frame.heuristicTree == nil)
     }
 }

--- a/RockxyTests/Core/Services/ReadinessCoordinatorTests.swift
+++ b/RockxyTests/Core/Services/ReadinessCoordinatorTests.swift
@@ -97,6 +97,18 @@ struct ReadinessCoordinatorTests {
         coordinator.setCaptureActive(false)
     }
 
+    @Test("refresh uses async proxy probe for proxy mode")
+    @MainActor
+    func refreshUsesAsyncProxyProbe() async {
+        let coordinator = ReadinessCoordinator.shared
+        coordinator.injectSystemProxyEnabledProbeForTests { true }
+        defer { coordinator.resetSystemProxyEnabledProbeForTests() }
+
+        await coordinator.refresh()
+
+        #expect(coordinator.proxyMode == .direct)
+    }
+
     // MARK: - Derived Capabilities
 
     @Test("canInterceptHTTPS reflects cert readiness")

--- a/RockxyTests/Helpers/TestFixtures.swift
+++ b/RockxyTests/Helpers/TestFixtures.swift
@@ -47,9 +47,12 @@ enum TestFixtures {
     )
         -> HTTPRequestData
     {
-        HTTPRequestData(
+        guard let url = URL(string: url) else {
+            preconditionFailure("Expected valid fixture URL")
+        }
+        return HTTPRequestData(
             method: method,
-            url: URL(string: url)!,
+            url: url,
             httpVersion: "HTTP/1.1",
             headers: headers,
             body: nil
@@ -158,9 +161,12 @@ enum TestFixtures {
             "operationName": operationName as Any
         ]
         let bodyData = try? JSONSerialization.data(withJSONObject: queryBody)
+        guard let url = URL(string: "https://api.example.com/graphql") else {
+            preconditionFailure("Expected valid GraphQL fixture URL")
+        }
         let request = HTTPRequestData(
             method: "POST",
-            url: URL(string: "https://api.example.com/graphql")!,
+            url: url,
             httpVersion: "HTTP/1.1",
             headers: [HTTPHeader(name: "Content-Type", value: "application/json")],
             body: bodyData,
@@ -177,6 +183,50 @@ enum TestFixtures {
         return transaction
     }
 
+    static func makeGRPCTransaction(
+        requestBody: Data? = grpcFrame(payload: Data([0x08, 0x96, 0x01])),
+        responseBody: Data? = grpcFrame(payload: Data([0x12, 0x07]) + Data("Stephen".utf8))
+    )
+        -> HTTPTransaction
+    {
+        guard let url = URL(string: "https://api.example.com/user.v1.UserService/GetProfile") else {
+            preconditionFailure("Expected valid gRPC fixture URL")
+        }
+        let request = HTTPRequestData(
+            method: "POST",
+            url: url,
+            httpVersion: "HTTP/2",
+            headers: [
+                HTTPHeader(name: "Content-Type", value: "application/grpc+proto"),
+                HTTPHeader(name: "TE", value: "trailers"),
+            ],
+            body: requestBody,
+            contentType: .protobuf
+        )
+        let response = HTTPResponseData(
+            statusCode: 200,
+            statusMessage: "OK",
+            headers: [
+                HTTPHeader(name: "Content-Type", value: "application/grpc+proto"),
+                HTTPHeader(name: "grpc-status", value: "0"),
+                HTTPHeader(name: "grpc-message", value: "OK"),
+            ],
+            body: responseBody,
+            contentType: .protobuf
+        )
+        return HTTPTransaction(request: request, response: response, state: .completed)
+    }
+
+    static func grpcFrame(compressedFlag: UInt8 = 0, payload: Data) -> Data {
+        var frame = Data([compressedFlag])
+        let length = UInt32(payload.count).bigEndian
+        withUnsafeBytes(of: length) { bytes in
+            frame.append(contentsOf: bytes)
+        }
+        frame.append(payload)
+        return frame
+    }
+
     static func makeWebSocketTransaction() -> HTTPTransaction {
         let request = makeRequest(url: "wss://ws.example.com/stream")
         let connection = WebSocketConnection(upgradeRequest: request)
@@ -184,7 +234,7 @@ enum TestFixtures {
             let frame = WebSocketFrameData(
                 direction: i % 2 == 0 ? .sent : .received,
                 opcode: .text,
-                payload: "Frame \(i)".data(using: .utf8)!
+                payload: Data("Frame \(i)".utf8)
             )
             connection.addFrame(frame)
         }
@@ -455,7 +505,7 @@ enum TestFixtures {
     @available(
         *,
         deprecated,
-        message: "Writes to real app-support Plugins directory; use createTempPlugin(id:enabled:in:defaults:) with makeIsolatedPluginEnv() or makeIsolatedPluginDir() for isolated tests."
+        message: "Writes to the real app-support Plugins directory; prefer isolated plugin fixtures."
     )
     static func createTempPlugin(id: String, enabled: Bool) throws -> URL {
         try createTempPlugin(
@@ -485,7 +535,10 @@ enum TestFixtures {
     /// with the suite name so callers can clear the persistent domain on teardown.
     static func makeNamedIsolatedDefaults() -> (defaults: UserDefaults, suiteName: String) {
         let suiteName = "RockxyPluginTests-\(UUID().uuidString)"
-        return (UserDefaults(suiteName: suiteName)!, suiteName)
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            preconditionFailure("Expected isolated UserDefaults suite")
+        }
+        return (defaults, suiteName)
     }
 
     /// Creates a fully isolated plugin test environment.

--- a/RockxyTests/Models/UI/ProtocolFilterTests.swift
+++ b/RockxyTests/Models/UI/ProtocolFilterTests.swift
@@ -29,6 +29,13 @@ struct ProtocolFilterTests {
         #expect(ProtocolFilter.websocket.matches(transaction))
     }
 
+    @Test("gRPC filter matches transaction with gRPC metadata")
+    func grpcMatches() {
+        let transaction = TestFixtures.makeGRPCTransaction()
+        #expect(ProtocolFilter.grpc.matches(transaction))
+        #expect(!ProtocolFilter.other.matches(transaction))
+    }
+
     // MARK: - Content Type Matching
 
     @Test("JSON filter matches JSON content type")

--- a/RockxyTests/ViewModels/DeveloperSetupViewModelTests.swift
+++ b/RockxyTests/ViewModels/DeveloperSetupViewModelTests.swift
@@ -184,14 +184,14 @@ struct DeveloperSetupViewModelTests {
     }
 
     @Test("Automation sheet state only opens for supported targets and resets on target change")
-    func automationSheetStateFollowsTargetSupport() {
+    func automationSheetStateFollowsTargetSupport() async {
         let viewModel = DeveloperSetupViewModel(coordinator: MainContentCoordinator())
 
         #expect(viewModel.supportsAutomation == true)
         viewModel.openAutomationSheet()
         #expect(viewModel.showsAutomationSheet == true)
 
-        viewModel.selectTarget(.postman)
+        await viewModel.selectTarget(.postman)
         #expect(viewModel.showsAutomationSheet == false)
         #expect(viewModel.supportsAutomation == false)
 
@@ -214,9 +214,9 @@ struct DeveloperSetupViewModelTests {
     }
 
     @Test("Inspector setup actions keep Manual available when Automatic is not shipped")
-    func inspectorSetupActionsKeepManualAvailableForManualTargets() {
+    func inspectorSetupActionsKeepManualAvailableForManualTargets() async {
         let viewModel = DeveloperSetupViewModel(coordinator: MainContentCoordinator())
-        viewModel.selectTarget(.postman)
+        await viewModel.selectTarget(.postman)
 
         let actions = viewModel.setupModeActions
 
@@ -394,7 +394,7 @@ struct DeveloperSetupViewModelTests {
     }
 
     @Test("Flutter ships hybrid manual snippets, guide content, and validation")
-    func flutterHybridWorkflow() {
+    func flutterHybridWorkflow() async {
         let workflow = DeveloperSetupWorkflowCatalog.workflow(for: .flutter)
         #expect(workflow.snippets.map(\.id) == [
             .flutterDio5,
@@ -407,7 +407,7 @@ struct DeveloperSetupViewModelTests {
         #expect(DeveloperSetupGuideCatalog.content(for: .flutter) != nil)
 
         let viewModel = DeveloperSetupViewModel(coordinator: MainContentCoordinator())
-        viewModel.selectTarget(.flutter)
+        await viewModel.selectTarget(.flutter)
 
         #expect(viewModel.toolbarCopyEnabled)
         #expect(viewModel.toolbarVerifyEnabled)
@@ -419,7 +419,7 @@ struct DeveloperSetupViewModelTests {
     }
 
     @Test("React Native ships hybrid snippets, guide content, and validation")
-    func reactNativeHybridWorkflow() {
+    func reactNativeHybridWorkflow() async {
         let workflow = DeveloperSetupWorkflowCatalog.workflow(for: .reactNative)
         #expect(workflow.snippets.map(\.id) == [
             .reactNativeFetchProbe,
@@ -431,7 +431,7 @@ struct DeveloperSetupViewModelTests {
         #expect(DeveloperSetupGuideCatalog.content(for: .reactNative) != nil)
 
         let viewModel = DeveloperSetupViewModel(coordinator: MainContentCoordinator())
-        viewModel.selectTarget(.reactNative)
+        await viewModel.selectTarget(.reactNative)
 
         #expect(viewModel.toolbarCopyEnabled)
         #expect(viewModel.toolbarVerifyEnabled)

--- a/RockxyTests/Views/Inspector/InspectorRoutingTests.swift
+++ b/RockxyTests/Views/Inspector/InspectorRoutingTests.swift
@@ -196,6 +196,12 @@ struct InspectorRoutingTests {
         #expect(tab == nil)
     }
 
+    @Test("Plain HTTP transaction still supports empty gRPC tab")
+    func httpSupportsEmptyGRPCTab() {
+        let tx = TestFixtures.makeTransaction()
+        #expect(ProtocolTabKind.isSupported(.grpc, by: tx))
+    }
+
     @Test("Switching WS → HTTP clears protocol tab")
     func wsToHttpClearsProtocol() {
         let wsTx = TestFixtures.makeWebSocketTransaction()

--- a/RockxyTests/Views/Inspector/InspectorRoutingTests.swift
+++ b/RockxyTests/Views/Inspector/InspectorRoutingTests.swift
@@ -31,6 +31,12 @@ struct InspectorRoutingTests {
         #expect(transaction.graphQLInfo?.operationType == .query)
     }
 
+    @Test("gRPC transaction is detected from HTTP metadata")
+    func grpcTransactionHasInspectionMetadata() {
+        let transaction = TestFixtures.makeGRPCTransaction()
+        #expect(GRPCDetector.isGRPC(transaction: transaction))
+    }
+
     @Test("WebSocket transaction preserves HTTP response for handshake inspection")
     func webSocketPreservesHTTPResponse() {
         let transaction = TestFixtures.makeWebSocketTransaction()
@@ -175,6 +181,14 @@ struct InspectorRoutingTests {
         #expect(tab == .graphql)
     }
 
+    @Test("gRPC transaction defaults to .grpc protocol tab")
+    func grpcDefaultsToGRPCTab() {
+        let tx = TestFixtures.makeGRPCTransaction()
+        let tab = ProtocolTabKind.defaultFor(tx)
+        #expect(tab == .grpc)
+        #expect(ProtocolTabKind.isSupported(.grpc, by: tx))
+    }
+
     @Test("Plain HTTP transaction defaults to nil protocol tab")
     func httpDefaultsToNilTab() {
         let tx = TestFixtures.makeTransaction()
@@ -234,6 +248,18 @@ struct InspectorRoutingTests {
 
         tab = ProtocolTabKind.defaultFor(gql)
         #expect(tab == .graphql)
+    }
+
+    @Test("Switching GraphQL → gRPC transitions protocol tab correctly")
+    func graphQLToGRPCTransition() {
+        let gql = TestFixtures.makeGraphQLTransaction()
+        let grpc = TestFixtures.makeGRPCTransaction()
+
+        var tab = ProtocolTabKind.defaultFor(gql)
+        #expect(tab == .graphql)
+
+        tab = ProtocolTabKind.defaultFor(grpc)
+        #expect(tab == .grpc)
     }
 
     @Test("Manual switch to nil preserves until next transaction change")


### PR DESCRIPTION
## Summary
- Prevent launch/readiness crashes by moving passive system proxy checks off the main actor.
- Reuse coordinator readiness state in onboarding instead of running duplicate synchronous proxy probes from SwiftUI updates.
- Harden adjacent Developer Setup runtime checks and process log monitoring so child-process waits do not run inline with UI lifecycle work.

## Root Cause
Rockxy could synchronously run `route` and `networksetup` while SwiftUI was applying readiness changes during launch or app activation. That blocked the main thread inside `waitUntilExit`, which could crash on macOS 26.5.1 during the display/update cycle.

## Validation
- `xcodebuild -project Rockxy.xcodeproj -scheme Rockxy -destination 'platform=macOS' test`
- Focused SwiftLint on touched production/readiness files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added gRPC detection and a dedicated inspector tab with message frames, metadata, status, and decoded payload details.
  * Added a new gRPC protocol filter and improved protocol tab selection for gRPC traffic.
  * Expanded content-type recognition to better classify gRPC and protobuf payloads.

* **Bug Fixes**
  * Improved handling of truncated or partially parsed message frames.
  * Made several readiness and setup flows more reliable by using async updates and safer state handling.

* **Tests**
  * Added coverage for gRPC detection, protocol filtering, and routing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->