### PR TITLE
release: promote develop to main

### DIFF
--- a/Rockxy/Core/Detection/AITrafficDetector.swift
+++ b/Rockxy/Core/Detection/AITrafficDetector.swift
@@ -16,6 +16,17 @@ nonisolated enum AITrafficDetector {
         isLikelyAI(snapshot: AITrafficSnapshot(transaction: transaction))
     }
 
+    static func signal(transaction: HTTPTransaction) -> AITrafficSignal {
+        signal(snapshot: AITrafficSnapshot(transaction: transaction))
+    }
+
+    static func signal(snapshot: AITrafficSnapshot) -> AITrafficSignal {
+        if let provider = provider(from: snapshot) {
+            return AITrafficSignal(isLikelyAI: true, provider: provider)
+        }
+        return AITrafficSignal(isLikelyAI: isLikelyAI(snapshot: snapshot), provider: nil)
+    }
+
     static func isLikelyAI(snapshot: AITrafficSnapshot) -> Bool {
         if provider(from: snapshot) != nil {
             return true
@@ -493,6 +504,25 @@ enum AIProvider: String, Sendable {
         case .openAICompatible: "OpenAI-compatible"
         case .anthropic: "Anthropic"
         }
+    }
+}
+
+struct AITrafficSignal: Equatable, Sendable {
+    let isLikelyAI: Bool
+    let provider: AIProvider?
+
+    var tableLabel: String {
+        isLikelyAI ? "AI" : ""
+    }
+
+    var accessibilityLabel: String {
+        guard isLikelyAI else {
+            return ""
+        }
+        if let provider {
+            return "Likely AI model traffic: \(provider.displayName)"
+        }
+        return "Likely AI model traffic"
     }
 }
 

--- a/Rockxy/Core/Detection/AITrafficDetector.swift
+++ b/Rockxy/Core/Detection/AITrafficDetector.swift
@@ -1,0 +1,565 @@
+import Foundation
+
+// MARK: - AITrafficDetector
+
+/// Lightweight, bounded parser for AI-model HTTP traffic.
+///
+/// The detector intentionally works from captured HTTP evidence only. It does not infer
+/// provider internals, token boundaries, or pricing when those fields are not present.
+nonisolated enum AITrafficDetector {
+    // MARK: Internal
+
+    static let maxBodyBytes = 256 * 1_024
+    static let maxQuickScanBytes = 16 * 1_024
+
+    static func isLikelyAI(transaction: HTTPTransaction) -> Bool {
+        isLikelyAI(snapshot: AITrafficSnapshot(transaction: transaction))
+    }
+
+    static func isLikelyAI(snapshot: AITrafficSnapshot) -> Bool {
+        if provider(from: snapshot) != nil {
+            return true
+        }
+
+        let requestPrefix = snapshot.requestBody
+            .flatMap { String(bytes: $0.prefix(maxQuickScanBytes), encoding: .utf8)?.lowercased() } ?? ""
+        if requestPrefix.contains(#""model""#),
+           requestPrefix.contains(#""messages""#)
+            || requestPrefix.contains(#""input""#)
+            || requestPrefix.contains(#""tools""#)
+        {
+            return true
+        }
+
+        let responsePrefix = snapshot.responseBody
+            .flatMap { String(bytes: $0.prefix(maxQuickScanBytes), encoding: .utf8)?.lowercased() } ?? ""
+        return responsePrefix.contains(#""usage""#)
+            && (responsePrefix.contains(#""input_tokens""#)
+                || responsePrefix.contains(#""output_tokens""#)
+                || responsePrefix.contains(#""prompt_tokens""#)
+                || responsePrefix.contains(#""completion_tokens""#))
+    }
+
+    static func detect(transaction: HTTPTransaction) -> AIInspection? {
+        detect(snapshot: AITrafficSnapshot(transaction: transaction))
+    }
+
+    static func detect(snapshot: AITrafficSnapshot) -> AIInspection? {
+        let requestJSON = parseJSONObject(snapshot.requestBody)
+        let responseJSON = parseJSONObject(snapshot.responseBody)
+        let streamEvents = parseSSEEvents(snapshot.responseBody)
+        let resolvedProvider = provider(from: snapshot) ?? provider(from: requestJSON, responseJSON: responseJSON)
+
+        guard let resolvedProvider,
+              isLikelyAI(snapshot: snapshot)
+        else {
+            return nil
+        }
+
+        let usage = usage(from: responseJSON, streamEvents: streamEvents)
+        let toolCalls = toolCalls(from: requestJSON, responseJSON: responseJSON, streamEvents: streamEvents)
+        let events = eventSummaries(
+            snapshot: snapshot,
+            responseJSON: responseJSON,
+            streamEvents: streamEvents,
+            toolCalls: toolCalls
+        )
+        let retrieval = retrievalMatches(snapshot: snapshot, responseJSON: responseJSON)
+        let warnings = warnings(
+            snapshot: snapshot,
+            requestJSON: requestJSON,
+            toolCalls: toolCalls,
+            retrieval: retrieval
+        )
+
+        return AIInspection(
+            provider: resolvedProvider,
+            model: stringValue(forKey: "model", in: requestJSON)
+                ?? stringValue(forKey: "model", in: responseJSON),
+            endpoint: snapshot.path.isEmpty ? snapshot.urlString : snapshot.path,
+            isStreaming: isStreaming(snapshot: snapshot, requestJSON: requestJSON, streamEvents: streamEvents),
+            httpStatusCode: snapshot.responseStatusCode,
+            duration: snapshot.duration,
+            usage: usage,
+            toolCalls: toolCalls,
+            events: events,
+            retrieval: retrieval,
+            warnings: warnings,
+            unavailableFields: unavailableFields(usage: usage, events: events, toolCalls: toolCalls)
+        )
+    }
+
+    // MARK: Private
+
+    private static func provider(from snapshot: AITrafficSnapshot) -> AIProvider? {
+        let host = snapshot.host.lowercased()
+        let path = snapshot.path.lowercased()
+        let headerNames = snapshot.requestHeaders.map { $0.name.lowercased() }
+
+        if host.contains("anthropic.com") || headerNames.contains("anthropic-version") {
+            return .anthropic
+        }
+        if host.contains("openai.com")
+            || path.contains("/v1/responses")
+            || path.contains("/v1/chat/completions")
+            || path.contains("/v1/embeddings")
+        {
+            return .openAICompatible
+        }
+        if path.contains("/chat/completions") || path.contains("/embeddings") {
+            return .openAICompatible
+        }
+        return nil
+    }
+
+    private static func provider(from requestJSON: [String: Any]?, responseJSON: [String: Any]?) -> AIProvider? {
+        if stringValue(forKey: "model", in: requestJSON) != nil || stringValue(forKey: "model", in: responseJSON) != nil {
+            return .openAICompatible
+        }
+        return nil
+    }
+
+    private static func parseJSONObject(_ data: Data?) -> [String: Any]? {
+        guard let data, !data.isEmpty, data.count <= maxBodyBytes else {
+            return nil
+        }
+        return (try? JSONSerialization.jsonObject(with: data)) as? [String: Any]
+    }
+
+    private static func stringValue(forKey key: String, in json: [String: Any]?) -> String? {
+        json?[key] as? String
+    }
+
+    private static func intValue(forKey key: String, in json: [String: Any]?) -> Int? {
+        if let int = json?[key] as? Int {
+            return int
+        }
+        if let number = json?[key] as? NSNumber {
+            return number.intValue
+        }
+        return nil
+    }
+
+    private static func boolValue(forKey key: String, in json: [String: Any]?) -> Bool? {
+        if let bool = json?[key] as? Bool {
+            return bool
+        }
+        if let number = json?[key] as? NSNumber {
+            return number.boolValue
+        }
+        return nil
+    }
+
+    private static func usage(from responseJSON: [String: Any]?, streamEvents: [AIStreamEvent]) -> AIUsage? {
+        if let usage = usageObject(from: responseJSON) {
+            return usage
+        }
+
+        for event in streamEvents.reversed() {
+            guard let json = parseJSONObject(Data(event.data.utf8)),
+                  let usage = usageObject(from: json)
+            else {
+                continue
+            }
+            return usage
+        }
+        return nil
+    }
+
+    private static func usageObject(from json: [String: Any]?) -> AIUsage? {
+        guard let raw = json?["usage"] as? [String: Any] else {
+            return nil
+        }
+
+        let cached = (raw["prompt_tokens_details"] as? [String: Any])
+            .flatMap { intValue(forKey: "cached_tokens", in: $0) }
+        let input = intValue(forKey: "input_tokens", in: raw)
+            ?? intValue(forKey: "prompt_tokens", in: raw)
+        let output = intValue(forKey: "output_tokens", in: raw)
+            ?? intValue(forKey: "completion_tokens", in: raw)
+        let total = intValue(forKey: "total_tokens", in: raw)
+            ?? [input, output].compactMap { $0 }.reduce(0, +)
+
+        guard input != nil || output != nil || total > 0 else {
+            return nil
+        }
+        return AIUsage(inputTokens: input, cachedTokens: cached, outputTokens: output, totalTokens: total)
+    }
+
+    private static func toolCalls(
+        from requestJSON: [String: Any]?,
+        responseJSON: [String: Any]?,
+        streamEvents: [AIStreamEvent]
+    )
+        -> [AIToolCall]
+    {
+        var calls: [AIToolCall] = []
+        if let tools = requestJSON?["tools"] as? [[String: Any]] {
+            calls += tools.compactMap { tool in
+                let name = tool["name"] as? String
+                    ?? (tool["function"] as? [String: Any])?["name"] as? String
+                return name.map {
+                    AIToolCall(name: $0, argumentsPreview: nil, state: .declared)
+                }
+            }
+        }
+
+        calls += responseToolCalls(from: responseJSON)
+
+        for event in streamEvents where event.event?.lowercased().contains("tool") == true || event.data.contains("tool") {
+            guard let json = parseJSONObject(Data(event.data.utf8)) else {
+                calls.append(AIToolCall(name: "tool_call", argumentsPreview: event.data, state: .partial))
+                continue
+            }
+            if let name = stringValue(forKey: "name", in: json) {
+                calls.append(AIToolCall(
+                    name: name,
+                    argumentsPreview: stringValue(forKey: "arguments", in: json),
+                    state: .streaming
+                ))
+            }
+        }
+
+        return Array(calls.prefix(12))
+    }
+
+    private static func responseToolCalls(from responseJSON: [String: Any]?) -> [AIToolCall] {
+        if let output = responseJSON?["output"] as? [[String: Any]] {
+            return output.compactMap { item in
+                guard (item["type"] as? String)?.contains("function") == true else {
+                    return nil
+                }
+                return AIToolCall(
+                    name: item["name"] as? String ?? "tool_call",
+                    argumentsPreview: item["arguments"] as? String,
+                    state: .completed
+                )
+            }
+        }
+
+        let choices = responseJSON?["choices"] as? [[String: Any]]
+        let message = choices?.first?["message"] as? [String: Any]
+        let calls = message?["tool_calls"] as? [[String: Any]] ?? []
+        return calls.compactMap { call in
+            let function = call["function"] as? [String: Any]
+            return AIToolCall(
+                name: function?["name"] as? String ?? "tool_call",
+                argumentsPreview: function?["arguments"] as? String,
+                state: .completed
+            )
+        }
+    }
+
+    private static func eventSummaries(
+        snapshot: AITrafficSnapshot,
+        responseJSON: [String: Any]?,
+        streamEvents: [AIStreamEvent],
+        toolCalls: [AIToolCall]
+    )
+        -> [AIEventSummary]
+    {
+        if !streamEvents.isEmpty {
+            return streamEvents.enumerated().map { index, event in
+                let eventName = event.event ?? "data"
+                let category: AIEventCategory = eventName.lowercased().contains("tool") ? .tool : .stream
+                let severity: AIEventSeverity = eventName.lowercased().contains("error") ? .error : .normal
+                return AIEventSummary(
+                    id: "stream-\(index)",
+                    title: eventName,
+                    detail: event.data,
+                    offsetLabel: "#\(index + 1)",
+                    category: category,
+                    severity: severity
+                )
+            }
+        }
+
+        var events: [AIEventSummary] = [
+            AIEventSummary(
+                id: "request",
+                title: "model request",
+                detail: snapshot.urlString,
+                offsetLabel: "request",
+                category: .request,
+                severity: .normal
+            )
+        ]
+        events += toolCalls.enumerated().map { index, tool in
+            AIEventSummary(
+                id: "tool-\(index)",
+                title: tool.name,
+                detail: tool.argumentsPreview ?? tool.state.displayName,
+                offsetLabel: tool.state.displayName,
+                category: .tool,
+                severity: .normal
+            )
+        }
+        if let status = snapshot.responseStatusCode {
+            events.append(AIEventSummary(
+                id: "response",
+                title: "response",
+                detail: responseJSON?["status"] as? String ?? "HTTP \(status)",
+                offsetLabel: "\(status)",
+                category: .response,
+                severity: status >= 400 ? .error : .normal
+            ))
+        }
+        return events
+    }
+
+    private static func retrievalMatches(
+        snapshot: AITrafficSnapshot,
+        responseJSON: [String: Any]?
+    )
+        -> [AIRetrievalMatch]
+    {
+        let path = snapshot.path.lowercased()
+        guard path.contains("search") || path.contains("embedding") || path.contains("retrieval") else {
+            return []
+        }
+
+        let matches = responseJSON?["matches"] as? [[String: Any]]
+            ?? responseJSON?["data"] as? [[String: Any]]
+            ?? []
+        return matches.prefix(8).enumerated().map { index, match in
+            let source = match["id"] as? String ?? "match-\(index + 1)"
+            let score = (match["score"] as? NSNumber)?.doubleValue
+            return AIRetrievalMatch(
+                source: source,
+                score: score,
+                signal: path.contains("embedding") ? "embedding" : "retrieval",
+                risk: (match["snippet"] as? String)?.lowercased().contains("secret") == true ? "sensitive-context" : "visible"
+            )
+        }
+    }
+
+    private static func warnings(
+        snapshot: AITrafficSnapshot,
+        requestJSON: [String: Any]?,
+        toolCalls: [AIToolCall],
+        retrieval: [AIRetrievalMatch]
+    )
+        -> [AIWarning]
+    {
+        var warnings: [AIWarning] = []
+        if headerValue(named: "authorization", in: snapshot.requestHeaders) != nil
+            || headerValue(named: "x-api-key", in: snapshot.requestHeaders) != nil
+        {
+            warnings.append(AIWarning(message: "Authentication header is present.", severity: .redaction))
+        }
+        if requestJSON?["input"] != nil || requestJSON?["messages"] != nil {
+            warnings.append(AIWarning(message: "Prompt content may require redaction.", severity: .redaction))
+        }
+        if !toolCalls.isEmpty {
+            warnings.append(AIWarning(message: "Tool arguments may contain sensitive data.", severity: .redaction))
+        }
+        if retrieval.contains(where: { $0.risk == "sensitive-context" }) {
+            warnings.append(AIWarning(message: "Retrieved context includes sensitive-looking snippets.", severity: .redaction))
+        }
+        if let status = snapshot.responseStatusCode, status >= 400 {
+            warnings.append(AIWarning(message: "Provider returned HTTP \(status).", severity: .error))
+        }
+        return warnings
+    }
+
+    private static func unavailableFields(
+        usage: AIUsage?,
+        events: [AIEventSummary],
+        toolCalls: [AIToolCall]
+    )
+        -> [String]
+    {
+        var fields: [String] = []
+        if usage == nil {
+            fields.append("usage")
+        }
+        if events.allSatisfy({ $0.category != .stream }) {
+            fields.append("stream events")
+        }
+        if toolCalls.isEmpty {
+            fields.append("tool calls")
+        }
+        return fields
+    }
+
+    private static func isStreaming(
+        snapshot: AITrafficSnapshot,
+        requestJSON: [String: Any]?,
+        streamEvents: [AIStreamEvent]
+    )
+        -> Bool
+    {
+        boolValue(forKey: "stream", in: requestJSON) == true
+            || !streamEvents.isEmpty
+            || headerValue(named: "content-type", in: snapshot.responseHeaders)?.lowercased().contains("text/event-stream") == true
+    }
+
+    private static func parseSSEEvents(_ data: Data?) -> [AIStreamEvent] {
+        guard let data,
+              data.count <= maxBodyBytes,
+              let text = String(data: data, encoding: .utf8),
+              text.contains("data:")
+        else {
+            return []
+        }
+
+        var events: [AIStreamEvent] = []
+        var currentEvent: String?
+        var currentData: [String] = []
+
+        func flush() {
+            guard !currentData.isEmpty else {
+                currentEvent = nil
+                return
+            }
+            let data = currentData.joined(separator: "\n")
+            if data.trimmingCharacters(in: .whitespacesAndNewlines) != "[DONE]" {
+                events.append(AIStreamEvent(event: currentEvent, data: data))
+            }
+            currentEvent = nil
+            currentData = []
+        }
+
+        for rawLine in text.split(separator: "\n", omittingEmptySubsequences: false) {
+            let line = rawLine.trimmingCharacters(in: .whitespacesAndNewlines)
+            if line.isEmpty {
+                flush()
+            } else if line.hasPrefix("event:") {
+                currentEvent = String(line.dropFirst("event:".count)).trimmingCharacters(in: .whitespaces)
+            } else if line.hasPrefix("data:") {
+                currentData.append(String(line.dropFirst("data:".count)).trimmingCharacters(in: .whitespaces))
+            }
+        }
+        flush()
+        return Array(events.prefix(200))
+    }
+
+    private static func headerValue(named name: String, in headers: [HTTPHeader]) -> String? {
+        headers.first { $0.name.caseInsensitiveCompare(name) == .orderedSame }?.value
+    }
+}
+
+// MARK: - AITrafficSnapshot
+
+struct AITrafficSnapshot: Sendable {
+    init(transaction: HTTPTransaction) {
+        requestMethod = transaction.request.method
+        urlString = transaction.request.url.absoluteString
+        host = transaction.request.host
+        path = transaction.request.path
+        requestHeaders = transaction.request.headers
+        requestBody = transaction.request.body
+        responseStatusCode = transaction.response?.statusCode
+        responseHeaders = transaction.response?.headers ?? []
+        responseBody = transaction.response?.body
+        duration = transaction.timingInfo?.totalDuration ?? transaction.measuredDuration
+    }
+
+    let requestMethod: String
+    let urlString: String
+    let host: String
+    let path: String
+    let requestHeaders: [HTTPHeader]
+    let requestBody: Data?
+    let responseStatusCode: Int?
+    let responseHeaders: [HTTPHeader]
+    let responseBody: Data?
+    let duration: TimeInterval?
+}
+
+// MARK: - AIInspection
+
+struct AIInspection: Equatable, Sendable {
+    let provider: AIProvider
+    let model: String?
+    let endpoint: String
+    let isStreaming: Bool
+    let httpStatusCode: Int?
+    let duration: TimeInterval?
+    let usage: AIUsage?
+    let toolCalls: [AIToolCall]
+    let events: [AIEventSummary]
+    let retrieval: [AIRetrievalMatch]
+    let warnings: [AIWarning]
+    let unavailableFields: [String]
+}
+
+enum AIProvider: String, Sendable {
+    case openAICompatible
+    case anthropic
+
+    var displayName: String {
+        switch self {
+        case .openAICompatible: "OpenAI-compatible"
+        case .anthropic: "Anthropic"
+        }
+    }
+}
+
+struct AIUsage: Equatable, Sendable {
+    let inputTokens: Int?
+    let cachedTokens: Int?
+    let outputTokens: Int?
+    let totalTokens: Int
+}
+
+struct AIToolCall: Equatable, Sendable {
+    let name: String
+    let argumentsPreview: String?
+    let state: AIToolCallState
+}
+
+enum AIToolCallState: String, Sendable {
+    case declared
+    case streaming
+    case completed
+    case partial
+
+    var displayName: String {
+        rawValue
+    }
+}
+
+struct AIEventSummary: Equatable, Identifiable, Sendable {
+    let id: String
+    let title: String
+    let detail: String
+    let offsetLabel: String
+    let category: AIEventCategory
+    let severity: AIEventSeverity
+}
+
+enum AIEventCategory: String, Sendable {
+    case request
+    case stream
+    case tool
+    case response
+}
+
+enum AIEventSeverity: String, Sendable {
+    case normal
+    case warning
+    case error
+}
+
+struct AIRetrievalMatch: Equatable, Sendable {
+    let source: String
+    let score: Double?
+    let signal: String
+    let risk: String
+}
+
+struct AIWarning: Equatable, Sendable {
+    let message: String
+    let severity: AIWarningSeverity
+}
+
+enum AIWarningSeverity: String, Sendable {
+    case redaction
+    case error
+}
+
+private struct AIStreamEvent: Equatable {
+    let event: String?
+    let data: String
+}

--- a/Rockxy/Models/UI/HeaderColumnStore.swift
+++ b/Rockxy/Models/UI/HeaderColumnStore.swift
@@ -25,6 +25,7 @@ final class HeaderColumnStore {
     var discoveredRequestHeaders: [String] = []
     var discoveredResponseHeaders: [String] = []
     var hiddenBuiltInColumns: Set<String> = []
+    var visibleDefaultHiddenBuiltInColumns: Set<String> = []
 
     var enabledColumns: [HeaderColumn] {
         columns.filter(\.isEnabled)
@@ -179,16 +180,26 @@ final class HeaderColumnStore {
     }
 
     func toggleBuiltInColumn(_ columnID: String) {
-        if hiddenBuiltInColumns.contains(columnID) {
-            hiddenBuiltInColumns.remove(columnID)
-        } else {
+        if isBuiltInColumnVisible(columnID) {
+            visibleDefaultHiddenBuiltInColumns.remove(columnID)
             hiddenBuiltInColumns.insert(columnID)
+        } else {
+            hiddenBuiltInColumns.remove(columnID)
+            if Self.defaultHiddenBuiltInColumns.contains(columnID) {
+                visibleDefaultHiddenBuiltInColumns.insert(columnID)
+            }
         }
         saveHiddenColumns()
     }
 
     func isBuiltInColumnVisible(_ columnID: String) -> Bool {
-        !hiddenBuiltInColumns.contains(columnID)
+        if hiddenBuiltInColumns.contains(columnID) {
+            return false
+        }
+        if Self.defaultHiddenBuiltInColumns.contains(columnID) {
+            return visibleDefaultHiddenBuiltInColumns.contains(columnID)
+        }
+        return true
     }
 
     func reload() {
@@ -202,6 +213,8 @@ final class HeaderColumnStore {
     private static let discoveredReqKey = RockxyIdentity.current.defaultsKey("discoveredReqHeaders")
     private static let discoveredResKey = RockxyIdentity.current.defaultsKey("discoveredResHeaders")
     private static let hiddenColumnsKey = RockxyIdentity.current.defaultsKey("hiddenBuiltInColumns")
+    private static let visibleDefaultHiddenColumnsKey = RockxyIdentity.current.defaultsKey("visibleDefaultHiddenBuiltInColumns")
+    private static let defaultHiddenBuiltInColumns: Set<String> = ["ai"]
 
     // Internal dedup sets for O(1) membership checks during incremental discovery
     private var discoveredRequestHeaderSet: Set<String> = []
@@ -210,6 +223,10 @@ final class HeaderColumnStore {
     private func saveHiddenColumns() {
         let array = Array(hiddenBuiltInColumns)
         UserDefaults.standard.set(array, forKey: Self.hiddenColumnsKey)
+        UserDefaults.standard.set(
+            Array(visibleDefaultHiddenBuiltInColumns),
+            forKey: Self.visibleDefaultHiddenColumnsKey
+        )
     }
 
     // MARK: - Persistence
@@ -226,6 +243,9 @@ final class HeaderColumnStore {
     private func load() {
         if let hidden = UserDefaults.standard.stringArray(forKey: Self.hiddenColumnsKey) {
             hiddenBuiltInColumns = Set(hidden)
+        }
+        if let visibleDefaultHidden = UserDefaults.standard.stringArray(forKey: Self.visibleDefaultHiddenColumnsKey) {
+            visibleDefaultHiddenBuiltInColumns = Set(visibleDefaultHidden)
         }
         if let reqHeaders = UserDefaults.standard.stringArray(forKey: Self.discoveredReqKey) {
             discoveredRequestHeaders = reqHeaders

--- a/Rockxy/Models/UI/RequestListRow.swift
+++ b/Rockxy/Models/UI/RequestListRow.swift
@@ -41,6 +41,7 @@ struct RequestListRow: Identifiable {
         comment = transaction.comment
         highlightColor = transaction.highlightColor
         isTLSFailure = transaction.isTLSFailure
+        aiTrafficSignal = AITrafficDetector.signal(transaction: transaction)
         graphQLOpName = transaction.graphQLInfo?.operationName
         graphQLOpType = transaction.graphQLInfo?.operationType.rawValue
         isWebSocket = transaction.webSocketConnection != nil
@@ -75,6 +76,7 @@ struct RequestListRow: Identifiable {
     let comment: String?
     let highlightColor: HighlightColor?
     let isTLSFailure: Bool
+    let aiTrafficSignal: AITrafficSignal
     let graphQLOpName: String?
     let graphQLOpType: String?
     let isWebSocket: Bool
@@ -169,6 +171,8 @@ extension RequestListRow {
             compareOptionalInt(lhs.responseSize, rhs.responseSize)
         case "ssl":
             compareInt(lhs.sslState.rawValue, rhs.sslState.rawValue)
+        case "ai":
+            compareAISignal(lhs, rhs)
         case "queryName":
             compareQueryName(lhs, rhs)
         case "client":
@@ -238,6 +242,16 @@ extension RequestListRow {
         default:
             .orderedSame
         }
+    }
+
+    private static func compareAISignal(_ lhs: RequestListRow, _ rhs: RequestListRow) -> ComparisonResult {
+        let presence = compareBool(lhs.aiTrafficSignal.isLikelyAI, rhs.aiTrafficSignal.isLikelyAI)
+        if presence != .orderedSame {
+            return presence
+        }
+        let lhsProvider = lhs.aiTrafficSignal.provider?.displayName ?? ""
+        let rhsProvider = rhs.aiTrafficSignal.provider?.displayName ?? ""
+        return lhsProvider.localizedCompare(rhsProvider)
     }
 
     private static func defaultSSLState(forScheme scheme: String) -> SSLState {

--- a/Rockxy/Models/UI/ResponseInspectorTab.swift
+++ b/Rockxy/Models/UI/ResponseInspectorTab.swift
@@ -2,6 +2,7 @@ import Foundation
 
 /// Tabs for the response half of the split inspector panel.
 enum ResponseInspectorTab: String, CaseIterable {
+    case ai
     case headers
     case body
     case setCookie
@@ -10,8 +11,15 @@ enum ResponseInspectorTab: String, CaseIterable {
 
     // MARK: Internal
 
+    static func availableTabs(hasAIInspection: Bool) -> [ResponseInspectorTab] {
+        allCases.filter { tab in
+            hasAIInspection || tab != .ai
+        }
+    }
+
     var displayName: String {
         switch self {
+        case .ai: "AI"
         case .headers: "Headers"
         case .body: "Body"
         case .setCookie: "Set-Cookie"

--- a/Rockxy/Views/Inspector/AIInspectorView.swift
+++ b/Rockxy/Views/Inspector/AIInspectorView.swift
@@ -1,0 +1,417 @@
+import SwiftUI
+
+// MARK: - AIInspectorView
+
+/// Native response-inspector tab for captured AI model traffic.
+///
+/// The view renders from a bounded detector snapshot so switching selected transactions
+/// cannot leave stale parser output in the inspector.
+struct AIInspectorView: View {
+    // MARK: Internal
+
+    let transaction: HTTPTransaction
+
+    var body: some View {
+        Group {
+            if isLoading {
+                ProgressView()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else if let inspection {
+                VStack(spacing: 0) {
+                    summaryStrip(inspection)
+                    Divider()
+                    HSplitView {
+                        eventList(inspection)
+                            .frame(minWidth: 220, idealWidth: 280, maxWidth: 360)
+                        detailPane(inspection)
+                            .frame(minWidth: 280, maxWidth: .infinity)
+                    }
+                }
+            } else {
+                InspectorEmptyStateView(
+                    String(localized: "No AI Metadata"),
+                    systemImage: "sparkles",
+                    description: String(localized: "This response does not look like captured AI model traffic.")
+                )
+            }
+        }
+        .task(id: transaction.id) {
+            await loadInspection()
+        }
+    }
+
+    // MARK: Private
+
+    @State private var inspection: AIInspection?
+    @State private var selectedEventID: String?
+    @State private var filter: AIInspectorEventFilter = .all
+    @State private var isLoading = true
+    @Environment(\.appUIDisplayMetrics) private var metrics
+
+    private var selectedEvent: AIEventSummary? {
+        guard let inspection else {
+            return nil
+        }
+        if let selectedEventID,
+           let event = inspection.events.first(where: { $0.id == selectedEventID })
+        {
+            return event
+        }
+        return inspection.events.first
+    }
+
+    private func loadInspection() async {
+        isLoading = true
+        let snapshot = AITrafficSnapshot(transaction: transaction)
+        let transactionID = transaction.id
+        let detected = await Task.detached(priority: .userInitiated) {
+            AITrafficDetector.detect(snapshot: snapshot)
+        }.value
+
+        guard transaction.id == transactionID else {
+            return
+        }
+        inspection = detected
+        selectedEventID = detected?.events.first?.id
+        isLoading = false
+    }
+
+    private func summaryStrip(_ inspection: AIInspection) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(spacing: 18) {
+                summaryItem(String(localized: "Provider"), value: inspection.provider.displayName)
+                summaryItem(String(localized: "Model"), value: inspection.model ?? String(localized: "Unavailable"))
+                summaryItem(String(localized: "Finish"), value: finishLabel(for: inspection))
+                summaryItem(String(localized: "Confidence"), value: confidenceLabel(for: inspection))
+            }
+
+            Text(unavailableSummary(for: inspection))
+                .font(.system(size: metrics.metadataFontSize))
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+                .truncationMode(.tail)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(.quaternary.opacity(0.5))
+    }
+
+    private func summaryItem(_ label: String, value: String) -> some View {
+        HStack(spacing: 4) {
+            Text(label)
+                .font(.system(size: metrics.secondaryFontSize))
+                .foregroundStyle(.secondary)
+            Text(value)
+                .font(.system(size: metrics.secondaryFontSize, weight: .medium, design: .monospaced))
+                .lineLimit(1)
+                .truncationMode(.middle)
+                .textSelection(.enabled)
+        }
+    }
+
+    private func eventList(_ inspection: AIInspection) -> some View {
+        VStack(spacing: 0) {
+            Picker(selection: $filter) {
+                Text(String(localized: "All")).tag(AIInspectorEventFilter.all)
+                Text(String(localized: "Stream")).tag(AIInspectorEventFilter.stream)
+                Text(String(localized: "Tools")).tag(AIInspectorEventFilter.tools)
+            } label: {
+                EmptyView()
+            }
+            .pickerStyle(.segmented)
+            .controlSize(.small)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 6)
+
+            Divider()
+
+            let events = filteredEvents(inspection.events)
+            if events.isEmpty {
+                InspectorEmptyStateView(
+                    String(localized: "No Events"),
+                    systemImage: "list.bullet",
+                    description: String(localized: "No captured events match this filter.")
+                )
+            } else {
+                List(events, selection: $selectedEventID) { event in
+                    eventRow(event)
+                        .tag(event.id)
+                }
+                .listStyle(.inset(alternatesRowBackgrounds: true))
+            }
+        }
+    }
+
+    private func eventRow(_ event: AIEventSummary) -> some View {
+        HStack(spacing: 6) {
+            severityDot(event.severity)
+            Text(event.title)
+                .font(.system(size: metrics.metadataFontSize, design: .monospaced))
+                .lineLimit(1)
+                .truncationMode(.middle)
+            Spacer(minLength: 8)
+            Text(event.offsetLabel)
+                .font(.system(size: metrics.metadataFontSize, design: .monospaced))
+                .foregroundStyle(event.severity == .error ? .red : .secondary)
+                .lineLimit(1)
+        }
+    }
+
+    private func severityDot(_ severity: AIEventSeverity) -> some View {
+        Circle()
+            .fill(severity == .error ? Color.red : Color.accentColor)
+            .frame(width: 7, height: 7)
+    }
+
+    private func detailPane(_ inspection: AIInspection) -> some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 14) {
+                timingSection(inspection)
+                usageSection(inspection)
+                toolChainSection(inspection)
+                retrievalSection(inspection)
+                warningSection(inspection)
+                selectedEventSection
+            }
+            .padding(12)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    private func timingSection(_ inspection: AIInspection) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            sectionHeader(String(localized: "Timing and Stream"))
+            HStack(spacing: 14) {
+                metadataPair(String(localized: "Duration"), value: durationLabel(inspection.duration))
+                metadataPair(String(localized: "Streaming"), value: inspection.isStreaming ? String(localized: "Yes") : String(localized: "No"))
+                metadataPair(String(localized: "Events"), value: "\(inspection.events.count)")
+            }
+            streamBars(inspection.events)
+            Text(String(localized: "SSE cadence is shown from captured events. Token boundaries stay unavailable unless the provider exposes them."))
+                .font(.system(size: metrics.metadataFontSize))
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private func streamBars(_ events: [AIEventSummary]) -> some View {
+        HStack(alignment: .bottom, spacing: 5) {
+            ForEach(Array(events.prefix(18).enumerated()), id: \.element.id) { index, event in
+                RoundedRectangle(cornerRadius: 1.5)
+                    .fill(event.category == .tool ? Color.orange : Color.accentColor)
+                    .frame(width: 8, height: CGFloat(10 + ((index * 7) % 24)))
+                    .help(event.title)
+            }
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 6)
+        .frame(height: 48, alignment: .bottomLeading)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color(nsColor: .controlBackgroundColor), in: RoundedRectangle(cornerRadius: 4))
+    }
+
+    @ViewBuilder private func usageSection(_ inspection: AIInspection) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            sectionHeader(String(localized: "Usage"))
+            if let usage = inspection.usage {
+                HStack(spacing: 16) {
+                    metadataPair(String(localized: "Input"), value: tokenLabel(usage.inputTokens))
+                    metadataPair(String(localized: "Cached"), value: tokenLabel(usage.cachedTokens))
+                    metadataPair(String(localized: "Output"), value: tokenLabel(usage.outputTokens))
+                    metadataPair(String(localized: "Total"), value: "\(usage.totalTokens)")
+                }
+                tokenBar(usage)
+            } else {
+                unavailableText(String(localized: "Usage fields were not present in the captured provider response."))
+            }
+        }
+    }
+
+    private func tokenBar(_ usage: AIUsage) -> some View {
+        GeometryReader { proxy in
+            let input = CGFloat(usage.inputTokens ?? 0)
+            let cached = CGFloat(usage.cachedTokens ?? 0)
+            let output = CGFloat(usage.outputTokens ?? 0)
+            let total = max(CGFloat(usage.totalTokens), 1)
+            let width = proxy.size.width
+
+            HStack(spacing: 0) {
+                Rectangle()
+                    .fill(Color.purple)
+                    .frame(width: width * input / total)
+                Rectangle()
+                    .fill(Color.blue.opacity(0.65))
+                    .frame(width: width * cached / total)
+                Rectangle()
+                    .fill(Color.green)
+                    .frame(width: width * output / total)
+                Rectangle()
+                    .fill(Color(nsColor: .separatorColor).opacity(0.5))
+            }
+            .clipShape(RoundedRectangle(cornerRadius: 3))
+        }
+        .frame(height: 10)
+    }
+
+    private func toolChainSection(_ inspection: AIInspection) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            sectionHeader(String(localized: "Tool Chain"))
+            if inspection.toolCalls.isEmpty {
+                unavailableText(String(localized: "No tool-call payloads were visible in the captured traffic."))
+            } else {
+                ForEach(Array(inspection.toolCalls.enumerated()), id: \.offset) { index, tool in
+                    HStack(spacing: 10) {
+                        Text("\(index + 1)")
+                            .font(.system(size: metrics.metadataFontSize, weight: .semibold, design: .monospaced))
+                            .foregroundStyle(.secondary)
+                            .frame(width: 18, alignment: .trailing)
+                        Text(tool.name)
+                            .font(.system(size: metrics.metadataFontSize, weight: .medium, design: .monospaced))
+                        Spacer()
+                        Text(tool.state.displayName)
+                            .font(.system(size: metrics.metadataFontSize))
+                            .foregroundStyle(.secondary)
+                    }
+                    Divider()
+                }
+            }
+        }
+    }
+
+    private func retrievalSection(_ inspection: AIInspection) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            sectionHeader(String(localized: "Retrieval"))
+            if inspection.retrieval.isEmpty {
+                unavailableText(String(localized: "No retrieval or embedding result was visible for this selected transaction."))
+            } else {
+                ForEach(Array(inspection.retrieval.enumerated()), id: \.offset) { _, match in
+                    HStack {
+                        Text(match.source)
+                            .font(.system(size: metrics.metadataFontSize, weight: .medium, design: .monospaced))
+                        Spacer()
+                        Text(scoreLabel(match.score))
+                            .foregroundStyle(.secondary)
+                        Text(match.risk)
+                            .foregroundStyle(match.risk.contains("sensitive") ? .red : .secondary)
+                    }
+                    .font(.system(size: metrics.metadataFontSize))
+                    Divider()
+                }
+            }
+        }
+    }
+
+    private func warningSection(_ inspection: AIInspection) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            sectionHeader(String(localized: "Warnings"))
+            if inspection.warnings.isEmpty {
+                unavailableText(String(localized: "No AI-specific warning was detected from visible traffic fields."))
+            } else {
+                ForEach(Array(inspection.warnings.enumerated()), id: \.offset) { _, warning in
+                    Label(warning.message, systemImage: warning.severity == .error ? "exclamationmark.triangle" : "lock.shield")
+                        .font(.system(size: metrics.metadataFontSize, weight: .medium))
+                        .foregroundStyle(warning.severity == .error ? .red : .orange)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder private var selectedEventSection: some View {
+        if let selectedEvent {
+            VStack(alignment: .leading, spacing: 8) {
+                sectionHeader(String(localized: "Selected Event"))
+                Text(selectedEvent.detail)
+                    .font(.system(size: metrics.metadataFontSize, design: .monospaced))
+                    .textSelection(.enabled)
+                    .lineLimit(8)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(8)
+                    .background(Color(nsColor: .textBackgroundColor), in: RoundedRectangle(cornerRadius: 4))
+            }
+        }
+    }
+
+    private func sectionHeader(_ title: String) -> some View {
+        HStack(spacing: 4) {
+            Image(systemName: "chevron.down")
+                .font(.system(size: metrics.badgeFontSize))
+                .foregroundStyle(.secondary)
+            Text(title)
+                .font(.system(size: metrics.secondaryFontSize, weight: .semibold))
+        }
+    }
+
+    private func metadataPair(_ label: String, value: String) -> some View {
+        HStack(spacing: 4) {
+            Text(label)
+                .foregroundStyle(.secondary)
+            Text(value)
+                .fontWeight(.medium)
+                .textSelection(.enabled)
+        }
+        .font(.system(size: metrics.metadataFontSize, design: .monospaced))
+    }
+
+    private func unavailableText(_ text: String) -> some View {
+        Text(text)
+            .font(.system(size: metrics.metadataFontSize))
+            .foregroundStyle(.secondary)
+    }
+
+    private func filteredEvents(_ events: [AIEventSummary]) -> [AIEventSummary] {
+        switch filter {
+        case .all:
+            events
+        case .stream:
+            events.filter { $0.category == .stream }
+        case .tools:
+            events.filter { $0.category == .tool }
+        }
+    }
+
+    private func durationLabel(_ duration: TimeInterval?) -> String {
+        duration.map { DurationFormatter.format(seconds: $0) } ?? String(localized: "Unavailable")
+    }
+
+    private func tokenLabel(_ value: Int?) -> String {
+        value.map(String.init) ?? String(localized: "Unavailable")
+    }
+
+    private func scoreLabel(_ score: Double?) -> String {
+        guard let score else {
+            return String(localized: "Unavailable")
+        }
+        return String(format: "%.2f", score)
+    }
+
+    private func finishLabel(for inspection: AIInspection) -> String {
+        if inspection.events.contains(where: { $0.title.lowercased().contains("completed") }) {
+            return String(localized: "completed")
+        }
+        if let status = inspection.httpStatusCode, status >= 400 {
+            return "HTTP \(status)"
+        }
+        return String(localized: "Unavailable")
+    }
+
+    private func confidenceLabel(for inspection: AIInspection) -> String {
+        inspection.events.contains(where: { $0.category == .stream || $0.category == .tool })
+            ? String(localized: "observed + derived")
+            : String(localized: "observed")
+    }
+
+    private func unavailableSummary(for inspection: AIInspection) -> String {
+        if inspection.unavailableFields.isEmpty {
+            return String(localized: "All displayed values come from visible captured traffic.")
+        }
+        return String(localized: "Unavailable: \(inspection.unavailableFields.joined(separator: ", ")). Missing fields are not inferred.")
+    }
+}
+
+// MARK: - AIInspectorEventFilter
+
+private enum AIInspectorEventFilter: Hashable {
+    case all
+    case stream
+    case tools
+}

--- a/Rockxy/Views/Inspector/ResponseInspectorView.swift
+++ b/Rockxy/Views/Inspector/ResponseInspectorView.swift
@@ -86,7 +86,7 @@ struct ResponseInspectorView: View {
                     .padding(.horizontal, 4)
             }
 
-            ForEach(ResponseInspectorTab.allCases, id: \.self) { tab in
+            ForEach(ResponseInspectorTab.availableTabs(hasAIInspection: hasAIInspection), id: \.self) { tab in
                 InspectorTabButton(
                     title: tab.displayName,
                     isActive: protocolTab == nil && selectedPreviewTab == nil && selectedTab == tab
@@ -331,6 +331,16 @@ struct ResponseInspectorView: View {
             encryptedHTTPSPrompt(prompt)
         } else if let response = transaction.response {
             switch selectedTab {
+            case .ai:
+                if hasAIInspection {
+                    AIInspectorView(transaction: transaction)
+                } else {
+                    InspectorEmptyStateView(
+                        String(localized: "No AI Metadata"),
+                        systemImage: "sparkles",
+                        description: String(localized: "This response does not look like captured AI model traffic.")
+                    )
+                }
             case .headers:
                 responseHeadersView(response: response)
             case .body:
@@ -523,6 +533,11 @@ struct ResponseInspectorView: View {
     }
 
     private func syncInspectorStateForTransaction() {
+        let supportsAIInspection = hasAIInspection
+        if selectedTab == .ai, !supportsAIInspection {
+            selectedTab = .headers
+        }
+
         if let selectedPreviewTab,
            !previewTabStore.responseTabs.contains(where: { $0.id == selectedPreviewTab.id })
         {
@@ -533,6 +548,9 @@ struct ResponseInspectorView: View {
         switch selectionIntent {
         case .automatic:
             protocolTab = ProtocolTabKind.defaultFor(transaction)
+            if protocolTab == nil, supportsAIInspection {
+                selectedTab = .ai
+            }
         case .native,
              .preview:
             protocolTab = nil
@@ -565,6 +583,10 @@ struct ResponseInspectorView: View {
             return false
         }
         return !body.isEmpty
+    }
+
+    private var hasAIInspection: Bool {
+        AITrafficDetector.isLikelyAI(transaction: transaction)
     }
 
     private func prettyJSONString(from data: Data, sortedKeys: Bool) -> String? {

--- a/Rockxy/Views/RequestList/RequestTableView.swift
+++ b/Rockxy/Views/RequestList/RequestTableView.swift
@@ -202,6 +202,7 @@ struct RequestTableView: NSViewRepresentable {
     private static func makeColumns() -> [NSTableColumn] {
         let specs: [ColumnSpec] = [
             ColumnSpec(id: "status", title: "", width: 22, minWidth: 22),
+            ColumnSpec(id: "ai", title: String(localized: "AI"), width: 38, minWidth: 32),
             ColumnSpec(id: "row", title: String(localized: "ID"), width: 46, minWidth: 36),
             ColumnSpec(id: "url", title: String(localized: "URL"), width: 300, minWidth: 200),
             ColumnSpec(id: "client", title: String(localized: "Client"), width: 120, minWidth: 60),
@@ -230,6 +231,8 @@ struct RequestTableView: NSViewRepresentable {
             if spec.id == "status" {
                 column.resizingMask = []
                 column.maxWidth = 22
+            } else if spec.id == "ai" {
+                column.maxWidth = 44
             } else if spec.id == "ssl" {
                 column.maxWidth = 42
             } else {
@@ -629,6 +632,7 @@ extension RequestTableView {
 
             switch columnID {
             case "status": return 22
+            case "ai": return 38
             case "row": return 46
             case "ssl": return 38
             default: break
@@ -652,6 +656,9 @@ extension RequestTableView {
                 case "client":
                     text = rowData.clientApp ?? ""
                     font = metrics.appKitFont()
+                case "ai":
+                    text = rowData.aiTrafficSignal.tableLabel
+                    font = metrics.appKitFont(weight: .semibold)
                 case "method":
                     text = rowData.method
                     font = metrics.appKitFont(weight: .semibold)
@@ -1521,6 +1528,7 @@ extension RequestTableView {
             // Built-in column visibility
             let builtInColumns: [(id: String, title: String)] = [
                 ("status", String(localized: "Status Icon")),
+                ("ai", String(localized: "AI")),
                 ("row", "#"),
                 ("url", String(localized: "URL")),
                 ("client", String(localized: "Client")),
@@ -2100,6 +2108,7 @@ extension RequestTableView {
             cell.textColor = .labelColor
             cell.alignment = .left
             cell.font = metrics.appKitFont()
+            cell.toolTip = nil
 
             switch column {
             case "row":
@@ -2112,6 +2121,15 @@ extension RequestTableView {
                 cell.stringValue = rowData.host + rowData.path
                 cell.font = metrics.appKitFont(monospaced: true)
                 cell.textColor = .labelColor
+
+            case "ai":
+                cell.alignment = .center
+                cell.stringValue = rowData.aiTrafficSignal.tableLabel
+                cell.toolTip = rowData.aiTrafficSignal.accessibilityLabel.isEmpty
+                    ? nil
+                    : rowData.aiTrafficSignal.accessibilityLabel
+                cell.font = metrics.appKitFont(weight: .semibold)
+                cell.textColor = rowData.aiTrafficSignal.isLikelyAI ? .controlAccentColor : .tertiaryLabelColor
 
             case "method":
                 cell.alignment = .center

--- a/RockxyTests/Core/Detection/AITrafficDetectorTests.swift
+++ b/RockxyTests/Core/Detection/AITrafficDetectorTests.swift
@@ -1,0 +1,128 @@
+import Foundation
+@testable import Rockxy
+import Testing
+
+struct AITrafficDetectorTests {
+    @Test("OpenAI-compatible streaming traffic exposes model, usage, stream events, and tools")
+    func openAIStreamingTrafficExposesInspectionSignals() throws {
+        let requestBody = Data(#"{"model":"gpt-4.1-mini","input":"fixture prompt","stream":true,"tools":[{"name":"lookup_order"}]}"#.utf8)
+        let responseBody = Data("""
+        event: response.created
+        data: {"id":"resp_fixture","model":"gpt-4.1-mini"}
+
+        event: response.output_text.delta
+        data: {"delta":"hello"}
+
+        event: response.tool_call.delta
+        data: {"name":"lookup_order","arguments":"{\\\"order_id\\\":\\\"fixture-order\\\"}"}
+
+        event: response.completed
+        data: {"usage":{"input_tokens":920,"output_tokens":568,"total_tokens":1488}}
+
+        """.utf8)
+        let transaction = makeTransaction(
+            url: "https://api.openai.com/v1/responses",
+            requestBody: requestBody,
+            responseHeaders: [HTTPHeader(name: "Content-Type", value: "text/event-stream")],
+            responseBody: responseBody
+        )
+
+        let inspection = try #require(AITrafficDetector.detect(transaction: transaction))
+
+        #expect(inspection.provider == .openAICompatible)
+        #expect(inspection.model == "gpt-4.1-mini")
+        #expect(inspection.isStreaming)
+        #expect(inspection.usage?.inputTokens == 920)
+        #expect(inspection.usage?.outputTokens == 568)
+        #expect(inspection.events.contains { $0.title == "response.tool_call.delta" })
+        #expect(inspection.toolCalls.contains { $0.name == "lookup_order" })
+        #expect(inspection.warnings.contains { $0.message.contains("Prompt content") })
+    }
+
+    @Test("Anthropic message traffic is detected without inventing missing usage")
+    func anthropicTrafficKeepsMissingUsageUnavailable() throws {
+        let requestBody = Data(#"{"model":"claude-sonnet-fixture","messages":[{"role":"user","content":"fixture"}]}"#.utf8)
+        let transaction = makeTransaction(
+            url: "https://api.anthropic.com/v1/messages",
+            requestHeaders: [
+                HTTPHeader(name: "Content-Type", value: "application/json"),
+                HTTPHeader(name: "anthropic-version", value: "2023-06-01"),
+            ],
+            requestBody: requestBody,
+            responseBody: Data(#"{"type":"message","model":"claude-sonnet-fixture","content":[]}"#.utf8)
+        )
+
+        let inspection = try #require(AITrafficDetector.detect(transaction: transaction))
+
+        #expect(inspection.provider == .anthropic)
+        #expect(inspection.model == "claude-sonnet-fixture")
+        #expect(inspection.usage == nil)
+        #expect(inspection.unavailableFields.contains("usage"))
+    }
+
+    @Test("Ordinary HTTP traffic does not expose AI inspection")
+    func ordinaryHTTPTrafficDoesNotExposeAIInspection() {
+        let transaction = TestFixtures.makeTransaction(
+            method: "GET",
+            url: "https://api.example.com/orders",
+            statusCode: 200
+        )
+
+        #expect(!AITrafficDetector.isLikelyAI(transaction: transaction))
+        #expect(AITrafficDetector.detect(transaction: transaction) == nil)
+        #expect(!ResponseInspectorTab.availableTabs(hasAIInspection: false).contains(.ai))
+    }
+
+    @Test("AI tab is available only when AI metadata is likely")
+    func aiTabAvailabilityFollowsDetection() {
+        let requestBody = Data(#"{"model":"gpt-4.1-mini","input":"fixture"}"#.utf8)
+        let transaction = makeTransaction(
+            url: "https://localhost:11434/v1/responses",
+            requestBody: requestBody
+        )
+
+        #expect(AITrafficDetector.isLikelyAI(transaction: transaction))
+        #expect(ResponseInspectorTab.availableTabs(hasAIInspection: true).contains(.ai))
+    }
+
+    private func makeTransaction(
+        url: String,
+        requestHeaders: [HTTPHeader] = [
+            HTTPHeader(name: "Content-Type", value: "application/json"),
+            HTTPHeader(name: "Authorization", value: "Bearer synthetic-token"),
+        ],
+        requestBody: Data? = nil,
+        responseHeaders: [HTTPHeader] = [HTTPHeader(name: "Content-Type", value: "application/json")],
+        responseBody: Data? = nil
+    )
+        -> HTTPTransaction
+    {
+        guard let requestURL = URL(string: url) else {
+            preconditionFailure("Expected valid fixture URL")
+        }
+        let request = HTTPRequestData(
+            method: "POST",
+            url: requestURL,
+            httpVersion: "HTTP/1.1",
+            headers: requestHeaders,
+            body: requestBody,
+            contentType: .json
+        )
+        let response = HTTPResponseData(
+            statusCode: 200,
+            statusMessage: "OK",
+            headers: responseHeaders,
+            body: responseBody,
+            contentType: .json
+        )
+        let transaction = HTTPTransaction(request: request, response: response, state: .completed)
+        transaction.timingInfo = TimingInfo(
+            dnsLookup: 0.001,
+            tcpConnection: 0.002,
+            tlsHandshake: 0.003,
+            timeToFirstByte: 0.642,
+            contentTransfer: 3.192
+        )
+        return transaction
+    }
+}

--- a/RockxyTests/Core/Detection/ProtocolFixtureCorpusTests.swift
+++ b/RockxyTests/Core/Detection/ProtocolFixtureCorpusTests.swift
@@ -1,0 +1,156 @@
+import Foundation
+import Testing
+
+@Suite("Protocol Fixture Corpus")
+struct ProtocolFixtureCorpusTests {
+    @Test("Fixture IDs are unique and stable")
+    func fixtureIDsAreUniqueAndStable() {
+        let ids = ProtocolFixtureCorpus.fixtures.map(\.id)
+
+        #expect(Set(ids).count == ids.count)
+        #expect(ids.allSatisfy { !$0.contains(" ") })
+        #expect(ids.allSatisfy { $0.contains(".") })
+    }
+
+    @Test("Fixtures satisfy the shared schema contract")
+    func fixturesSatisfySharedSchemaContract() {
+        let failures = ProtocolFixtureCorpus.fixtures.flatMap(ProtocolFixtureValidation.validate)
+
+        #expect(failures.isEmpty, Comment(rawValue: failures.joined(separator: "\n")))
+    }
+
+    @Test("Corpus covers foundation protocol families")
+    func corpusCoversFoundationProtocolFamilies() {
+        let families = Set(ProtocolFixtureCorpus.fixtures.map(\.family))
+
+        #expect(families.isSuperset(of: [.ordinaryHTTP, .ai, .web3RPC, .x402, .unknown]))
+    }
+
+    @Test("Protocol fixtures include UX contract expectations")
+    func protocolFixturesIncludeUXContractExpectations() {
+        for fixture in ProtocolFixtureCorpus.fixtures where fixture.family != .ordinaryHTTP {
+            let ux = fixture.expected.ux
+
+            #expect(!ux.requestListBadges.isEmpty, "\(fixture.id) must declare request-list badge expectations")
+            #expect(!ux.optionalColumns.isEmpty, "\(fixture.id) must declare optional-column expectations")
+            #expect(!ux.inspectorTabs.isEmpty, "\(fixture.id) must declare inspector-tab expectations")
+            #expect(!ux.exportSummaryFields.isEmpty, "\(fixture.id) must declare export-summary expectations")
+            #expect(!ux.mcpSummaryFields.isEmpty, "\(fixture.id) must declare MCP-summary expectations")
+        }
+    }
+
+    @Test("Malformed fixtures declare bounded fallback behavior")
+    func malformedFixturesDeclareFallbackBehavior() {
+        let malformedFixtures = ProtocolFixtureCorpus.fixtures.filter { $0.safetyClass == .malformed }
+
+        #expect(!malformedFixtures.isEmpty)
+        for fixture in malformedFixtures {
+            #expect(fixture.expected.ux.fallbackBehavior != nil, "\(fixture.id) must declare fallback behavior")
+            #expect(fixture.expected.metadataHints.contains("fallback"), "\(fixture.id) must include fallback metadata hint")
+        }
+    }
+
+    @Test("Corpus passes public safety scan")
+    func corpusPassesPublicSafetyScan() {
+        let findings = ProtocolFixtureCorpus.fixtures.flatMap(ProtocolFixtureSafetyScanner.scan)
+
+        #expect(findings.isEmpty, Comment(rawValue: findings.map(formatFinding).joined(separator: "\n")))
+    }
+
+    @Test("Safety scanner catches local paths")
+    func safetyScannerCatchesLocalPaths() {
+        let findings = ProtocolFixtureSafetyScanner.scan(text: #"{"path":"/Users/example/private.json"}"#)
+
+        #expect(findings.contains { $0.reason.contains("local filesystem path") })
+    }
+
+    @Test("Safety scanner catches production-looking tokens")
+    func safetyScannerCatchesProductionLookingTokens() {
+        let findings = ProtocolFixtureSafetyScanner.scan(text: "Authorization: Bearer abcdefghijklmnopqrstuvwxyz123456")
+
+        #expect(findings.contains { $0.reason.contains("bearer token") })
+    }
+
+    @Test("Safety scanner allows synthetic token placeholders")
+    func safetyScannerAllowsSyntheticTokenPlaceholders() {
+        let findings = ProtocolFixtureSafetyScanner.scan(text: "Authorization: Bearer synthetic-ai-token")
+
+        #expect(findings.isEmpty)
+    }
+
+    @Test("Safety scanner catches non-synthetic hosts in messages")
+    func safetyScannerCatchesNonSyntheticHosts() {
+        let fixture = ProtocolFixture(
+            id: "manual.real-host",
+            title: "Manual real host fixture",
+            family: .ordinaryHTTP,
+            scenarioTags: ["manual"],
+            traffic: ProtocolFixtureTraffic(exchanges: [
+                ProtocolFixtureExchange(
+                    request: ProtocolFixtureMessage(method: "GET", url: "https://production.example.net/data")
+                )
+            ]),
+            expected: ProtocolFixtureExpectations(
+                metadataHints: ["manual"],
+                redaction: ProtocolFixtureRedactionExpectation(
+                    sensitiveFields: [],
+                    redactedMarkers: [],
+                    safeFields: []
+                ),
+                ux: ProtocolFixtureUXExpectation(
+                    requestListBadges: ["Manual"],
+                    optionalColumns: ["kind": "manual"],
+                    inspectorTabs: ["Raw"],
+                    warningStates: [],
+                    exportSummaryFields: ["host"],
+                    mcpSummaryFields: ["host"],
+                    fallbackBehavior: nil
+                )
+            ),
+            safetyClass: .ordinary,
+            sizeClass: .small,
+            traceability: ProtocolFixtureTraceability(parentIssue: 176, childIssues: [186], futureIssues: [])
+        )
+
+        let findings = ProtocolFixtureSafetyScanner.scan(fixture)
+
+        #expect(findings.contains { $0.reason.contains("non-synthetic host") })
+    }
+
+    @Test("Safety scanner catches private-key-like material")
+    func safetyScannerCatchesPrivateKeyLikeMaterial() {
+        let findings = ProtocolFixtureSafetyScanner.scan(text: "0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")
+
+        #expect(findings.contains { $0.reason.contains("private-key-like") })
+    }
+
+    @Test("Safety scanner allows example.com email placeholders")
+    func safetyScannerAllowsExampleEmailPlaceholders() {
+        let findings = ProtocolFixtureSafetyScanner.scan(text: "owner@example.com")
+
+        #expect(findings.isEmpty)
+    }
+
+    @Test("Safety scanner catches personal email-like values")
+    func safetyScannerCatchesPersonalEmailLikeValues() {
+        let findings = ProtocolFixtureSafetyScanner.scan(text: "owner@real-company.invalid")
+
+        #expect(findings.contains { $0.reason.contains("personal email-like") })
+    }
+
+    @Test("Fixtures trace back to parent and Group A child issues")
+    func fixturesTraceBackToParentAndGroupAChildIssues() {
+        let requiredChildIssues: Set<Int> = [186, 187, 194, 195]
+        let requiredFutureIssues: Set<Int> = [143, 144, 145, 146, 177, 178, 179, 180]
+
+        for fixture in ProtocolFixtureCorpus.fixtures {
+            #expect(fixture.traceability.parentIssue == 176)
+            #expect(fixture.traceability.childIssues.isSuperset(of: requiredChildIssues))
+            #expect(fixture.traceability.futureIssues.isSuperset(of: requiredFutureIssues))
+        }
+    }
+
+    private func formatFinding(_ finding: ProtocolFixtureSafetyScanner.Finding) -> String {
+        "\(finding.fixtureID): \(finding.reason): \(finding.excerpt)"
+    }
+}

--- a/RockxyTests/Core/Detection/ProtocolFixtureCorpusTests.swift
+++ b/RockxyTests/Core/Detection/ProtocolFixtureCorpusTests.swift
@@ -26,6 +26,62 @@ struct ProtocolFixtureCorpusTests {
         #expect(families.isSuperset(of: [.ordinaryHTTP, .ai, .web3RPC, .x402, .unknown]))
     }
 
+    @Test("AI streaming fixtures cover tool calls, malformed streams, and provider errors")
+    func aiStreamingFixturesCoverRequiredScenarios() {
+        let aiTags = tags(for: .ai)
+
+        #expect(aiTags.isSuperset(of: ["openai", "anthropic", "streaming", "tool-call", "interrupted"]))
+        #expect(aiTags.isSuperset(of: ["provider-error", "no-usage-summary", "malformed"]))
+    }
+
+    @Test("AI retrieval fixtures cover embeddings, vector search, and RAG")
+    func aiRetrievalFixturesCoverRequiredScenarios() {
+        let aiTags = tags(for: .ai)
+
+        #expect(aiTags.isSuperset(of: ["embeddings", "vector-search", "retrieval", "rag", "sensitive-context"]))
+    }
+
+    @Test("EVM JSON-RPC fixtures cover method, batch, error, malformed, and large cases")
+    func evmJSONRPCFixturesCoverRequiredScenarios() {
+        let evmFixtures = fixtures(containing: "evm")
+        let evmTags = Set(evmFixtures.flatMap(\.scenarioTags))
+
+        #expect(evmTags.isSuperset(of: ["estimate-gas", "receipt", "signed-payload"]))
+        #expect(evmTags.isSuperset(of: ["batch", "error", "malformed", "large"]))
+        #expect(evmFixtures.contains { $0.sizeClass == .boundedStress })
+    }
+
+    @Test("Solana fixtures cover HTTP RPC and WebSocket subscription lifecycle")
+    func solanaFixturesCoverRequiredScenarios() {
+        let solanaFixtures = fixtures(containing: "solana")
+        let solanaTags = Set(solanaFixtures.flatMap(\.scenarioTags))
+
+        #expect(solanaTags.isSuperset(of: ["http-rpc", "websocket-rpc", "subscription", "notification", "unsubscribe"]))
+        #expect(solanaTags.isSuperset(of: ["malformed", "long-session"]))
+        #expect(solanaFixtures.contains { !$0.traffic.webSocketMessages.isEmpty })
+    }
+
+    @Test("x402 fixtures cover payment retry, malformed, missing proof, and provider error")
+    func x402FixturesCoverRequiredScenarios() {
+        let x402Tags = tags(for: .x402)
+
+        #expect(x402Tags.isSuperset(of: ["payment-required", "retry", "success"]))
+        #expect(x402Tags.isSuperset(of: ["malformed", "missing-proof", "provider-error", "sensitive-metadata"]))
+    }
+
+    @Test("Hostile fixtures declare bounded parser safety behavior")
+    func hostileFixturesDeclareBoundedParserSafetyBehavior() {
+        let hostileFixtures = fixtures(containing: "hostile")
+        let hostileTags = Set(hostileFixtures.flatMap(\.scenarioTags))
+
+        #expect(hostileTags.isSuperset(of: ["oversized", "deep-nesting", "long-string", "truncated", "partial"]))
+        #expect(hostileTags.contains("malformed-bytes"))
+        for fixture in hostileFixtures {
+            #expect(fixture.expected.ux.fallbackBehavior != nil, "\(fixture.id) must declare bounded fallback behavior")
+            #expect(fixture.traffic.estimatedPayloadBytes <= 32_000, "\(fixture.id) must stay inside the corpus budget")
+        }
+    }
+
     @Test("Protocol fixtures include UX contract expectations")
     func protocolFixturesIncludeUXContractExpectations() {
         for fixture in ProtocolFixtureCorpus.fixtures where fixture.family != .ordinaryHTTP {
@@ -138,6 +194,15 @@ struct ProtocolFixtureCorpusTests {
         #expect(findings.contains { $0.reason.contains("personal email-like") })
     }
 
+    @Test("Safety scanner catches seed phrase-like samples")
+    func safetyScannerCatchesSeedPhraseLikeSamples() {
+        let findings = ProtocolFixtureSafetyScanner.scan(
+            text: "abandon ability able about above absent absorb abstract absurd abuse access accident"
+        )
+
+        #expect(findings.contains { $0.reason.contains("seed phrase-like") })
+    }
+
     @Test("Fixtures trace back to parent and Group A child issues")
     func fixturesTraceBackToParentAndGroupAChildIssues() {
         let requiredChildIssues: Set<Int> = [186, 187, 194, 195]
@@ -150,7 +215,22 @@ struct ProtocolFixtureCorpusTests {
         }
     }
 
+    @Test("Child issues are represented by corpus fixtures")
+    func childIssuesAreRepresentedByCorpusFixtures() {
+        let representedIssues = Set(ProtocolFixtureCorpus.fixtures.flatMap(\.traceability.childIssues))
+
+        #expect(representedIssues.isSuperset(of: [186, 187, 188, 189, 190, 191, 192, 193, 194, 195]))
+    }
+
     private func formatFinding(_ finding: ProtocolFixtureSafetyScanner.Finding) -> String {
         "\(finding.fixtureID): \(finding.reason): \(finding.excerpt)"
+    }
+
+    private func tags(for family: ProtocolFixtureFamily) -> Set<String> {
+        Set(ProtocolFixtureCorpus.fixtures.filter { $0.family == family }.flatMap(\.scenarioTags))
+    }
+
+    private func fixtures(containing tag: String) -> [ProtocolFixture] {
+        ProtocolFixtureCorpus.fixtures.filter { $0.scenarioTags.contains(tag) }
     }
 }

--- a/RockxyTests/Helpers/ProtocolFixtureCorpus+Fixtures.swift
+++ b/RockxyTests/Helpers/ProtocolFixtureCorpus+Fixtures.swift
@@ -1,0 +1,1090 @@
+import Foundation
+
+// MARK: - Corpus Smoke Fixtures
+
+extension ProtocolFixture {
+    static let commonTraceability = ProtocolFixtureTraceability(
+        parentIssue: 176,
+        childIssues: [186, 187, 194, 195],
+        futureIssues: [143, 144, 145, 146, 177, 178, 179, 180]
+    )
+
+    static let httpJSONSmoke = ProtocolFixture(
+        id: "foundation.http-json.redaction-smoke",
+        title: "Ordinary JSON request with synthetic redaction candidate",
+        family: .ordinaryHTTP,
+        scenarioTags: ["http", "json", "redaction-smoke"],
+        traffic: ProtocolFixtureTraffic(exchanges: [
+            ProtocolFixtureExchange(
+                request: ProtocolFixtureMessage(
+                    method: "POST",
+                    url: "https://api.example.com/v1/debug-smoke",
+                    headers: [.init(name: "Content-Type", value: "application/json")],
+                    body: #"{"request_id":"fixture-request","api_key":"synthetic-api-key"}"#
+                ),
+                response: ProtocolFixtureMessage(
+                    method: "HTTP",
+                    url: "https://api.example.com/v1/debug-smoke",
+                    statusCode: 200,
+                    headers: [.init(name: "Content-Type", value: "application/json")],
+                    body: #"{"ok":true,"request_id":"fixture-request"}"#
+                )
+            )
+        ]),
+        expected: ProtocolFixtureExpectations(
+            metadataHints: ["http", "json"],
+            redaction: ProtocolFixtureRedactionExpectation(
+                sensitiveFields: ["api_key"],
+                redactedMarkers: ["[REDACTED]"],
+                safeFields: ["request_id", "ok"]
+            ),
+            ux: ProtocolFixtureUXExpectation(
+                requestListBadges: ["JSON"],
+                optionalColumns: ["content": "JSON"],
+                inspectorTabs: ["Headers", "JSON", "Raw"],
+                warningStates: [],
+                exportSummaryFields: ["method", "host", "status", "redacted_fields"],
+                mcpSummaryFields: ["method", "url", "status", "redacted"],
+                fallbackBehavior: nil
+            )
+        ),
+        safetyClass: .containsSyntheticSensitiveData,
+        sizeClass: .small,
+        traceability: commonTraceability
+    )
+
+    static let aiSSEContractSmoke = ProtocolFixture(
+        id: "foundation.ai-sse.contract-smoke",
+        title: "AI streaming response with synthetic tool call",
+        family: .ai,
+        scenarioTags: ["ai", "sse", "streaming", "tool-call", "contract-smoke"],
+        traffic: ProtocolFixtureTraffic(exchanges: [
+            ProtocolFixtureExchange(
+                request: ProtocolFixtureMessage(
+                    method: "POST",
+                    url: "https://ai.example.com/v1/responses",
+                    headers: [
+                        .init(name: "Content-Type", value: "application/json"),
+                        .init(name: "Authorization", value: "Bearer synthetic-ai-token"),
+                    ],
+                    body: #"{"model":"synthetic-model","input":"[SYNTHETIC_PROMPT]","tool_choice":"auto"}"#
+                ),
+                response: ProtocolFixtureMessage(
+                    method: "HTTP",
+                    url: "https://ai.example.com/v1/responses",
+                    statusCode: 200,
+                    headers: [.init(name: "Content-Type", value: "text/event-stream")],
+                    body: nil
+                ),
+                streamEvents: [
+                    .init(event: "response.created", data: #"{"id":"resp_fixture","model":"synthetic-model"}"#),
+                    .init(event: "response.tool_call.delta", data: #"{"name":"lookup_order","arguments":"{\"order_id\":\"fixture-order\"}"}"#),
+                    .init(event: "response.completed", data: #"{"id":"resp_fixture","status":"completed"}"#),
+                ]
+            )
+        ]),
+        expected: ProtocolFixtureExpectations(
+            metadataHints: ["ai", "streaming", "tool_call", "model_request"],
+            redaction: ProtocolFixtureRedactionExpectation(
+                sensitiveFields: ["Authorization", "input", "tool_choice", "arguments"],
+                redactedMarkers: ["[REDACTED]"],
+                safeFields: ["model", "status"]
+            ),
+            ux: ProtocolFixtureUXExpectation(
+                requestListBadges: ["AI", "Stream"],
+                optionalColumns: ["protocol": "AI", "streaming": "true"],
+                inspectorTabs: ["AI", "Stream", "Tool Calls", "Raw"],
+                warningStates: ["prompt_redaction_candidate", "tool_payload_redaction_candidate"],
+                exportSummaryFields: ["model", "stream_event_count", "tool_call_count", "redacted_fields"],
+                mcpSummaryFields: ["model", "status", "streaming", "redacted"],
+                fallbackBehavior: nil
+            )
+        ),
+        safetyClass: .containsSyntheticSensitiveData,
+        sizeClass: .small,
+        traceability: commonTraceability
+    )
+
+    static let aiAnthropicSSEContractSmoke = ProtocolFixture(
+        id: "ai.anthropic-sse.tool-use-contract",
+        title: "Anthropic-style SSE stream with synthetic tool use",
+        family: .ai,
+        scenarioTags: ["ai", "anthropic", "sse", "streaming", "tool-call", "issue-188"],
+        traffic: ProtocolFixtureTraffic(exchanges: [
+            ProtocolFixtureExchange(
+                request: ProtocolFixtureMessage(
+                    method: "POST",
+                    url: "https://ai.example.com/v1/messages",
+                    headers: [
+                        .init(name: "Content-Type", value: "application/json"),
+                        .init(name: "X-API-Key", value: "synthetic-ai-token"),
+                    ],
+                    body: #"{"model":"synthetic-claude","messages":[{"role":"user","content":"[SYNTHETIC_PROMPT]"}],"tools":[{"name":"lookup_fixture"}]}"#
+                ),
+                response: ProtocolFixtureMessage(
+                    method: "HTTP",
+                    url: "https://ai.example.com/v1/messages",
+                    statusCode: 200,
+                    headers: [.init(name: "Content-Type", value: "text/event-stream")]
+                ),
+                streamEvents: [
+                    .init(event: "message_start", data: #"{"message":{"id":"msg_fixture","model":"synthetic-claude"}}"#),
+                    .init(event: "content_block_start", data: #"{"type":"tool_use","name":"lookup_fixture","input":{}}"#),
+                    .init(event: "content_block_delta", data: #"{"partial_json":"{\"query\":\"synthetic"}}"#),
+                    .init(event: "content_block_delta", data: #"{"partial_json":" context\"}"}"#),
+                    .init(event: "message_stop", data: #"{"stop_reason":"tool_use"}"#),
+                ]
+            )
+        ]),
+        expected: aiStreamingExpectations(
+            hints: ["ai", "streaming", "tool_call", "anthropic_style", "model_request"],
+            fallback: nil
+        ),
+        safetyClass: .containsSyntheticSensitiveData,
+        sizeClass: .small,
+        traceability: issueTraceability([188])
+    )
+
+    static let aiInterruptedToolCallContractSmoke = ProtocolFixture(
+        id: "ai.openai-sse.interrupted-tool-call",
+        title: "OpenAI-style stream with interrupted partial tool arguments",
+        family: .ai,
+        scenarioTags: ["ai", "openai", "sse", "streaming", "tool-call", "interrupted", "malformed", "issue-188"],
+        traffic: ProtocolFixtureTraffic(exchanges: [
+            ProtocolFixtureExchange(
+                request: ProtocolFixtureMessage(
+                    method: "POST",
+                    url: "https://ai.example.com/v1/responses",
+                    headers: [.init(name: "Authorization", value: "Bearer synthetic-ai-token")],
+                    body: #"{"model":"synthetic-model","input":"[SYNTHETIC_PROMPT]","stream":true}"#
+                ),
+                response: ProtocolFixtureMessage(
+                    method: "HTTP",
+                    url: "https://ai.example.com/v1/responses",
+                    statusCode: 200,
+                    headers: [.init(name: "Content-Type", value: "text/event-stream")]
+                ),
+                streamEvents: [
+                    .init(event: "response.tool_call.delta", data: #"{"arguments":"{\"order_id\":\"fixture-""#),
+                    .init(event: nil, data: "not-json-stream-event"),
+                ]
+            )
+        ]),
+        expected: aiStreamingExpectations(
+            hints: ["ai", "streaming", "tool_call", "interrupted", "malformed", "fallback"],
+            fallback: "Show bounded stream fallback and mark partial tool arguments as redaction candidates."
+        ),
+        safetyClass: .malformed,
+        sizeClass: .small,
+        traceability: issueTraceability([188, 193])
+    )
+
+    static let aiProviderErrorNoUsageContractSmoke = ProtocolFixture(
+        id: "ai.provider-error.no-usage-summary",
+        title: "AI provider error stream ending without final usage",
+        family: .ai,
+        scenarioTags: ["ai", "sse", "provider-error", "no-usage-summary", "issue-188"],
+        traffic: ProtocolFixtureTraffic(exchanges: [
+            ProtocolFixtureExchange(
+                request: ProtocolFixtureMessage(
+                    method: "POST",
+                    url: "https://ai.example.com/v1/responses",
+                    headers: [.init(name: "Authorization", value: "Bearer synthetic-ai-token")],
+                    body: #"{"model":"synthetic-model","input":"[SYNTHETIC_PROMPT]","stream":true}"#
+                ),
+                response: ProtocolFixtureMessage(
+                    method: "HTTP",
+                    url: "https://ai.example.com/v1/responses",
+                    statusCode: 429,
+                    headers: [.init(name: "Content-Type", value: "text/event-stream")]
+                ),
+                streamEvents: [
+                    .init(event: "error", data: #"{"type":"rate_limit_error","message":"synthetic provider error"}"#),
+                ]
+            )
+        ]),
+        expected: aiStreamingExpectations(
+            hints: ["ai", "provider_error", "streaming", "missing_usage_summary"],
+            fallback: "Summarize provider error without requiring a final usage chunk."
+        ),
+        safetyClass: .containsSyntheticSensitiveData,
+        sizeClass: .small,
+        traceability: issueTraceability([188])
+    )
+
+    static let aiEmbeddingContractSmoke = ProtocolFixture(
+        id: "ai.embedding.vector-search-contract",
+        title: "Embedding request followed by vector-search response",
+        family: .ai,
+        scenarioTags: ["ai", "embeddings", "vector-search", "retrieval", "issue-189"],
+        traffic: ProtocolFixtureTraffic(exchanges: [
+            ProtocolFixtureExchange(
+                request: ProtocolFixtureMessage(
+                    method: "POST",
+                    url: "https://vector.example.com/v1/embeddings",
+                    headers: [.init(name: "Authorization", value: "Bearer synthetic-vector-token")],
+                    body: #"{"model":"synthetic-embedding-model","input":["synthetic document chunk"]}"#
+                ),
+                response: ProtocolFixtureMessage(
+                    method: "HTTP",
+                    url: "https://vector.example.com/v1/embeddings",
+                    statusCode: 200,
+                    headers: [.init(name: "Content-Type", value: "application/json")],
+                    body: #"{"data":[{"embedding":[0.01,0.02,0.03],"index":0}],"usage":{"total_tokens":3}}"#
+                )
+            ),
+            ProtocolFixtureExchange(
+                request: ProtocolFixtureMessage(
+                    method: "POST",
+                    url: "https://vector.example.com/v1/search",
+                    body: #"{"query_embedding":[0.01,0.02,0.03],"top_k":2,"namespace":"synthetic-space"}"#
+                ),
+                response: ProtocolFixtureMessage(
+                    method: "HTTP",
+                    url: "https://vector.example.com/v1/search",
+                    statusCode: 200,
+                    body: #"{"matches":[{"id":"doc-fixture-1","score":0.91,"snippet":"public synthetic snippet"}]}"#
+                )
+            )
+        ]),
+        expected: aiRetrievalExpectations(
+            hints: ["ai", "embedding", "vector_search", "retrieval"],
+            warnings: ["retrieved_context_redaction_candidate"],
+            fallback: nil
+        ),
+        safetyClass: .containsSyntheticSensitiveData,
+        sizeClass: .small,
+        traceability: issueTraceability([189])
+    )
+
+    static let aiRAGContractSmoke = ProtocolFixture(
+        id: "ai.rag.synthetic-context-contract",
+        title: "RAG flow with public and sensitive synthetic context",
+        family: .ai,
+        scenarioTags: ["ai", "rag", "retrieval", "sensitive-context", "model-call", "issue-189"],
+        traffic: ProtocolFixtureTraffic(exchanges: [
+            ProtocolFixtureExchange(
+                request: ProtocolFixtureMessage(
+                    method: "POST",
+                    url: "https://ai.example.com/v1/responses",
+                    headers: [.init(name: "Authorization", value: "Bearer synthetic-ai-token")],
+                    body: #"""
+                    {
+                      "model": "synthetic-model",
+                      "input": [
+                        {"role": "system", "content": "Use retrieved context"},
+                        {"role": "user", "content": "[SYNTHETIC_PROMPT]"},
+                        {"role": "tool", "content": "public synthetic snippet; fake-account-id fixture-account"}
+                      ]
+                    }
+                    """#
+                ),
+                response: ProtocolFixtureMessage(
+                    method: "HTTP",
+                    url: "https://ai.example.com/v1/responses",
+                    statusCode: 200,
+                    body: #"{"id":"resp_rag_fixture","output_text":"synthetic answer"}"#
+                )
+            )
+        ]),
+        expected: aiRetrievalExpectations(
+            hints: ["ai", "rag", "retrieved_context", "model_request"],
+            warnings: ["retrieved_context_redaction_candidate", "prompt_redaction_candidate"],
+            fallback: nil
+        ),
+        safetyClass: .containsSyntheticSensitiveData,
+        sizeClass: .small,
+        traceability: issueTraceability([189])
+    )
+
+    static let aiMalformedRetrievalContractSmoke = ProtocolFixture(
+        id: "ai.embedding.malformed-vector-payload",
+        title: "Malformed embedding/vector payload with fallback",
+        family: .ai,
+        scenarioTags: ["ai", "embeddings", "vector-search", "malformed", "fallback", "issue-189"],
+        traffic: ProtocolFixtureTraffic(exchanges: [
+            ProtocolFixtureExchange(
+                request: ProtocolFixtureMessage(
+                    method: "POST",
+                    url: "https://vector.example.com/v1/search",
+                    body: #"{"query_embedding":[0.01,"unterminated""#
+                ),
+                response: ProtocolFixtureMessage(
+                    method: "HTTP",
+                    url: "https://vector.example.com/v1/search",
+                    statusCode: 400,
+                    body: #"{"error":"synthetic malformed vector payload"}"#
+                )
+            )
+        ]),
+        expected: aiRetrievalExpectations(
+            hints: ["ai", "embedding", "vector_search", "malformed", "fallback"],
+            warnings: ["malformed_payload"],
+            fallback: "Show raw fallback and omit embedding/vector summary when vector payload parsing fails."
+        ),
+        safetyClass: .malformed,
+        sizeClass: .small,
+        traceability: issueTraceability([189, 193])
+    )
+
+    static let evmJSONRPCContractSmoke = ProtocolFixture(
+        id: "foundation.evm-json-rpc.contract-smoke",
+        title: "EVM JSON-RPC request with synthetic method summary",
+        family: .web3RPC,
+        scenarioTags: ["web3", "evm", "json-rpc", "contract-smoke"],
+        traffic: ProtocolFixtureTraffic(exchanges: [
+            ProtocolFixtureExchange(
+                request: ProtocolFixtureMessage(
+                    method: "POST",
+                    url: "https://rpc.example.com/evm",
+                    headers: [.init(name: "Content-Type", value: "application/json")],
+                    body: #"""
+                    {"jsonrpc":"2.0","id":"fixture-1","method":"eth_call","params":[{"to":"0xSyntheticContract","data":"0xsyntheticCallData"},"latest"]}
+                    """#
+                ),
+                response: ProtocolFixtureMessage(
+                    method: "HTTP",
+                    url: "https://rpc.example.com/evm",
+                    statusCode: 200,
+                    headers: [.init(name: "Content-Type", value: "application/json")],
+                    body: #"{"jsonrpc":"2.0","id":"fixture-1","result":"0xsyntheticResult"}"#
+                )
+            )
+        ]),
+        expected: ProtocolFixtureExpectations(
+            metadataHints: ["web3", "json_rpc", "evm", "eth_call"],
+            redaction: ProtocolFixtureRedactionExpectation(
+                sensitiveFields: ["params.data"],
+                redactedMarkers: ["[REDACTED]"],
+                safeFields: ["jsonrpc", "method", "id"]
+            ),
+            ux: ProtocolFixtureUXExpectation(
+                requestListBadges: ["RPC", "EVM"],
+                optionalColumns: ["rpc_method": "eth_call"],
+                inspectorTabs: ["RPC", "JSON", "Raw"],
+                warningStates: [],
+                exportSummaryFields: ["rpc_method", "chain_hint", "redacted_fields"],
+                mcpSummaryFields: ["rpc_method", "status", "redacted"],
+                fallbackBehavior: nil
+            )
+        ),
+        safetyClass: .containsSyntheticSensitiveData,
+        sizeClass: .small,
+        traceability: commonTraceability
+    )
+
+    static let evmGasReceiptAndSendRawContractSmoke = ProtocolFixture(
+        id: "web3.evm.gas-receipt-sendraw-contract",
+        title: "EVM gas estimate, receipt lookup, and raw transaction-like payload",
+        family: .web3RPC,
+        scenarioTags: ["web3", "evm", "json-rpc", "estimate-gas", "receipt", "signed-payload", "issue-190"],
+        traffic: ProtocolFixtureTraffic(exchanges: [
+            evmExchange(
+                body: #"""
+                {"jsonrpc":"2.0","id":"gas-1","method":"eth_estimateGas","params":[{"to":"0xSyntheticContract","data":"0xsyntheticCallData"}]}
+                """#,
+                response: #"{"jsonrpc":"2.0","id":"gas-1","result":"0x5208"}"#
+            ),
+            evmExchange(
+                body: #"{"jsonrpc":"2.0","id":"receipt-1","method":"eth_getTransactionReceipt","params":["0xsyntheticTransactionHash"]}"#,
+                response: #"{"jsonrpc":"2.0","id":"receipt-1","result":{"status":"0x1","transactionHash":"0xsyntheticTransactionHash"}}"#
+            ),
+            evmExchange(
+                body: #"{"jsonrpc":"2.0","id":"send-1","method":"eth_sendRawTransaction","params":["synthetic-signed-transaction-payload"]}"#,
+                response: #"{"jsonrpc":"2.0","id":"send-1","result":"0xsyntheticBroadcastHash"}"#
+            ),
+        ]),
+        expected: web3Expectations(
+            badges: ["RPC", "EVM"],
+            hints: [
+                "web3",
+                "json_rpc",
+                "evm",
+                "eth_estimateGas",
+                "eth_getTransactionReceipt",
+                "eth_sendRawTransaction",
+            ],
+            redaction: ["params.data", "params.raw_transaction"],
+            warnings: ["signed_payload_redaction_candidate"],
+            fallback: nil
+        ),
+        safetyClass: .containsSyntheticSensitiveData,
+        sizeClass: .small,
+        traceability: issueTraceability([190])
+    )
+
+    static let evmBatchErrorAndLargeContractSmoke = ProtocolFixture(
+        id: "web3.evm.batch-error-large-contract",
+        title: "EVM JSON-RPC batch with mixed success, error, and bounded large sample",
+        family: .web3RPC,
+        scenarioTags: [
+            "web3",
+            "evm",
+            "json-rpc",
+            "batch",
+            "error",
+            "large",
+            "high-volume",
+            "issue-190",
+            "issue-193",
+        ],
+        traffic: ProtocolFixtureTraffic(
+            exchanges: [
+                evmExchange(
+                    body: evmBatchRequest(count: 24),
+                    response: #"""
+                    [
+                      {"jsonrpc":"2.0","id":"batch-0","result":"0x1"},
+                      {"jsonrpc":"2.0","id":"batch-1","error":{"code":-32000,"message":"synthetic execution error"}}
+                    ]
+                    """#
+                ),
+            ],
+            estimatedPayloadBytes: 9_000
+        ),
+        expected: web3Expectations(
+            badges: ["RPC", "Batch"],
+            hints: ["web3", "json_rpc", "evm", "batch", "provider_error", "bounded_large"],
+            redaction: ["params.data"],
+            warnings: ["large_payload", "rpc_error"],
+            fallback: "Keep request-list parsing bounded and summarize batch count without expanding every item."
+        ),
+        safetyClass: .large,
+        sizeClass: .boundedStress,
+        traceability: issueTraceability([190, 193])
+    )
+
+    static let evmMalformedJSONRPCContractSmoke = ProtocolFixture(
+        id: "web3.evm.malformed-json-rpc-contract",
+        title: "Malformed EVM JSON-RPC payload with safe fallback",
+        family: .web3RPC,
+        scenarioTags: ["web3", "evm", "json-rpc", "malformed", "fallback", "issue-190"],
+        traffic: ProtocolFixtureTraffic(exchanges: [
+            evmExchange(
+                body: #"{"jsonrpc":"2.0","id":"bad","method":"eth_call","params":["#,
+                response: #"{"jsonrpc":"2.0","id":"bad","error":{"code":-32700,"message":"synthetic parse error"}}"#
+            ),
+        ]),
+        expected: web3Expectations(
+            badges: ["RPC", "Malformed"],
+            hints: ["web3", "json_rpc", "evm", "malformed", "fallback"],
+            redaction: ["params"],
+            warnings: ["malformed_payload"],
+            fallback: "Show raw fallback without classifying a method when JSON-RPC parsing fails."
+        ),
+        safetyClass: .malformed,
+        sizeClass: .small,
+        traceability: issueTraceability([190, 193])
+    )
+
+    static let solanaHTTPRPCContractSmoke = ProtocolFixture(
+        id: "web3.solana.http-rpc-contract",
+        title: "Solana HTTP JSON-RPC request and response",
+        family: .web3RPC,
+        scenarioTags: ["web3", "solana", "json-rpc", "http-rpc", "issue-191"],
+        traffic: ProtocolFixtureTraffic(exchanges: [
+            ProtocolFixtureExchange(
+                request: ProtocolFixtureMessage(
+                    method: "POST",
+                    url: "https://solana.example.com",
+                    headers: [.init(name: "Content-Type", value: "application/json")],
+                    body: #"""
+                    {"jsonrpc":"2.0","id":"solana-1","method":"getLatestBlockhash","params":[{"commitment":"confirmed"}]}
+                    """#
+                ),
+                response: ProtocolFixtureMessage(
+                    method: "HTTP",
+                    url: "https://solana.example.com",
+                    statusCode: 200,
+                    headers: [.init(name: "Content-Type", value: "application/json")],
+                    body: #"""
+                    {"jsonrpc":"2.0","id":"solana-1","result":{"value":{"blockhash":"synthetic-blockhash","lastValidBlockHeight":123}}}
+                    """#
+                )
+            )
+        ]),
+        expected: web3Expectations(
+            badges: ["RPC", "Solana"],
+            hints: ["web3", "json_rpc", "solana", "getLatestBlockhash"],
+            redaction: [],
+            warnings: [],
+            fallback: nil
+        ),
+        safetyClass: .ordinary,
+        sizeClass: .small,
+        traceability: issueTraceability([191])
+    )
+
+    static let solanaWebSocketSubscriptionContractSmoke = ProtocolFixture(
+        id: "web3.solana.websocket-subscription-contract",
+        title: "Solana WebSocket subscription lifecycle",
+        family: .web3RPC,
+        scenarioTags: [
+            "web3",
+            "solana",
+            "websocket-rpc",
+            "subscription",
+            "notification",
+            "unsubscribe",
+            "issue-191",
+        ],
+        traffic: ProtocolFixtureTraffic(
+            webSocketMessages: [
+                .init(
+                    direction: .clientToServer,
+                    url: "wss://solana.example.com",
+                    body: #"""
+                    {"jsonrpc":"2.0","id":1,"method":"logsSubscribe","params":[{"mentions":["SyntheticAccount111"]}]}
+                    """#
+                ),
+                .init(
+                    direction: .serverToClient,
+                    url: "wss://solana.example.com",
+                    body: #"{"jsonrpc":"2.0","id":1,"result":42}"#
+                ),
+                .init(
+                    direction: .serverToClient,
+                    url: "wss://solana.example.com",
+                    body: #"""
+                    {
+                      "jsonrpc": "2.0",
+                      "method": "logsNotification",
+                      "params": {
+                        "subscription": 42,
+                        "result": {
+                          "value": {
+                            "signature": "synthetic-signature",
+                            "logs": ["Program log: synthetic"]
+                          }
+                        }
+                      }
+                    }
+                    """#
+                ),
+                .init(
+                    direction: .clientToServer,
+                    url: "wss://solana.example.com",
+                    body: #"{"jsonrpc":"2.0","id":2,"method":"logsUnsubscribe","params":[42]}"#
+                ),
+                .init(
+                    direction: .serverToClient,
+                    url: "wss://solana.example.com",
+                    body: #"{"jsonrpc":"2.0","id":2,"result":true}"#
+                ),
+            ]
+        ),
+        expected: web3Expectations(
+            badges: ["RPC", "Solana", "WS"],
+            hints: ["web3", "json_rpc", "solana", "subscription", "notification", "unsubscribe"],
+            redaction: ["params.mentions", "signature"],
+            warnings: ["subscription_lifecycle"],
+            fallback: nil
+        ),
+        safetyClass: .containsSyntheticSensitiveData,
+        sizeClass: .small,
+        traceability: issueTraceability([191])
+    )
+
+    static let solanaLongAndMalformedSubscriptionContractSmoke = ProtocolFixture(
+        id: "web3.solana.long-malformed-subscription",
+        title: "Solana long subscription sample with malformed notification",
+        family: .web3RPC,
+        scenarioTags: [
+            "web3",
+            "solana",
+            "websocket-rpc",
+            "subscription",
+            "malformed",
+            "long-session",
+            "issue-191",
+            "issue-193",
+        ],
+        traffic: ProtocolFixtureTraffic(
+            webSocketMessages: [
+                .init(
+                    direction: .serverToClient,
+                    url: "wss://solana.example.com",
+                    body: solanaNotificationSample(count: 16)
+                ),
+                .init(
+                    direction: .serverToClient,
+                    url: "wss://solana.example.com",
+                    body: #"{"jsonrpc":"2.0","method":"logsNotification","params":"#
+                ),
+                .init(
+                    direction: .serverToClient,
+                    url: "wss://solana.example.com",
+                    body: #"{"jsonrpc":"2.0","method":"logsNotification","error":{"code":-32000,"message":"synthetic subscription error"}}"#
+                ),
+            ],
+            estimatedPayloadBytes: 6_000
+        ),
+        expected: web3Expectations(
+            badges: ["RPC", "Solana", "WS"],
+            hints: ["web3", "json_rpc", "solana", "subscription", "malformed", "fallback"],
+            redaction: ["signature"],
+            warnings: ["malformed_payload", "large_payload"],
+            fallback: "Summarize bounded notification count and show raw fallback for malformed subscription messages."
+        ),
+        safetyClass: .malformed,
+        sizeClass: .boundedStress,
+        traceability: issueTraceability([191, 193])
+    )
+
+    static let x402ContractSmoke = ProtocolFixture(
+        id: "foundation.x402.contract-smoke",
+        title: "x402-style payment-required retry flow",
+        family: .x402,
+        scenarioTags: ["x402", "payment-required", "retry", "success", "contract-smoke"],
+        traffic: ProtocolFixtureTraffic(exchanges: [
+            ProtocolFixtureExchange(
+                request: ProtocolFixtureMessage(
+                    method: "GET",
+                    url: "https://payments.example.com/protected/report",
+                    headers: [.init(name: "Accept", value: "application/json")]
+                ),
+                response: ProtocolFixtureMessage(
+                    method: "HTTP",
+                    url: "https://payments.example.com/protected/report",
+                    statusCode: 402,
+                    headers: [.init(name: "Content-Type", value: "application/json")],
+                    body: #"{"x402Version":1,"paymentRequired":true,"challenge":"synthetic-payment-challenge"}"#
+                )
+            ),
+            ProtocolFixtureExchange(
+                request: ProtocolFixtureMessage(
+                    method: "GET",
+                    url: "https://payments.example.com/protected/report",
+                    headers: [
+                        .init(name: "Accept", value: "application/json"),
+                        .init(name: "X-Payment", value: "synthetic-payment-proof"),
+                    ]
+                ),
+                response: ProtocolFixtureMessage(
+                    method: "HTTP",
+                    url: "https://payments.example.com/protected/report",
+                    statusCode: 200,
+                    headers: [.init(name: "Content-Type", value: "application/json")],
+                    body: #"{"ok":true,"receipt":"synthetic-receipt"}"#
+                )
+            )
+        ]),
+        expected: ProtocolFixtureExpectations(
+            metadataHints: ["x402", "payment_required", "retry_flow"],
+            redaction: ProtocolFixtureRedactionExpectation(
+                sensitiveFields: ["X-Payment", "challenge", "receipt"],
+                redactedMarkers: ["[REDACTED]"],
+                safeFields: ["x402Version", "paymentRequired", "ok"]
+            ),
+            ux: ProtocolFixtureUXExpectation(
+                requestListBadges: ["x402", "402"],
+                optionalColumns: ["payment_flow": "required_then_success"],
+                inspectorTabs: ["Payment", "Headers", "Raw"],
+                warningStates: ["payment_metadata_redaction_candidate"],
+                exportSummaryFields: ["payment_required", "retry_count", "redacted_fields"],
+                mcpSummaryFields: ["payment_flow", "status", "redacted"],
+                fallbackBehavior: nil
+            )
+        ),
+        safetyClass: .containsSyntheticSensitiveData,
+        sizeClass: .small,
+        traceability: commonTraceability
+    )
+
+    static let x402MalformedAndMissingProofContractSmoke = ProtocolFixture(
+        id: "x402.malformed-missing-proof-contract",
+        title: "x402 malformed challenge and missing payment proof",
+        family: .x402,
+        scenarioTags: ["x402", "payment-required", "malformed", "missing-proof", "fallback", "issue-192"],
+        traffic: ProtocolFixtureTraffic(exchanges: [
+            ProtocolFixtureExchange(
+                request: ProtocolFixtureMessage(
+                    method: "GET",
+                    url: "https://payments.example.com/protected/malformed",
+                    headers: [.init(name: "Accept", value: "application/json")]
+                ),
+                response: ProtocolFixtureMessage(
+                    method: "HTTP",
+                    url: "https://payments.example.com/protected/malformed",
+                    statusCode: 402,
+                    headers: [.init(name: "Content-Type", value: "application/json")],
+                    body: #"{"x402Version":1,"paymentRequired":true,"challenge":"#
+                )
+            ),
+            ProtocolFixtureExchange(
+                request: ProtocolFixtureMessage(
+                    method: "GET",
+                    url: "https://payments.example.com/protected/malformed",
+                    headers: [.init(name: "Accept", value: "application/json")]
+                ),
+                response: ProtocolFixtureMessage(
+                    method: "HTTP",
+                    url: "https://payments.example.com/protected/malformed",
+                    statusCode: 402,
+                    headers: [.init(name: "Content-Type", value: "application/json")],
+                    body: #"{"x402Version":1,"paymentRequired":true,"error":"missing synthetic payment proof"}"#
+                )
+            )
+        ]),
+        expected: x402Expectations(
+            hints: ["x402", "payment_required", "malformed", "missing_proof", "fallback"],
+            warnings: ["payment_metadata_redaction_candidate", "malformed_payload"],
+            fallback: "Show payment-required state and raw fallback when the challenge is malformed or proof is missing."
+        ),
+        safetyClass: .malformed,
+        sizeClass: .small,
+        traceability: issueTraceability([192, 193])
+    )
+
+    static let x402ProviderErrorMetadataContractSmoke = ProtocolFixture(
+        id: "x402.provider-error-sensitive-metadata",
+        title: "x402 provider error with synthetic payment metadata",
+        family: .x402,
+        scenarioTags: ["x402", "provider-error", "payment-metadata", "sensitive-metadata", "issue-192"],
+        traffic: ProtocolFixtureTraffic(exchanges: [
+            ProtocolFixtureExchange(
+                request: ProtocolFixtureMessage(
+                    method: "GET",
+                    url: "https://payments.example.com/protected/report",
+                    headers: [
+                        .init(name: "Authorization", value: "Bearer synthetic-payment-token"),
+                        .init(name: "X-Payment", value: "synthetic-payment-proof"),
+                    ]
+                ),
+                response: ProtocolFixtureMessage(
+                    method: "HTTP",
+                    url: "https://payments.example.com/protected/report",
+                    statusCode: 402,
+                    headers: [.init(name: "Content-Type", value: "application/json")],
+                    body: #"""
+                    {"error":"synthetic provider rejected payment","paymentMetadata":{"network":"synthetic-chain","account":"synthetic-account","receipt":"synthetic-receipt"}}
+                    """#
+                )
+            )
+        ]),
+        expected: x402Expectations(
+            hints: ["x402", "payment_required", "provider_error", "payment_metadata"],
+            warnings: ["payment_metadata_redaction_candidate", "export_destination_warning"],
+            fallback: nil
+        ),
+        safetyClass: .containsSyntheticSensitiveData,
+        sizeClass: .small,
+        traceability: issueTraceability([192])
+    )
+
+    static let malformedPayloadContractSmoke = ProtocolFixture(
+        id: "foundation.malformed-json.contract-smoke",
+        title: "Malformed JSON payload with bounded fallback contract",
+        family: .unknown,
+        scenarioTags: ["malformed", "json", "fallback", "contract-smoke"],
+        traffic: ProtocolFixtureTraffic(exchanges: [
+            ProtocolFixtureExchange(
+                request: ProtocolFixtureMessage(
+                    method: "POST",
+                    url: "https://test.invalid/malformed",
+                    headers: [.init(name: "Content-Type", value: "application/json")],
+                    body: #"{"message":"unterminated""#
+                ),
+                response: ProtocolFixtureMessage(
+                    method: "HTTP",
+                    url: "https://test.invalid/malformed",
+                    statusCode: 400,
+                    headers: [.init(name: "Content-Type", value: "text/plain")],
+                    body: "Malformed synthetic payload"
+                )
+            )
+        ]),
+        expected: ProtocolFixtureExpectations(
+            metadataHints: ["malformed", "fallback"],
+            redaction: ProtocolFixtureRedactionExpectation(
+                sensitiveFields: [],
+                redactedMarkers: [],
+                safeFields: ["message"]
+            ),
+            ux: ProtocolFixtureUXExpectation(
+                requestListBadges: ["Malformed"],
+                optionalColumns: ["parse_state": "failed"],
+                inspectorTabs: ["Raw"],
+                warningStates: ["malformed_payload"],
+                exportSummaryFields: ["parse_state", "omitted_protocol_summary"],
+                mcpSummaryFields: ["parse_state"],
+                fallbackBehavior: "Show bounded raw fallback without protocol-specific inspector content."
+            )
+        ),
+        safetyClass: .malformed,
+        sizeClass: .small,
+        traceability: commonTraceability
+    )
+
+    static let hostileOversizedDeepJSONContractSmoke = ProtocolFixture(
+        id: "hostile.oversized-deep-json-contract",
+        title: "Oversized and deeply nested JSON with bounded parser expectations",
+        family: .unknown,
+        scenarioTags: ["hostile", "oversized", "deep-nesting", "large", "fallback", "issue-193"],
+        traffic: ProtocolFixtureTraffic(
+            exchanges: [
+                ProtocolFixtureExchange(
+                    request: ProtocolFixtureMessage(
+                        method: "POST",
+                        url: "https://test.invalid/large-json",
+                        headers: [.init(name: "Content-Type", value: "application/json")],
+                        body: #"{"root":{"level1":{"level2":{"level3":{"level4":{"level5":{"secret":"synthetic-api-key","items":["# + repeatedItems(80) + #"]}}}}}}"#
+                    ),
+                    response: ProtocolFixtureMessage(
+                        method: "HTTP",
+                        url: "https://test.invalid/large-json",
+                        statusCode: 200,
+                        body: #"{"ok":true}"#
+                    )
+                ),
+            ],
+            estimatedPayloadBytes: 14_000
+        ),
+        expected: hostileExpectations(
+            hints: ["hostile", "oversized", "deep_nesting", "fallback"],
+            warnings: ["large_payload", "parser_budget"],
+            fallback: "Avoid request-list expansion; inspector work should be bounded and cancellable."
+        ),
+        safetyClass: .large,
+        sizeClass: .boundedStress,
+        traceability: issueTraceability([193])
+    )
+
+    static let hostileLongStringTruncatedContractSmoke = ProtocolFixture(
+        id: "hostile.long-string-truncated-contract",
+        title: "Long string values and truncated response body",
+        family: .unknown,
+        scenarioTags: ["hostile", "long-string", "truncated", "fallback", "issue-193"],
+        traffic: ProtocolFixtureTraffic(
+            exchanges: [
+                ProtocolFixtureExchange(
+                    request: ProtocolFixtureMessage(
+                        method: "POST",
+                        url: "https://test.invalid/long-string",
+                        headers: [.init(name: "Content-Type", value: "application/json")],
+                        body: #"{"message":""# + repeatedScalar("synthetic-long-value-", count: 160) + #""}"#
+                    ),
+                    response: ProtocolFixtureMessage(
+                        method: "HTTP",
+                        url: "https://test.invalid/long-string",
+                        statusCode: 206,
+                        body: #"{"partial":"synthetic truncated response""#
+                    )
+                ),
+            ],
+            estimatedPayloadBytes: 8_000
+        ),
+        expected: hostileExpectations(
+            hints: ["hostile", "long_string", "truncated", "fallback"],
+            warnings: ["truncated_payload", "parser_budget"],
+            fallback: "Show truncation state and keep export summaries explicit about omitted body content."
+        ),
+        safetyClass: .large,
+        sizeClass: .boundedStress,
+        traceability: issueTraceability([193])
+    )
+
+    static let hostilePartialSSEAndBytesContractSmoke = ProtocolFixture(
+        id: "hostile.partial-sse-malformed-bytes",
+        title: "Partial SSE stream and malformed byte-like payload",
+        family: .ai,
+        scenarioTags: ["hostile", "ai", "sse", "partial", "malformed-bytes", "fallback", "issue-193"],
+        traffic: ProtocolFixtureTraffic(exchanges: [
+            ProtocolFixtureExchange(
+                request: ProtocolFixtureMessage(
+                    method: "POST",
+                    url: "https://ai.example.com/v1/responses",
+                    headers: [.init(name: "Authorization", value: "Bearer synthetic-ai-token")],
+                    body: #"{"model":"synthetic-model","input":"[SYNTHETIC_PROMPT]","stream":true}"#
+                ),
+                response: ProtocolFixtureMessage(
+                    method: "HTTP",
+                    url: "https://ai.example.com/v1/responses",
+                    statusCode: 200,
+                    headers: [.init(name: "Content-Type", value: "text/event-stream")],
+                    body: "synthetic-byte-prefix \\xF0\\x28\\x8C\\x28 replacement-marker"
+                ),
+                streamEvents: [
+                    .init(event: "response.output_text.delta", data: #"{"delta":"partial synthetic text"}"#),
+                    .init(event: nil, data: "data: [synthetic stream continues without completion]"),
+                ]
+            )
+        ]),
+        expected: aiStreamingExpectations(
+            hints: ["ai", "streaming", "partial", "malformed_bytes", "fallback"],
+            fallback: "Treat partial SSE and malformed byte-like payload as bounded raw fallback."
+        ),
+        safetyClass: .malformed,
+        sizeClass: .medium,
+        traceability: issueTraceability([188, 193])
+    )
+
+    static func issueTraceability(_ issues: Set<Int>) -> ProtocolFixtureTraceability {
+        ProtocolFixtureTraceability(
+            parentIssue: 176,
+            childIssues: commonTraceability.childIssues.union(issues),
+            futureIssues: commonTraceability.futureIssues
+        )
+    }
+
+    static func aiStreamingExpectations(
+        hints: Set<String>,
+        fallback: String?
+    ) -> ProtocolFixtureExpectations {
+        ProtocolFixtureExpectations(
+            metadataHints: hints,
+            redaction: ProtocolFixtureRedactionExpectation(
+                sensitiveFields: ["Authorization", "X-API-Key", "input", "messages.content", "arguments", "partial_json"],
+                redactedMarkers: ["[REDACTED]"],
+                safeFields: ["model", "status", "stop_reason"]
+            ),
+            ux: ProtocolFixtureUXExpectation(
+                requestListBadges: ["AI", "Stream"],
+                optionalColumns: ["protocol": "AI", "streaming": "true"],
+                inspectorTabs: ["AI", "Stream", "Tool Calls", "Raw"],
+                warningStates: fallback == nil ? ["prompt_redaction_candidate"] : ["prompt_redaction_candidate", "malformed_payload"],
+                exportSummaryFields: ["model", "stream_event_count", "tool_call_count", "redacted_fields"],
+                mcpSummaryFields: ["model", "status", "streaming", "redacted"],
+                fallbackBehavior: fallback
+            )
+        )
+    }
+
+    static func aiRetrievalExpectations(
+        hints: Set<String>,
+        warnings: [String],
+        fallback: String?
+    ) -> ProtocolFixtureExpectations {
+        ProtocolFixtureExpectations(
+            metadataHints: hints,
+            redaction: ProtocolFixtureRedactionExpectation(
+                sensitiveFields: ["Authorization", "input", "retrieved_context", "messages.content", "query_embedding"],
+                redactedMarkers: ["[REDACTED]"],
+                safeFields: ["model", "usage.total_tokens", "matches.score"]
+            ),
+            ux: ProtocolFixtureUXExpectation(
+                requestListBadges: ["AI", "RAG"],
+                optionalColumns: ["protocol": "AI", "retrieval": "true"],
+                inspectorTabs: ["AI", "Retrieval", "JSON", "Raw"],
+                warningStates: warnings,
+                exportSummaryFields: ["model", "retrieval_step_count", "redacted_fields"],
+                mcpSummaryFields: ["model", "retrieval", "redacted"],
+                fallbackBehavior: fallback
+            )
+        )
+    }
+
+    static func web3Expectations(
+        badges: [String],
+        hints: Set<String>,
+        redaction: Set<String>,
+        warnings: [String],
+        fallback: String?
+    ) -> ProtocolFixtureExpectations {
+        ProtocolFixtureExpectations(
+            metadataHints: hints,
+            redaction: ProtocolFixtureRedactionExpectation(
+                sensitiveFields: redaction.union(["Authorization", "provider_api_key"]),
+                redactedMarkers: ["[REDACTED]"],
+                safeFields: ["jsonrpc", "method", "id", "status"]
+            ),
+            ux: ProtocolFixtureUXExpectation(
+                requestListBadges: badges,
+                optionalColumns: ["rpc": "true", "family": "web3"],
+                inspectorTabs: ["RPC", "JSON", "Raw"],
+                warningStates: warnings,
+                exportSummaryFields: ["rpc_method", "batch_count", "chain_hint", "redacted_fields"],
+                mcpSummaryFields: ["rpc_method", "status", "redacted"],
+                fallbackBehavior: fallback
+            )
+        )
+    }
+
+    static func x402Expectations(
+        hints: Set<String>,
+        warnings: [String],
+        fallback: String?
+    ) -> ProtocolFixtureExpectations {
+        ProtocolFixtureExpectations(
+            metadataHints: hints,
+            redaction: ProtocolFixtureRedactionExpectation(
+                sensitiveFields: ["Authorization", "X-Payment", "challenge", "receipt", "paymentMetadata"],
+                redactedMarkers: ["[REDACTED]"],
+                safeFields: ["x402Version", "paymentRequired", "ok", "error"]
+            ),
+            ux: ProtocolFixtureUXExpectation(
+                requestListBadges: ["x402", "402"],
+                optionalColumns: ["payment_flow": "true"],
+                inspectorTabs: ["Payment", "Headers", "Raw"],
+                warningStates: warnings,
+                exportSummaryFields: ["payment_required", "retry_count", "provider_error", "redacted_fields"],
+                mcpSummaryFields: ["payment_flow", "status", "redacted"],
+                fallbackBehavior: fallback
+            )
+        )
+    }
+
+    static func hostileExpectations(
+        hints: Set<String>,
+        warnings: [String],
+        fallback: String
+    ) -> ProtocolFixtureExpectations {
+        ProtocolFixtureExpectations(
+            metadataHints: hints,
+            redaction: ProtocolFixtureRedactionExpectation(
+                sensitiveFields: ["secret", "api_key", "Authorization"],
+                redactedMarkers: ["[REDACTED]"],
+                safeFields: ["parse_state", "truncated", "omitted_protocol_summary"]
+            ),
+            ux: ProtocolFixtureUXExpectation(
+                requestListBadges: ["Bounded"],
+                optionalColumns: ["parse_state": "bounded"],
+                inspectorTabs: ["Raw"],
+                warningStates: warnings,
+                exportSummaryFields: ["parse_state", "truncation_state", "omitted_body_bytes"],
+                mcpSummaryFields: ["parse_state", "redacted"],
+                fallbackBehavior: fallback
+            )
+        )
+    }
+
+    static func evmExchange(body: String, response: String) -> ProtocolFixtureExchange {
+        ProtocolFixtureExchange(
+            request: ProtocolFixtureMessage(
+                method: "POST",
+                url: "https://rpc.example.com/evm",
+                headers: [.init(name: "Content-Type", value: "application/json")],
+                body: body
+            ),
+            response: ProtocolFixtureMessage(
+                method: "HTTP",
+                url: "https://rpc.example.com/evm",
+                statusCode: 200,
+                headers: [.init(name: "Content-Type", value: "application/json")],
+                body: response
+            )
+        )
+    }
+
+    static func evmBatchRequest(count: Int) -> String {
+        let calls = (0 ..< count).map { index in
+            #"{"jsonrpc":"2.0","id":"batch-\#(index)","method":"eth_call","params":[{"to":"0xSyntheticContract","data":"0xsyntheticCallData"},"latest"]}"#
+        }
+        return "[\(calls.joined(separator: ","))]"
+    }
+
+    static func solanaNotificationSample(count: Int) -> String {
+        let logs = (0 ..< count).map { index in
+            #"{"signature":"synthetic-signature-\#(index)","logs":["Program log: synthetic-\#(index)"]}"#
+        }.joined(separator: ",")
+        return #"{"jsonrpc":"2.0","method":"logsNotification","params":{"subscription":42,"result":{"items":[\#(logs)]}}}"#
+    }
+
+    static func repeatedItems(_ count: Int) -> String {
+        (0 ..< count).map { #""synthetic-item-\#($0)""# }.joined(separator: ",")
+    }
+
+    static func repeatedScalar(_ value: String, count: Int) -> String {
+        Array(repeating: value, count: count).joined()
+    }
+}

--- a/RockxyTests/Helpers/ProtocolFixtureCorpus.md
+++ b/RockxyTests/Helpers/ProtocolFixtureCorpus.md
@@ -65,5 +65,26 @@ Group A foundation work is tracked by:
 
 - #186 schema, loader, and validation harness
 - #187 UX contract expectations
+- #188 AI streaming and tool-call fixtures
+- #189 AI embeddings, RAG, and retrieval fixtures
+- #190 EVM JSON-RPC fixtures
+- #191 Solana RPC and subscription fixtures
+- #192 x402 payment-flow fixtures
+- #193 hostile, malformed, and large-payload fixtures
 - #194 public-safety gates
 - #195 fixture-to-feature traceability
+
+## Extension Process
+
+When adding a fixture:
+
+1. Choose the smallest synthetic payload that represents the protocol shape.
+2. Add scenario tags that map to the relevant issue and protocol behavior.
+3. Declare expected metadata hints, redaction fields, UX contract fields, safety
+   class, size class, and traceability.
+4. Use `webSocketMessages` for subscription or bidirectional message flows.
+5. Set `estimatedPayloadBytes` for bounded stress fixtures.
+6. Add or update tests that prove the new issue coverage and safety behavior.
+
+UX contract fields are planning contracts for future app behavior. They should
+not be described as shipped UI unless the production view code implements them.

--- a/RockxyTests/Helpers/ProtocolFixtureCorpus.md
+++ b/RockxyTests/Helpers/ProtocolFixtureCorpus.md
@@ -1,0 +1,69 @@
+# Protocol Fixture Corpus
+
+The protocol fixture corpus is Rockxy's test-only source of truth for future
+protocol-aware debugging work. It is intentionally synthetic, offline, and
+public-safe.
+
+## Purpose
+
+Use this corpus to test protocol metadata, redaction, inspector routing, export
+summaries, MCP-safe summaries, session compatibility, and parser safety without
+depending on ad hoc captures.
+
+The umbrella tracker is RockxyApp/Rockxy#176.
+
+## Fixture Contract
+
+Every fixture should declare:
+
+- a stable `id`
+- a `family`
+- scenario tags
+- request/response or stream payload shape
+- expected metadata hints
+- redaction expectations
+- UX contract expectations
+- safety class
+- size class
+- issue traceability
+
+UX contract fields describe expected future behavior. They do not mean the UI is
+already implemented.
+
+## Safety Rules
+
+Fixtures must be synthetic or sanitized.
+
+Do not add:
+
+- real captured traffic
+- real API keys or bearer tokens
+- private keys
+- seed phrases
+- production payment proofs
+- personal data
+- local filesystem paths
+- production provider URLs
+
+Prefer `example.com`, `test.invalid`, and obvious synthetic placeholders such as
+`synthetic-api-key`.
+
+## Roadmap Mapping
+
+The corpus supports:
+
+- #143 protocol metadata architecture
+- #144 privacy classification
+- #145 redacted debugging-session bundles
+- #146 export preview
+- #177 parser safety budgets
+- #178 session and HAR compatibility
+- #179 inspector tab routing
+- #180 large-session performance tests
+
+Group A foundation work is tracked by:
+
+- #186 schema, loader, and validation harness
+- #187 UX contract expectations
+- #194 public-safety gates
+- #195 fixture-to-feature traceability

--- a/RockxyTests/Helpers/ProtocolFixtureCorpus.swift
+++ b/RockxyTests/Helpers/ProtocolFixtureCorpus.swift
@@ -1,0 +1,536 @@
+import Foundation
+
+// MARK: - ProtocolFixtureCorpus
+
+enum ProtocolFixtureCorpus {
+    static let fixtures: [ProtocolFixture] = [
+        .httpJSONSmoke,
+        .aiSSEContractSmoke,
+        .evmJSONRPCContractSmoke,
+        .x402ContractSmoke,
+        .malformedPayloadContractSmoke,
+    ]
+
+    static let allowedSyntheticHosts: Set<String> = [
+        "api.example.com",
+        "ai.example.com",
+        "rpc.example.com",
+        "payments.example.com",
+        "test.invalid",
+    ]
+}
+
+// MARK: - Protocol Fixture Schema
+
+struct ProtocolFixture: Equatable, Identifiable {
+    let id: String
+    let title: String
+    let family: ProtocolFixtureFamily
+    let scenarioTags: Set<String>
+    let traffic: ProtocolFixtureTraffic
+    let expected: ProtocolFixtureExpectations
+    let safetyClass: ProtocolFixtureSafetyClass
+    let sizeClass: ProtocolFixtureSizeClass
+    let traceability: ProtocolFixtureTraceability
+}
+
+enum ProtocolFixtureFamily: String, CaseIterable {
+    case ordinaryHTTP = "ordinary-http"
+    case ai = "ai"
+    case web3RPC = "web3-rpc"
+    case x402 = "x402"
+    case unknown = "unknown"
+}
+
+enum ProtocolFixtureSafetyClass: String, CaseIterable {
+    case ordinary
+    case containsSyntheticSensitiveData
+    case malformed
+    case hostile
+    case large
+}
+
+enum ProtocolFixtureSizeClass: String, CaseIterable {
+    case small
+    case medium
+    case boundedStress
+}
+
+struct ProtocolFixtureTraffic: Equatable {
+    let exchanges: [ProtocolFixtureExchange]
+}
+
+struct ProtocolFixtureExchange: Equatable {
+    let request: ProtocolFixtureMessage
+    let response: ProtocolFixtureMessage?
+    let streamEvents: [ProtocolFixtureStreamEvent]
+
+    init(
+        request: ProtocolFixtureMessage,
+        response: ProtocolFixtureMessage? = nil,
+        streamEvents: [ProtocolFixtureStreamEvent] = []
+    ) {
+        self.request = request
+        self.response = response
+        self.streamEvents = streamEvents
+    }
+}
+
+struct ProtocolFixtureMessage: Equatable {
+    let method: String
+    let url: String
+    let statusCode: Int?
+    let headers: [ProtocolFixtureHeader]
+    let body: String?
+
+    init(
+        method: String,
+        url: String,
+        statusCode: Int? = nil,
+        headers: [ProtocolFixtureHeader] = [],
+        body: String? = nil
+    ) {
+        self.method = method
+        self.url = url
+        self.statusCode = statusCode
+        self.headers = headers
+        self.body = body
+    }
+}
+
+struct ProtocolFixtureHeader: Equatable {
+    let name: String
+    let value: String
+}
+
+struct ProtocolFixtureStreamEvent: Equatable {
+    let event: String?
+    let data: String
+}
+
+struct ProtocolFixtureExpectations: Equatable {
+    let metadataHints: Set<String>
+    let redaction: ProtocolFixtureRedactionExpectation
+    let ux: ProtocolFixtureUXExpectation
+}
+
+struct ProtocolFixtureRedactionExpectation: Equatable {
+    let sensitiveFields: Set<String>
+    let redactedMarkers: Set<String>
+    let safeFields: Set<String>
+}
+
+struct ProtocolFixtureUXExpectation: Equatable {
+    let requestListBadges: [String]
+    let optionalColumns: [String: String]
+    let inspectorTabs: [String]
+    let warningStates: [String]
+    let exportSummaryFields: [String]
+    let mcpSummaryFields: [String]
+    let fallbackBehavior: String?
+}
+
+struct ProtocolFixtureTraceability: Equatable {
+    let parentIssue: Int
+    let childIssues: Set<Int>
+    let futureIssues: Set<Int>
+}
+
+// MARK: - Corpus Smoke Fixtures
+
+private extension ProtocolFixture {
+    static let commonTraceability = ProtocolFixtureTraceability(
+        parentIssue: 176,
+        childIssues: [186, 187, 194, 195],
+        futureIssues: [143, 144, 145, 146, 177, 178, 179, 180]
+    )
+
+    static let httpJSONSmoke = ProtocolFixture(
+        id: "foundation.http-json.redaction-smoke",
+        title: "Ordinary JSON request with synthetic redaction candidate",
+        family: .ordinaryHTTP,
+        scenarioTags: ["http", "json", "redaction-smoke"],
+        traffic: ProtocolFixtureTraffic(exchanges: [
+            ProtocolFixtureExchange(
+                request: ProtocolFixtureMessage(
+                    method: "POST",
+                    url: "https://api.example.com/v1/debug-smoke",
+                    headers: [.init(name: "Content-Type", value: "application/json")],
+                    body: #"{"request_id":"fixture-request","api_key":"synthetic-api-key"}"#
+                ),
+                response: ProtocolFixtureMessage(
+                    method: "HTTP",
+                    url: "https://api.example.com/v1/debug-smoke",
+                    statusCode: 200,
+                    headers: [.init(name: "Content-Type", value: "application/json")],
+                    body: #"{"ok":true,"request_id":"fixture-request"}"#
+                )
+            )
+        ]),
+        expected: ProtocolFixtureExpectations(
+            metadataHints: ["http", "json"],
+            redaction: ProtocolFixtureRedactionExpectation(
+                sensitiveFields: ["api_key"],
+                redactedMarkers: ["[REDACTED]"],
+                safeFields: ["request_id", "ok"]
+            ),
+            ux: ProtocolFixtureUXExpectation(
+                requestListBadges: ["JSON"],
+                optionalColumns: ["content": "JSON"],
+                inspectorTabs: ["Headers", "JSON", "Raw"],
+                warningStates: [],
+                exportSummaryFields: ["method", "host", "status", "redacted_fields"],
+                mcpSummaryFields: ["method", "url", "status", "redacted"],
+                fallbackBehavior: nil
+            )
+        ),
+        safetyClass: .containsSyntheticSensitiveData,
+        sizeClass: .small,
+        traceability: commonTraceability
+    )
+
+    static let aiSSEContractSmoke = ProtocolFixture(
+        id: "foundation.ai-sse.contract-smoke",
+        title: "AI streaming response with synthetic tool call",
+        family: .ai,
+        scenarioTags: ["ai", "sse", "streaming", "tool-call", "contract-smoke"],
+        traffic: ProtocolFixtureTraffic(exchanges: [
+            ProtocolFixtureExchange(
+                request: ProtocolFixtureMessage(
+                    method: "POST",
+                    url: "https://ai.example.com/v1/responses",
+                    headers: [
+                        .init(name: "Content-Type", value: "application/json"),
+                        .init(name: "Authorization", value: "Bearer synthetic-ai-token"),
+                    ],
+                    body: #"{"model":"synthetic-model","input":"[SYNTHETIC_PROMPT]","tool_choice":"auto"}"#
+                ),
+                response: ProtocolFixtureMessage(
+                    method: "HTTP",
+                    url: "https://ai.example.com/v1/responses",
+                    statusCode: 200,
+                    headers: [.init(name: "Content-Type", value: "text/event-stream")],
+                    body: nil
+                ),
+                streamEvents: [
+                    .init(event: "response.created", data: #"{"id":"resp_fixture","model":"synthetic-model"}"#),
+                    .init(event: "response.tool_call.delta", data: #"{"name":"lookup_order","arguments":"{\"order_id\":\"fixture-order\"}"}"#),
+                    .init(event: "response.completed", data: #"{"id":"resp_fixture","status":"completed"}"#),
+                ]
+            )
+        ]),
+        expected: ProtocolFixtureExpectations(
+            metadataHints: ["ai", "streaming", "tool_call", "model_request"],
+            redaction: ProtocolFixtureRedactionExpectation(
+                sensitiveFields: ["Authorization", "input", "tool_choice", "arguments"],
+                redactedMarkers: ["[REDACTED]"],
+                safeFields: ["model", "status"]
+            ),
+            ux: ProtocolFixtureUXExpectation(
+                requestListBadges: ["AI", "Stream"],
+                optionalColumns: ["protocol": "AI", "streaming": "true"],
+                inspectorTabs: ["AI", "Stream", "Tool Calls", "Raw"],
+                warningStates: ["prompt_redaction_candidate", "tool_payload_redaction_candidate"],
+                exportSummaryFields: ["model", "stream_event_count", "tool_call_count", "redacted_fields"],
+                mcpSummaryFields: ["model", "status", "streaming", "redacted"],
+                fallbackBehavior: nil
+            )
+        ),
+        safetyClass: .containsSyntheticSensitiveData,
+        sizeClass: .small,
+        traceability: commonTraceability
+    )
+
+    static let evmJSONRPCContractSmoke = ProtocolFixture(
+        id: "foundation.evm-json-rpc.contract-smoke",
+        title: "EVM JSON-RPC request with synthetic method summary",
+        family: .web3RPC,
+        scenarioTags: ["web3", "evm", "json-rpc", "contract-smoke"],
+        traffic: ProtocolFixtureTraffic(exchanges: [
+            ProtocolFixtureExchange(
+                request: ProtocolFixtureMessage(
+                    method: "POST",
+                    url: "https://rpc.example.com/evm",
+                    headers: [.init(name: "Content-Type", value: "application/json")],
+                    body: #"{"jsonrpc":"2.0","id":"fixture-1","method":"eth_call","params":[{"to":"0xSyntheticContract","data":"0xsyntheticCallData"},"latest"]}"#
+                ),
+                response: ProtocolFixtureMessage(
+                    method: "HTTP",
+                    url: "https://rpc.example.com/evm",
+                    statusCode: 200,
+                    headers: [.init(name: "Content-Type", value: "application/json")],
+                    body: #"{"jsonrpc":"2.0","id":"fixture-1","result":"0xsyntheticResult"}"#
+                )
+            )
+        ]),
+        expected: ProtocolFixtureExpectations(
+            metadataHints: ["web3", "json_rpc", "evm", "eth_call"],
+            redaction: ProtocolFixtureRedactionExpectation(
+                sensitiveFields: ["params.data"],
+                redactedMarkers: ["[REDACTED]"],
+                safeFields: ["jsonrpc", "method", "id"]
+            ),
+            ux: ProtocolFixtureUXExpectation(
+                requestListBadges: ["RPC", "EVM"],
+                optionalColumns: ["rpc_method": "eth_call"],
+                inspectorTabs: ["RPC", "JSON", "Raw"],
+                warningStates: [],
+                exportSummaryFields: ["rpc_method", "chain_hint", "redacted_fields"],
+                mcpSummaryFields: ["rpc_method", "status", "redacted"],
+                fallbackBehavior: nil
+            )
+        ),
+        safetyClass: .containsSyntheticSensitiveData,
+        sizeClass: .small,
+        traceability: commonTraceability
+    )
+
+    static let x402ContractSmoke = ProtocolFixture(
+        id: "foundation.x402.contract-smoke",
+        title: "x402-style payment-required retry flow",
+        family: .x402,
+        scenarioTags: ["x402", "payment-required", "retry", "contract-smoke"],
+        traffic: ProtocolFixtureTraffic(exchanges: [
+            ProtocolFixtureExchange(
+                request: ProtocolFixtureMessage(
+                    method: "GET",
+                    url: "https://payments.example.com/protected/report",
+                    headers: [.init(name: "Accept", value: "application/json")]
+                ),
+                response: ProtocolFixtureMessage(
+                    method: "HTTP",
+                    url: "https://payments.example.com/protected/report",
+                    statusCode: 402,
+                    headers: [.init(name: "Content-Type", value: "application/json")],
+                    body: #"{"x402Version":1,"paymentRequired":true,"challenge":"synthetic-payment-challenge"}"#
+                )
+            ),
+            ProtocolFixtureExchange(
+                request: ProtocolFixtureMessage(
+                    method: "GET",
+                    url: "https://payments.example.com/protected/report",
+                    headers: [
+                        .init(name: "Accept", value: "application/json"),
+                        .init(name: "X-Payment", value: "synthetic-payment-proof"),
+                    ]
+                ),
+                response: ProtocolFixtureMessage(
+                    method: "HTTP",
+                    url: "https://payments.example.com/protected/report",
+                    statusCode: 200,
+                    headers: [.init(name: "Content-Type", value: "application/json")],
+                    body: #"{"ok":true,"receipt":"synthetic-receipt"}"#
+                )
+            )
+        ]),
+        expected: ProtocolFixtureExpectations(
+            metadataHints: ["x402", "payment_required", "retry_flow"],
+            redaction: ProtocolFixtureRedactionExpectation(
+                sensitiveFields: ["X-Payment", "challenge", "receipt"],
+                redactedMarkers: ["[REDACTED]"],
+                safeFields: ["x402Version", "paymentRequired", "ok"]
+            ),
+            ux: ProtocolFixtureUXExpectation(
+                requestListBadges: ["x402", "402"],
+                optionalColumns: ["payment_flow": "required_then_success"],
+                inspectorTabs: ["Payment", "Headers", "Raw"],
+                warningStates: ["payment_metadata_redaction_candidate"],
+                exportSummaryFields: ["payment_required", "retry_count", "redacted_fields"],
+                mcpSummaryFields: ["payment_flow", "status", "redacted"],
+                fallbackBehavior: nil
+            )
+        ),
+        safetyClass: .containsSyntheticSensitiveData,
+        sizeClass: .small,
+        traceability: commonTraceability
+    )
+
+    static let malformedPayloadContractSmoke = ProtocolFixture(
+        id: "foundation.malformed-json.contract-smoke",
+        title: "Malformed JSON payload with bounded fallback contract",
+        family: .unknown,
+        scenarioTags: ["malformed", "json", "fallback", "contract-smoke"],
+        traffic: ProtocolFixtureTraffic(exchanges: [
+            ProtocolFixtureExchange(
+                request: ProtocolFixtureMessage(
+                    method: "POST",
+                    url: "https://test.invalid/malformed",
+                    headers: [.init(name: "Content-Type", value: "application/json")],
+                    body: #"{"message":"unterminated""#
+                ),
+                response: ProtocolFixtureMessage(
+                    method: "HTTP",
+                    url: "https://test.invalid/malformed",
+                    statusCode: 400,
+                    headers: [.init(name: "Content-Type", value: "text/plain")],
+                    body: "Malformed synthetic payload"
+                )
+            )
+        ]),
+        expected: ProtocolFixtureExpectations(
+            metadataHints: ["malformed", "fallback"],
+            redaction: ProtocolFixtureRedactionExpectation(
+                sensitiveFields: [],
+                redactedMarkers: [],
+                safeFields: ["message"]
+            ),
+            ux: ProtocolFixtureUXExpectation(
+                requestListBadges: ["Malformed"],
+                optionalColumns: ["parse_state": "failed"],
+                inspectorTabs: ["Raw"],
+                warningStates: ["malformed_payload"],
+                exportSummaryFields: ["parse_state", "omitted_protocol_summary"],
+                mcpSummaryFields: ["parse_state"],
+                fallbackBehavior: "Show bounded raw fallback without protocol-specific inspector content."
+            )
+        ),
+        safetyClass: .malformed,
+        sizeClass: .small,
+        traceability: commonTraceability
+    )
+}
+
+// MARK: - Validation
+
+enum ProtocolFixtureValidation {
+    static func validate(_ fixture: ProtocolFixture) -> [String] {
+        var failures: [String] = []
+
+        if fixture.id.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            failures.append("Fixture ID is empty.")
+        }
+        if fixture.title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            failures.append("\(fixture.id): title is empty.")
+        }
+        if fixture.scenarioTags.isEmpty {
+            failures.append("\(fixture.id): scenarioTags must not be empty.")
+        }
+        if fixture.traffic.exchanges.isEmpty {
+            failures.append("\(fixture.id): traffic.exchanges must not be empty.")
+        }
+        if fixture.expected.metadataHints.isEmpty {
+            failures.append("\(fixture.id): expected.metadataHints must not be empty.")
+        }
+        if fixture.expected.ux.requestListBadges.isEmpty {
+            failures.append("\(fixture.id): expected.ux.requestListBadges must not be empty.")
+        }
+        if fixture.expected.ux.inspectorTabs.isEmpty {
+            failures.append("\(fixture.id): expected.ux.inspectorTabs must not be empty.")
+        }
+        if fixture.expected.ux.exportSummaryFields.isEmpty {
+            failures.append("\(fixture.id): expected.ux.exportSummaryFields must not be empty.")
+        }
+        if fixture.expected.ux.mcpSummaryFields.isEmpty {
+            failures.append("\(fixture.id): expected.ux.mcpSummaryFields must not be empty.")
+        }
+        if fixture.traceability.parentIssue != 176 {
+            failures.append("\(fixture.id): traceability.parentIssue must be #176.")
+        }
+        if !fixture.traceability.childIssues.isSuperset(of: [186, 187, 194, 195]) {
+            failures.append("\(fixture.id): traceability.childIssues must include Group A child issues.")
+        }
+
+        return failures
+    }
+}
+
+// MARK: - Safety Scanner
+
+enum ProtocolFixtureSafetyScanner {
+    struct Finding: Equatable {
+        let fixtureID: String
+        let reason: String
+        let excerpt: String
+    }
+
+    static func scan(_ fixture: ProtocolFixture) -> [Finding] {
+        var findings: [Finding] = []
+
+        for exchange in fixture.traffic.exchanges {
+            findings.append(contentsOf: scan(message: exchange.request, fixtureID: fixture.id))
+            if let response = exchange.response {
+                findings.append(contentsOf: scan(message: response, fixtureID: fixture.id))
+            }
+            for event in exchange.streamEvents {
+                findings.append(contentsOf: scan(text: event.event ?? "", fixtureID: fixture.id, context: "stream event"))
+                findings.append(contentsOf: scan(text: event.data, fixtureID: fixture.id, context: "stream data"))
+            }
+        }
+
+        return findings
+    }
+
+    static func scan(text: String, fixtureID: String = "manual-scan", context: String = "text") -> [Finding] {
+        let patterns: [(reason: String, regex: String)] = [
+            ("local filesystem path", #"(?:/Users/|/private/var/|/Volumes/|[A-Za-z]:\\Users\\)"#),
+            ("private key PEM block", #"-----BEGIN [A-Z ]*PRIVATE KEY-----"#),
+            ("OpenAI-style production token", #"\bsk-[A-Za-z0-9_-]{16,}"#),
+            ("GitHub production token", #"\b(?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9_]{16,}"#),
+            ("Slack production token", #"\bxox[baprs]-[A-Za-z0-9-]{16,}"#),
+            ("AWS access key", #"\bAKIA[0-9A-Z]{16}\b"#),
+            ("Ethereum private-key-like value", #"\b0x[0-9a-fA-F]{64}\b"#),
+            ("realistic bearer token", #"Bearer\s+(?!(?:synthetic|fake|example)[A-Za-z0-9._~+/-]*\b)[A-Za-z0-9._~+/-]{20,}"#),
+        ]
+
+        var findings: [Finding] = []
+        for pattern in patterns {
+            if let match = firstMatch(pattern.regex, in: text) {
+                findings.append(Finding(fixtureID: fixtureID, reason: "\(context): \(pattern.reason)", excerpt: match))
+            }
+        }
+
+        findings.append(contentsOf: scanEmails(text: text, fixtureID: fixtureID, context: context))
+        return findings
+    }
+
+    private static func scan(message: ProtocolFixtureMessage, fixtureID: String) -> [Finding] {
+        var findings = scanHost(message.url, fixtureID: fixtureID)
+        findings.append(contentsOf: scan(text: message.url, fixtureID: fixtureID, context: "url"))
+        findings.append(contentsOf: message.headers.flatMap { header in
+            scan(text: "\(header.name): \(header.value)", fixtureID: fixtureID, context: "header")
+        })
+        if let body = message.body {
+            findings.append(contentsOf: scan(text: body, fixtureID: fixtureID, context: "body"))
+        }
+        return findings
+    }
+
+    private static func scanHost(_ urlString: String, fixtureID: String) -> [Finding] {
+        guard let url = URL(string: urlString), let host = url.host else {
+            return [Finding(fixtureID: fixtureID, reason: "url: invalid URL", excerpt: urlString)]
+        }
+
+        if ProtocolFixtureCorpus.allowedSyntheticHosts.contains(host) {
+            return []
+        }
+
+        return [Finding(fixtureID: fixtureID, reason: "url: non-synthetic host", excerpt: host)]
+    }
+
+    private static func scanEmails(text: String, fixtureID: String, context: String) -> [Finding] {
+        let emailRegex = #"[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}"#
+        return matches(emailRegex, in: text).compactMap { match in
+            if match.lowercased().hasSuffix("@example.com") {
+                return nil
+            }
+            return Finding(fixtureID: fixtureID, reason: "\(context): personal email-like value", excerpt: match)
+        }
+    }
+
+    private static func firstMatch(_ pattern: String, in text: String) -> String? {
+        matches(pattern, in: text).first
+    }
+
+    private static func matches(_ pattern: String, in text: String) -> [String] {
+        guard let regex = try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive]) else {
+            return []
+        }
+        let range = NSRange(text.startIndex ..< text.endIndex, in: text)
+        return regex.matches(in: text, range: range).compactMap { match in
+            guard let swiftRange = Range(match.range, in: text) else {
+                return nil
+            }
+            return String(text[swiftRange])
+        }
+    }
+}

--- a/RockxyTests/Helpers/ProtocolFixtureCorpus.swift
+++ b/RockxyTests/Helpers/ProtocolFixtureCorpus.swift
@@ -6,15 +6,34 @@ enum ProtocolFixtureCorpus {
     static let fixtures: [ProtocolFixture] = [
         .httpJSONSmoke,
         .aiSSEContractSmoke,
+        .aiAnthropicSSEContractSmoke,
+        .aiInterruptedToolCallContractSmoke,
+        .aiProviderErrorNoUsageContractSmoke,
+        .aiEmbeddingContractSmoke,
+        .aiRAGContractSmoke,
+        .aiMalformedRetrievalContractSmoke,
         .evmJSONRPCContractSmoke,
+        .evmGasReceiptAndSendRawContractSmoke,
+        .evmBatchErrorAndLargeContractSmoke,
+        .evmMalformedJSONRPCContractSmoke,
+        .solanaHTTPRPCContractSmoke,
+        .solanaWebSocketSubscriptionContractSmoke,
+        .solanaLongAndMalformedSubscriptionContractSmoke,
         .x402ContractSmoke,
+        .x402MalformedAndMissingProofContractSmoke,
+        .x402ProviderErrorMetadataContractSmoke,
         .malformedPayloadContractSmoke,
+        .hostileOversizedDeepJSONContractSmoke,
+        .hostileLongStringTruncatedContractSmoke,
+        .hostilePartialSSEAndBytesContractSmoke,
     ]
 
     static let allowedSyntheticHosts: Set<String> = [
         "api.example.com",
         "ai.example.com",
         "rpc.example.com",
+        "solana.example.com",
+        "vector.example.com",
         "payments.example.com",
         "test.invalid",
     ]
@@ -58,6 +77,18 @@ enum ProtocolFixtureSizeClass: String, CaseIterable {
 
 struct ProtocolFixtureTraffic: Equatable {
     let exchanges: [ProtocolFixtureExchange]
+    let webSocketMessages: [ProtocolFixtureWebSocketMessage]
+    let estimatedPayloadBytes: Int
+
+    init(
+        exchanges: [ProtocolFixtureExchange] = [],
+        webSocketMessages: [ProtocolFixtureWebSocketMessage] = [],
+        estimatedPayloadBytes: Int = 0
+    ) {
+        self.exchanges = exchanges
+        self.webSocketMessages = webSocketMessages
+        self.estimatedPayloadBytes = estimatedPayloadBytes
+    }
 }
 
 struct ProtocolFixtureExchange: Equatable {
@@ -108,6 +139,17 @@ struct ProtocolFixtureStreamEvent: Equatable {
     let data: String
 }
 
+struct ProtocolFixtureWebSocketMessage: Equatable {
+    let direction: ProtocolFixtureWebSocketDirection
+    let url: String
+    let body: String
+}
+
+enum ProtocolFixtureWebSocketDirection: String, CaseIterable {
+    case clientToServer
+    case serverToClient
+}
+
 struct ProtocolFixtureExpectations: Equatable {
     let metadataHints: Set<String>
     let redaction: ProtocolFixtureRedactionExpectation
@@ -136,260 +178,6 @@ struct ProtocolFixtureTraceability: Equatable {
     let futureIssues: Set<Int>
 }
 
-// MARK: - Corpus Smoke Fixtures
-
-private extension ProtocolFixture {
-    static let commonTraceability = ProtocolFixtureTraceability(
-        parentIssue: 176,
-        childIssues: [186, 187, 194, 195],
-        futureIssues: [143, 144, 145, 146, 177, 178, 179, 180]
-    )
-
-    static let httpJSONSmoke = ProtocolFixture(
-        id: "foundation.http-json.redaction-smoke",
-        title: "Ordinary JSON request with synthetic redaction candidate",
-        family: .ordinaryHTTP,
-        scenarioTags: ["http", "json", "redaction-smoke"],
-        traffic: ProtocolFixtureTraffic(exchanges: [
-            ProtocolFixtureExchange(
-                request: ProtocolFixtureMessage(
-                    method: "POST",
-                    url: "https://api.example.com/v1/debug-smoke",
-                    headers: [.init(name: "Content-Type", value: "application/json")],
-                    body: #"{"request_id":"fixture-request","api_key":"synthetic-api-key"}"#
-                ),
-                response: ProtocolFixtureMessage(
-                    method: "HTTP",
-                    url: "https://api.example.com/v1/debug-smoke",
-                    statusCode: 200,
-                    headers: [.init(name: "Content-Type", value: "application/json")],
-                    body: #"{"ok":true,"request_id":"fixture-request"}"#
-                )
-            )
-        ]),
-        expected: ProtocolFixtureExpectations(
-            metadataHints: ["http", "json"],
-            redaction: ProtocolFixtureRedactionExpectation(
-                sensitiveFields: ["api_key"],
-                redactedMarkers: ["[REDACTED]"],
-                safeFields: ["request_id", "ok"]
-            ),
-            ux: ProtocolFixtureUXExpectation(
-                requestListBadges: ["JSON"],
-                optionalColumns: ["content": "JSON"],
-                inspectorTabs: ["Headers", "JSON", "Raw"],
-                warningStates: [],
-                exportSummaryFields: ["method", "host", "status", "redacted_fields"],
-                mcpSummaryFields: ["method", "url", "status", "redacted"],
-                fallbackBehavior: nil
-            )
-        ),
-        safetyClass: .containsSyntheticSensitiveData,
-        sizeClass: .small,
-        traceability: commonTraceability
-    )
-
-    static let aiSSEContractSmoke = ProtocolFixture(
-        id: "foundation.ai-sse.contract-smoke",
-        title: "AI streaming response with synthetic tool call",
-        family: .ai,
-        scenarioTags: ["ai", "sse", "streaming", "tool-call", "contract-smoke"],
-        traffic: ProtocolFixtureTraffic(exchanges: [
-            ProtocolFixtureExchange(
-                request: ProtocolFixtureMessage(
-                    method: "POST",
-                    url: "https://ai.example.com/v1/responses",
-                    headers: [
-                        .init(name: "Content-Type", value: "application/json"),
-                        .init(name: "Authorization", value: "Bearer synthetic-ai-token"),
-                    ],
-                    body: #"{"model":"synthetic-model","input":"[SYNTHETIC_PROMPT]","tool_choice":"auto"}"#
-                ),
-                response: ProtocolFixtureMessage(
-                    method: "HTTP",
-                    url: "https://ai.example.com/v1/responses",
-                    statusCode: 200,
-                    headers: [.init(name: "Content-Type", value: "text/event-stream")],
-                    body: nil
-                ),
-                streamEvents: [
-                    .init(event: "response.created", data: #"{"id":"resp_fixture","model":"synthetic-model"}"#),
-                    .init(event: "response.tool_call.delta", data: #"{"name":"lookup_order","arguments":"{\"order_id\":\"fixture-order\"}"}"#),
-                    .init(event: "response.completed", data: #"{"id":"resp_fixture","status":"completed"}"#),
-                ]
-            )
-        ]),
-        expected: ProtocolFixtureExpectations(
-            metadataHints: ["ai", "streaming", "tool_call", "model_request"],
-            redaction: ProtocolFixtureRedactionExpectation(
-                sensitiveFields: ["Authorization", "input", "tool_choice", "arguments"],
-                redactedMarkers: ["[REDACTED]"],
-                safeFields: ["model", "status"]
-            ),
-            ux: ProtocolFixtureUXExpectation(
-                requestListBadges: ["AI", "Stream"],
-                optionalColumns: ["protocol": "AI", "streaming": "true"],
-                inspectorTabs: ["AI", "Stream", "Tool Calls", "Raw"],
-                warningStates: ["prompt_redaction_candidate", "tool_payload_redaction_candidate"],
-                exportSummaryFields: ["model", "stream_event_count", "tool_call_count", "redacted_fields"],
-                mcpSummaryFields: ["model", "status", "streaming", "redacted"],
-                fallbackBehavior: nil
-            )
-        ),
-        safetyClass: .containsSyntheticSensitiveData,
-        sizeClass: .small,
-        traceability: commonTraceability
-    )
-
-    static let evmJSONRPCContractSmoke = ProtocolFixture(
-        id: "foundation.evm-json-rpc.contract-smoke",
-        title: "EVM JSON-RPC request with synthetic method summary",
-        family: .web3RPC,
-        scenarioTags: ["web3", "evm", "json-rpc", "contract-smoke"],
-        traffic: ProtocolFixtureTraffic(exchanges: [
-            ProtocolFixtureExchange(
-                request: ProtocolFixtureMessage(
-                    method: "POST",
-                    url: "https://rpc.example.com/evm",
-                    headers: [.init(name: "Content-Type", value: "application/json")],
-                    body: #"{"jsonrpc":"2.0","id":"fixture-1","method":"eth_call","params":[{"to":"0xSyntheticContract","data":"0xsyntheticCallData"},"latest"]}"#
-                ),
-                response: ProtocolFixtureMessage(
-                    method: "HTTP",
-                    url: "https://rpc.example.com/evm",
-                    statusCode: 200,
-                    headers: [.init(name: "Content-Type", value: "application/json")],
-                    body: #"{"jsonrpc":"2.0","id":"fixture-1","result":"0xsyntheticResult"}"#
-                )
-            )
-        ]),
-        expected: ProtocolFixtureExpectations(
-            metadataHints: ["web3", "json_rpc", "evm", "eth_call"],
-            redaction: ProtocolFixtureRedactionExpectation(
-                sensitiveFields: ["params.data"],
-                redactedMarkers: ["[REDACTED]"],
-                safeFields: ["jsonrpc", "method", "id"]
-            ),
-            ux: ProtocolFixtureUXExpectation(
-                requestListBadges: ["RPC", "EVM"],
-                optionalColumns: ["rpc_method": "eth_call"],
-                inspectorTabs: ["RPC", "JSON", "Raw"],
-                warningStates: [],
-                exportSummaryFields: ["rpc_method", "chain_hint", "redacted_fields"],
-                mcpSummaryFields: ["rpc_method", "status", "redacted"],
-                fallbackBehavior: nil
-            )
-        ),
-        safetyClass: .containsSyntheticSensitiveData,
-        sizeClass: .small,
-        traceability: commonTraceability
-    )
-
-    static let x402ContractSmoke = ProtocolFixture(
-        id: "foundation.x402.contract-smoke",
-        title: "x402-style payment-required retry flow",
-        family: .x402,
-        scenarioTags: ["x402", "payment-required", "retry", "contract-smoke"],
-        traffic: ProtocolFixtureTraffic(exchanges: [
-            ProtocolFixtureExchange(
-                request: ProtocolFixtureMessage(
-                    method: "GET",
-                    url: "https://payments.example.com/protected/report",
-                    headers: [.init(name: "Accept", value: "application/json")]
-                ),
-                response: ProtocolFixtureMessage(
-                    method: "HTTP",
-                    url: "https://payments.example.com/protected/report",
-                    statusCode: 402,
-                    headers: [.init(name: "Content-Type", value: "application/json")],
-                    body: #"{"x402Version":1,"paymentRequired":true,"challenge":"synthetic-payment-challenge"}"#
-                )
-            ),
-            ProtocolFixtureExchange(
-                request: ProtocolFixtureMessage(
-                    method: "GET",
-                    url: "https://payments.example.com/protected/report",
-                    headers: [
-                        .init(name: "Accept", value: "application/json"),
-                        .init(name: "X-Payment", value: "synthetic-payment-proof"),
-                    ]
-                ),
-                response: ProtocolFixtureMessage(
-                    method: "HTTP",
-                    url: "https://payments.example.com/protected/report",
-                    statusCode: 200,
-                    headers: [.init(name: "Content-Type", value: "application/json")],
-                    body: #"{"ok":true,"receipt":"synthetic-receipt"}"#
-                )
-            )
-        ]),
-        expected: ProtocolFixtureExpectations(
-            metadataHints: ["x402", "payment_required", "retry_flow"],
-            redaction: ProtocolFixtureRedactionExpectation(
-                sensitiveFields: ["X-Payment", "challenge", "receipt"],
-                redactedMarkers: ["[REDACTED]"],
-                safeFields: ["x402Version", "paymentRequired", "ok"]
-            ),
-            ux: ProtocolFixtureUXExpectation(
-                requestListBadges: ["x402", "402"],
-                optionalColumns: ["payment_flow": "required_then_success"],
-                inspectorTabs: ["Payment", "Headers", "Raw"],
-                warningStates: ["payment_metadata_redaction_candidate"],
-                exportSummaryFields: ["payment_required", "retry_count", "redacted_fields"],
-                mcpSummaryFields: ["payment_flow", "status", "redacted"],
-                fallbackBehavior: nil
-            )
-        ),
-        safetyClass: .containsSyntheticSensitiveData,
-        sizeClass: .small,
-        traceability: commonTraceability
-    )
-
-    static let malformedPayloadContractSmoke = ProtocolFixture(
-        id: "foundation.malformed-json.contract-smoke",
-        title: "Malformed JSON payload with bounded fallback contract",
-        family: .unknown,
-        scenarioTags: ["malformed", "json", "fallback", "contract-smoke"],
-        traffic: ProtocolFixtureTraffic(exchanges: [
-            ProtocolFixtureExchange(
-                request: ProtocolFixtureMessage(
-                    method: "POST",
-                    url: "https://test.invalid/malformed",
-                    headers: [.init(name: "Content-Type", value: "application/json")],
-                    body: #"{"message":"unterminated""#
-                ),
-                response: ProtocolFixtureMessage(
-                    method: "HTTP",
-                    url: "https://test.invalid/malformed",
-                    statusCode: 400,
-                    headers: [.init(name: "Content-Type", value: "text/plain")],
-                    body: "Malformed synthetic payload"
-                )
-            )
-        ]),
-        expected: ProtocolFixtureExpectations(
-            metadataHints: ["malformed", "fallback"],
-            redaction: ProtocolFixtureRedactionExpectation(
-                sensitiveFields: [],
-                redactedMarkers: [],
-                safeFields: ["message"]
-            ),
-            ux: ProtocolFixtureUXExpectation(
-                requestListBadges: ["Malformed"],
-                optionalColumns: ["parse_state": "failed"],
-                inspectorTabs: ["Raw"],
-                warningStates: ["malformed_payload"],
-                exportSummaryFields: ["parse_state", "omitted_protocol_summary"],
-                mcpSummaryFields: ["parse_state"],
-                fallbackBehavior: "Show bounded raw fallback without protocol-specific inspector content."
-            )
-        ),
-        safetyClass: .malformed,
-        sizeClass: .small,
-        traceability: commonTraceability
-    )
-}
-
 // MARK: - Validation
 
 enum ProtocolFixtureValidation {
@@ -405,8 +193,8 @@ enum ProtocolFixtureValidation {
         if fixture.scenarioTags.isEmpty {
             failures.append("\(fixture.id): scenarioTags must not be empty.")
         }
-        if fixture.traffic.exchanges.isEmpty {
-            failures.append("\(fixture.id): traffic.exchanges must not be empty.")
+        if fixture.traffic.exchanges.isEmpty && fixture.traffic.webSocketMessages.isEmpty {
+            failures.append("\(fixture.id): traffic must include exchanges or WebSocket messages.")
         }
         if fixture.expected.metadataHints.isEmpty {
             failures.append("\(fixture.id): expected.metadataHints must not be empty.")
@@ -428,6 +216,18 @@ enum ProtocolFixtureValidation {
         }
         if !fixture.traceability.childIssues.isSuperset(of: [186, 187, 194, 195]) {
             failures.append("\(fixture.id): traceability.childIssues must include Group A child issues.")
+        }
+        if fixture.safetyClass == .malformed && fixture.expected.ux.fallbackBehavior == nil {
+            failures.append("\(fixture.id): malformed fixtures must declare fallback behavior.")
+        }
+        if fixture.safetyClass == .large && fixture.sizeClass != .boundedStress {
+            failures.append("\(fixture.id): large fixtures must use boundedStress size class.")
+        }
+        if fixture.sizeClass == .boundedStress && fixture.traffic.estimatedPayloadBytes <= 0 {
+            failures.append("\(fixture.id): boundedStress fixtures must declare estimatedPayloadBytes.")
+        }
+        if fixture.traffic.estimatedPayloadBytes > 32_000 {
+            failures.append("\(fixture.id): estimatedPayloadBytes exceeds the test corpus budget.")
         }
 
         return failures
@@ -456,6 +256,10 @@ enum ProtocolFixtureSafetyScanner {
                 findings.append(contentsOf: scan(text: event.data, fixtureID: fixture.id, context: "stream data"))
             }
         }
+        for message in fixture.traffic.webSocketMessages {
+            findings.append(contentsOf: scanHost(message.url, fixtureID: fixture.id))
+            findings.append(contentsOf: scan(text: message.body, fixtureID: fixture.id, context: "websocket body"))
+        }
 
         return findings
     }
@@ -470,6 +274,7 @@ enum ProtocolFixtureSafetyScanner {
             ("AWS access key", #"\bAKIA[0-9A-Z]{16}\b"#),
             ("Ethereum private-key-like value", #"\b0x[0-9a-fA-F]{64}\b"#),
             ("realistic bearer token", #"Bearer\s+(?!(?:synthetic|fake|example)[A-Za-z0-9._~+/-]*\b)[A-Za-z0-9._~+/-]{20,}"#),
+            ("seed phrase-like sample", #"\b(?:abandon|ability|able|about|above|absent|absorb|abstract|absurd|abuse)\s+(?:[a-z]+\s+){10,23}[a-z]+\b"#),
         ]
 
         var findings: [Finding] = []

--- a/RockxyTests/Helpers/TestIdentity.swift
+++ b/RockxyTests/Helpers/TestIdentity.swift
@@ -41,6 +41,7 @@ enum TestIdentity {
     static let discoveredRequestHeadersKey = "\(defaultsPrefix).discoveredReqHeaders"
     static let discoveredResponseHeadersKey = "\(defaultsPrefix).discoveredResHeaders"
     static let hiddenBuiltInColumnsKey = "\(defaultsPrefix).hiddenBuiltInColumns"
+    static let visibleDefaultHiddenBuiltInColumnsKey = "\(defaultsPrefix).visibleDefaultHiddenBuiltInColumns"
     static let showAlertOnQuitKey = "\(defaultsPrefix).showAlertOnQuit"
     static let recordOnLaunchKey = "\(defaultsPrefix).recordOnLaunch"
     static let autoSelectPortKey = "\(defaultsPrefix).autoSelectPort"

--- a/RockxyTests/Models/UI/HeaderColumnStoreTests.swift
+++ b/RockxyTests/Models/UI/HeaderColumnStoreTests.swift
@@ -194,6 +194,20 @@ struct HeaderColumnStoreTests {
         #expect(store.isBuiltInColumnVisible("url"))
     }
 
+    @Test("AI built-in column is hidden by default but can be enabled")
+    func aiBuiltInColumnDefaultVisibility() {
+        let store = makeCleanStore()
+
+        #expect(!store.isBuiltInColumnVisible("ai"))
+        store.toggleBuiltInColumn("ai")
+        #expect(store.isBuiltInColumnVisible("ai"))
+
+        let store2 = HeaderColumnStore()
+        #expect(store2.isBuiltInColumnVisible("ai"))
+        store2.toggleBuiltInColumn("ai")
+        #expect(!store2.isBuiltInColumnVisible("ai"))
+    }
+
     @Test("Hidden built-in columns persist")
     func hiddenBuiltInPersist() {
         let store = makeCleanStore()
@@ -290,6 +304,10 @@ struct HeaderColumnStoreTests {
         clearDefaultsKey("discoveredReqHeaders", fallback: TestIdentity.discoveredRequestHeadersKey)
         clearDefaultsKey("discoveredResHeaders", fallback: TestIdentity.discoveredResponseHeadersKey)
         clearDefaultsKey("hiddenBuiltInColumns", fallback: TestIdentity.hiddenBuiltInColumnsKey)
+        clearDefaultsKey(
+            "visibleDefaultHiddenBuiltInColumns",
+            fallback: TestIdentity.visibleDefaultHiddenBuiltInColumnsKey
+        )
         return HeaderColumnStore()
     }
 

--- a/RockxyTests/Models/UI/RequestListRowTests.swift
+++ b/RockxyTests/Models/UI/RequestListRowTests.swift
@@ -99,6 +99,21 @@ struct RequestListRowTests {
         #expect(row.isTLSFailure == true)
     }
 
+    @Test("AI traffic signal is extracted from model-provider requests")
+    func aiTrafficSignal() {
+        let transaction = TestFixtures.makeTransaction(
+            method: "POST",
+            url: "https://api.openai.com/v1/responses",
+            statusCode: 200
+        )
+
+        let row = RequestListRow(from: transaction)
+
+        #expect(row.aiTrafficSignal.isLikelyAI)
+        #expect(row.aiTrafficSignal.provider == .openAICompatible)
+        #expect(row.aiTrafficSignal.tableLabel == "AI")
+    }
+
     @Test("Body sizes extracted from request and response")
     func bodySizes() {
         let transaction = TestFixtures.makeTransactionWithBody(
@@ -202,6 +217,16 @@ struct RequestListRowTests {
 
         #expect(RequestListRow.compare(http, https, using: descriptors) == true)
         #expect(RequestListRow.compare(https, http, using: descriptors) == false)
+    }
+
+    @Test("Sort by AI groups ordinary traffic before AI traffic")
+    func sortByAI() {
+        let ordinary = makeRow(host: "example.com")
+        let ai = makeRow(host: "api.openai.com", path: "/v1/responses")
+        let descriptors = [NSSortDescriptor(key: "ai", ascending: true)]
+
+        #expect(RequestListRow.compare(ordinary, ai, using: descriptors) == true)
+        #expect(RequestListRow.compare(ai, ordinary, using: descriptors) == false)
     }
 
     @Test("SSL state can represent intercepted HTTPS separately from tunneled HTTPS")


### PR DESCRIPTION
## Summary
- Promote the latest validated `develop` changes into `main`.
- Includes the protocol fixture corpus foundation from #196.
- Includes the native AI response inspector and optional request-list AI signal from #197.

## Validation
- #196 passed its focused protocol fixture corpus tests, scoped SwiftLint, and diff checks before merge.
- #197 passed scoped SwiftLint, focused AI/request-list/inspector tests, and Debug build before merge.
- Current branch comparison is limited to the merged #196 and #197 changes.

## Notes
- No additional source changes are introduced by this PR.
- This PR is a branch promotion from `develop` to `main`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an AI traffic indicator to request lists, including a new column and sorting option.
  * Added a dedicated AI inspection tab showing detected provider, model, usage, tools, streaming details, retrieval info, and warnings.
  * AI-related details now appear automatically for matching requests and are hidden when unavailable.

* **Bug Fixes**
  * Improved built-in column visibility so the AI column can be shown after being hidden by default.
  * Prevented stale AI inspection results from appearing when switching transactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->