### PR TITLE
feat: add native AI response inspector

### DIFF
--- a/Rockxy/Core/Detection/AITrafficDetector.swift
+++ b/Rockxy/Core/Detection/AITrafficDetector.swift
@@ -16,6 +16,17 @@ nonisolated enum AITrafficDetector {
         isLikelyAI(snapshot: AITrafficSnapshot(transaction: transaction))
     }
 
+    static func signal(transaction: HTTPTransaction) -> AITrafficSignal {
+        signal(snapshot: AITrafficSnapshot(transaction: transaction))
+    }
+
+    static func signal(snapshot: AITrafficSnapshot) -> AITrafficSignal {
+        if let provider = provider(from: snapshot) {
+            return AITrafficSignal(isLikelyAI: true, provider: provider)
+        }
+        return AITrafficSignal(isLikelyAI: isLikelyAI(snapshot: snapshot), provider: nil)
+    }
+
     static func isLikelyAI(snapshot: AITrafficSnapshot) -> Bool {
         if provider(from: snapshot) != nil {
             return true
@@ -493,6 +504,25 @@ enum AIProvider: String, Sendable {
         case .openAICompatible: "OpenAI-compatible"
         case .anthropic: "Anthropic"
         }
+    }
+}
+
+struct AITrafficSignal: Equatable, Sendable {
+    let isLikelyAI: Bool
+    let provider: AIProvider?
+
+    var tableLabel: String {
+        isLikelyAI ? "AI" : ""
+    }
+
+    var accessibilityLabel: String {
+        guard isLikelyAI else {
+            return ""
+        }
+        if let provider {
+            return "Likely AI model traffic: \(provider.displayName)"
+        }
+        return "Likely AI model traffic"
     }
 }
 

--- a/Rockxy/Core/Detection/AITrafficDetector.swift
+++ b/Rockxy/Core/Detection/AITrafficDetector.swift
@@ -1,0 +1,565 @@
+import Foundation
+
+// MARK: - AITrafficDetector
+
+/// Lightweight, bounded parser for AI-model HTTP traffic.
+///
+/// The detector intentionally works from captured HTTP evidence only. It does not infer
+/// provider internals, token boundaries, or pricing when those fields are not present.
+nonisolated enum AITrafficDetector {
+    // MARK: Internal
+
+    static let maxBodyBytes = 256 * 1_024
+    static let maxQuickScanBytes = 16 * 1_024
+
+    static func isLikelyAI(transaction: HTTPTransaction) -> Bool {
+        isLikelyAI(snapshot: AITrafficSnapshot(transaction: transaction))
+    }
+
+    static func isLikelyAI(snapshot: AITrafficSnapshot) -> Bool {
+        if provider(from: snapshot) != nil {
+            return true
+        }
+
+        let requestPrefix = snapshot.requestBody
+            .flatMap { String(bytes: $0.prefix(maxQuickScanBytes), encoding: .utf8)?.lowercased() } ?? ""
+        if requestPrefix.contains(#""model""#),
+           requestPrefix.contains(#""messages""#)
+            || requestPrefix.contains(#""input""#)
+            || requestPrefix.contains(#""tools""#)
+        {
+            return true
+        }
+
+        let responsePrefix = snapshot.responseBody
+            .flatMap { String(bytes: $0.prefix(maxQuickScanBytes), encoding: .utf8)?.lowercased() } ?? ""
+        return responsePrefix.contains(#""usage""#)
+            && (responsePrefix.contains(#""input_tokens""#)
+                || responsePrefix.contains(#""output_tokens""#)
+                || responsePrefix.contains(#""prompt_tokens""#)
+                || responsePrefix.contains(#""completion_tokens""#))
+    }
+
+    static func detect(transaction: HTTPTransaction) -> AIInspection? {
+        detect(snapshot: AITrafficSnapshot(transaction: transaction))
+    }
+
+    static func detect(snapshot: AITrafficSnapshot) -> AIInspection? {
+        let requestJSON = parseJSONObject(snapshot.requestBody)
+        let responseJSON = parseJSONObject(snapshot.responseBody)
+        let streamEvents = parseSSEEvents(snapshot.responseBody)
+        let resolvedProvider = provider(from: snapshot) ?? provider(from: requestJSON, responseJSON: responseJSON)
+
+        guard let resolvedProvider,
+              isLikelyAI(snapshot: snapshot)
+        else {
+            return nil
+        }
+
+        let usage = usage(from: responseJSON, streamEvents: streamEvents)
+        let toolCalls = toolCalls(from: requestJSON, responseJSON: responseJSON, streamEvents: streamEvents)
+        let events = eventSummaries(
+            snapshot: snapshot,
+            responseJSON: responseJSON,
+            streamEvents: streamEvents,
+            toolCalls: toolCalls
+        )
+        let retrieval = retrievalMatches(snapshot: snapshot, responseJSON: responseJSON)
+        let warnings = warnings(
+            snapshot: snapshot,
+            requestJSON: requestJSON,
+            toolCalls: toolCalls,
+            retrieval: retrieval
+        )
+
+        return AIInspection(
+            provider: resolvedProvider,
+            model: stringValue(forKey: "model", in: requestJSON)
+                ?? stringValue(forKey: "model", in: responseJSON),
+            endpoint: snapshot.path.isEmpty ? snapshot.urlString : snapshot.path,
+            isStreaming: isStreaming(snapshot: snapshot, requestJSON: requestJSON, streamEvents: streamEvents),
+            httpStatusCode: snapshot.responseStatusCode,
+            duration: snapshot.duration,
+            usage: usage,
+            toolCalls: toolCalls,
+            events: events,
+            retrieval: retrieval,
+            warnings: warnings,
+            unavailableFields: unavailableFields(usage: usage, events: events, toolCalls: toolCalls)
+        )
+    }
+
+    // MARK: Private
+
+    private static func provider(from snapshot: AITrafficSnapshot) -> AIProvider? {
+        let host = snapshot.host.lowercased()
+        let path = snapshot.path.lowercased()
+        let headerNames = snapshot.requestHeaders.map { $0.name.lowercased() }
+
+        if host.contains("anthropic.com") || headerNames.contains("anthropic-version") {
+            return .anthropic
+        }
+        if host.contains("openai.com")
+            || path.contains("/v1/responses")
+            || path.contains("/v1/chat/completions")
+            || path.contains("/v1/embeddings")
+        {
+            return .openAICompatible
+        }
+        if path.contains("/chat/completions") || path.contains("/embeddings") {
+            return .openAICompatible
+        }
+        return nil
+    }
+
+    private static func provider(from requestJSON: [String: Any]?, responseJSON: [String: Any]?) -> AIProvider? {
+        if stringValue(forKey: "model", in: requestJSON) != nil || stringValue(forKey: "model", in: responseJSON) != nil {
+            return .openAICompatible
+        }
+        return nil
+    }
+
+    private static func parseJSONObject(_ data: Data?) -> [String: Any]? {
+        guard let data, !data.isEmpty, data.count <= maxBodyBytes else {
+            return nil
+        }
+        return (try? JSONSerialization.jsonObject(with: data)) as? [String: Any]
+    }
+
+    private static func stringValue(forKey key: String, in json: [String: Any]?) -> String? {
+        json?[key] as? String
+    }
+
+    private static func intValue(forKey key: String, in json: [String: Any]?) -> Int? {
+        if let int = json?[key] as? Int {
+            return int
+        }
+        if let number = json?[key] as? NSNumber {
+            return number.intValue
+        }
+        return nil
+    }
+
+    private static func boolValue(forKey key: String, in json: [String: Any]?) -> Bool? {
+        if let bool = json?[key] as? Bool {
+            return bool
+        }
+        if let number = json?[key] as? NSNumber {
+            return number.boolValue
+        }
+        return nil
+    }
+
+    private static func usage(from responseJSON: [String: Any]?, streamEvents: [AIStreamEvent]) -> AIUsage? {
+        if let usage = usageObject(from: responseJSON) {
+            return usage
+        }
+
+        for event in streamEvents.reversed() {
+            guard let json = parseJSONObject(Data(event.data.utf8)),
+                  let usage = usageObject(from: json)
+            else {
+                continue
+            }
+            return usage
+        }
+        return nil
+    }
+
+    private static func usageObject(from json: [String: Any]?) -> AIUsage? {
+        guard let raw = json?["usage"] as? [String: Any] else {
+            return nil
+        }
+
+        let cached = (raw["prompt_tokens_details"] as? [String: Any])
+            .flatMap { intValue(forKey: "cached_tokens", in: $0) }
+        let input = intValue(forKey: "input_tokens", in: raw)
+            ?? intValue(forKey: "prompt_tokens", in: raw)
+        let output = intValue(forKey: "output_tokens", in: raw)
+            ?? intValue(forKey: "completion_tokens", in: raw)
+        let total = intValue(forKey: "total_tokens", in: raw)
+            ?? [input, output].compactMap { $0 }.reduce(0, +)
+
+        guard input != nil || output != nil || total > 0 else {
+            return nil
+        }
+        return AIUsage(inputTokens: input, cachedTokens: cached, outputTokens: output, totalTokens: total)
+    }
+
+    private static func toolCalls(
+        from requestJSON: [String: Any]?,
+        responseJSON: [String: Any]?,
+        streamEvents: [AIStreamEvent]
+    )
+        -> [AIToolCall]
+    {
+        var calls: [AIToolCall] = []
+        if let tools = requestJSON?["tools"] as? [[String: Any]] {
+            calls += tools.compactMap { tool in
+                let name = tool["name"] as? String
+                    ?? (tool["function"] as? [String: Any])?["name"] as? String
+                return name.map {
+                    AIToolCall(name: $0, argumentsPreview: nil, state: .declared)
+                }
+            }
+        }
+
+        calls += responseToolCalls(from: responseJSON)
+
+        for event in streamEvents where event.event?.lowercased().contains("tool") == true || event.data.contains("tool") {
+            guard let json = parseJSONObject(Data(event.data.utf8)) else {
+                calls.append(AIToolCall(name: "tool_call", argumentsPreview: event.data, state: .partial))
+                continue
+            }
+            if let name = stringValue(forKey: "name", in: json) {
+                calls.append(AIToolCall(
+                    name: name,
+                    argumentsPreview: stringValue(forKey: "arguments", in: json),
+                    state: .streaming
+                ))
+            }
+        }
+
+        return Array(calls.prefix(12))
+    }
+
+    private static func responseToolCalls(from responseJSON: [String: Any]?) -> [AIToolCall] {
+        if let output = responseJSON?["output"] as? [[String: Any]] {
+            return output.compactMap { item in
+                guard (item["type"] as? String)?.contains("function") == true else {
+                    return nil
+                }
+                return AIToolCall(
+                    name: item["name"] as? String ?? "tool_call",
+                    argumentsPreview: item["arguments"] as? String,
+                    state: .completed
+                )
+            }
+        }
+
+        let choices = responseJSON?["choices"] as? [[String: Any]]
+        let message = choices?.first?["message"] as? [String: Any]
+        let calls = message?["tool_calls"] as? [[String: Any]] ?? []
+        return calls.compactMap { call in
+            let function = call["function"] as? [String: Any]
+            return AIToolCall(
+                name: function?["name"] as? String ?? "tool_call",
+                argumentsPreview: function?["arguments"] as? String,
+                state: .completed
+            )
+        }
+    }
+
+    private static func eventSummaries(
+        snapshot: AITrafficSnapshot,
+        responseJSON: [String: Any]?,
+        streamEvents: [AIStreamEvent],
+        toolCalls: [AIToolCall]
+    )
+        -> [AIEventSummary]
+    {
+        if !streamEvents.isEmpty {
+            return streamEvents.enumerated().map { index, event in
+                let eventName = event.event ?? "data"
+                let category: AIEventCategory = eventName.lowercased().contains("tool") ? .tool : .stream
+                let severity: AIEventSeverity = eventName.lowercased().contains("error") ? .error : .normal
+                return AIEventSummary(
+                    id: "stream-\(index)",
+                    title: eventName,
+                    detail: event.data,
+                    offsetLabel: "#\(index + 1)",
+                    category: category,
+                    severity: severity
+                )
+            }
+        }
+
+        var events: [AIEventSummary] = [
+            AIEventSummary(
+                id: "request",
+                title: "model request",
+                detail: snapshot.urlString,
+                offsetLabel: "request",
+                category: .request,
+                severity: .normal
+            )
+        ]
+        events += toolCalls.enumerated().map { index, tool in
+            AIEventSummary(
+                id: "tool-\(index)",
+                title: tool.name,
+                detail: tool.argumentsPreview ?? tool.state.displayName,
+                offsetLabel: tool.state.displayName,
+                category: .tool,
+                severity: .normal
+            )
+        }
+        if let status = snapshot.responseStatusCode {
+            events.append(AIEventSummary(
+                id: "response",
+                title: "response",
+                detail: responseJSON?["status"] as? String ?? "HTTP \(status)",
+                offsetLabel: "\(status)",
+                category: .response,
+                severity: status >= 400 ? .error : .normal
+            ))
+        }
+        return events
+    }
+
+    private static func retrievalMatches(
+        snapshot: AITrafficSnapshot,
+        responseJSON: [String: Any]?
+    )
+        -> [AIRetrievalMatch]
+    {
+        let path = snapshot.path.lowercased()
+        guard path.contains("search") || path.contains("embedding") || path.contains("retrieval") else {
+            return []
+        }
+
+        let matches = responseJSON?["matches"] as? [[String: Any]]
+            ?? responseJSON?["data"] as? [[String: Any]]
+            ?? []
+        return matches.prefix(8).enumerated().map { index, match in
+            let source = match["id"] as? String ?? "match-\(index + 1)"
+            let score = (match["score"] as? NSNumber)?.doubleValue
+            return AIRetrievalMatch(
+                source: source,
+                score: score,
+                signal: path.contains("embedding") ? "embedding" : "retrieval",
+                risk: (match["snippet"] as? String)?.lowercased().contains("secret") == true ? "sensitive-context" : "visible"
+            )
+        }
+    }
+
+    private static func warnings(
+        snapshot: AITrafficSnapshot,
+        requestJSON: [String: Any]?,
+        toolCalls: [AIToolCall],
+        retrieval: [AIRetrievalMatch]
+    )
+        -> [AIWarning]
+    {
+        var warnings: [AIWarning] = []
+        if headerValue(named: "authorization", in: snapshot.requestHeaders) != nil
+            || headerValue(named: "x-api-key", in: snapshot.requestHeaders) != nil
+        {
+            warnings.append(AIWarning(message: "Authentication header is present.", severity: .redaction))
+        }
+        if requestJSON?["input"] != nil || requestJSON?["messages"] != nil {
+            warnings.append(AIWarning(message: "Prompt content may require redaction.", severity: .redaction))
+        }
+        if !toolCalls.isEmpty {
+            warnings.append(AIWarning(message: "Tool arguments may contain sensitive data.", severity: .redaction))
+        }
+        if retrieval.contains(where: { $0.risk == "sensitive-context" }) {
+            warnings.append(AIWarning(message: "Retrieved context includes sensitive-looking snippets.", severity: .redaction))
+        }
+        if let status = snapshot.responseStatusCode, status >= 400 {
+            warnings.append(AIWarning(message: "Provider returned HTTP \(status).", severity: .error))
+        }
+        return warnings
+    }
+
+    private static func unavailableFields(
+        usage: AIUsage?,
+        events: [AIEventSummary],
+        toolCalls: [AIToolCall]
+    )
+        -> [String]
+    {
+        var fields: [String] = []
+        if usage == nil {
+            fields.append("usage")
+        }
+        if events.allSatisfy({ $0.category != .stream }) {
+            fields.append("stream events")
+        }
+        if toolCalls.isEmpty {
+            fields.append("tool calls")
+        }
+        return fields
+    }
+
+    private static func isStreaming(
+        snapshot: AITrafficSnapshot,
+        requestJSON: [String: Any]?,
+        streamEvents: [AIStreamEvent]
+    )
+        -> Bool
+    {
+        boolValue(forKey: "stream", in: requestJSON) == true
+            || !streamEvents.isEmpty
+            || headerValue(named: "content-type", in: snapshot.responseHeaders)?.lowercased().contains("text/event-stream") == true
+    }
+
+    private static func parseSSEEvents(_ data: Data?) -> [AIStreamEvent] {
+        guard let data,
+              data.count <= maxBodyBytes,
+              let text = String(data: data, encoding: .utf8),
+              text.contains("data:")
+        else {
+            return []
+        }
+
+        var events: [AIStreamEvent] = []
+        var currentEvent: String?
+        var currentData: [String] = []
+
+        func flush() {
+            guard !currentData.isEmpty else {
+                currentEvent = nil
+                return
+            }
+            let data = currentData.joined(separator: "\n")
+            if data.trimmingCharacters(in: .whitespacesAndNewlines) != "[DONE]" {
+                events.append(AIStreamEvent(event: currentEvent, data: data))
+            }
+            currentEvent = nil
+            currentData = []
+        }
+
+        for rawLine in text.split(separator: "\n", omittingEmptySubsequences: false) {
+            let line = rawLine.trimmingCharacters(in: .whitespacesAndNewlines)
+            if line.isEmpty {
+                flush()
+            } else if line.hasPrefix("event:") {
+                currentEvent = String(line.dropFirst("event:".count)).trimmingCharacters(in: .whitespaces)
+            } else if line.hasPrefix("data:") {
+                currentData.append(String(line.dropFirst("data:".count)).trimmingCharacters(in: .whitespaces))
+            }
+        }
+        flush()
+        return Array(events.prefix(200))
+    }
+
+    private static func headerValue(named name: String, in headers: [HTTPHeader]) -> String? {
+        headers.first { $0.name.caseInsensitiveCompare(name) == .orderedSame }?.value
+    }
+}
+
+// MARK: - AITrafficSnapshot
+
+struct AITrafficSnapshot: Sendable {
+    init(transaction: HTTPTransaction) {
+        requestMethod = transaction.request.method
+        urlString = transaction.request.url.absoluteString
+        host = transaction.request.host
+        path = transaction.request.path
+        requestHeaders = transaction.request.headers
+        requestBody = transaction.request.body
+        responseStatusCode = transaction.response?.statusCode
+        responseHeaders = transaction.response?.headers ?? []
+        responseBody = transaction.response?.body
+        duration = transaction.timingInfo?.totalDuration ?? transaction.measuredDuration
+    }
+
+    let requestMethod: String
+    let urlString: String
+    let host: String
+    let path: String
+    let requestHeaders: [HTTPHeader]
+    let requestBody: Data?
+    let responseStatusCode: Int?
+    let responseHeaders: [HTTPHeader]
+    let responseBody: Data?
+    let duration: TimeInterval?
+}
+
+// MARK: - AIInspection
+
+struct AIInspection: Equatable, Sendable {
+    let provider: AIProvider
+    let model: String?
+    let endpoint: String
+    let isStreaming: Bool
+    let httpStatusCode: Int?
+    let duration: TimeInterval?
+    let usage: AIUsage?
+    let toolCalls: [AIToolCall]
+    let events: [AIEventSummary]
+    let retrieval: [AIRetrievalMatch]
+    let warnings: [AIWarning]
+    let unavailableFields: [String]
+}
+
+enum AIProvider: String, Sendable {
+    case openAICompatible
+    case anthropic
+
+    var displayName: String {
+        switch self {
+        case .openAICompatible: "OpenAI-compatible"
+        case .anthropic: "Anthropic"
+        }
+    }
+}
+
+struct AIUsage: Equatable, Sendable {
+    let inputTokens: Int?
+    let cachedTokens: Int?
+    let outputTokens: Int?
+    let totalTokens: Int
+}
+
+struct AIToolCall: Equatable, Sendable {
+    let name: String
+    let argumentsPreview: String?
+    let state: AIToolCallState
+}
+
+enum AIToolCallState: String, Sendable {
+    case declared
+    case streaming
+    case completed
+    case partial
+
+    var displayName: String {
+        rawValue
+    }
+}
+
+struct AIEventSummary: Equatable, Identifiable, Sendable {
+    let id: String
+    let title: String
+    let detail: String
+    let offsetLabel: String
+    let category: AIEventCategory
+    let severity: AIEventSeverity
+}
+
+enum AIEventCategory: String, Sendable {
+    case request
+    case stream
+    case tool
+    case response
+}
+
+enum AIEventSeverity: String, Sendable {
+    case normal
+    case warning
+    case error
+}
+
+struct AIRetrievalMatch: Equatable, Sendable {
+    let source: String
+    let score: Double?
+    let signal: String
+    let risk: String
+}
+
+struct AIWarning: Equatable, Sendable {
+    let message: String
+    let severity: AIWarningSeverity
+}
+
+enum AIWarningSeverity: String, Sendable {
+    case redaction
+    case error
+}
+
+private struct AIStreamEvent: Equatable {
+    let event: String?
+    let data: String
+}

--- a/Rockxy/Models/UI/HeaderColumnStore.swift
+++ b/Rockxy/Models/UI/HeaderColumnStore.swift
@@ -25,6 +25,7 @@ final class HeaderColumnStore {
     var discoveredRequestHeaders: [String] = []
     var discoveredResponseHeaders: [String] = []
     var hiddenBuiltInColumns: Set<String> = []
+    var visibleDefaultHiddenBuiltInColumns: Set<String> = []
 
     var enabledColumns: [HeaderColumn] {
         columns.filter(\.isEnabled)
@@ -179,16 +180,26 @@ final class HeaderColumnStore {
     }
 
     func toggleBuiltInColumn(_ columnID: String) {
-        if hiddenBuiltInColumns.contains(columnID) {
-            hiddenBuiltInColumns.remove(columnID)
-        } else {
+        if isBuiltInColumnVisible(columnID) {
+            visibleDefaultHiddenBuiltInColumns.remove(columnID)
             hiddenBuiltInColumns.insert(columnID)
+        } else {
+            hiddenBuiltInColumns.remove(columnID)
+            if Self.defaultHiddenBuiltInColumns.contains(columnID) {
+                visibleDefaultHiddenBuiltInColumns.insert(columnID)
+            }
         }
         saveHiddenColumns()
     }
 
     func isBuiltInColumnVisible(_ columnID: String) -> Bool {
-        !hiddenBuiltInColumns.contains(columnID)
+        if hiddenBuiltInColumns.contains(columnID) {
+            return false
+        }
+        if Self.defaultHiddenBuiltInColumns.contains(columnID) {
+            return visibleDefaultHiddenBuiltInColumns.contains(columnID)
+        }
+        return true
     }
 
     func reload() {
@@ -202,6 +213,8 @@ final class HeaderColumnStore {
     private static let discoveredReqKey = RockxyIdentity.current.defaultsKey("discoveredReqHeaders")
     private static let discoveredResKey = RockxyIdentity.current.defaultsKey("discoveredResHeaders")
     private static let hiddenColumnsKey = RockxyIdentity.current.defaultsKey("hiddenBuiltInColumns")
+    private static let visibleDefaultHiddenColumnsKey = RockxyIdentity.current.defaultsKey("visibleDefaultHiddenBuiltInColumns")
+    private static let defaultHiddenBuiltInColumns: Set<String> = ["ai"]
 
     // Internal dedup sets for O(1) membership checks during incremental discovery
     private var discoveredRequestHeaderSet: Set<String> = []
@@ -210,6 +223,10 @@ final class HeaderColumnStore {
     private func saveHiddenColumns() {
         let array = Array(hiddenBuiltInColumns)
         UserDefaults.standard.set(array, forKey: Self.hiddenColumnsKey)
+        UserDefaults.standard.set(
+            Array(visibleDefaultHiddenBuiltInColumns),
+            forKey: Self.visibleDefaultHiddenColumnsKey
+        )
     }
 
     // MARK: - Persistence
@@ -226,6 +243,9 @@ final class HeaderColumnStore {
     private func load() {
         if let hidden = UserDefaults.standard.stringArray(forKey: Self.hiddenColumnsKey) {
             hiddenBuiltInColumns = Set(hidden)
+        }
+        if let visibleDefaultHidden = UserDefaults.standard.stringArray(forKey: Self.visibleDefaultHiddenColumnsKey) {
+            visibleDefaultHiddenBuiltInColumns = Set(visibleDefaultHidden)
         }
         if let reqHeaders = UserDefaults.standard.stringArray(forKey: Self.discoveredReqKey) {
             discoveredRequestHeaders = reqHeaders

--- a/Rockxy/Models/UI/RequestListRow.swift
+++ b/Rockxy/Models/UI/RequestListRow.swift
@@ -41,6 +41,7 @@ struct RequestListRow: Identifiable {
         comment = transaction.comment
         highlightColor = transaction.highlightColor
         isTLSFailure = transaction.isTLSFailure
+        aiTrafficSignal = AITrafficDetector.signal(transaction: transaction)
         graphQLOpName = transaction.graphQLInfo?.operationName
         graphQLOpType = transaction.graphQLInfo?.operationType.rawValue
         isWebSocket = transaction.webSocketConnection != nil
@@ -75,6 +76,7 @@ struct RequestListRow: Identifiable {
     let comment: String?
     let highlightColor: HighlightColor?
     let isTLSFailure: Bool
+    let aiTrafficSignal: AITrafficSignal
     let graphQLOpName: String?
     let graphQLOpType: String?
     let isWebSocket: Bool
@@ -169,6 +171,8 @@ extension RequestListRow {
             compareOptionalInt(lhs.responseSize, rhs.responseSize)
         case "ssl":
             compareInt(lhs.sslState.rawValue, rhs.sslState.rawValue)
+        case "ai":
+            compareAISignal(lhs, rhs)
         case "queryName":
             compareQueryName(lhs, rhs)
         case "client":
@@ -238,6 +242,16 @@ extension RequestListRow {
         default:
             .orderedSame
         }
+    }
+
+    private static func compareAISignal(_ lhs: RequestListRow, _ rhs: RequestListRow) -> ComparisonResult {
+        let presence = compareBool(lhs.aiTrafficSignal.isLikelyAI, rhs.aiTrafficSignal.isLikelyAI)
+        if presence != .orderedSame {
+            return presence
+        }
+        let lhsProvider = lhs.aiTrafficSignal.provider?.displayName ?? ""
+        let rhsProvider = rhs.aiTrafficSignal.provider?.displayName ?? ""
+        return lhsProvider.localizedCompare(rhsProvider)
     }
 
     private static func defaultSSLState(forScheme scheme: String) -> SSLState {

--- a/Rockxy/Models/UI/ResponseInspectorTab.swift
+++ b/Rockxy/Models/UI/ResponseInspectorTab.swift
@@ -2,6 +2,7 @@ import Foundation
 
 /// Tabs for the response half of the split inspector panel.
 enum ResponseInspectorTab: String, CaseIterable {
+    case ai
     case headers
     case body
     case setCookie
@@ -10,8 +11,15 @@ enum ResponseInspectorTab: String, CaseIterable {
 
     // MARK: Internal
 
+    static func availableTabs(hasAIInspection: Bool) -> [ResponseInspectorTab] {
+        allCases.filter { tab in
+            hasAIInspection || tab != .ai
+        }
+    }
+
     var displayName: String {
         switch self {
+        case .ai: "AI"
         case .headers: "Headers"
         case .body: "Body"
         case .setCookie: "Set-Cookie"

--- a/Rockxy/Views/Inspector/AIInspectorView.swift
+++ b/Rockxy/Views/Inspector/AIInspectorView.swift
@@ -1,0 +1,417 @@
+import SwiftUI
+
+// MARK: - AIInspectorView
+
+/// Native response-inspector tab for captured AI model traffic.
+///
+/// The view renders from a bounded detector snapshot so switching selected transactions
+/// cannot leave stale parser output in the inspector.
+struct AIInspectorView: View {
+    // MARK: Internal
+
+    let transaction: HTTPTransaction
+
+    var body: some View {
+        Group {
+            if isLoading {
+                ProgressView()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else if let inspection {
+                VStack(spacing: 0) {
+                    summaryStrip(inspection)
+                    Divider()
+                    HSplitView {
+                        eventList(inspection)
+                            .frame(minWidth: 220, idealWidth: 280, maxWidth: 360)
+                        detailPane(inspection)
+                            .frame(minWidth: 280, maxWidth: .infinity)
+                    }
+                }
+            } else {
+                InspectorEmptyStateView(
+                    String(localized: "No AI Metadata"),
+                    systemImage: "sparkles",
+                    description: String(localized: "This response does not look like captured AI model traffic.")
+                )
+            }
+        }
+        .task(id: transaction.id) {
+            await loadInspection()
+        }
+    }
+
+    // MARK: Private
+
+    @State private var inspection: AIInspection?
+    @State private var selectedEventID: String?
+    @State private var filter: AIInspectorEventFilter = .all
+    @State private var isLoading = true
+    @Environment(\.appUIDisplayMetrics) private var metrics
+
+    private var selectedEvent: AIEventSummary? {
+        guard let inspection else {
+            return nil
+        }
+        if let selectedEventID,
+           let event = inspection.events.first(where: { $0.id == selectedEventID })
+        {
+            return event
+        }
+        return inspection.events.first
+    }
+
+    private func loadInspection() async {
+        isLoading = true
+        let snapshot = AITrafficSnapshot(transaction: transaction)
+        let transactionID = transaction.id
+        let detected = await Task.detached(priority: .userInitiated) {
+            AITrafficDetector.detect(snapshot: snapshot)
+        }.value
+
+        guard transaction.id == transactionID else {
+            return
+        }
+        inspection = detected
+        selectedEventID = detected?.events.first?.id
+        isLoading = false
+    }
+
+    private func summaryStrip(_ inspection: AIInspection) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(spacing: 18) {
+                summaryItem(String(localized: "Provider"), value: inspection.provider.displayName)
+                summaryItem(String(localized: "Model"), value: inspection.model ?? String(localized: "Unavailable"))
+                summaryItem(String(localized: "Finish"), value: finishLabel(for: inspection))
+                summaryItem(String(localized: "Confidence"), value: confidenceLabel(for: inspection))
+            }
+
+            Text(unavailableSummary(for: inspection))
+                .font(.system(size: metrics.metadataFontSize))
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+                .truncationMode(.tail)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(.quaternary.opacity(0.5))
+    }
+
+    private func summaryItem(_ label: String, value: String) -> some View {
+        HStack(spacing: 4) {
+            Text(label)
+                .font(.system(size: metrics.secondaryFontSize))
+                .foregroundStyle(.secondary)
+            Text(value)
+                .font(.system(size: metrics.secondaryFontSize, weight: .medium, design: .monospaced))
+                .lineLimit(1)
+                .truncationMode(.middle)
+                .textSelection(.enabled)
+        }
+    }
+
+    private func eventList(_ inspection: AIInspection) -> some View {
+        VStack(spacing: 0) {
+            Picker(selection: $filter) {
+                Text(String(localized: "All")).tag(AIInspectorEventFilter.all)
+                Text(String(localized: "Stream")).tag(AIInspectorEventFilter.stream)
+                Text(String(localized: "Tools")).tag(AIInspectorEventFilter.tools)
+            } label: {
+                EmptyView()
+            }
+            .pickerStyle(.segmented)
+            .controlSize(.small)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 6)
+
+            Divider()
+
+            let events = filteredEvents(inspection.events)
+            if events.isEmpty {
+                InspectorEmptyStateView(
+                    String(localized: "No Events"),
+                    systemImage: "list.bullet",
+                    description: String(localized: "No captured events match this filter.")
+                )
+            } else {
+                List(events, selection: $selectedEventID) { event in
+                    eventRow(event)
+                        .tag(event.id)
+                }
+                .listStyle(.inset(alternatesRowBackgrounds: true))
+            }
+        }
+    }
+
+    private func eventRow(_ event: AIEventSummary) -> some View {
+        HStack(spacing: 6) {
+            severityDot(event.severity)
+            Text(event.title)
+                .font(.system(size: metrics.metadataFontSize, design: .monospaced))
+                .lineLimit(1)
+                .truncationMode(.middle)
+            Spacer(minLength: 8)
+            Text(event.offsetLabel)
+                .font(.system(size: metrics.metadataFontSize, design: .monospaced))
+                .foregroundStyle(event.severity == .error ? .red : .secondary)
+                .lineLimit(1)
+        }
+    }
+
+    private func severityDot(_ severity: AIEventSeverity) -> some View {
+        Circle()
+            .fill(severity == .error ? Color.red : Color.accentColor)
+            .frame(width: 7, height: 7)
+    }
+
+    private func detailPane(_ inspection: AIInspection) -> some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 14) {
+                timingSection(inspection)
+                usageSection(inspection)
+                toolChainSection(inspection)
+                retrievalSection(inspection)
+                warningSection(inspection)
+                selectedEventSection
+            }
+            .padding(12)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    private func timingSection(_ inspection: AIInspection) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            sectionHeader(String(localized: "Timing and Stream"))
+            HStack(spacing: 14) {
+                metadataPair(String(localized: "Duration"), value: durationLabel(inspection.duration))
+                metadataPair(String(localized: "Streaming"), value: inspection.isStreaming ? String(localized: "Yes") : String(localized: "No"))
+                metadataPair(String(localized: "Events"), value: "\(inspection.events.count)")
+            }
+            streamBars(inspection.events)
+            Text(String(localized: "SSE cadence is shown from captured events. Token boundaries stay unavailable unless the provider exposes them."))
+                .font(.system(size: metrics.metadataFontSize))
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private func streamBars(_ events: [AIEventSummary]) -> some View {
+        HStack(alignment: .bottom, spacing: 5) {
+            ForEach(Array(events.prefix(18).enumerated()), id: \.element.id) { index, event in
+                RoundedRectangle(cornerRadius: 1.5)
+                    .fill(event.category == .tool ? Color.orange : Color.accentColor)
+                    .frame(width: 8, height: CGFloat(10 + ((index * 7) % 24)))
+                    .help(event.title)
+            }
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 6)
+        .frame(height: 48, alignment: .bottomLeading)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color(nsColor: .controlBackgroundColor), in: RoundedRectangle(cornerRadius: 4))
+    }
+
+    @ViewBuilder private func usageSection(_ inspection: AIInspection) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            sectionHeader(String(localized: "Usage"))
+            if let usage = inspection.usage {
+                HStack(spacing: 16) {
+                    metadataPair(String(localized: "Input"), value: tokenLabel(usage.inputTokens))
+                    metadataPair(String(localized: "Cached"), value: tokenLabel(usage.cachedTokens))
+                    metadataPair(String(localized: "Output"), value: tokenLabel(usage.outputTokens))
+                    metadataPair(String(localized: "Total"), value: "\(usage.totalTokens)")
+                }
+                tokenBar(usage)
+            } else {
+                unavailableText(String(localized: "Usage fields were not present in the captured provider response."))
+            }
+        }
+    }
+
+    private func tokenBar(_ usage: AIUsage) -> some View {
+        GeometryReader { proxy in
+            let input = CGFloat(usage.inputTokens ?? 0)
+            let cached = CGFloat(usage.cachedTokens ?? 0)
+            let output = CGFloat(usage.outputTokens ?? 0)
+            let total = max(CGFloat(usage.totalTokens), 1)
+            let width = proxy.size.width
+
+            HStack(spacing: 0) {
+                Rectangle()
+                    .fill(Color.purple)
+                    .frame(width: width * input / total)
+                Rectangle()
+                    .fill(Color.blue.opacity(0.65))
+                    .frame(width: width * cached / total)
+                Rectangle()
+                    .fill(Color.green)
+                    .frame(width: width * output / total)
+                Rectangle()
+                    .fill(Color(nsColor: .separatorColor).opacity(0.5))
+            }
+            .clipShape(RoundedRectangle(cornerRadius: 3))
+        }
+        .frame(height: 10)
+    }
+
+    private func toolChainSection(_ inspection: AIInspection) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            sectionHeader(String(localized: "Tool Chain"))
+            if inspection.toolCalls.isEmpty {
+                unavailableText(String(localized: "No tool-call payloads were visible in the captured traffic."))
+            } else {
+                ForEach(Array(inspection.toolCalls.enumerated()), id: \.offset) { index, tool in
+                    HStack(spacing: 10) {
+                        Text("\(index + 1)")
+                            .font(.system(size: metrics.metadataFontSize, weight: .semibold, design: .monospaced))
+                            .foregroundStyle(.secondary)
+                            .frame(width: 18, alignment: .trailing)
+                        Text(tool.name)
+                            .font(.system(size: metrics.metadataFontSize, weight: .medium, design: .monospaced))
+                        Spacer()
+                        Text(tool.state.displayName)
+                            .font(.system(size: metrics.metadataFontSize))
+                            .foregroundStyle(.secondary)
+                    }
+                    Divider()
+                }
+            }
+        }
+    }
+
+    private func retrievalSection(_ inspection: AIInspection) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            sectionHeader(String(localized: "Retrieval"))
+            if inspection.retrieval.isEmpty {
+                unavailableText(String(localized: "No retrieval or embedding result was visible for this selected transaction."))
+            } else {
+                ForEach(Array(inspection.retrieval.enumerated()), id: \.offset) { _, match in
+                    HStack {
+                        Text(match.source)
+                            .font(.system(size: metrics.metadataFontSize, weight: .medium, design: .monospaced))
+                        Spacer()
+                        Text(scoreLabel(match.score))
+                            .foregroundStyle(.secondary)
+                        Text(match.risk)
+                            .foregroundStyle(match.risk.contains("sensitive") ? .red : .secondary)
+                    }
+                    .font(.system(size: metrics.metadataFontSize))
+                    Divider()
+                }
+            }
+        }
+    }
+
+    private func warningSection(_ inspection: AIInspection) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            sectionHeader(String(localized: "Warnings"))
+            if inspection.warnings.isEmpty {
+                unavailableText(String(localized: "No AI-specific warning was detected from visible traffic fields."))
+            } else {
+                ForEach(Array(inspection.warnings.enumerated()), id: \.offset) { _, warning in
+                    Label(warning.message, systemImage: warning.severity == .error ? "exclamationmark.triangle" : "lock.shield")
+                        .font(.system(size: metrics.metadataFontSize, weight: .medium))
+                        .foregroundStyle(warning.severity == .error ? .red : .orange)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder private var selectedEventSection: some View {
+        if let selectedEvent {
+            VStack(alignment: .leading, spacing: 8) {
+                sectionHeader(String(localized: "Selected Event"))
+                Text(selectedEvent.detail)
+                    .font(.system(size: metrics.metadataFontSize, design: .monospaced))
+                    .textSelection(.enabled)
+                    .lineLimit(8)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(8)
+                    .background(Color(nsColor: .textBackgroundColor), in: RoundedRectangle(cornerRadius: 4))
+            }
+        }
+    }
+
+    private func sectionHeader(_ title: String) -> some View {
+        HStack(spacing: 4) {
+            Image(systemName: "chevron.down")
+                .font(.system(size: metrics.badgeFontSize))
+                .foregroundStyle(.secondary)
+            Text(title)
+                .font(.system(size: metrics.secondaryFontSize, weight: .semibold))
+        }
+    }
+
+    private func metadataPair(_ label: String, value: String) -> some View {
+        HStack(spacing: 4) {
+            Text(label)
+                .foregroundStyle(.secondary)
+            Text(value)
+                .fontWeight(.medium)
+                .textSelection(.enabled)
+        }
+        .font(.system(size: metrics.metadataFontSize, design: .monospaced))
+    }
+
+    private func unavailableText(_ text: String) -> some View {
+        Text(text)
+            .font(.system(size: metrics.metadataFontSize))
+            .foregroundStyle(.secondary)
+    }
+
+    private func filteredEvents(_ events: [AIEventSummary]) -> [AIEventSummary] {
+        switch filter {
+        case .all:
+            events
+        case .stream:
+            events.filter { $0.category == .stream }
+        case .tools:
+            events.filter { $0.category == .tool }
+        }
+    }
+
+    private func durationLabel(_ duration: TimeInterval?) -> String {
+        duration.map { DurationFormatter.format(seconds: $0) } ?? String(localized: "Unavailable")
+    }
+
+    private func tokenLabel(_ value: Int?) -> String {
+        value.map(String.init) ?? String(localized: "Unavailable")
+    }
+
+    private func scoreLabel(_ score: Double?) -> String {
+        guard let score else {
+            return String(localized: "Unavailable")
+        }
+        return String(format: "%.2f", score)
+    }
+
+    private func finishLabel(for inspection: AIInspection) -> String {
+        if inspection.events.contains(where: { $0.title.lowercased().contains("completed") }) {
+            return String(localized: "completed")
+        }
+        if let status = inspection.httpStatusCode, status >= 400 {
+            return "HTTP \(status)"
+        }
+        return String(localized: "Unavailable")
+    }
+
+    private func confidenceLabel(for inspection: AIInspection) -> String {
+        inspection.events.contains(where: { $0.category == .stream || $0.category == .tool })
+            ? String(localized: "observed + derived")
+            : String(localized: "observed")
+    }
+
+    private func unavailableSummary(for inspection: AIInspection) -> String {
+        if inspection.unavailableFields.isEmpty {
+            return String(localized: "All displayed values come from visible captured traffic.")
+        }
+        return String(localized: "Unavailable: \(inspection.unavailableFields.joined(separator: ", ")). Missing fields are not inferred.")
+    }
+}
+
+// MARK: - AIInspectorEventFilter
+
+private enum AIInspectorEventFilter: Hashable {
+    case all
+    case stream
+    case tools
+}

--- a/Rockxy/Views/Inspector/ResponseInspectorView.swift
+++ b/Rockxy/Views/Inspector/ResponseInspectorView.swift
@@ -86,7 +86,7 @@ struct ResponseInspectorView: View {
                     .padding(.horizontal, 4)
             }
 
-            ForEach(ResponseInspectorTab.allCases, id: \.self) { tab in
+            ForEach(ResponseInspectorTab.availableTabs(hasAIInspection: hasAIInspection), id: \.self) { tab in
                 InspectorTabButton(
                     title: tab.displayName,
                     isActive: protocolTab == nil && selectedPreviewTab == nil && selectedTab == tab
@@ -331,6 +331,16 @@ struct ResponseInspectorView: View {
             encryptedHTTPSPrompt(prompt)
         } else if let response = transaction.response {
             switch selectedTab {
+            case .ai:
+                if hasAIInspection {
+                    AIInspectorView(transaction: transaction)
+                } else {
+                    InspectorEmptyStateView(
+                        String(localized: "No AI Metadata"),
+                        systemImage: "sparkles",
+                        description: String(localized: "This response does not look like captured AI model traffic.")
+                    )
+                }
             case .headers:
                 responseHeadersView(response: response)
             case .body:
@@ -523,6 +533,11 @@ struct ResponseInspectorView: View {
     }
 
     private func syncInspectorStateForTransaction() {
+        let supportsAIInspection = hasAIInspection
+        if selectedTab == .ai, !supportsAIInspection {
+            selectedTab = .headers
+        }
+
         if let selectedPreviewTab,
            !previewTabStore.responseTabs.contains(where: { $0.id == selectedPreviewTab.id })
         {
@@ -533,6 +548,9 @@ struct ResponseInspectorView: View {
         switch selectionIntent {
         case .automatic:
             protocolTab = ProtocolTabKind.defaultFor(transaction)
+            if protocolTab == nil, supportsAIInspection {
+                selectedTab = .ai
+            }
         case .native,
              .preview:
             protocolTab = nil
@@ -565,6 +583,10 @@ struct ResponseInspectorView: View {
             return false
         }
         return !body.isEmpty
+    }
+
+    private var hasAIInspection: Bool {
+        AITrafficDetector.isLikelyAI(transaction: transaction)
     }
 
     private func prettyJSONString(from data: Data, sortedKeys: Bool) -> String? {

--- a/Rockxy/Views/RequestList/RequestTableView.swift
+++ b/Rockxy/Views/RequestList/RequestTableView.swift
@@ -202,6 +202,7 @@ struct RequestTableView: NSViewRepresentable {
     private static func makeColumns() -> [NSTableColumn] {
         let specs: [ColumnSpec] = [
             ColumnSpec(id: "status", title: "", width: 22, minWidth: 22),
+            ColumnSpec(id: "ai", title: String(localized: "AI"), width: 38, minWidth: 32),
             ColumnSpec(id: "row", title: String(localized: "ID"), width: 46, minWidth: 36),
             ColumnSpec(id: "url", title: String(localized: "URL"), width: 300, minWidth: 200),
             ColumnSpec(id: "client", title: String(localized: "Client"), width: 120, minWidth: 60),
@@ -230,6 +231,8 @@ struct RequestTableView: NSViewRepresentable {
             if spec.id == "status" {
                 column.resizingMask = []
                 column.maxWidth = 22
+            } else if spec.id == "ai" {
+                column.maxWidth = 44
             } else if spec.id == "ssl" {
                 column.maxWidth = 42
             } else {
@@ -629,6 +632,7 @@ extension RequestTableView {
 
             switch columnID {
             case "status": return 22
+            case "ai": return 38
             case "row": return 46
             case "ssl": return 38
             default: break
@@ -652,6 +656,9 @@ extension RequestTableView {
                 case "client":
                     text = rowData.clientApp ?? ""
                     font = metrics.appKitFont()
+                case "ai":
+                    text = rowData.aiTrafficSignal.tableLabel
+                    font = metrics.appKitFont(weight: .semibold)
                 case "method":
                     text = rowData.method
                     font = metrics.appKitFont(weight: .semibold)
@@ -1521,6 +1528,7 @@ extension RequestTableView {
             // Built-in column visibility
             let builtInColumns: [(id: String, title: String)] = [
                 ("status", String(localized: "Status Icon")),
+                ("ai", String(localized: "AI")),
                 ("row", "#"),
                 ("url", String(localized: "URL")),
                 ("client", String(localized: "Client")),
@@ -2100,6 +2108,7 @@ extension RequestTableView {
             cell.textColor = .labelColor
             cell.alignment = .left
             cell.font = metrics.appKitFont()
+            cell.toolTip = nil
 
             switch column {
             case "row":
@@ -2112,6 +2121,15 @@ extension RequestTableView {
                 cell.stringValue = rowData.host + rowData.path
                 cell.font = metrics.appKitFont(monospaced: true)
                 cell.textColor = .labelColor
+
+            case "ai":
+                cell.alignment = .center
+                cell.stringValue = rowData.aiTrafficSignal.tableLabel
+                cell.toolTip = rowData.aiTrafficSignal.accessibilityLabel.isEmpty
+                    ? nil
+                    : rowData.aiTrafficSignal.accessibilityLabel
+                cell.font = metrics.appKitFont(weight: .semibold)
+                cell.textColor = rowData.aiTrafficSignal.isLikelyAI ? .controlAccentColor : .tertiaryLabelColor
 
             case "method":
                 cell.alignment = .center

--- a/RockxyTests/Core/Detection/AITrafficDetectorTests.swift
+++ b/RockxyTests/Core/Detection/AITrafficDetectorTests.swift
@@ -1,0 +1,128 @@
+import Foundation
+@testable import Rockxy
+import Testing
+
+struct AITrafficDetectorTests {
+    @Test("OpenAI-compatible streaming traffic exposes model, usage, stream events, and tools")
+    func openAIStreamingTrafficExposesInspectionSignals() throws {
+        let requestBody = Data(#"{"model":"gpt-4.1-mini","input":"fixture prompt","stream":true,"tools":[{"name":"lookup_order"}]}"#.utf8)
+        let responseBody = Data("""
+        event: response.created
+        data: {"id":"resp_fixture","model":"gpt-4.1-mini"}
+
+        event: response.output_text.delta
+        data: {"delta":"hello"}
+
+        event: response.tool_call.delta
+        data: {"name":"lookup_order","arguments":"{\\\"order_id\\\":\\\"fixture-order\\\"}"}
+
+        event: response.completed
+        data: {"usage":{"input_tokens":920,"output_tokens":568,"total_tokens":1488}}
+
+        """.utf8)
+        let transaction = makeTransaction(
+            url: "https://api.openai.com/v1/responses",
+            requestBody: requestBody,
+            responseHeaders: [HTTPHeader(name: "Content-Type", value: "text/event-stream")],
+            responseBody: responseBody
+        )
+
+        let inspection = try #require(AITrafficDetector.detect(transaction: transaction))
+
+        #expect(inspection.provider == .openAICompatible)
+        #expect(inspection.model == "gpt-4.1-mini")
+        #expect(inspection.isStreaming)
+        #expect(inspection.usage?.inputTokens == 920)
+        #expect(inspection.usage?.outputTokens == 568)
+        #expect(inspection.events.contains { $0.title == "response.tool_call.delta" })
+        #expect(inspection.toolCalls.contains { $0.name == "lookup_order" })
+        #expect(inspection.warnings.contains { $0.message.contains("Prompt content") })
+    }
+
+    @Test("Anthropic message traffic is detected without inventing missing usage")
+    func anthropicTrafficKeepsMissingUsageUnavailable() throws {
+        let requestBody = Data(#"{"model":"claude-sonnet-fixture","messages":[{"role":"user","content":"fixture"}]}"#.utf8)
+        let transaction = makeTransaction(
+            url: "https://api.anthropic.com/v1/messages",
+            requestHeaders: [
+                HTTPHeader(name: "Content-Type", value: "application/json"),
+                HTTPHeader(name: "anthropic-version", value: "2023-06-01"),
+            ],
+            requestBody: requestBody,
+            responseBody: Data(#"{"type":"message","model":"claude-sonnet-fixture","content":[]}"#.utf8)
+        )
+
+        let inspection = try #require(AITrafficDetector.detect(transaction: transaction))
+
+        #expect(inspection.provider == .anthropic)
+        #expect(inspection.model == "claude-sonnet-fixture")
+        #expect(inspection.usage == nil)
+        #expect(inspection.unavailableFields.contains("usage"))
+    }
+
+    @Test("Ordinary HTTP traffic does not expose AI inspection")
+    func ordinaryHTTPTrafficDoesNotExposeAIInspection() {
+        let transaction = TestFixtures.makeTransaction(
+            method: "GET",
+            url: "https://api.example.com/orders",
+            statusCode: 200
+        )
+
+        #expect(!AITrafficDetector.isLikelyAI(transaction: transaction))
+        #expect(AITrafficDetector.detect(transaction: transaction) == nil)
+        #expect(!ResponseInspectorTab.availableTabs(hasAIInspection: false).contains(.ai))
+    }
+
+    @Test("AI tab is available only when AI metadata is likely")
+    func aiTabAvailabilityFollowsDetection() {
+        let requestBody = Data(#"{"model":"gpt-4.1-mini","input":"fixture"}"#.utf8)
+        let transaction = makeTransaction(
+            url: "https://localhost:11434/v1/responses",
+            requestBody: requestBody
+        )
+
+        #expect(AITrafficDetector.isLikelyAI(transaction: transaction))
+        #expect(ResponseInspectorTab.availableTabs(hasAIInspection: true).contains(.ai))
+    }
+
+    private func makeTransaction(
+        url: String,
+        requestHeaders: [HTTPHeader] = [
+            HTTPHeader(name: "Content-Type", value: "application/json"),
+            HTTPHeader(name: "Authorization", value: "Bearer synthetic-token"),
+        ],
+        requestBody: Data? = nil,
+        responseHeaders: [HTTPHeader] = [HTTPHeader(name: "Content-Type", value: "application/json")],
+        responseBody: Data? = nil
+    )
+        -> HTTPTransaction
+    {
+        guard let requestURL = URL(string: url) else {
+            preconditionFailure("Expected valid fixture URL")
+        }
+        let request = HTTPRequestData(
+            method: "POST",
+            url: requestURL,
+            httpVersion: "HTTP/1.1",
+            headers: requestHeaders,
+            body: requestBody,
+            contentType: .json
+        )
+        let response = HTTPResponseData(
+            statusCode: 200,
+            statusMessage: "OK",
+            headers: responseHeaders,
+            body: responseBody,
+            contentType: .json
+        )
+        let transaction = HTTPTransaction(request: request, response: response, state: .completed)
+        transaction.timingInfo = TimingInfo(
+            dnsLookup: 0.001,
+            tcpConnection: 0.002,
+            tlsHandshake: 0.003,
+            timeToFirstByte: 0.642,
+            contentTransfer: 3.192
+        )
+        return transaction
+    }
+}

--- a/RockxyTests/Helpers/TestIdentity.swift
+++ b/RockxyTests/Helpers/TestIdentity.swift
@@ -41,6 +41,7 @@ enum TestIdentity {
     static let discoveredRequestHeadersKey = "\(defaultsPrefix).discoveredReqHeaders"
     static let discoveredResponseHeadersKey = "\(defaultsPrefix).discoveredResHeaders"
     static let hiddenBuiltInColumnsKey = "\(defaultsPrefix).hiddenBuiltInColumns"
+    static let visibleDefaultHiddenBuiltInColumnsKey = "\(defaultsPrefix).visibleDefaultHiddenBuiltInColumns"
     static let showAlertOnQuitKey = "\(defaultsPrefix).showAlertOnQuit"
     static let recordOnLaunchKey = "\(defaultsPrefix).recordOnLaunch"
     static let autoSelectPortKey = "\(defaultsPrefix).autoSelectPort"

--- a/RockxyTests/Models/UI/HeaderColumnStoreTests.swift
+++ b/RockxyTests/Models/UI/HeaderColumnStoreTests.swift
@@ -194,6 +194,20 @@ struct HeaderColumnStoreTests {
         #expect(store.isBuiltInColumnVisible("url"))
     }
 
+    @Test("AI built-in column is hidden by default but can be enabled")
+    func aiBuiltInColumnDefaultVisibility() {
+        let store = makeCleanStore()
+
+        #expect(!store.isBuiltInColumnVisible("ai"))
+        store.toggleBuiltInColumn("ai")
+        #expect(store.isBuiltInColumnVisible("ai"))
+
+        let store2 = HeaderColumnStore()
+        #expect(store2.isBuiltInColumnVisible("ai"))
+        store2.toggleBuiltInColumn("ai")
+        #expect(!store2.isBuiltInColumnVisible("ai"))
+    }
+
     @Test("Hidden built-in columns persist")
     func hiddenBuiltInPersist() {
         let store = makeCleanStore()
@@ -290,6 +304,10 @@ struct HeaderColumnStoreTests {
         clearDefaultsKey("discoveredReqHeaders", fallback: TestIdentity.discoveredRequestHeadersKey)
         clearDefaultsKey("discoveredResHeaders", fallback: TestIdentity.discoveredResponseHeadersKey)
         clearDefaultsKey("hiddenBuiltInColumns", fallback: TestIdentity.hiddenBuiltInColumnsKey)
+        clearDefaultsKey(
+            "visibleDefaultHiddenBuiltInColumns",
+            fallback: TestIdentity.visibleDefaultHiddenBuiltInColumnsKey
+        )
         return HeaderColumnStore()
     }
 

--- a/RockxyTests/Models/UI/RequestListRowTests.swift
+++ b/RockxyTests/Models/UI/RequestListRowTests.swift
@@ -99,6 +99,21 @@ struct RequestListRowTests {
         #expect(row.isTLSFailure == true)
     }
 
+    @Test("AI traffic signal is extracted from model-provider requests")
+    func aiTrafficSignal() {
+        let transaction = TestFixtures.makeTransaction(
+            method: "POST",
+            url: "https://api.openai.com/v1/responses",
+            statusCode: 200
+        )
+
+        let row = RequestListRow(from: transaction)
+
+        #expect(row.aiTrafficSignal.isLikelyAI)
+        #expect(row.aiTrafficSignal.provider == .openAICompatible)
+        #expect(row.aiTrafficSignal.tableLabel == "AI")
+    }
+
     @Test("Body sizes extracted from request and response")
     func bodySizes() {
         let transaction = TestFixtures.makeTransactionWithBody(
@@ -202,6 +217,16 @@ struct RequestListRowTests {
 
         #expect(RequestListRow.compare(http, https, using: descriptors) == true)
         #expect(RequestListRow.compare(https, http, using: descriptors) == false)
+    }
+
+    @Test("Sort by AI groups ordinary traffic before AI traffic")
+    func sortByAI() {
+        let ordinary = makeRow(host: "example.com")
+        let ai = makeRow(host: "api.openai.com", path: "/v1/responses")
+        let descriptors = [NSSortDescriptor(key: "ai", ascending: true)]
+
+        #expect(RequestListRow.compare(ordinary, ai, using: descriptors) == true)
+        #expect(RequestListRow.compare(ai, ordinary, using: descriptors) == false)
     }
 
     @Test("SSL state can represent intercepted HTTPS separately from tunneled HTTPS")


### PR DESCRIPTION
## Summary
- Add a conditional native AI response inspector tab for likely model-provider traffic.
- Extract provider, model, usage, SSE events, tool calls, retrieval signals, and redaction/error warnings from visible captured HTTP data only.
- Keep parsing bounded and transaction-scoped so large bodies and transaction switches do not block the inspector.
- Route the response inspector to the AI tab automatically for likely AI traffic while hiding it for ordinary HTTP.
- Add an optional request-list `AI` built-in column that is hidden by default, sortable, and backed by a lightweight traffic signal.

## Validation
- `swiftlint lint --strict Rockxy/Core/Detection/AITrafficDetector.swift Rockxy/Views/Inspector/AIInspectorView.swift Rockxy/Views/Inspector/ResponseInspectorView.swift Rockxy/Models/UI/ResponseInspectorTab.swift RockxyTests/Core/Detection/AITrafficDetectorTests.swift`
- `swiftlint lint --strict Rockxy/Core/Detection/AITrafficDetector.swift Rockxy/Models/UI/RequestListRow.swift Rockxy/Models/UI/HeaderColumnStore.swift Rockxy/Views/RequestList/RequestTableView.swift RockxyTests/Models/UI/RequestListRowTests.swift RockxyTests/Models/UI/HeaderColumnStoreTests.swift RockxyTests/Helpers/TestIdentity.swift`
- `git diff --check`
- `xcodebuild -project Rockxy.xcodeproj -scheme Rockxy -destination 'platform=macOS' -only-testing:RockxyTests/AITrafficDetectorTests test`
- `xcodebuild -project Rockxy.xcodeproj -scheme Rockxy -destination 'platform=macOS' -only-testing:RockxyTests/InspectorRoutingTests test`
- `xcodebuild -project Rockxy.xcodeproj -scheme Rockxy -destination 'platform=macOS' -only-testing:RockxyTests/RequestListRowTests -only-testing:RockxyTests/HeaderColumnStoreTests -only-testing:RockxyTests/AITrafficDetectorTests test`
- `xcodebuild -project Rockxy.xcodeproj -scheme Rockxy -configuration Debug build`

Refs #148
Refs #149
Refs #150
Refs #151
Refs #152
