### PR TITLE
feat: add protocol fixture corpus foundation

### DIFF
--- a/RockxyTests/Core/Detection/ProtocolFixtureCorpusTests.swift
+++ b/RockxyTests/Core/Detection/ProtocolFixtureCorpusTests.swift
@@ -1,0 +1,156 @@
+import Foundation
+import Testing
+
+@Suite("Protocol Fixture Corpus")
+struct ProtocolFixtureCorpusTests {
+    @Test("Fixture IDs are unique and stable")
+    func fixtureIDsAreUniqueAndStable() {
+        let ids = ProtocolFixtureCorpus.fixtures.map(\.id)
+
+        #expect(Set(ids).count == ids.count)
+        #expect(ids.allSatisfy { !$0.contains(" ") })
+        #expect(ids.allSatisfy { $0.contains(".") })
+    }
+
+    @Test("Fixtures satisfy the shared schema contract")
+    func fixturesSatisfySharedSchemaContract() {
+        let failures = ProtocolFixtureCorpus.fixtures.flatMap(ProtocolFixtureValidation.validate)
+
+        #expect(failures.isEmpty, Comment(rawValue: failures.joined(separator: "\n")))
+    }
+
+    @Test("Corpus covers foundation protocol families")
+    func corpusCoversFoundationProtocolFamilies() {
+        let families = Set(ProtocolFixtureCorpus.fixtures.map(\.family))
+
+        #expect(families.isSuperset(of: [.ordinaryHTTP, .ai, .web3RPC, .x402, .unknown]))
+    }
+
+    @Test("Protocol fixtures include UX contract expectations")
+    func protocolFixturesIncludeUXContractExpectations() {
+        for fixture in ProtocolFixtureCorpus.fixtures where fixture.family != .ordinaryHTTP {
+            let ux = fixture.expected.ux
+
+            #expect(!ux.requestListBadges.isEmpty, "\(fixture.id) must declare request-list badge expectations")
+            #expect(!ux.optionalColumns.isEmpty, "\(fixture.id) must declare optional-column expectations")
+            #expect(!ux.inspectorTabs.isEmpty, "\(fixture.id) must declare inspector-tab expectations")
+            #expect(!ux.exportSummaryFields.isEmpty, "\(fixture.id) must declare export-summary expectations")
+            #expect(!ux.mcpSummaryFields.isEmpty, "\(fixture.id) must declare MCP-summary expectations")
+        }
+    }
+
+    @Test("Malformed fixtures declare bounded fallback behavior")
+    func malformedFixturesDeclareFallbackBehavior() {
+        let malformedFixtures = ProtocolFixtureCorpus.fixtures.filter { $0.safetyClass == .malformed }
+
+        #expect(!malformedFixtures.isEmpty)
+        for fixture in malformedFixtures {
+            #expect(fixture.expected.ux.fallbackBehavior != nil, "\(fixture.id) must declare fallback behavior")
+            #expect(fixture.expected.metadataHints.contains("fallback"), "\(fixture.id) must include fallback metadata hint")
+        }
+    }
+
+    @Test("Corpus passes public safety scan")
+    func corpusPassesPublicSafetyScan() {
+        let findings = ProtocolFixtureCorpus.fixtures.flatMap(ProtocolFixtureSafetyScanner.scan)
+
+        #expect(findings.isEmpty, Comment(rawValue: findings.map(formatFinding).joined(separator: "\n")))
+    }
+
+    @Test("Safety scanner catches local paths")
+    func safetyScannerCatchesLocalPaths() {
+        let findings = ProtocolFixtureSafetyScanner.scan(text: #"{"path":"/Users/example/private.json"}"#)
+
+        #expect(findings.contains { $0.reason.contains("local filesystem path") })
+    }
+
+    @Test("Safety scanner catches production-looking tokens")
+    func safetyScannerCatchesProductionLookingTokens() {
+        let findings = ProtocolFixtureSafetyScanner.scan(text: "Authorization: Bearer abcdefghijklmnopqrstuvwxyz123456")
+
+        #expect(findings.contains { $0.reason.contains("bearer token") })
+    }
+
+    @Test("Safety scanner allows synthetic token placeholders")
+    func safetyScannerAllowsSyntheticTokenPlaceholders() {
+        let findings = ProtocolFixtureSafetyScanner.scan(text: "Authorization: Bearer synthetic-ai-token")
+
+        #expect(findings.isEmpty)
+    }
+
+    @Test("Safety scanner catches non-synthetic hosts in messages")
+    func safetyScannerCatchesNonSyntheticHosts() {
+        let fixture = ProtocolFixture(
+            id: "manual.real-host",
+            title: "Manual real host fixture",
+            family: .ordinaryHTTP,
+            scenarioTags: ["manual"],
+            traffic: ProtocolFixtureTraffic(exchanges: [
+                ProtocolFixtureExchange(
+                    request: ProtocolFixtureMessage(method: "GET", url: "https://production.example.net/data")
+                )
+            ]),
+            expected: ProtocolFixtureExpectations(
+                metadataHints: ["manual"],
+                redaction: ProtocolFixtureRedactionExpectation(
+                    sensitiveFields: [],
+                    redactedMarkers: [],
+                    safeFields: []
+                ),
+                ux: ProtocolFixtureUXExpectation(
+                    requestListBadges: ["Manual"],
+                    optionalColumns: ["kind": "manual"],
+                    inspectorTabs: ["Raw"],
+                    warningStates: [],
+                    exportSummaryFields: ["host"],
+                    mcpSummaryFields: ["host"],
+                    fallbackBehavior: nil
+                )
+            ),
+            safetyClass: .ordinary,
+            sizeClass: .small,
+            traceability: ProtocolFixtureTraceability(parentIssue: 176, childIssues: [186], futureIssues: [])
+        )
+
+        let findings = ProtocolFixtureSafetyScanner.scan(fixture)
+
+        #expect(findings.contains { $0.reason.contains("non-synthetic host") })
+    }
+
+    @Test("Safety scanner catches private-key-like material")
+    func safetyScannerCatchesPrivateKeyLikeMaterial() {
+        let findings = ProtocolFixtureSafetyScanner.scan(text: "0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")
+
+        #expect(findings.contains { $0.reason.contains("private-key-like") })
+    }
+
+    @Test("Safety scanner allows example.com email placeholders")
+    func safetyScannerAllowsExampleEmailPlaceholders() {
+        let findings = ProtocolFixtureSafetyScanner.scan(text: "owner@example.com")
+
+        #expect(findings.isEmpty)
+    }
+
+    @Test("Safety scanner catches personal email-like values")
+    func safetyScannerCatchesPersonalEmailLikeValues() {
+        let findings = ProtocolFixtureSafetyScanner.scan(text: "owner@real-company.invalid")
+
+        #expect(findings.contains { $0.reason.contains("personal email-like") })
+    }
+
+    @Test("Fixtures trace back to parent and Group A child issues")
+    func fixturesTraceBackToParentAndGroupAChildIssues() {
+        let requiredChildIssues: Set<Int> = [186, 187, 194, 195]
+        let requiredFutureIssues: Set<Int> = [143, 144, 145, 146, 177, 178, 179, 180]
+
+        for fixture in ProtocolFixtureCorpus.fixtures {
+            #expect(fixture.traceability.parentIssue == 176)
+            #expect(fixture.traceability.childIssues.isSuperset(of: requiredChildIssues))
+            #expect(fixture.traceability.futureIssues.isSuperset(of: requiredFutureIssues))
+        }
+    }
+
+    private func formatFinding(_ finding: ProtocolFixtureSafetyScanner.Finding) -> String {
+        "\(finding.fixtureID): \(finding.reason): \(finding.excerpt)"
+    }
+}

--- a/RockxyTests/Core/Detection/ProtocolFixtureCorpusTests.swift
+++ b/RockxyTests/Core/Detection/ProtocolFixtureCorpusTests.swift
@@ -26,6 +26,62 @@ struct ProtocolFixtureCorpusTests {
         #expect(families.isSuperset(of: [.ordinaryHTTP, .ai, .web3RPC, .x402, .unknown]))
     }
 
+    @Test("AI streaming fixtures cover tool calls, malformed streams, and provider errors")
+    func aiStreamingFixturesCoverRequiredScenarios() {
+        let aiTags = tags(for: .ai)
+
+        #expect(aiTags.isSuperset(of: ["openai", "anthropic", "streaming", "tool-call", "interrupted"]))
+        #expect(aiTags.isSuperset(of: ["provider-error", "no-usage-summary", "malformed"]))
+    }
+
+    @Test("AI retrieval fixtures cover embeddings, vector search, and RAG")
+    func aiRetrievalFixturesCoverRequiredScenarios() {
+        let aiTags = tags(for: .ai)
+
+        #expect(aiTags.isSuperset(of: ["embeddings", "vector-search", "retrieval", "rag", "sensitive-context"]))
+    }
+
+    @Test("EVM JSON-RPC fixtures cover method, batch, error, malformed, and large cases")
+    func evmJSONRPCFixturesCoverRequiredScenarios() {
+        let evmFixtures = fixtures(containing: "evm")
+        let evmTags = Set(evmFixtures.flatMap(\.scenarioTags))
+
+        #expect(evmTags.isSuperset(of: ["estimate-gas", "receipt", "signed-payload"]))
+        #expect(evmTags.isSuperset(of: ["batch", "error", "malformed", "large"]))
+        #expect(evmFixtures.contains { $0.sizeClass == .boundedStress })
+    }
+
+    @Test("Solana fixtures cover HTTP RPC and WebSocket subscription lifecycle")
+    func solanaFixturesCoverRequiredScenarios() {
+        let solanaFixtures = fixtures(containing: "solana")
+        let solanaTags = Set(solanaFixtures.flatMap(\.scenarioTags))
+
+        #expect(solanaTags.isSuperset(of: ["http-rpc", "websocket-rpc", "subscription", "notification", "unsubscribe"]))
+        #expect(solanaTags.isSuperset(of: ["malformed", "long-session"]))
+        #expect(solanaFixtures.contains { !$0.traffic.webSocketMessages.isEmpty })
+    }
+
+    @Test("x402 fixtures cover payment retry, malformed, missing proof, and provider error")
+    func x402FixturesCoverRequiredScenarios() {
+        let x402Tags = tags(for: .x402)
+
+        #expect(x402Tags.isSuperset(of: ["payment-required", "retry", "success"]))
+        #expect(x402Tags.isSuperset(of: ["malformed", "missing-proof", "provider-error", "sensitive-metadata"]))
+    }
+
+    @Test("Hostile fixtures declare bounded parser safety behavior")
+    func hostileFixturesDeclareBoundedParserSafetyBehavior() {
+        let hostileFixtures = fixtures(containing: "hostile")
+        let hostileTags = Set(hostileFixtures.flatMap(\.scenarioTags))
+
+        #expect(hostileTags.isSuperset(of: ["oversized", "deep-nesting", "long-string", "truncated", "partial"]))
+        #expect(hostileTags.contains("malformed-bytes"))
+        for fixture in hostileFixtures {
+            #expect(fixture.expected.ux.fallbackBehavior != nil, "\(fixture.id) must declare bounded fallback behavior")
+            #expect(fixture.traffic.estimatedPayloadBytes <= 32_000, "\(fixture.id) must stay inside the corpus budget")
+        }
+    }
+
     @Test("Protocol fixtures include UX contract expectations")
     func protocolFixturesIncludeUXContractExpectations() {
         for fixture in ProtocolFixtureCorpus.fixtures where fixture.family != .ordinaryHTTP {
@@ -138,6 +194,15 @@ struct ProtocolFixtureCorpusTests {
         #expect(findings.contains { $0.reason.contains("personal email-like") })
     }
 
+    @Test("Safety scanner catches seed phrase-like samples")
+    func safetyScannerCatchesSeedPhraseLikeSamples() {
+        let findings = ProtocolFixtureSafetyScanner.scan(
+            text: "abandon ability able about above absent absorb abstract absurd abuse access accident"
+        )
+
+        #expect(findings.contains { $0.reason.contains("seed phrase-like") })
+    }
+
     @Test("Fixtures trace back to parent and Group A child issues")
     func fixturesTraceBackToParentAndGroupAChildIssues() {
         let requiredChildIssues: Set<Int> = [186, 187, 194, 195]
@@ -150,7 +215,22 @@ struct ProtocolFixtureCorpusTests {
         }
     }
 
+    @Test("Child issues are represented by corpus fixtures")
+    func childIssuesAreRepresentedByCorpusFixtures() {
+        let representedIssues = Set(ProtocolFixtureCorpus.fixtures.flatMap(\.traceability.childIssues))
+
+        #expect(representedIssues.isSuperset(of: [186, 187, 188, 189, 190, 191, 192, 193, 194, 195]))
+    }
+
     private func formatFinding(_ finding: ProtocolFixtureSafetyScanner.Finding) -> String {
         "\(finding.fixtureID): \(finding.reason): \(finding.excerpt)"
+    }
+
+    private func tags(for family: ProtocolFixtureFamily) -> Set<String> {
+        Set(ProtocolFixtureCorpus.fixtures.filter { $0.family == family }.flatMap(\.scenarioTags))
+    }
+
+    private func fixtures(containing tag: String) -> [ProtocolFixture] {
+        ProtocolFixtureCorpus.fixtures.filter { $0.scenarioTags.contains(tag) }
     }
 }

--- a/RockxyTests/Helpers/ProtocolFixtureCorpus+Fixtures.swift
+++ b/RockxyTests/Helpers/ProtocolFixtureCorpus+Fixtures.swift
@@ -1,0 +1,1090 @@
+import Foundation
+
+// MARK: - Corpus Smoke Fixtures
+
+extension ProtocolFixture {
+    static let commonTraceability = ProtocolFixtureTraceability(
+        parentIssue: 176,
+        childIssues: [186, 187, 194, 195],
+        futureIssues: [143, 144, 145, 146, 177, 178, 179, 180]
+    )
+
+    static let httpJSONSmoke = ProtocolFixture(
+        id: "foundation.http-json.redaction-smoke",
+        title: "Ordinary JSON request with synthetic redaction candidate",
+        family: .ordinaryHTTP,
+        scenarioTags: ["http", "json", "redaction-smoke"],
+        traffic: ProtocolFixtureTraffic(exchanges: [
+            ProtocolFixtureExchange(
+                request: ProtocolFixtureMessage(
+                    method: "POST",
+                    url: "https://api.example.com/v1/debug-smoke",
+                    headers: [.init(name: "Content-Type", value: "application/json")],
+                    body: #"{"request_id":"fixture-request","api_key":"synthetic-api-key"}"#
+                ),
+                response: ProtocolFixtureMessage(
+                    method: "HTTP",
+                    url: "https://api.example.com/v1/debug-smoke",
+                    statusCode: 200,
+                    headers: [.init(name: "Content-Type", value: "application/json")],
+                    body: #"{"ok":true,"request_id":"fixture-request"}"#
+                )
+            )
+        ]),
+        expected: ProtocolFixtureExpectations(
+            metadataHints: ["http", "json"],
+            redaction: ProtocolFixtureRedactionExpectation(
+                sensitiveFields: ["api_key"],
+                redactedMarkers: ["[REDACTED]"],
+                safeFields: ["request_id", "ok"]
+            ),
+            ux: ProtocolFixtureUXExpectation(
+                requestListBadges: ["JSON"],
+                optionalColumns: ["content": "JSON"],
+                inspectorTabs: ["Headers", "JSON", "Raw"],
+                warningStates: [],
+                exportSummaryFields: ["method", "host", "status", "redacted_fields"],
+                mcpSummaryFields: ["method", "url", "status", "redacted"],
+                fallbackBehavior: nil
+            )
+        ),
+        safetyClass: .containsSyntheticSensitiveData,
+        sizeClass: .small,
+        traceability: commonTraceability
+    )
+
+    static let aiSSEContractSmoke = ProtocolFixture(
+        id: "foundation.ai-sse.contract-smoke",
+        title: "AI streaming response with synthetic tool call",
+        family: .ai,
+        scenarioTags: ["ai", "sse", "streaming", "tool-call", "contract-smoke"],
+        traffic: ProtocolFixtureTraffic(exchanges: [
+            ProtocolFixtureExchange(
+                request: ProtocolFixtureMessage(
+                    method: "POST",
+                    url: "https://ai.example.com/v1/responses",
+                    headers: [
+                        .init(name: "Content-Type", value: "application/json"),
+                        .init(name: "Authorization", value: "Bearer synthetic-ai-token"),
+                    ],
+                    body: #"{"model":"synthetic-model","input":"[SYNTHETIC_PROMPT]","tool_choice":"auto"}"#
+                ),
+                response: ProtocolFixtureMessage(
+                    method: "HTTP",
+                    url: "https://ai.example.com/v1/responses",
+                    statusCode: 200,
+                    headers: [.init(name: "Content-Type", value: "text/event-stream")],
+                    body: nil
+                ),
+                streamEvents: [
+                    .init(event: "response.created", data: #"{"id":"resp_fixture","model":"synthetic-model"}"#),
+                    .init(event: "response.tool_call.delta", data: #"{"name":"lookup_order","arguments":"{\"order_id\":\"fixture-order\"}"}"#),
+                    .init(event: "response.completed", data: #"{"id":"resp_fixture","status":"completed"}"#),
+                ]
+            )
+        ]),
+        expected: ProtocolFixtureExpectations(
+            metadataHints: ["ai", "streaming", "tool_call", "model_request"],
+            redaction: ProtocolFixtureRedactionExpectation(
+                sensitiveFields: ["Authorization", "input", "tool_choice", "arguments"],
+                redactedMarkers: ["[REDACTED]"],
+                safeFields: ["model", "status"]
+            ),
+            ux: ProtocolFixtureUXExpectation(
+                requestListBadges: ["AI", "Stream"],
+                optionalColumns: ["protocol": "AI", "streaming": "true"],
+                inspectorTabs: ["AI", "Stream", "Tool Calls", "Raw"],
+                warningStates: ["prompt_redaction_candidate", "tool_payload_redaction_candidate"],
+                exportSummaryFields: ["model", "stream_event_count", "tool_call_count", "redacted_fields"],
+                mcpSummaryFields: ["model", "status", "streaming", "redacted"],
+                fallbackBehavior: nil
+            )
+        ),
+        safetyClass: .containsSyntheticSensitiveData,
+        sizeClass: .small,
+        traceability: commonTraceability
+    )
+
+    static let aiAnthropicSSEContractSmoke = ProtocolFixture(
+        id: "ai.anthropic-sse.tool-use-contract",
+        title: "Anthropic-style SSE stream with synthetic tool use",
+        family: .ai,
+        scenarioTags: ["ai", "anthropic", "sse", "streaming", "tool-call", "issue-188"],
+        traffic: ProtocolFixtureTraffic(exchanges: [
+            ProtocolFixtureExchange(
+                request: ProtocolFixtureMessage(
+                    method: "POST",
+                    url: "https://ai.example.com/v1/messages",
+                    headers: [
+                        .init(name: "Content-Type", value: "application/json"),
+                        .init(name: "X-API-Key", value: "synthetic-ai-token"),
+                    ],
+                    body: #"{"model":"synthetic-claude","messages":[{"role":"user","content":"[SYNTHETIC_PROMPT]"}],"tools":[{"name":"lookup_fixture"}]}"#
+                ),
+                response: ProtocolFixtureMessage(
+                    method: "HTTP",
+                    url: "https://ai.example.com/v1/messages",
+                    statusCode: 200,
+                    headers: [.init(name: "Content-Type", value: "text/event-stream")]
+                ),
+                streamEvents: [
+                    .init(event: "message_start", data: #"{"message":{"id":"msg_fixture","model":"synthetic-claude"}}"#),
+                    .init(event: "content_block_start", data: #"{"type":"tool_use","name":"lookup_fixture","input":{}}"#),
+                    .init(event: "content_block_delta", data: #"{"partial_json":"{\"query\":\"synthetic"}}"#),
+                    .init(event: "content_block_delta", data: #"{"partial_json":" context\"}"}"#),
+                    .init(event: "message_stop", data: #"{"stop_reason":"tool_use"}"#),
+                ]
+            )
+        ]),
+        expected: aiStreamingExpectations(
+            hints: ["ai", "streaming", "tool_call", "anthropic_style", "model_request"],
+            fallback: nil
+        ),
+        safetyClass: .containsSyntheticSensitiveData,
+        sizeClass: .small,
+        traceability: issueTraceability([188])
+    )
+
+    static let aiInterruptedToolCallContractSmoke = ProtocolFixture(
+        id: "ai.openai-sse.interrupted-tool-call",
+        title: "OpenAI-style stream with interrupted partial tool arguments",
+        family: .ai,
+        scenarioTags: ["ai", "openai", "sse", "streaming", "tool-call", "interrupted", "malformed", "issue-188"],
+        traffic: ProtocolFixtureTraffic(exchanges: [
+            ProtocolFixtureExchange(
+                request: ProtocolFixtureMessage(
+                    method: "POST",
+                    url: "https://ai.example.com/v1/responses",
+                    headers: [.init(name: "Authorization", value: "Bearer synthetic-ai-token")],
+                    body: #"{"model":"synthetic-model","input":"[SYNTHETIC_PROMPT]","stream":true}"#
+                ),
+                response: ProtocolFixtureMessage(
+                    method: "HTTP",
+                    url: "https://ai.example.com/v1/responses",
+                    statusCode: 200,
+                    headers: [.init(name: "Content-Type", value: "text/event-stream")]
+                ),
+                streamEvents: [
+                    .init(event: "response.tool_call.delta", data: #"{"arguments":"{\"order_id\":\"fixture-""#),
+                    .init(event: nil, data: "not-json-stream-event"),
+                ]
+            )
+        ]),
+        expected: aiStreamingExpectations(
+            hints: ["ai", "streaming", "tool_call", "interrupted", "malformed", "fallback"],
+            fallback: "Show bounded stream fallback and mark partial tool arguments as redaction candidates."
+        ),
+        safetyClass: .malformed,
+        sizeClass: .small,
+        traceability: issueTraceability([188, 193])
+    )
+
+    static let aiProviderErrorNoUsageContractSmoke = ProtocolFixture(
+        id: "ai.provider-error.no-usage-summary",
+        title: "AI provider error stream ending without final usage",
+        family: .ai,
+        scenarioTags: ["ai", "sse", "provider-error", "no-usage-summary", "issue-188"],
+        traffic: ProtocolFixtureTraffic(exchanges: [
+            ProtocolFixtureExchange(
+                request: ProtocolFixtureMessage(
+                    method: "POST",
+                    url: "https://ai.example.com/v1/responses",
+                    headers: [.init(name: "Authorization", value: "Bearer synthetic-ai-token")],
+                    body: #"{"model":"synthetic-model","input":"[SYNTHETIC_PROMPT]","stream":true}"#
+                ),
+                response: ProtocolFixtureMessage(
+                    method: "HTTP",
+                    url: "https://ai.example.com/v1/responses",
+                    statusCode: 429,
+                    headers: [.init(name: "Content-Type", value: "text/event-stream")]
+                ),
+                streamEvents: [
+                    .init(event: "error", data: #"{"type":"rate_limit_error","message":"synthetic provider error"}"#),
+                ]
+            )
+        ]),
+        expected: aiStreamingExpectations(
+            hints: ["ai", "provider_error", "streaming", "missing_usage_summary"],
+            fallback: "Summarize provider error without requiring a final usage chunk."
+        ),
+        safetyClass: .containsSyntheticSensitiveData,
+        sizeClass: .small,
+        traceability: issueTraceability([188])
+    )
+
+    static let aiEmbeddingContractSmoke = ProtocolFixture(
+        id: "ai.embedding.vector-search-contract",
+        title: "Embedding request followed by vector-search response",
+        family: .ai,
+        scenarioTags: ["ai", "embeddings", "vector-search", "retrieval", "issue-189"],
+        traffic: ProtocolFixtureTraffic(exchanges: [
+            ProtocolFixtureExchange(
+                request: ProtocolFixtureMessage(
+                    method: "POST",
+                    url: "https://vector.example.com/v1/embeddings",
+                    headers: [.init(name: "Authorization", value: "Bearer synthetic-vector-token")],
+                    body: #"{"model":"synthetic-embedding-model","input":["synthetic document chunk"]}"#
+                ),
+                response: ProtocolFixtureMessage(
+                    method: "HTTP",
+                    url: "https://vector.example.com/v1/embeddings",
+                    statusCode: 200,
+                    headers: [.init(name: "Content-Type", value: "application/json")],
+                    body: #"{"data":[{"embedding":[0.01,0.02,0.03],"index":0}],"usage":{"total_tokens":3}}"#
+                )
+            ),
+            ProtocolFixtureExchange(
+                request: ProtocolFixtureMessage(
+                    method: "POST",
+                    url: "https://vector.example.com/v1/search",
+                    body: #"{"query_embedding":[0.01,0.02,0.03],"top_k":2,"namespace":"synthetic-space"}"#
+                ),
+                response: ProtocolFixtureMessage(
+                    method: "HTTP",
+                    url: "https://vector.example.com/v1/search",
+                    statusCode: 200,
+                    body: #"{"matches":[{"id":"doc-fixture-1","score":0.91,"snippet":"public synthetic snippet"}]}"#
+                )
+            )
+        ]),
+        expected: aiRetrievalExpectations(
+            hints: ["ai", "embedding", "vector_search", "retrieval"],
+            warnings: ["retrieved_context_redaction_candidate"],
+            fallback: nil
+        ),
+        safetyClass: .containsSyntheticSensitiveData,
+        sizeClass: .small,
+        traceability: issueTraceability([189])
+    )
+
+    static let aiRAGContractSmoke = ProtocolFixture(
+        id: "ai.rag.synthetic-context-contract",
+        title: "RAG flow with public and sensitive synthetic context",
+        family: .ai,
+        scenarioTags: ["ai", "rag", "retrieval", "sensitive-context", "model-call", "issue-189"],
+        traffic: ProtocolFixtureTraffic(exchanges: [
+            ProtocolFixtureExchange(
+                request: ProtocolFixtureMessage(
+                    method: "POST",
+                    url: "https://ai.example.com/v1/responses",
+                    headers: [.init(name: "Authorization", value: "Bearer synthetic-ai-token")],
+                    body: #"""
+                    {
+                      "model": "synthetic-model",
+                      "input": [
+                        {"role": "system", "content": "Use retrieved context"},
+                        {"role": "user", "content": "[SYNTHETIC_PROMPT]"},
+                        {"role": "tool", "content": "public synthetic snippet; fake-account-id fixture-account"}
+                      ]
+                    }
+                    """#
+                ),
+                response: ProtocolFixtureMessage(
+                    method: "HTTP",
+                    url: "https://ai.example.com/v1/responses",
+                    statusCode: 200,
+                    body: #"{"id":"resp_rag_fixture","output_text":"synthetic answer"}"#
+                )
+            )
+        ]),
+        expected: aiRetrievalExpectations(
+            hints: ["ai", "rag", "retrieved_context", "model_request"],
+            warnings: ["retrieved_context_redaction_candidate", "prompt_redaction_candidate"],
+            fallback: nil
+        ),
+        safetyClass: .containsSyntheticSensitiveData,
+        sizeClass: .small,
+        traceability: issueTraceability([189])
+    )
+
+    static let aiMalformedRetrievalContractSmoke = ProtocolFixture(
+        id: "ai.embedding.malformed-vector-payload",
+        title: "Malformed embedding/vector payload with fallback",
+        family: .ai,
+        scenarioTags: ["ai", "embeddings", "vector-search", "malformed", "fallback", "issue-189"],
+        traffic: ProtocolFixtureTraffic(exchanges: [
+            ProtocolFixtureExchange(
+                request: ProtocolFixtureMessage(
+                    method: "POST",
+                    url: "https://vector.example.com/v1/search",
+                    body: #"{"query_embedding":[0.01,"unterminated""#
+                ),
+                response: ProtocolFixtureMessage(
+                    method: "HTTP",
+                    url: "https://vector.example.com/v1/search",
+                    statusCode: 400,
+                    body: #"{"error":"synthetic malformed vector payload"}"#
+                )
+            )
+        ]),
+        expected: aiRetrievalExpectations(
+            hints: ["ai", "embedding", "vector_search", "malformed", "fallback"],
+            warnings: ["malformed_payload"],
+            fallback: "Show raw fallback and omit embedding/vector summary when vector payload parsing fails."
+        ),
+        safetyClass: .malformed,
+        sizeClass: .small,
+        traceability: issueTraceability([189, 193])
+    )
+
+    static let evmJSONRPCContractSmoke = ProtocolFixture(
+        id: "foundation.evm-json-rpc.contract-smoke",
+        title: "EVM JSON-RPC request with synthetic method summary",
+        family: .web3RPC,
+        scenarioTags: ["web3", "evm", "json-rpc", "contract-smoke"],
+        traffic: ProtocolFixtureTraffic(exchanges: [
+            ProtocolFixtureExchange(
+                request: ProtocolFixtureMessage(
+                    method: "POST",
+                    url: "https://rpc.example.com/evm",
+                    headers: [.init(name: "Content-Type", value: "application/json")],
+                    body: #"""
+                    {"jsonrpc":"2.0","id":"fixture-1","method":"eth_call","params":[{"to":"0xSyntheticContract","data":"0xsyntheticCallData"},"latest"]}
+                    """#
+                ),
+                response: ProtocolFixtureMessage(
+                    method: "HTTP",
+                    url: "https://rpc.example.com/evm",
+                    statusCode: 200,
+                    headers: [.init(name: "Content-Type", value: "application/json")],
+                    body: #"{"jsonrpc":"2.0","id":"fixture-1","result":"0xsyntheticResult"}"#
+                )
+            )
+        ]),
+        expected: ProtocolFixtureExpectations(
+            metadataHints: ["web3", "json_rpc", "evm", "eth_call"],
+            redaction: ProtocolFixtureRedactionExpectation(
+                sensitiveFields: ["params.data"],
+                redactedMarkers: ["[REDACTED]"],
+                safeFields: ["jsonrpc", "method", "id"]
+            ),
+            ux: ProtocolFixtureUXExpectation(
+                requestListBadges: ["RPC", "EVM"],
+                optionalColumns: ["rpc_method": "eth_call"],
+                inspectorTabs: ["RPC", "JSON", "Raw"],
+                warningStates: [],
+                exportSummaryFields: ["rpc_method", "chain_hint", "redacted_fields"],
+                mcpSummaryFields: ["rpc_method", "status", "redacted"],
+                fallbackBehavior: nil
+            )
+        ),
+        safetyClass: .containsSyntheticSensitiveData,
+        sizeClass: .small,
+        traceability: commonTraceability
+    )
+
+    static let evmGasReceiptAndSendRawContractSmoke = ProtocolFixture(
+        id: "web3.evm.gas-receipt-sendraw-contract",
+        title: "EVM gas estimate, receipt lookup, and raw transaction-like payload",
+        family: .web3RPC,
+        scenarioTags: ["web3", "evm", "json-rpc", "estimate-gas", "receipt", "signed-payload", "issue-190"],
+        traffic: ProtocolFixtureTraffic(exchanges: [
+            evmExchange(
+                body: #"""
+                {"jsonrpc":"2.0","id":"gas-1","method":"eth_estimateGas","params":[{"to":"0xSyntheticContract","data":"0xsyntheticCallData"}]}
+                """#,
+                response: #"{"jsonrpc":"2.0","id":"gas-1","result":"0x5208"}"#
+            ),
+            evmExchange(
+                body: #"{"jsonrpc":"2.0","id":"receipt-1","method":"eth_getTransactionReceipt","params":["0xsyntheticTransactionHash"]}"#,
+                response: #"{"jsonrpc":"2.0","id":"receipt-1","result":{"status":"0x1","transactionHash":"0xsyntheticTransactionHash"}}"#
+            ),
+            evmExchange(
+                body: #"{"jsonrpc":"2.0","id":"send-1","method":"eth_sendRawTransaction","params":["synthetic-signed-transaction-payload"]}"#,
+                response: #"{"jsonrpc":"2.0","id":"send-1","result":"0xsyntheticBroadcastHash"}"#
+            ),
+        ]),
+        expected: web3Expectations(
+            badges: ["RPC", "EVM"],
+            hints: [
+                "web3",
+                "json_rpc",
+                "evm",
+                "eth_estimateGas",
+                "eth_getTransactionReceipt",
+                "eth_sendRawTransaction",
+            ],
+            redaction: ["params.data", "params.raw_transaction"],
+            warnings: ["signed_payload_redaction_candidate"],
+            fallback: nil
+        ),
+        safetyClass: .containsSyntheticSensitiveData,
+        sizeClass: .small,
+        traceability: issueTraceability([190])
+    )
+
+    static let evmBatchErrorAndLargeContractSmoke = ProtocolFixture(
+        id: "web3.evm.batch-error-large-contract",
+        title: "EVM JSON-RPC batch with mixed success, error, and bounded large sample",
+        family: .web3RPC,
+        scenarioTags: [
+            "web3",
+            "evm",
+            "json-rpc",
+            "batch",
+            "error",
+            "large",
+            "high-volume",
+            "issue-190",
+            "issue-193",
+        ],
+        traffic: ProtocolFixtureTraffic(
+            exchanges: [
+                evmExchange(
+                    body: evmBatchRequest(count: 24),
+                    response: #"""
+                    [
+                      {"jsonrpc":"2.0","id":"batch-0","result":"0x1"},
+                      {"jsonrpc":"2.0","id":"batch-1","error":{"code":-32000,"message":"synthetic execution error"}}
+                    ]
+                    """#
+                ),
+            ],
+            estimatedPayloadBytes: 9_000
+        ),
+        expected: web3Expectations(
+            badges: ["RPC", "Batch"],
+            hints: ["web3", "json_rpc", "evm", "batch", "provider_error", "bounded_large"],
+            redaction: ["params.data"],
+            warnings: ["large_payload", "rpc_error"],
+            fallback: "Keep request-list parsing bounded and summarize batch count without expanding every item."
+        ),
+        safetyClass: .large,
+        sizeClass: .boundedStress,
+        traceability: issueTraceability([190, 193])
+    )
+
+    static let evmMalformedJSONRPCContractSmoke = ProtocolFixture(
+        id: "web3.evm.malformed-json-rpc-contract",
+        title: "Malformed EVM JSON-RPC payload with safe fallback",
+        family: .web3RPC,
+        scenarioTags: ["web3", "evm", "json-rpc", "malformed", "fallback", "issue-190"],
+        traffic: ProtocolFixtureTraffic(exchanges: [
+            evmExchange(
+                body: #"{"jsonrpc":"2.0","id":"bad","method":"eth_call","params":["#,
+                response: #"{"jsonrpc":"2.0","id":"bad","error":{"code":-32700,"message":"synthetic parse error"}}"#
+            ),
+        ]),
+        expected: web3Expectations(
+            badges: ["RPC", "Malformed"],
+            hints: ["web3", "json_rpc", "evm", "malformed", "fallback"],
+            redaction: ["params"],
+            warnings: ["malformed_payload"],
+            fallback: "Show raw fallback without classifying a method when JSON-RPC parsing fails."
+        ),
+        safetyClass: .malformed,
+        sizeClass: .small,
+        traceability: issueTraceability([190, 193])
+    )
+
+    static let solanaHTTPRPCContractSmoke = ProtocolFixture(
+        id: "web3.solana.http-rpc-contract",
+        title: "Solana HTTP JSON-RPC request and response",
+        family: .web3RPC,
+        scenarioTags: ["web3", "solana", "json-rpc", "http-rpc", "issue-191"],
+        traffic: ProtocolFixtureTraffic(exchanges: [
+            ProtocolFixtureExchange(
+                request: ProtocolFixtureMessage(
+                    method: "POST",
+                    url: "https://solana.example.com",
+                    headers: [.init(name: "Content-Type", value: "application/json")],
+                    body: #"""
+                    {"jsonrpc":"2.0","id":"solana-1","method":"getLatestBlockhash","params":[{"commitment":"confirmed"}]}
+                    """#
+                ),
+                response: ProtocolFixtureMessage(
+                    method: "HTTP",
+                    url: "https://solana.example.com",
+                    statusCode: 200,
+                    headers: [.init(name: "Content-Type", value: "application/json")],
+                    body: #"""
+                    {"jsonrpc":"2.0","id":"solana-1","result":{"value":{"blockhash":"synthetic-blockhash","lastValidBlockHeight":123}}}
+                    """#
+                )
+            )
+        ]),
+        expected: web3Expectations(
+            badges: ["RPC", "Solana"],
+            hints: ["web3", "json_rpc", "solana", "getLatestBlockhash"],
+            redaction: [],
+            warnings: [],
+            fallback: nil
+        ),
+        safetyClass: .ordinary,
+        sizeClass: .small,
+        traceability: issueTraceability([191])
+    )
+
+    static let solanaWebSocketSubscriptionContractSmoke = ProtocolFixture(
+        id: "web3.solana.websocket-subscription-contract",
+        title: "Solana WebSocket subscription lifecycle",
+        family: .web3RPC,
+        scenarioTags: [
+            "web3",
+            "solana",
+            "websocket-rpc",
+            "subscription",
+            "notification",
+            "unsubscribe",
+            "issue-191",
+        ],
+        traffic: ProtocolFixtureTraffic(
+            webSocketMessages: [
+                .init(
+                    direction: .clientToServer,
+                    url: "wss://solana.example.com",
+                    body: #"""
+                    {"jsonrpc":"2.0","id":1,"method":"logsSubscribe","params":[{"mentions":["SyntheticAccount111"]}]}
+                    """#
+                ),
+                .init(
+                    direction: .serverToClient,
+                    url: "wss://solana.example.com",
+                    body: #"{"jsonrpc":"2.0","id":1,"result":42}"#
+                ),
+                .init(
+                    direction: .serverToClient,
+                    url: "wss://solana.example.com",
+                    body: #"""
+                    {
+                      "jsonrpc": "2.0",
+                      "method": "logsNotification",
+                      "params": {
+                        "subscription": 42,
+                        "result": {
+                          "value": {
+                            "signature": "synthetic-signature",
+                            "logs": ["Program log: synthetic"]
+                          }
+                        }
+                      }
+                    }
+                    """#
+                ),
+                .init(
+                    direction: .clientToServer,
+                    url: "wss://solana.example.com",
+                    body: #"{"jsonrpc":"2.0","id":2,"method":"logsUnsubscribe","params":[42]}"#
+                ),
+                .init(
+                    direction: .serverToClient,
+                    url: "wss://solana.example.com",
+                    body: #"{"jsonrpc":"2.0","id":2,"result":true}"#
+                ),
+            ]
+        ),
+        expected: web3Expectations(
+            badges: ["RPC", "Solana", "WS"],
+            hints: ["web3", "json_rpc", "solana", "subscription", "notification", "unsubscribe"],
+            redaction: ["params.mentions", "signature"],
+            warnings: ["subscription_lifecycle"],
+            fallback: nil
+        ),
+        safetyClass: .containsSyntheticSensitiveData,
+        sizeClass: .small,
+        traceability: issueTraceability([191])
+    )
+
+    static let solanaLongAndMalformedSubscriptionContractSmoke = ProtocolFixture(
+        id: "web3.solana.long-malformed-subscription",
+        title: "Solana long subscription sample with malformed notification",
+        family: .web3RPC,
+        scenarioTags: [
+            "web3",
+            "solana",
+            "websocket-rpc",
+            "subscription",
+            "malformed",
+            "long-session",
+            "issue-191",
+            "issue-193",
+        ],
+        traffic: ProtocolFixtureTraffic(
+            webSocketMessages: [
+                .init(
+                    direction: .serverToClient,
+                    url: "wss://solana.example.com",
+                    body: solanaNotificationSample(count: 16)
+                ),
+                .init(
+                    direction: .serverToClient,
+                    url: "wss://solana.example.com",
+                    body: #"{"jsonrpc":"2.0","method":"logsNotification","params":"#
+                ),
+                .init(
+                    direction: .serverToClient,
+                    url: "wss://solana.example.com",
+                    body: #"{"jsonrpc":"2.0","method":"logsNotification","error":{"code":-32000,"message":"synthetic subscription error"}}"#
+                ),
+            ],
+            estimatedPayloadBytes: 6_000
+        ),
+        expected: web3Expectations(
+            badges: ["RPC", "Solana", "WS"],
+            hints: ["web3", "json_rpc", "solana", "subscription", "malformed", "fallback"],
+            redaction: ["signature"],
+            warnings: ["malformed_payload", "large_payload"],
+            fallback: "Summarize bounded notification count and show raw fallback for malformed subscription messages."
+        ),
+        safetyClass: .malformed,
+        sizeClass: .boundedStress,
+        traceability: issueTraceability([191, 193])
+    )
+
+    static let x402ContractSmoke = ProtocolFixture(
+        id: "foundation.x402.contract-smoke",
+        title: "x402-style payment-required retry flow",
+        family: .x402,
+        scenarioTags: ["x402", "payment-required", "retry", "success", "contract-smoke"],
+        traffic: ProtocolFixtureTraffic(exchanges: [
+            ProtocolFixtureExchange(
+                request: ProtocolFixtureMessage(
+                    method: "GET",
+                    url: "https://payments.example.com/protected/report",
+                    headers: [.init(name: "Accept", value: "application/json")]
+                ),
+                response: ProtocolFixtureMessage(
+                    method: "HTTP",
+                    url: "https://payments.example.com/protected/report",
+                    statusCode: 402,
+                    headers: [.init(name: "Content-Type", value: "application/json")],
+                    body: #"{"x402Version":1,"paymentRequired":true,"challenge":"synthetic-payment-challenge"}"#
+                )
+            ),
+            ProtocolFixtureExchange(
+                request: ProtocolFixtureMessage(
+                    method: "GET",
+                    url: "https://payments.example.com/protected/report",
+                    headers: [
+                        .init(name: "Accept", value: "application/json"),
+                        .init(name: "X-Payment", value: "synthetic-payment-proof"),
+                    ]
+                ),
+                response: ProtocolFixtureMessage(
+                    method: "HTTP",
+                    url: "https://payments.example.com/protected/report",
+                    statusCode: 200,
+                    headers: [.init(name: "Content-Type", value: "application/json")],
+                    body: #"{"ok":true,"receipt":"synthetic-receipt"}"#
+                )
+            )
+        ]),
+        expected: ProtocolFixtureExpectations(
+            metadataHints: ["x402", "payment_required", "retry_flow"],
+            redaction: ProtocolFixtureRedactionExpectation(
+                sensitiveFields: ["X-Payment", "challenge", "receipt"],
+                redactedMarkers: ["[REDACTED]"],
+                safeFields: ["x402Version", "paymentRequired", "ok"]
+            ),
+            ux: ProtocolFixtureUXExpectation(
+                requestListBadges: ["x402", "402"],
+                optionalColumns: ["payment_flow": "required_then_success"],
+                inspectorTabs: ["Payment", "Headers", "Raw"],
+                warningStates: ["payment_metadata_redaction_candidate"],
+                exportSummaryFields: ["payment_required", "retry_count", "redacted_fields"],
+                mcpSummaryFields: ["payment_flow", "status", "redacted"],
+                fallbackBehavior: nil
+            )
+        ),
+        safetyClass: .containsSyntheticSensitiveData,
+        sizeClass: .small,
+        traceability: commonTraceability
+    )
+
+    static let x402MalformedAndMissingProofContractSmoke = ProtocolFixture(
+        id: "x402.malformed-missing-proof-contract",
+        title: "x402 malformed challenge and missing payment proof",
+        family: .x402,
+        scenarioTags: ["x402", "payment-required", "malformed", "missing-proof", "fallback", "issue-192"],
+        traffic: ProtocolFixtureTraffic(exchanges: [
+            ProtocolFixtureExchange(
+                request: ProtocolFixtureMessage(
+                    method: "GET",
+                    url: "https://payments.example.com/protected/malformed",
+                    headers: [.init(name: "Accept", value: "application/json")]
+                ),
+                response: ProtocolFixtureMessage(
+                    method: "HTTP",
+                    url: "https://payments.example.com/protected/malformed",
+                    statusCode: 402,
+                    headers: [.init(name: "Content-Type", value: "application/json")],
+                    body: #"{"x402Version":1,"paymentRequired":true,"challenge":"#
+                )
+            ),
+            ProtocolFixtureExchange(
+                request: ProtocolFixtureMessage(
+                    method: "GET",
+                    url: "https://payments.example.com/protected/malformed",
+                    headers: [.init(name: "Accept", value: "application/json")]
+                ),
+                response: ProtocolFixtureMessage(
+                    method: "HTTP",
+                    url: "https://payments.example.com/protected/malformed",
+                    statusCode: 402,
+                    headers: [.init(name: "Content-Type", value: "application/json")],
+                    body: #"{"x402Version":1,"paymentRequired":true,"error":"missing synthetic payment proof"}"#
+                )
+            )
+        ]),
+        expected: x402Expectations(
+            hints: ["x402", "payment_required", "malformed", "missing_proof", "fallback"],
+            warnings: ["payment_metadata_redaction_candidate", "malformed_payload"],
+            fallback: "Show payment-required state and raw fallback when the challenge is malformed or proof is missing."
+        ),
+        safetyClass: .malformed,
+        sizeClass: .small,
+        traceability: issueTraceability([192, 193])
+    )
+
+    static let x402ProviderErrorMetadataContractSmoke = ProtocolFixture(
+        id: "x402.provider-error-sensitive-metadata",
+        title: "x402 provider error with synthetic payment metadata",
+        family: .x402,
+        scenarioTags: ["x402", "provider-error", "payment-metadata", "sensitive-metadata", "issue-192"],
+        traffic: ProtocolFixtureTraffic(exchanges: [
+            ProtocolFixtureExchange(
+                request: ProtocolFixtureMessage(
+                    method: "GET",
+                    url: "https://payments.example.com/protected/report",
+                    headers: [
+                        .init(name: "Authorization", value: "Bearer synthetic-payment-token"),
+                        .init(name: "X-Payment", value: "synthetic-payment-proof"),
+                    ]
+                ),
+                response: ProtocolFixtureMessage(
+                    method: "HTTP",
+                    url: "https://payments.example.com/protected/report",
+                    statusCode: 402,
+                    headers: [.init(name: "Content-Type", value: "application/json")],
+                    body: #"""
+                    {"error":"synthetic provider rejected payment","paymentMetadata":{"network":"synthetic-chain","account":"synthetic-account","receipt":"synthetic-receipt"}}
+                    """#
+                )
+            )
+        ]),
+        expected: x402Expectations(
+            hints: ["x402", "payment_required", "provider_error", "payment_metadata"],
+            warnings: ["payment_metadata_redaction_candidate", "export_destination_warning"],
+            fallback: nil
+        ),
+        safetyClass: .containsSyntheticSensitiveData,
+        sizeClass: .small,
+        traceability: issueTraceability([192])
+    )
+
+    static let malformedPayloadContractSmoke = ProtocolFixture(
+        id: "foundation.malformed-json.contract-smoke",
+        title: "Malformed JSON payload with bounded fallback contract",
+        family: .unknown,
+        scenarioTags: ["malformed", "json", "fallback", "contract-smoke"],
+        traffic: ProtocolFixtureTraffic(exchanges: [
+            ProtocolFixtureExchange(
+                request: ProtocolFixtureMessage(
+                    method: "POST",
+                    url: "https://test.invalid/malformed",
+                    headers: [.init(name: "Content-Type", value: "application/json")],
+                    body: #"{"message":"unterminated""#
+                ),
+                response: ProtocolFixtureMessage(
+                    method: "HTTP",
+                    url: "https://test.invalid/malformed",
+                    statusCode: 400,
+                    headers: [.init(name: "Content-Type", value: "text/plain")],
+                    body: "Malformed synthetic payload"
+                )
+            )
+        ]),
+        expected: ProtocolFixtureExpectations(
+            metadataHints: ["malformed", "fallback"],
+            redaction: ProtocolFixtureRedactionExpectation(
+                sensitiveFields: [],
+                redactedMarkers: [],
+                safeFields: ["message"]
+            ),
+            ux: ProtocolFixtureUXExpectation(
+                requestListBadges: ["Malformed"],
+                optionalColumns: ["parse_state": "failed"],
+                inspectorTabs: ["Raw"],
+                warningStates: ["malformed_payload"],
+                exportSummaryFields: ["parse_state", "omitted_protocol_summary"],
+                mcpSummaryFields: ["parse_state"],
+                fallbackBehavior: "Show bounded raw fallback without protocol-specific inspector content."
+            )
+        ),
+        safetyClass: .malformed,
+        sizeClass: .small,
+        traceability: commonTraceability
+    )
+
+    static let hostileOversizedDeepJSONContractSmoke = ProtocolFixture(
+        id: "hostile.oversized-deep-json-contract",
+        title: "Oversized and deeply nested JSON with bounded parser expectations",
+        family: .unknown,
+        scenarioTags: ["hostile", "oversized", "deep-nesting", "large", "fallback", "issue-193"],
+        traffic: ProtocolFixtureTraffic(
+            exchanges: [
+                ProtocolFixtureExchange(
+                    request: ProtocolFixtureMessage(
+                        method: "POST",
+                        url: "https://test.invalid/large-json",
+                        headers: [.init(name: "Content-Type", value: "application/json")],
+                        body: #"{"root":{"level1":{"level2":{"level3":{"level4":{"level5":{"secret":"synthetic-api-key","items":["# + repeatedItems(80) + #"]}}}}}}"#
+                    ),
+                    response: ProtocolFixtureMessage(
+                        method: "HTTP",
+                        url: "https://test.invalid/large-json",
+                        statusCode: 200,
+                        body: #"{"ok":true}"#
+                    )
+                ),
+            ],
+            estimatedPayloadBytes: 14_000
+        ),
+        expected: hostileExpectations(
+            hints: ["hostile", "oversized", "deep_nesting", "fallback"],
+            warnings: ["large_payload", "parser_budget"],
+            fallback: "Avoid request-list expansion; inspector work should be bounded and cancellable."
+        ),
+        safetyClass: .large,
+        sizeClass: .boundedStress,
+        traceability: issueTraceability([193])
+    )
+
+    static let hostileLongStringTruncatedContractSmoke = ProtocolFixture(
+        id: "hostile.long-string-truncated-contract",
+        title: "Long string values and truncated response body",
+        family: .unknown,
+        scenarioTags: ["hostile", "long-string", "truncated", "fallback", "issue-193"],
+        traffic: ProtocolFixtureTraffic(
+            exchanges: [
+                ProtocolFixtureExchange(
+                    request: ProtocolFixtureMessage(
+                        method: "POST",
+                        url: "https://test.invalid/long-string",
+                        headers: [.init(name: "Content-Type", value: "application/json")],
+                        body: #"{"message":""# + repeatedScalar("synthetic-long-value-", count: 160) + #""}"#
+                    ),
+                    response: ProtocolFixtureMessage(
+                        method: "HTTP",
+                        url: "https://test.invalid/long-string",
+                        statusCode: 206,
+                        body: #"{"partial":"synthetic truncated response""#
+                    )
+                ),
+            ],
+            estimatedPayloadBytes: 8_000
+        ),
+        expected: hostileExpectations(
+            hints: ["hostile", "long_string", "truncated", "fallback"],
+            warnings: ["truncated_payload", "parser_budget"],
+            fallback: "Show truncation state and keep export summaries explicit about omitted body content."
+        ),
+        safetyClass: .large,
+        sizeClass: .boundedStress,
+        traceability: issueTraceability([193])
+    )
+
+    static let hostilePartialSSEAndBytesContractSmoke = ProtocolFixture(
+        id: "hostile.partial-sse-malformed-bytes",
+        title: "Partial SSE stream and malformed byte-like payload",
+        family: .ai,
+        scenarioTags: ["hostile", "ai", "sse", "partial", "malformed-bytes", "fallback", "issue-193"],
+        traffic: ProtocolFixtureTraffic(exchanges: [
+            ProtocolFixtureExchange(
+                request: ProtocolFixtureMessage(
+                    method: "POST",
+                    url: "https://ai.example.com/v1/responses",
+                    headers: [.init(name: "Authorization", value: "Bearer synthetic-ai-token")],
+                    body: #"{"model":"synthetic-model","input":"[SYNTHETIC_PROMPT]","stream":true}"#
+                ),
+                response: ProtocolFixtureMessage(
+                    method: "HTTP",
+                    url: "https://ai.example.com/v1/responses",
+                    statusCode: 200,
+                    headers: [.init(name: "Content-Type", value: "text/event-stream")],
+                    body: "synthetic-byte-prefix \\xF0\\x28\\x8C\\x28 replacement-marker"
+                ),
+                streamEvents: [
+                    .init(event: "response.output_text.delta", data: #"{"delta":"partial synthetic text"}"#),
+                    .init(event: nil, data: "data: [synthetic stream continues without completion]"),
+                ]
+            )
+        ]),
+        expected: aiStreamingExpectations(
+            hints: ["ai", "streaming", "partial", "malformed_bytes", "fallback"],
+            fallback: "Treat partial SSE and malformed byte-like payload as bounded raw fallback."
+        ),
+        safetyClass: .malformed,
+        sizeClass: .medium,
+        traceability: issueTraceability([188, 193])
+    )
+
+    static func issueTraceability(_ issues: Set<Int>) -> ProtocolFixtureTraceability {
+        ProtocolFixtureTraceability(
+            parentIssue: 176,
+            childIssues: commonTraceability.childIssues.union(issues),
+            futureIssues: commonTraceability.futureIssues
+        )
+    }
+
+    static func aiStreamingExpectations(
+        hints: Set<String>,
+        fallback: String?
+    ) -> ProtocolFixtureExpectations {
+        ProtocolFixtureExpectations(
+            metadataHints: hints,
+            redaction: ProtocolFixtureRedactionExpectation(
+                sensitiveFields: ["Authorization", "X-API-Key", "input", "messages.content", "arguments", "partial_json"],
+                redactedMarkers: ["[REDACTED]"],
+                safeFields: ["model", "status", "stop_reason"]
+            ),
+            ux: ProtocolFixtureUXExpectation(
+                requestListBadges: ["AI", "Stream"],
+                optionalColumns: ["protocol": "AI", "streaming": "true"],
+                inspectorTabs: ["AI", "Stream", "Tool Calls", "Raw"],
+                warningStates: fallback == nil ? ["prompt_redaction_candidate"] : ["prompt_redaction_candidate", "malformed_payload"],
+                exportSummaryFields: ["model", "stream_event_count", "tool_call_count", "redacted_fields"],
+                mcpSummaryFields: ["model", "status", "streaming", "redacted"],
+                fallbackBehavior: fallback
+            )
+        )
+    }
+
+    static func aiRetrievalExpectations(
+        hints: Set<String>,
+        warnings: [String],
+        fallback: String?
+    ) -> ProtocolFixtureExpectations {
+        ProtocolFixtureExpectations(
+            metadataHints: hints,
+            redaction: ProtocolFixtureRedactionExpectation(
+                sensitiveFields: ["Authorization", "input", "retrieved_context", "messages.content", "query_embedding"],
+                redactedMarkers: ["[REDACTED]"],
+                safeFields: ["model", "usage.total_tokens", "matches.score"]
+            ),
+            ux: ProtocolFixtureUXExpectation(
+                requestListBadges: ["AI", "RAG"],
+                optionalColumns: ["protocol": "AI", "retrieval": "true"],
+                inspectorTabs: ["AI", "Retrieval", "JSON", "Raw"],
+                warningStates: warnings,
+                exportSummaryFields: ["model", "retrieval_step_count", "redacted_fields"],
+                mcpSummaryFields: ["model", "retrieval", "redacted"],
+                fallbackBehavior: fallback
+            )
+        )
+    }
+
+    static func web3Expectations(
+        badges: [String],
+        hints: Set<String>,
+        redaction: Set<String>,
+        warnings: [String],
+        fallback: String?
+    ) -> ProtocolFixtureExpectations {
+        ProtocolFixtureExpectations(
+            metadataHints: hints,
+            redaction: ProtocolFixtureRedactionExpectation(
+                sensitiveFields: redaction.union(["Authorization", "provider_api_key"]),
+                redactedMarkers: ["[REDACTED]"],
+                safeFields: ["jsonrpc", "method", "id", "status"]
+            ),
+            ux: ProtocolFixtureUXExpectation(
+                requestListBadges: badges,
+                optionalColumns: ["rpc": "true", "family": "web3"],
+                inspectorTabs: ["RPC", "JSON", "Raw"],
+                warningStates: warnings,
+                exportSummaryFields: ["rpc_method", "batch_count", "chain_hint", "redacted_fields"],
+                mcpSummaryFields: ["rpc_method", "status", "redacted"],
+                fallbackBehavior: fallback
+            )
+        )
+    }
+
+    static func x402Expectations(
+        hints: Set<String>,
+        warnings: [String],
+        fallback: String?
+    ) -> ProtocolFixtureExpectations {
+        ProtocolFixtureExpectations(
+            metadataHints: hints,
+            redaction: ProtocolFixtureRedactionExpectation(
+                sensitiveFields: ["Authorization", "X-Payment", "challenge", "receipt", "paymentMetadata"],
+                redactedMarkers: ["[REDACTED]"],
+                safeFields: ["x402Version", "paymentRequired", "ok", "error"]
+            ),
+            ux: ProtocolFixtureUXExpectation(
+                requestListBadges: ["x402", "402"],
+                optionalColumns: ["payment_flow": "true"],
+                inspectorTabs: ["Payment", "Headers", "Raw"],
+                warningStates: warnings,
+                exportSummaryFields: ["payment_required", "retry_count", "provider_error", "redacted_fields"],
+                mcpSummaryFields: ["payment_flow", "status", "redacted"],
+                fallbackBehavior: fallback
+            )
+        )
+    }
+
+    static func hostileExpectations(
+        hints: Set<String>,
+        warnings: [String],
+        fallback: String
+    ) -> ProtocolFixtureExpectations {
+        ProtocolFixtureExpectations(
+            metadataHints: hints,
+            redaction: ProtocolFixtureRedactionExpectation(
+                sensitiveFields: ["secret", "api_key", "Authorization"],
+                redactedMarkers: ["[REDACTED]"],
+                safeFields: ["parse_state", "truncated", "omitted_protocol_summary"]
+            ),
+            ux: ProtocolFixtureUXExpectation(
+                requestListBadges: ["Bounded"],
+                optionalColumns: ["parse_state": "bounded"],
+                inspectorTabs: ["Raw"],
+                warningStates: warnings,
+                exportSummaryFields: ["parse_state", "truncation_state", "omitted_body_bytes"],
+                mcpSummaryFields: ["parse_state", "redacted"],
+                fallbackBehavior: fallback
+            )
+        )
+    }
+
+    static func evmExchange(body: String, response: String) -> ProtocolFixtureExchange {
+        ProtocolFixtureExchange(
+            request: ProtocolFixtureMessage(
+                method: "POST",
+                url: "https://rpc.example.com/evm",
+                headers: [.init(name: "Content-Type", value: "application/json")],
+                body: body
+            ),
+            response: ProtocolFixtureMessage(
+                method: "HTTP",
+                url: "https://rpc.example.com/evm",
+                statusCode: 200,
+                headers: [.init(name: "Content-Type", value: "application/json")],
+                body: response
+            )
+        )
+    }
+
+    static func evmBatchRequest(count: Int) -> String {
+        let calls = (0 ..< count).map { index in
+            #"{"jsonrpc":"2.0","id":"batch-\#(index)","method":"eth_call","params":[{"to":"0xSyntheticContract","data":"0xsyntheticCallData"},"latest"]}"#
+        }
+        return "[\(calls.joined(separator: ","))]"
+    }
+
+    static func solanaNotificationSample(count: Int) -> String {
+        let logs = (0 ..< count).map { index in
+            #"{"signature":"synthetic-signature-\#(index)","logs":["Program log: synthetic-\#(index)"]}"#
+        }.joined(separator: ",")
+        return #"{"jsonrpc":"2.0","method":"logsNotification","params":{"subscription":42,"result":{"items":[\#(logs)]}}}"#
+    }
+
+    static func repeatedItems(_ count: Int) -> String {
+        (0 ..< count).map { #""synthetic-item-\#($0)""# }.joined(separator: ",")
+    }
+
+    static func repeatedScalar(_ value: String, count: Int) -> String {
+        Array(repeating: value, count: count).joined()
+    }
+}

--- a/RockxyTests/Helpers/ProtocolFixtureCorpus.md
+++ b/RockxyTests/Helpers/ProtocolFixtureCorpus.md
@@ -65,5 +65,26 @@ Group A foundation work is tracked by:
 
 - #186 schema, loader, and validation harness
 - #187 UX contract expectations
+- #188 AI streaming and tool-call fixtures
+- #189 AI embeddings, RAG, and retrieval fixtures
+- #190 EVM JSON-RPC fixtures
+- #191 Solana RPC and subscription fixtures
+- #192 x402 payment-flow fixtures
+- #193 hostile, malformed, and large-payload fixtures
 - #194 public-safety gates
 - #195 fixture-to-feature traceability
+
+## Extension Process
+
+When adding a fixture:
+
+1. Choose the smallest synthetic payload that represents the protocol shape.
+2. Add scenario tags that map to the relevant issue and protocol behavior.
+3. Declare expected metadata hints, redaction fields, UX contract fields, safety
+   class, size class, and traceability.
+4. Use `webSocketMessages` for subscription or bidirectional message flows.
+5. Set `estimatedPayloadBytes` for bounded stress fixtures.
+6. Add or update tests that prove the new issue coverage and safety behavior.
+
+UX contract fields are planning contracts for future app behavior. They should
+not be described as shipped UI unless the production view code implements them.

--- a/RockxyTests/Helpers/ProtocolFixtureCorpus.md
+++ b/RockxyTests/Helpers/ProtocolFixtureCorpus.md
@@ -1,0 +1,69 @@
+# Protocol Fixture Corpus
+
+The protocol fixture corpus is Rockxy's test-only source of truth for future
+protocol-aware debugging work. It is intentionally synthetic, offline, and
+public-safe.
+
+## Purpose
+
+Use this corpus to test protocol metadata, redaction, inspector routing, export
+summaries, MCP-safe summaries, session compatibility, and parser safety without
+depending on ad hoc captures.
+
+The umbrella tracker is RockxyApp/Rockxy#176.
+
+## Fixture Contract
+
+Every fixture should declare:
+
+- a stable `id`
+- a `family`
+- scenario tags
+- request/response or stream payload shape
+- expected metadata hints
+- redaction expectations
+- UX contract expectations
+- safety class
+- size class
+- issue traceability
+
+UX contract fields describe expected future behavior. They do not mean the UI is
+already implemented.
+
+## Safety Rules
+
+Fixtures must be synthetic or sanitized.
+
+Do not add:
+
+- real captured traffic
+- real API keys or bearer tokens
+- private keys
+- seed phrases
+- production payment proofs
+- personal data
+- local filesystem paths
+- production provider URLs
+
+Prefer `example.com`, `test.invalid`, and obvious synthetic placeholders such as
+`synthetic-api-key`.
+
+## Roadmap Mapping
+
+The corpus supports:
+
+- #143 protocol metadata architecture
+- #144 privacy classification
+- #145 redacted debugging-session bundles
+- #146 export preview
+- #177 parser safety budgets
+- #178 session and HAR compatibility
+- #179 inspector tab routing
+- #180 large-session performance tests
+
+Group A foundation work is tracked by:
+
+- #186 schema, loader, and validation harness
+- #187 UX contract expectations
+- #194 public-safety gates
+- #195 fixture-to-feature traceability

--- a/RockxyTests/Helpers/ProtocolFixtureCorpus.swift
+++ b/RockxyTests/Helpers/ProtocolFixtureCorpus.swift
@@ -1,0 +1,536 @@
+import Foundation
+
+// MARK: - ProtocolFixtureCorpus
+
+enum ProtocolFixtureCorpus {
+    static let fixtures: [ProtocolFixture] = [
+        .httpJSONSmoke,
+        .aiSSEContractSmoke,
+        .evmJSONRPCContractSmoke,
+        .x402ContractSmoke,
+        .malformedPayloadContractSmoke,
+    ]
+
+    static let allowedSyntheticHosts: Set<String> = [
+        "api.example.com",
+        "ai.example.com",
+        "rpc.example.com",
+        "payments.example.com",
+        "test.invalid",
+    ]
+}
+
+// MARK: - Protocol Fixture Schema
+
+struct ProtocolFixture: Equatable, Identifiable {
+    let id: String
+    let title: String
+    let family: ProtocolFixtureFamily
+    let scenarioTags: Set<String>
+    let traffic: ProtocolFixtureTraffic
+    let expected: ProtocolFixtureExpectations
+    let safetyClass: ProtocolFixtureSafetyClass
+    let sizeClass: ProtocolFixtureSizeClass
+    let traceability: ProtocolFixtureTraceability
+}
+
+enum ProtocolFixtureFamily: String, CaseIterable {
+    case ordinaryHTTP = "ordinary-http"
+    case ai = "ai"
+    case web3RPC = "web3-rpc"
+    case x402 = "x402"
+    case unknown = "unknown"
+}
+
+enum ProtocolFixtureSafetyClass: String, CaseIterable {
+    case ordinary
+    case containsSyntheticSensitiveData
+    case malformed
+    case hostile
+    case large
+}
+
+enum ProtocolFixtureSizeClass: String, CaseIterable {
+    case small
+    case medium
+    case boundedStress
+}
+
+struct ProtocolFixtureTraffic: Equatable {
+    let exchanges: [ProtocolFixtureExchange]
+}
+
+struct ProtocolFixtureExchange: Equatable {
+    let request: ProtocolFixtureMessage
+    let response: ProtocolFixtureMessage?
+    let streamEvents: [ProtocolFixtureStreamEvent]
+
+    init(
+        request: ProtocolFixtureMessage,
+        response: ProtocolFixtureMessage? = nil,
+        streamEvents: [ProtocolFixtureStreamEvent] = []
+    ) {
+        self.request = request
+        self.response = response
+        self.streamEvents = streamEvents
+    }
+}
+
+struct ProtocolFixtureMessage: Equatable {
+    let method: String
+    let url: String
+    let statusCode: Int?
+    let headers: [ProtocolFixtureHeader]
+    let body: String?
+
+    init(
+        method: String,
+        url: String,
+        statusCode: Int? = nil,
+        headers: [ProtocolFixtureHeader] = [],
+        body: String? = nil
+    ) {
+        self.method = method
+        self.url = url
+        self.statusCode = statusCode
+        self.headers = headers
+        self.body = body
+    }
+}
+
+struct ProtocolFixtureHeader: Equatable {
+    let name: String
+    let value: String
+}
+
+struct ProtocolFixtureStreamEvent: Equatable {
+    let event: String?
+    let data: String
+}
+
+struct ProtocolFixtureExpectations: Equatable {
+    let metadataHints: Set<String>
+    let redaction: ProtocolFixtureRedactionExpectation
+    let ux: ProtocolFixtureUXExpectation
+}
+
+struct ProtocolFixtureRedactionExpectation: Equatable {
+    let sensitiveFields: Set<String>
+    let redactedMarkers: Set<String>
+    let safeFields: Set<String>
+}
+
+struct ProtocolFixtureUXExpectation: Equatable {
+    let requestListBadges: [String]
+    let optionalColumns: [String: String]
+    let inspectorTabs: [String]
+    let warningStates: [String]
+    let exportSummaryFields: [String]
+    let mcpSummaryFields: [String]
+    let fallbackBehavior: String?
+}
+
+struct ProtocolFixtureTraceability: Equatable {
+    let parentIssue: Int
+    let childIssues: Set<Int>
+    let futureIssues: Set<Int>
+}
+
+// MARK: - Corpus Smoke Fixtures
+
+private extension ProtocolFixture {
+    static let commonTraceability = ProtocolFixtureTraceability(
+        parentIssue: 176,
+        childIssues: [186, 187, 194, 195],
+        futureIssues: [143, 144, 145, 146, 177, 178, 179, 180]
+    )
+
+    static let httpJSONSmoke = ProtocolFixture(
+        id: "foundation.http-json.redaction-smoke",
+        title: "Ordinary JSON request with synthetic redaction candidate",
+        family: .ordinaryHTTP,
+        scenarioTags: ["http", "json", "redaction-smoke"],
+        traffic: ProtocolFixtureTraffic(exchanges: [
+            ProtocolFixtureExchange(
+                request: ProtocolFixtureMessage(
+                    method: "POST",
+                    url: "https://api.example.com/v1/debug-smoke",
+                    headers: [.init(name: "Content-Type", value: "application/json")],
+                    body: #"{"request_id":"fixture-request","api_key":"synthetic-api-key"}"#
+                ),
+                response: ProtocolFixtureMessage(
+                    method: "HTTP",
+                    url: "https://api.example.com/v1/debug-smoke",
+                    statusCode: 200,
+                    headers: [.init(name: "Content-Type", value: "application/json")],
+                    body: #"{"ok":true,"request_id":"fixture-request"}"#
+                )
+            )
+        ]),
+        expected: ProtocolFixtureExpectations(
+            metadataHints: ["http", "json"],
+            redaction: ProtocolFixtureRedactionExpectation(
+                sensitiveFields: ["api_key"],
+                redactedMarkers: ["[REDACTED]"],
+                safeFields: ["request_id", "ok"]
+            ),
+            ux: ProtocolFixtureUXExpectation(
+                requestListBadges: ["JSON"],
+                optionalColumns: ["content": "JSON"],
+                inspectorTabs: ["Headers", "JSON", "Raw"],
+                warningStates: [],
+                exportSummaryFields: ["method", "host", "status", "redacted_fields"],
+                mcpSummaryFields: ["method", "url", "status", "redacted"],
+                fallbackBehavior: nil
+            )
+        ),
+        safetyClass: .containsSyntheticSensitiveData,
+        sizeClass: .small,
+        traceability: commonTraceability
+    )
+
+    static let aiSSEContractSmoke = ProtocolFixture(
+        id: "foundation.ai-sse.contract-smoke",
+        title: "AI streaming response with synthetic tool call",
+        family: .ai,
+        scenarioTags: ["ai", "sse", "streaming", "tool-call", "contract-smoke"],
+        traffic: ProtocolFixtureTraffic(exchanges: [
+            ProtocolFixtureExchange(
+                request: ProtocolFixtureMessage(
+                    method: "POST",
+                    url: "https://ai.example.com/v1/responses",
+                    headers: [
+                        .init(name: "Content-Type", value: "application/json"),
+                        .init(name: "Authorization", value: "Bearer synthetic-ai-token"),
+                    ],
+                    body: #"{"model":"synthetic-model","input":"[SYNTHETIC_PROMPT]","tool_choice":"auto"}"#
+                ),
+                response: ProtocolFixtureMessage(
+                    method: "HTTP",
+                    url: "https://ai.example.com/v1/responses",
+                    statusCode: 200,
+                    headers: [.init(name: "Content-Type", value: "text/event-stream")],
+                    body: nil
+                ),
+                streamEvents: [
+                    .init(event: "response.created", data: #"{"id":"resp_fixture","model":"synthetic-model"}"#),
+                    .init(event: "response.tool_call.delta", data: #"{"name":"lookup_order","arguments":"{\"order_id\":\"fixture-order\"}"}"#),
+                    .init(event: "response.completed", data: #"{"id":"resp_fixture","status":"completed"}"#),
+                ]
+            )
+        ]),
+        expected: ProtocolFixtureExpectations(
+            metadataHints: ["ai", "streaming", "tool_call", "model_request"],
+            redaction: ProtocolFixtureRedactionExpectation(
+                sensitiveFields: ["Authorization", "input", "tool_choice", "arguments"],
+                redactedMarkers: ["[REDACTED]"],
+                safeFields: ["model", "status"]
+            ),
+            ux: ProtocolFixtureUXExpectation(
+                requestListBadges: ["AI", "Stream"],
+                optionalColumns: ["protocol": "AI", "streaming": "true"],
+                inspectorTabs: ["AI", "Stream", "Tool Calls", "Raw"],
+                warningStates: ["prompt_redaction_candidate", "tool_payload_redaction_candidate"],
+                exportSummaryFields: ["model", "stream_event_count", "tool_call_count", "redacted_fields"],
+                mcpSummaryFields: ["model", "status", "streaming", "redacted"],
+                fallbackBehavior: nil
+            )
+        ),
+        safetyClass: .containsSyntheticSensitiveData,
+        sizeClass: .small,
+        traceability: commonTraceability
+    )
+
+    static let evmJSONRPCContractSmoke = ProtocolFixture(
+        id: "foundation.evm-json-rpc.contract-smoke",
+        title: "EVM JSON-RPC request with synthetic method summary",
+        family: .web3RPC,
+        scenarioTags: ["web3", "evm", "json-rpc", "contract-smoke"],
+        traffic: ProtocolFixtureTraffic(exchanges: [
+            ProtocolFixtureExchange(
+                request: ProtocolFixtureMessage(
+                    method: "POST",
+                    url: "https://rpc.example.com/evm",
+                    headers: [.init(name: "Content-Type", value: "application/json")],
+                    body: #"{"jsonrpc":"2.0","id":"fixture-1","method":"eth_call","params":[{"to":"0xSyntheticContract","data":"0xsyntheticCallData"},"latest"]}"#
+                ),
+                response: ProtocolFixtureMessage(
+                    method: "HTTP",
+                    url: "https://rpc.example.com/evm",
+                    statusCode: 200,
+                    headers: [.init(name: "Content-Type", value: "application/json")],
+                    body: #"{"jsonrpc":"2.0","id":"fixture-1","result":"0xsyntheticResult"}"#
+                )
+            )
+        ]),
+        expected: ProtocolFixtureExpectations(
+            metadataHints: ["web3", "json_rpc", "evm", "eth_call"],
+            redaction: ProtocolFixtureRedactionExpectation(
+                sensitiveFields: ["params.data"],
+                redactedMarkers: ["[REDACTED]"],
+                safeFields: ["jsonrpc", "method", "id"]
+            ),
+            ux: ProtocolFixtureUXExpectation(
+                requestListBadges: ["RPC", "EVM"],
+                optionalColumns: ["rpc_method": "eth_call"],
+                inspectorTabs: ["RPC", "JSON", "Raw"],
+                warningStates: [],
+                exportSummaryFields: ["rpc_method", "chain_hint", "redacted_fields"],
+                mcpSummaryFields: ["rpc_method", "status", "redacted"],
+                fallbackBehavior: nil
+            )
+        ),
+        safetyClass: .containsSyntheticSensitiveData,
+        sizeClass: .small,
+        traceability: commonTraceability
+    )
+
+    static let x402ContractSmoke = ProtocolFixture(
+        id: "foundation.x402.contract-smoke",
+        title: "x402-style payment-required retry flow",
+        family: .x402,
+        scenarioTags: ["x402", "payment-required", "retry", "contract-smoke"],
+        traffic: ProtocolFixtureTraffic(exchanges: [
+            ProtocolFixtureExchange(
+                request: ProtocolFixtureMessage(
+                    method: "GET",
+                    url: "https://payments.example.com/protected/report",
+                    headers: [.init(name: "Accept", value: "application/json")]
+                ),
+                response: ProtocolFixtureMessage(
+                    method: "HTTP",
+                    url: "https://payments.example.com/protected/report",
+                    statusCode: 402,
+                    headers: [.init(name: "Content-Type", value: "application/json")],
+                    body: #"{"x402Version":1,"paymentRequired":true,"challenge":"synthetic-payment-challenge"}"#
+                )
+            ),
+            ProtocolFixtureExchange(
+                request: ProtocolFixtureMessage(
+                    method: "GET",
+                    url: "https://payments.example.com/protected/report",
+                    headers: [
+                        .init(name: "Accept", value: "application/json"),
+                        .init(name: "X-Payment", value: "synthetic-payment-proof"),
+                    ]
+                ),
+                response: ProtocolFixtureMessage(
+                    method: "HTTP",
+                    url: "https://payments.example.com/protected/report",
+                    statusCode: 200,
+                    headers: [.init(name: "Content-Type", value: "application/json")],
+                    body: #"{"ok":true,"receipt":"synthetic-receipt"}"#
+                )
+            )
+        ]),
+        expected: ProtocolFixtureExpectations(
+            metadataHints: ["x402", "payment_required", "retry_flow"],
+            redaction: ProtocolFixtureRedactionExpectation(
+                sensitiveFields: ["X-Payment", "challenge", "receipt"],
+                redactedMarkers: ["[REDACTED]"],
+                safeFields: ["x402Version", "paymentRequired", "ok"]
+            ),
+            ux: ProtocolFixtureUXExpectation(
+                requestListBadges: ["x402", "402"],
+                optionalColumns: ["payment_flow": "required_then_success"],
+                inspectorTabs: ["Payment", "Headers", "Raw"],
+                warningStates: ["payment_metadata_redaction_candidate"],
+                exportSummaryFields: ["payment_required", "retry_count", "redacted_fields"],
+                mcpSummaryFields: ["payment_flow", "status", "redacted"],
+                fallbackBehavior: nil
+            )
+        ),
+        safetyClass: .containsSyntheticSensitiveData,
+        sizeClass: .small,
+        traceability: commonTraceability
+    )
+
+    static let malformedPayloadContractSmoke = ProtocolFixture(
+        id: "foundation.malformed-json.contract-smoke",
+        title: "Malformed JSON payload with bounded fallback contract",
+        family: .unknown,
+        scenarioTags: ["malformed", "json", "fallback", "contract-smoke"],
+        traffic: ProtocolFixtureTraffic(exchanges: [
+            ProtocolFixtureExchange(
+                request: ProtocolFixtureMessage(
+                    method: "POST",
+                    url: "https://test.invalid/malformed",
+                    headers: [.init(name: "Content-Type", value: "application/json")],
+                    body: #"{"message":"unterminated""#
+                ),
+                response: ProtocolFixtureMessage(
+                    method: "HTTP",
+                    url: "https://test.invalid/malformed",
+                    statusCode: 400,
+                    headers: [.init(name: "Content-Type", value: "text/plain")],
+                    body: "Malformed synthetic payload"
+                )
+            )
+        ]),
+        expected: ProtocolFixtureExpectations(
+            metadataHints: ["malformed", "fallback"],
+            redaction: ProtocolFixtureRedactionExpectation(
+                sensitiveFields: [],
+                redactedMarkers: [],
+                safeFields: ["message"]
+            ),
+            ux: ProtocolFixtureUXExpectation(
+                requestListBadges: ["Malformed"],
+                optionalColumns: ["parse_state": "failed"],
+                inspectorTabs: ["Raw"],
+                warningStates: ["malformed_payload"],
+                exportSummaryFields: ["parse_state", "omitted_protocol_summary"],
+                mcpSummaryFields: ["parse_state"],
+                fallbackBehavior: "Show bounded raw fallback without protocol-specific inspector content."
+            )
+        ),
+        safetyClass: .malformed,
+        sizeClass: .small,
+        traceability: commonTraceability
+    )
+}
+
+// MARK: - Validation
+
+enum ProtocolFixtureValidation {
+    static func validate(_ fixture: ProtocolFixture) -> [String] {
+        var failures: [String] = []
+
+        if fixture.id.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            failures.append("Fixture ID is empty.")
+        }
+        if fixture.title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            failures.append("\(fixture.id): title is empty.")
+        }
+        if fixture.scenarioTags.isEmpty {
+            failures.append("\(fixture.id): scenarioTags must not be empty.")
+        }
+        if fixture.traffic.exchanges.isEmpty {
+            failures.append("\(fixture.id): traffic.exchanges must not be empty.")
+        }
+        if fixture.expected.metadataHints.isEmpty {
+            failures.append("\(fixture.id): expected.metadataHints must not be empty.")
+        }
+        if fixture.expected.ux.requestListBadges.isEmpty {
+            failures.append("\(fixture.id): expected.ux.requestListBadges must not be empty.")
+        }
+        if fixture.expected.ux.inspectorTabs.isEmpty {
+            failures.append("\(fixture.id): expected.ux.inspectorTabs must not be empty.")
+        }
+        if fixture.expected.ux.exportSummaryFields.isEmpty {
+            failures.append("\(fixture.id): expected.ux.exportSummaryFields must not be empty.")
+        }
+        if fixture.expected.ux.mcpSummaryFields.isEmpty {
+            failures.append("\(fixture.id): expected.ux.mcpSummaryFields must not be empty.")
+        }
+        if fixture.traceability.parentIssue != 176 {
+            failures.append("\(fixture.id): traceability.parentIssue must be #176.")
+        }
+        if !fixture.traceability.childIssues.isSuperset(of: [186, 187, 194, 195]) {
+            failures.append("\(fixture.id): traceability.childIssues must include Group A child issues.")
+        }
+
+        return failures
+    }
+}
+
+// MARK: - Safety Scanner
+
+enum ProtocolFixtureSafetyScanner {
+    struct Finding: Equatable {
+        let fixtureID: String
+        let reason: String
+        let excerpt: String
+    }
+
+    static func scan(_ fixture: ProtocolFixture) -> [Finding] {
+        var findings: [Finding] = []
+
+        for exchange in fixture.traffic.exchanges {
+            findings.append(contentsOf: scan(message: exchange.request, fixtureID: fixture.id))
+            if let response = exchange.response {
+                findings.append(contentsOf: scan(message: response, fixtureID: fixture.id))
+            }
+            for event in exchange.streamEvents {
+                findings.append(contentsOf: scan(text: event.event ?? "", fixtureID: fixture.id, context: "stream event"))
+                findings.append(contentsOf: scan(text: event.data, fixtureID: fixture.id, context: "stream data"))
+            }
+        }
+
+        return findings
+    }
+
+    static func scan(text: String, fixtureID: String = "manual-scan", context: String = "text") -> [Finding] {
+        let patterns: [(reason: String, regex: String)] = [
+            ("local filesystem path", #"(?:/Users/|/private/var/|/Volumes/|[A-Za-z]:\\Users\\)"#),
+            ("private key PEM block", #"-----BEGIN [A-Z ]*PRIVATE KEY-----"#),
+            ("OpenAI-style production token", #"\bsk-[A-Za-z0-9_-]{16,}"#),
+            ("GitHub production token", #"\b(?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9_]{16,}"#),
+            ("Slack production token", #"\bxox[baprs]-[A-Za-z0-9-]{16,}"#),
+            ("AWS access key", #"\bAKIA[0-9A-Z]{16}\b"#),
+            ("Ethereum private-key-like value", #"\b0x[0-9a-fA-F]{64}\b"#),
+            ("realistic bearer token", #"Bearer\s+(?!(?:synthetic|fake|example)[A-Za-z0-9._~+/-]*\b)[A-Za-z0-9._~+/-]{20,}"#),
+        ]
+
+        var findings: [Finding] = []
+        for pattern in patterns {
+            if let match = firstMatch(pattern.regex, in: text) {
+                findings.append(Finding(fixtureID: fixtureID, reason: "\(context): \(pattern.reason)", excerpt: match))
+            }
+        }
+
+        findings.append(contentsOf: scanEmails(text: text, fixtureID: fixtureID, context: context))
+        return findings
+    }
+
+    private static func scan(message: ProtocolFixtureMessage, fixtureID: String) -> [Finding] {
+        var findings = scanHost(message.url, fixtureID: fixtureID)
+        findings.append(contentsOf: scan(text: message.url, fixtureID: fixtureID, context: "url"))
+        findings.append(contentsOf: message.headers.flatMap { header in
+            scan(text: "\(header.name): \(header.value)", fixtureID: fixtureID, context: "header")
+        })
+        if let body = message.body {
+            findings.append(contentsOf: scan(text: body, fixtureID: fixtureID, context: "body"))
+        }
+        return findings
+    }
+
+    private static func scanHost(_ urlString: String, fixtureID: String) -> [Finding] {
+        guard let url = URL(string: urlString), let host = url.host else {
+            return [Finding(fixtureID: fixtureID, reason: "url: invalid URL", excerpt: urlString)]
+        }
+
+        if ProtocolFixtureCorpus.allowedSyntheticHosts.contains(host) {
+            return []
+        }
+
+        return [Finding(fixtureID: fixtureID, reason: "url: non-synthetic host", excerpt: host)]
+    }
+
+    private static func scanEmails(text: String, fixtureID: String, context: String) -> [Finding] {
+        let emailRegex = #"[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}"#
+        return matches(emailRegex, in: text).compactMap { match in
+            if match.lowercased().hasSuffix("@example.com") {
+                return nil
+            }
+            return Finding(fixtureID: fixtureID, reason: "\(context): personal email-like value", excerpt: match)
+        }
+    }
+
+    private static func firstMatch(_ pattern: String, in text: String) -> String? {
+        matches(pattern, in: text).first
+    }
+
+    private static func matches(_ pattern: String, in text: String) -> [String] {
+        guard let regex = try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive]) else {
+            return []
+        }
+        let range = NSRange(text.startIndex ..< text.endIndex, in: text)
+        return regex.matches(in: text, range: range).compactMap { match in
+            guard let swiftRange = Range(match.range, in: text) else {
+                return nil
+            }
+            return String(text[swiftRange])
+        }
+    }
+}

--- a/RockxyTests/Helpers/ProtocolFixtureCorpus.swift
+++ b/RockxyTests/Helpers/ProtocolFixtureCorpus.swift
@@ -6,15 +6,34 @@ enum ProtocolFixtureCorpus {
     static let fixtures: [ProtocolFixture] = [
         .httpJSONSmoke,
         .aiSSEContractSmoke,
+        .aiAnthropicSSEContractSmoke,
+        .aiInterruptedToolCallContractSmoke,
+        .aiProviderErrorNoUsageContractSmoke,
+        .aiEmbeddingContractSmoke,
+        .aiRAGContractSmoke,
+        .aiMalformedRetrievalContractSmoke,
         .evmJSONRPCContractSmoke,
+        .evmGasReceiptAndSendRawContractSmoke,
+        .evmBatchErrorAndLargeContractSmoke,
+        .evmMalformedJSONRPCContractSmoke,
+        .solanaHTTPRPCContractSmoke,
+        .solanaWebSocketSubscriptionContractSmoke,
+        .solanaLongAndMalformedSubscriptionContractSmoke,
         .x402ContractSmoke,
+        .x402MalformedAndMissingProofContractSmoke,
+        .x402ProviderErrorMetadataContractSmoke,
         .malformedPayloadContractSmoke,
+        .hostileOversizedDeepJSONContractSmoke,
+        .hostileLongStringTruncatedContractSmoke,
+        .hostilePartialSSEAndBytesContractSmoke,
     ]
 
     static let allowedSyntheticHosts: Set<String> = [
         "api.example.com",
         "ai.example.com",
         "rpc.example.com",
+        "solana.example.com",
+        "vector.example.com",
         "payments.example.com",
         "test.invalid",
     ]
@@ -58,6 +77,18 @@ enum ProtocolFixtureSizeClass: String, CaseIterable {
 
 struct ProtocolFixtureTraffic: Equatable {
     let exchanges: [ProtocolFixtureExchange]
+    let webSocketMessages: [ProtocolFixtureWebSocketMessage]
+    let estimatedPayloadBytes: Int
+
+    init(
+        exchanges: [ProtocolFixtureExchange] = [],
+        webSocketMessages: [ProtocolFixtureWebSocketMessage] = [],
+        estimatedPayloadBytes: Int = 0
+    ) {
+        self.exchanges = exchanges
+        self.webSocketMessages = webSocketMessages
+        self.estimatedPayloadBytes = estimatedPayloadBytes
+    }
 }
 
 struct ProtocolFixtureExchange: Equatable {
@@ -108,6 +139,17 @@ struct ProtocolFixtureStreamEvent: Equatable {
     let data: String
 }
 
+struct ProtocolFixtureWebSocketMessage: Equatable {
+    let direction: ProtocolFixtureWebSocketDirection
+    let url: String
+    let body: String
+}
+
+enum ProtocolFixtureWebSocketDirection: String, CaseIterable {
+    case clientToServer
+    case serverToClient
+}
+
 struct ProtocolFixtureExpectations: Equatable {
     let metadataHints: Set<String>
     let redaction: ProtocolFixtureRedactionExpectation
@@ -136,260 +178,6 @@ struct ProtocolFixtureTraceability: Equatable {
     let futureIssues: Set<Int>
 }
 
-// MARK: - Corpus Smoke Fixtures
-
-private extension ProtocolFixture {
-    static let commonTraceability = ProtocolFixtureTraceability(
-        parentIssue: 176,
-        childIssues: [186, 187, 194, 195],
-        futureIssues: [143, 144, 145, 146, 177, 178, 179, 180]
-    )
-
-    static let httpJSONSmoke = ProtocolFixture(
-        id: "foundation.http-json.redaction-smoke",
-        title: "Ordinary JSON request with synthetic redaction candidate",
-        family: .ordinaryHTTP,
-        scenarioTags: ["http", "json", "redaction-smoke"],
-        traffic: ProtocolFixtureTraffic(exchanges: [
-            ProtocolFixtureExchange(
-                request: ProtocolFixtureMessage(
-                    method: "POST",
-                    url: "https://api.example.com/v1/debug-smoke",
-                    headers: [.init(name: "Content-Type", value: "application/json")],
-                    body: #"{"request_id":"fixture-request","api_key":"synthetic-api-key"}"#
-                ),
-                response: ProtocolFixtureMessage(
-                    method: "HTTP",
-                    url: "https://api.example.com/v1/debug-smoke",
-                    statusCode: 200,
-                    headers: [.init(name: "Content-Type", value: "application/json")],
-                    body: #"{"ok":true,"request_id":"fixture-request"}"#
-                )
-            )
-        ]),
-        expected: ProtocolFixtureExpectations(
-            metadataHints: ["http", "json"],
-            redaction: ProtocolFixtureRedactionExpectation(
-                sensitiveFields: ["api_key"],
-                redactedMarkers: ["[REDACTED]"],
-                safeFields: ["request_id", "ok"]
-            ),
-            ux: ProtocolFixtureUXExpectation(
-                requestListBadges: ["JSON"],
-                optionalColumns: ["content": "JSON"],
-                inspectorTabs: ["Headers", "JSON", "Raw"],
-                warningStates: [],
-                exportSummaryFields: ["method", "host", "status", "redacted_fields"],
-                mcpSummaryFields: ["method", "url", "status", "redacted"],
-                fallbackBehavior: nil
-            )
-        ),
-        safetyClass: .containsSyntheticSensitiveData,
-        sizeClass: .small,
-        traceability: commonTraceability
-    )
-
-    static let aiSSEContractSmoke = ProtocolFixture(
-        id: "foundation.ai-sse.contract-smoke",
-        title: "AI streaming response with synthetic tool call",
-        family: .ai,
-        scenarioTags: ["ai", "sse", "streaming", "tool-call", "contract-smoke"],
-        traffic: ProtocolFixtureTraffic(exchanges: [
-            ProtocolFixtureExchange(
-                request: ProtocolFixtureMessage(
-                    method: "POST",
-                    url: "https://ai.example.com/v1/responses",
-                    headers: [
-                        .init(name: "Content-Type", value: "application/json"),
-                        .init(name: "Authorization", value: "Bearer synthetic-ai-token"),
-                    ],
-                    body: #"{"model":"synthetic-model","input":"[SYNTHETIC_PROMPT]","tool_choice":"auto"}"#
-                ),
-                response: ProtocolFixtureMessage(
-                    method: "HTTP",
-                    url: "https://ai.example.com/v1/responses",
-                    statusCode: 200,
-                    headers: [.init(name: "Content-Type", value: "text/event-stream")],
-                    body: nil
-                ),
-                streamEvents: [
-                    .init(event: "response.created", data: #"{"id":"resp_fixture","model":"synthetic-model"}"#),
-                    .init(event: "response.tool_call.delta", data: #"{"name":"lookup_order","arguments":"{\"order_id\":\"fixture-order\"}"}"#),
-                    .init(event: "response.completed", data: #"{"id":"resp_fixture","status":"completed"}"#),
-                ]
-            )
-        ]),
-        expected: ProtocolFixtureExpectations(
-            metadataHints: ["ai", "streaming", "tool_call", "model_request"],
-            redaction: ProtocolFixtureRedactionExpectation(
-                sensitiveFields: ["Authorization", "input", "tool_choice", "arguments"],
-                redactedMarkers: ["[REDACTED]"],
-                safeFields: ["model", "status"]
-            ),
-            ux: ProtocolFixtureUXExpectation(
-                requestListBadges: ["AI", "Stream"],
-                optionalColumns: ["protocol": "AI", "streaming": "true"],
-                inspectorTabs: ["AI", "Stream", "Tool Calls", "Raw"],
-                warningStates: ["prompt_redaction_candidate", "tool_payload_redaction_candidate"],
-                exportSummaryFields: ["model", "stream_event_count", "tool_call_count", "redacted_fields"],
-                mcpSummaryFields: ["model", "status", "streaming", "redacted"],
-                fallbackBehavior: nil
-            )
-        ),
-        safetyClass: .containsSyntheticSensitiveData,
-        sizeClass: .small,
-        traceability: commonTraceability
-    )
-
-    static let evmJSONRPCContractSmoke = ProtocolFixture(
-        id: "foundation.evm-json-rpc.contract-smoke",
-        title: "EVM JSON-RPC request with synthetic method summary",
-        family: .web3RPC,
-        scenarioTags: ["web3", "evm", "json-rpc", "contract-smoke"],
-        traffic: ProtocolFixtureTraffic(exchanges: [
-            ProtocolFixtureExchange(
-                request: ProtocolFixtureMessage(
-                    method: "POST",
-                    url: "https://rpc.example.com/evm",
-                    headers: [.init(name: "Content-Type", value: "application/json")],
-                    body: #"{"jsonrpc":"2.0","id":"fixture-1","method":"eth_call","params":[{"to":"0xSyntheticContract","data":"0xsyntheticCallData"},"latest"]}"#
-                ),
-                response: ProtocolFixtureMessage(
-                    method: "HTTP",
-                    url: "https://rpc.example.com/evm",
-                    statusCode: 200,
-                    headers: [.init(name: "Content-Type", value: "application/json")],
-                    body: #"{"jsonrpc":"2.0","id":"fixture-1","result":"0xsyntheticResult"}"#
-                )
-            )
-        ]),
-        expected: ProtocolFixtureExpectations(
-            metadataHints: ["web3", "json_rpc", "evm", "eth_call"],
-            redaction: ProtocolFixtureRedactionExpectation(
-                sensitiveFields: ["params.data"],
-                redactedMarkers: ["[REDACTED]"],
-                safeFields: ["jsonrpc", "method", "id"]
-            ),
-            ux: ProtocolFixtureUXExpectation(
-                requestListBadges: ["RPC", "EVM"],
-                optionalColumns: ["rpc_method": "eth_call"],
-                inspectorTabs: ["RPC", "JSON", "Raw"],
-                warningStates: [],
-                exportSummaryFields: ["rpc_method", "chain_hint", "redacted_fields"],
-                mcpSummaryFields: ["rpc_method", "status", "redacted"],
-                fallbackBehavior: nil
-            )
-        ),
-        safetyClass: .containsSyntheticSensitiveData,
-        sizeClass: .small,
-        traceability: commonTraceability
-    )
-
-    static let x402ContractSmoke = ProtocolFixture(
-        id: "foundation.x402.contract-smoke",
-        title: "x402-style payment-required retry flow",
-        family: .x402,
-        scenarioTags: ["x402", "payment-required", "retry", "contract-smoke"],
-        traffic: ProtocolFixtureTraffic(exchanges: [
-            ProtocolFixtureExchange(
-                request: ProtocolFixtureMessage(
-                    method: "GET",
-                    url: "https://payments.example.com/protected/report",
-                    headers: [.init(name: "Accept", value: "application/json")]
-                ),
-                response: ProtocolFixtureMessage(
-                    method: "HTTP",
-                    url: "https://payments.example.com/protected/report",
-                    statusCode: 402,
-                    headers: [.init(name: "Content-Type", value: "application/json")],
-                    body: #"{"x402Version":1,"paymentRequired":true,"challenge":"synthetic-payment-challenge"}"#
-                )
-            ),
-            ProtocolFixtureExchange(
-                request: ProtocolFixtureMessage(
-                    method: "GET",
-                    url: "https://payments.example.com/protected/report",
-                    headers: [
-                        .init(name: "Accept", value: "application/json"),
-                        .init(name: "X-Payment", value: "synthetic-payment-proof"),
-                    ]
-                ),
-                response: ProtocolFixtureMessage(
-                    method: "HTTP",
-                    url: "https://payments.example.com/protected/report",
-                    statusCode: 200,
-                    headers: [.init(name: "Content-Type", value: "application/json")],
-                    body: #"{"ok":true,"receipt":"synthetic-receipt"}"#
-                )
-            )
-        ]),
-        expected: ProtocolFixtureExpectations(
-            metadataHints: ["x402", "payment_required", "retry_flow"],
-            redaction: ProtocolFixtureRedactionExpectation(
-                sensitiveFields: ["X-Payment", "challenge", "receipt"],
-                redactedMarkers: ["[REDACTED]"],
-                safeFields: ["x402Version", "paymentRequired", "ok"]
-            ),
-            ux: ProtocolFixtureUXExpectation(
-                requestListBadges: ["x402", "402"],
-                optionalColumns: ["payment_flow": "required_then_success"],
-                inspectorTabs: ["Payment", "Headers", "Raw"],
-                warningStates: ["payment_metadata_redaction_candidate"],
-                exportSummaryFields: ["payment_required", "retry_count", "redacted_fields"],
-                mcpSummaryFields: ["payment_flow", "status", "redacted"],
-                fallbackBehavior: nil
-            )
-        ),
-        safetyClass: .containsSyntheticSensitiveData,
-        sizeClass: .small,
-        traceability: commonTraceability
-    )
-
-    static let malformedPayloadContractSmoke = ProtocolFixture(
-        id: "foundation.malformed-json.contract-smoke",
-        title: "Malformed JSON payload with bounded fallback contract",
-        family: .unknown,
-        scenarioTags: ["malformed", "json", "fallback", "contract-smoke"],
-        traffic: ProtocolFixtureTraffic(exchanges: [
-            ProtocolFixtureExchange(
-                request: ProtocolFixtureMessage(
-                    method: "POST",
-                    url: "https://test.invalid/malformed",
-                    headers: [.init(name: "Content-Type", value: "application/json")],
-                    body: #"{"message":"unterminated""#
-                ),
-                response: ProtocolFixtureMessage(
-                    method: "HTTP",
-                    url: "https://test.invalid/malformed",
-                    statusCode: 400,
-                    headers: [.init(name: "Content-Type", value: "text/plain")],
-                    body: "Malformed synthetic payload"
-                )
-            )
-        ]),
-        expected: ProtocolFixtureExpectations(
-            metadataHints: ["malformed", "fallback"],
-            redaction: ProtocolFixtureRedactionExpectation(
-                sensitiveFields: [],
-                redactedMarkers: [],
-                safeFields: ["message"]
-            ),
-            ux: ProtocolFixtureUXExpectation(
-                requestListBadges: ["Malformed"],
-                optionalColumns: ["parse_state": "failed"],
-                inspectorTabs: ["Raw"],
-                warningStates: ["malformed_payload"],
-                exportSummaryFields: ["parse_state", "omitted_protocol_summary"],
-                mcpSummaryFields: ["parse_state"],
-                fallbackBehavior: "Show bounded raw fallback without protocol-specific inspector content."
-            )
-        ),
-        safetyClass: .malformed,
-        sizeClass: .small,
-        traceability: commonTraceability
-    )
-}
-
 // MARK: - Validation
 
 enum ProtocolFixtureValidation {
@@ -405,8 +193,8 @@ enum ProtocolFixtureValidation {
         if fixture.scenarioTags.isEmpty {
             failures.append("\(fixture.id): scenarioTags must not be empty.")
         }
-        if fixture.traffic.exchanges.isEmpty {
-            failures.append("\(fixture.id): traffic.exchanges must not be empty.")
+        if fixture.traffic.exchanges.isEmpty && fixture.traffic.webSocketMessages.isEmpty {
+            failures.append("\(fixture.id): traffic must include exchanges or WebSocket messages.")
         }
         if fixture.expected.metadataHints.isEmpty {
             failures.append("\(fixture.id): expected.metadataHints must not be empty.")
@@ -428,6 +216,18 @@ enum ProtocolFixtureValidation {
         }
         if !fixture.traceability.childIssues.isSuperset(of: [186, 187, 194, 195]) {
             failures.append("\(fixture.id): traceability.childIssues must include Group A child issues.")
+        }
+        if fixture.safetyClass == .malformed && fixture.expected.ux.fallbackBehavior == nil {
+            failures.append("\(fixture.id): malformed fixtures must declare fallback behavior.")
+        }
+        if fixture.safetyClass == .large && fixture.sizeClass != .boundedStress {
+            failures.append("\(fixture.id): large fixtures must use boundedStress size class.")
+        }
+        if fixture.sizeClass == .boundedStress && fixture.traffic.estimatedPayloadBytes <= 0 {
+            failures.append("\(fixture.id): boundedStress fixtures must declare estimatedPayloadBytes.")
+        }
+        if fixture.traffic.estimatedPayloadBytes > 32_000 {
+            failures.append("\(fixture.id): estimatedPayloadBytes exceeds the test corpus budget.")
         }
 
         return failures
@@ -456,6 +256,10 @@ enum ProtocolFixtureSafetyScanner {
                 findings.append(contentsOf: scan(text: event.data, fixtureID: fixture.id, context: "stream data"))
             }
         }
+        for message in fixture.traffic.webSocketMessages {
+            findings.append(contentsOf: scanHost(message.url, fixtureID: fixture.id))
+            findings.append(contentsOf: scan(text: message.body, fixtureID: fixture.id, context: "websocket body"))
+        }
 
         return findings
     }
@@ -470,6 +274,7 @@ enum ProtocolFixtureSafetyScanner {
             ("AWS access key", #"\bAKIA[0-9A-Z]{16}\b"#),
             ("Ethereum private-key-like value", #"\b0x[0-9a-fA-F]{64}\b"#),
             ("realistic bearer token", #"Bearer\s+(?!(?:synthetic|fake|example)[A-Za-z0-9._~+/-]*\b)[A-Za-z0-9._~+/-]{20,}"#),
+            ("seed phrase-like sample", #"\b(?:abandon|ability|able|about|above|absent|absorb|abstract|absurd|abuse)\s+(?:[a-z]+\s+){10,23}[a-z]+\b"#),
         ]
 
         var findings: [Finding] = []


### PR DESCRIPTION
## Description
Expands the test-only protocol fixture corpus for the protocol-aware debugging roadmap. The corpus now defines synthetic, public-safe contracts for protocol metadata, redaction, inspector routing expectations, export summaries, MCP-safe summaries, parser fallback behavior, and traceability across the full Group A delivery set.

Refs #176
Refs #186
Refs #187
Refs #188
Refs #189
Refs #190
Refs #191
Refs #192
Refs #193
Refs #194
Refs #195

## Changes

- Added a shared protocol fixture schema and validation harness for ordinary HTTP, AI streaming, AI embeddings/retrieval, EVM JSON-RPC, Solana RPC/subscriptions, x402 payment flows, malformed payloads, and bounded hostile payloads.
- Split fixture definitions into a dedicated helper file so the schema, validation, and corpus data stay maintainable as coverage grows.
- Added fixture coverage tests for tool-call streams, interrupted provider streams, embedding/vector/RAG flows, EVM batch/error/large cases, Solana WebSocket lifecycle cases, x402 retry/error cases, hostile payload fallback behavior, safety scanning, and issue traceability.
- Extended safety scanning to cover WebSocket payloads, synthetic host allow-listing, seed phrase-like samples, and bounded stress payload budgets.
- Updated the test-only corpus guide with the Group A issue map and extension process.

## Design Scope

- No production UI surfaces are changed in this PR.
- UX fields in the corpus are contract expectations for future implementation and should not be treated as shipped UI behavior until the app views implement them.

## Validation

- `xcodebuild -project Rockxy.xcodeproj -scheme Rockxy -destination 'platform=macOS' -only-testing:RockxyTests/ProtocolFixtureCorpusTests test`
- `swiftlint lint --strict RockxyTests/Helpers/ProtocolFixtureCorpus.swift RockxyTests/Helpers/ProtocolFixtureCorpus+Fixtures.swift RockxyTests/Core/Detection/ProtocolFixtureCorpusTests.swift`
- `git diff --check`
- `git diff --cached --check`

Note: full `swiftlint lint --strict` currently reports existing file-length violations in `Rockxy/Views/Rules/MapLocalWindowView.swift` and `Rockxy/Views/Main/WorkspaceWindowManager.swift`, outside this PR.

## Checklist

- [x] Tests added or updated
- [x] `CHANGELOG.md` updated under `[Unreleased]` (not needed: test-only foundation, no user-facing behavior)
- [x] Docs updated in `docs/` if the change affects user-facing behavior (not needed: no user-facing behavior)
- [x] User-facing strings localized with `String(localized:)` (not needed: no user-facing strings)
- [x] No SwiftLint / SwiftFormat violations (`swiftlint lint --strict && swiftformat .`) (focused SwiftLint passes; full SwiftLint has unrelated existing file-length violations noted above)
- [x] If this PR touches helper packaging, release scripts, or platform compatibility claims, Intel + Apple Silicon validation was updated or re-run (not applicable)

## CLA

This project requires a signed [Contributor License Agreement](CLA.md).
If this is your first contribution, the CLA Assistant bot will comment on this PR
with instructions. You must sign the CLA before this PR can be merged.