### PR TITLE
Add Web3 RPC inspector

### DIFF
--- a/Rockxy/Core/Detection/Web3RPCDetector.swift
+++ b/Rockxy/Core/Detection/Web3RPCDetector.swift
@@ -1,0 +1,329 @@
+import Foundation
+
+// MARK: - Web3RPCDetector
+
+/// Bounded detector for visible Web3 JSON-RPC carried over captured HTTP traffic.
+enum Web3RPCDetector {
+    // MARK: Internal
+
+    static let maxPayloadBytes = 1_048_576
+
+    static func detect(request: HTTPRequestData, response: HTTPResponseData? = nil) -> Web3RPCInfo? {
+        guard request.method.caseInsensitiveCompare("CONNECT") != .orderedSame,
+              let requestBody = request.body,
+              !requestBody.isEmpty,
+              requestBody.count <= maxPayloadBytes,
+              let requestRoot = parseJSON(requestBody) else
+        {
+            return nil
+        }
+
+        let requests = parseRequests(from: requestRoot)
+        let web3Requests = requests.filter { isWeb3Method($0.method) }
+        guard let primary = web3Requests.first else {
+            return nil
+        }
+
+        let responses = parseResponses(from: response?.body)
+        let primaryResponse = responseEntry(matching: primary.id, in: responses) ?? responses.first
+        let batch = makeBatchSummary(requestRoot: requestRoot, requests: requests, web3Requests: web3Requests, responses: responses)
+        let error = primaryResponse?.error ?? responses.compactMap(\.error).first
+        let family = family(for: primary.method)
+
+        return Web3RPCInfo(
+            family: family,
+            providerHost: request.host,
+            method: batch == nil ? primary.method : nil,
+            requestID: batch == nil ? primary.id : nil,
+            batch: batch,
+            error: error,
+            chainHint: chainHint(method: primary.method, response: primaryResponse),
+            transactionHash: transactionHash(method: primary.method, request: primary, response: primaryResponse),
+            blockIdentifier: blockIdentifier(method: primary.method, request: primary, response: primaryResponse),
+            requestPayloadSize: request.body?.count,
+            responsePayloadSize: response?.body?.count
+        )
+    }
+
+    // MARK: Private
+
+    private struct RPCRequest {
+        let method: String
+        let id: String?
+        let params: Any?
+    }
+
+    private struct RPCResponse {
+        let id: String?
+        let result: Any?
+        let error: Web3RPCError?
+    }
+
+    private static let evmMethodPrefixes = [
+        "eth_",
+        "net_",
+        "web3_",
+        "debug_",
+        "trace_",
+        "txpool_",
+        "personal_",
+        "wallet_",
+        "evm_",
+        "hardhat_",
+        "anvil_",
+        "ots_",
+        "erigon_",
+        "parity_",
+        "bor_",
+        "zks_",
+        "optimism_",
+    ]
+
+    private static let solanaMethods: Set<String> = [
+        "getAccountInfo",
+        "getBalance",
+        "getBlock",
+        "getBlockHeight",
+        "getBlockProduction",
+        "getBlockTime",
+        "getBlocks",
+        "getClusterNodes",
+        "getEpochInfo",
+        "getFeeForMessage",
+        "getHealth",
+        "getIdentity",
+        "getLatestBlockhash",
+        "getLeaderSchedule",
+        "getMinimumBalanceForRentExemption",
+        "getMultipleAccounts",
+        "getProgramAccounts",
+        "getRecentPerformanceSamples",
+        "getSignaturesForAddress",
+        "getSignatureStatuses",
+        "getSlot",
+        "getSupply",
+        "getTokenAccountBalance",
+        "getTokenAccountsByOwner",
+        "getTransaction",
+        "getTransactionCount",
+        "getVersion",
+        "requestAirdrop",
+        "sendTransaction",
+        "simulateTransaction",
+    ]
+
+    private static func parseJSON(_ data: Data) -> Any? {
+        try? JSONSerialization.jsonObject(with: data)
+    }
+
+    private static func parseRequests(from root: Any) -> [RPCRequest] {
+        if let object = root as? [String: Any], let request = parseRequestObject(object) {
+            return [request]
+        }
+        if let array = root as? [[String: Any]] {
+            return array.compactMap(parseRequestObject)
+        }
+        return []
+    }
+
+    private static func parseRequestObject(_ object: [String: Any]) -> RPCRequest? {
+        guard let method = object["method"] as? String else {
+            return nil
+        }
+        return RPCRequest(
+            method: method,
+            id: rpcIDDescription(object["id"]),
+            params: object["params"]
+        )
+    }
+
+    private static func parseResponses(from body: Data?) -> [RPCResponse] {
+        guard let body, !body.isEmpty, body.count <= maxPayloadBytes, let root = parseJSON(body) else {
+            return []
+        }
+        if let object = root as? [String: Any] {
+            return [parseResponseObject(object)]
+        }
+        if let array = root as? [[String: Any]] {
+            return array.map(parseResponseObject)
+        }
+        return []
+    }
+
+    private static func parseResponseObject(_ object: [String: Any]) -> RPCResponse {
+        RPCResponse(
+            id: rpcIDDescription(object["id"]),
+            result: object["result"],
+            error: parseError(object["error"])
+        )
+    }
+
+    private static func parseError(_ value: Any?) -> Web3RPCError? {
+        guard let object = value as? [String: Any] else {
+            return nil
+        }
+        let code = intValue(object["code"])
+        let message = object["message"] as? String
+        guard code != nil || message != nil else {
+            return nil
+        }
+        return Web3RPCError(code: code, message: message)
+    }
+
+    private static func makeBatchSummary(
+        requestRoot: Any,
+        requests: [RPCRequest],
+        web3Requests: [RPCRequest],
+        responses: [RPCResponse]
+    )
+        -> Web3RPCBatchSummary?
+    {
+        guard requestRoot is [Any] else {
+            return nil
+        }
+
+        let methods = Array(web3Requests.map(\.method).prefix(6))
+        return Web3RPCBatchSummary(
+            requestCount: requests.count,
+            web3RequestCount: web3Requests.count,
+            responseCount: responses.isEmpty ? nil : responses.count,
+            errorCount: responses.compactMap(\.error).count,
+            methods: methods
+        )
+    }
+
+    private static func responseEntry(matching id: String?, in responses: [RPCResponse]) -> RPCResponse? {
+        guard let id else {
+            return nil
+        }
+        return responses.first { $0.id == id }
+    }
+
+    private static func isWeb3Method(_ method: String) -> Bool {
+        evmMethodPrefixes.contains { method.hasPrefix($0) } || solanaMethods.contains(method)
+    }
+
+    private static func family(for method: String) -> Web3RPCFamily {
+        solanaMethods.contains(method) ? .solana : .evm
+    }
+
+    private static func chainHint(method: String, response: RPCResponse?) -> Web3RPCChainHint? {
+        if method == "eth_chainId", let chainID = stringValue(response?.result) {
+            return Web3RPCChainHint(chainID: chainID)
+        }
+        return nil
+    }
+
+    private static func transactionHash(method: String, request: RPCRequest, response: RPCResponse?) -> String? {
+        if method == "eth_sendRawTransaction", let hash = stringValue(response?.result), looksLikeHash(hash) {
+            return hash
+        }
+        if ["eth_getTransactionByHash", "eth_getTransactionReceipt"].contains(method),
+           let hash = arrayValue(request.params)?.first.flatMap(stringValue),
+           looksLikeHash(hash)
+        {
+            return hash
+        }
+        if method == "eth_getLogs",
+           let firstLog = arrayValue(response?.result)?.first as? [String: Any],
+           let hash = firstLog["transactionHash"].flatMap(stringValue),
+           looksLikeHash(hash)
+        {
+            return hash
+        }
+        if method == "sendTransaction", let signature = stringValue(response?.result), !signature.isEmpty {
+            return signature
+        }
+        return nil
+    }
+
+    private static func blockIdentifier(method: String, request: RPCRequest, response: RPCResponse?) -> String? {
+        if ["eth_call", "eth_estimateGas"].contains(method),
+           let params = arrayValue(request.params),
+           params.count > 1
+        {
+            return stringValue(params[1])
+        }
+
+        if method == "eth_getLogs",
+           let filter = arrayValue(request.params)?.first as? [String: Any]
+        {
+            if let blockHash = filter["blockHash"].flatMap(stringValue) {
+                return blockHash
+            }
+            let fromBlock = filter["fromBlock"].flatMap(stringValue)
+            let toBlock = filter["toBlock"].flatMap(stringValue)
+            if let fromBlock, let toBlock {
+                return "\(fromBlock)...\(toBlock)"
+            }
+            return fromBlock ?? toBlock
+        }
+
+        if ["eth_getBlockByHash", "eth_getBlockByNumber"].contains(method),
+           let block = arrayValue(request.params)?.first.flatMap(stringValue)
+        {
+            return block
+        }
+
+        if let resultObject = response?.result as? [String: Any],
+           let blockNumber = resultObject["blockNumber"].flatMap(stringValue)
+        {
+            return blockNumber
+        }
+
+        if method == "eth_getLogs",
+           let firstLog = arrayValue(response?.result)?.first as? [String: Any],
+           let blockNumber = firstLog["blockNumber"].flatMap(stringValue)
+        {
+            return blockNumber
+        }
+
+        return nil
+    }
+
+    private static func rpcIDDescription(_ value: Any?) -> String? {
+        switch value {
+        case let string as String:
+            return string
+        case let number as NSNumber where CFGetTypeID(number) != CFBooleanGetTypeID():
+            return number.stringValue
+        default:
+            return nil
+        }
+    }
+
+    private static func stringValue(_ value: Any?) -> String? {
+        switch value {
+        case let string as String:
+            return string
+        case let number as NSNumber where CFGetTypeID(number) != CFBooleanGetTypeID():
+            return number.stringValue
+        default:
+            return nil
+        }
+    }
+
+    private static func intValue(_ value: Any?) -> Int? {
+        switch value {
+        case let int as Int:
+            return int
+        case let number as NSNumber where CFGetTypeID(number) != CFBooleanGetTypeID():
+            return number.intValue
+        case let string as String:
+            return Int(string)
+        default:
+            return nil
+        }
+    }
+
+    private static func arrayValue(_ value: Any?) -> [Any]? {
+        value as? [Any]
+    }
+
+    private static func looksLikeHash(_ value: String) -> Bool {
+        guard value.hasPrefix("0x"), value.count == 66 else {
+            return false
+        }
+        return value.dropFirst(2).allSatisfy(\.isHexDigit)
+    }
+}

--- a/Rockxy/Core/ProxyEngine/UpstreamResponseHandler.swift
+++ b/Rockxy/Core/ProxyEngine/UpstreamResponseHandler.swift
@@ -675,7 +675,8 @@ final class UpstreamResponseHandler: ChannelInboundHandler, @unchecked Sendable 
             response: responseData,
             state: .completed,
             timingInfo: timing,
-            graphQLInfo: graphQLInfo
+            graphQLInfo: graphQLInfo,
+            web3RPCInfo: Web3RPCDetector.detect(request: requestData, response: responseData)
         )
         transaction.sourcePort = sourcePort
         transaction.clientApp = Self.extractAppFromUserAgent(requestData.headers)

--- a/Rockxy/Core/Utilities/RequestCopyFormatter.swift
+++ b/Rockxy/Core/Utilities/RequestCopyFormatter.swift
@@ -49,7 +49,7 @@ enum RequestCopyFormatter {
         case "size":
             return transaction.response?.body.map { SizeFormatter.format(bytes: $0.count) } ?? ""
         case "queryName":
-            return transaction.graphQLInfo?.operationName ?? ""
+            return web3RPCMethodDescription(transaction.web3RPCInfo) ?? transaction.graphQLInfo?.operationName ?? ""
         default:
             if column.hasPrefix("reqHeader.") || column.hasPrefix("resHeader.") {
                 return HeaderColumnStore.resolveValue(for: column, transaction: transaction)
@@ -191,5 +191,21 @@ enum RequestCopyFormatter {
 
     private static func shellQuote(_ value: String) -> String {
         "'" + value.replacingOccurrences(of: "'", with: "'\\''") + "'"
+    }
+
+    private static func web3RPCMethodDescription(_ info: Web3RPCInfo?) -> String? {
+        guard let info else {
+            return nil
+        }
+        if let method = info.method {
+            return method
+        }
+        guard let batch = info.batch else {
+            return nil
+        }
+        if let first = batch.methods.first {
+            return batch.methods.count > 1 ? "\(first) + \(batch.methods.count - 1)" : first
+        }
+        return "\(batch.web3RequestCount) calls"
     }
 }

--- a/Rockxy/Core/Utilities/SensitiveDataRedactor.swift
+++ b/Rockxy/Core/Utilities/SensitiveDataRedactor.swift
@@ -41,6 +41,17 @@ struct SensitiveDataRedactor {
         "passwd",
         "pwd",
         "private_key",
+        "private-key",
+        "privatekey",
+        "seed",
+        "seed_phrase",
+        "seed-phrase",
+        "seedphrase",
+        "mnemonic",
+        "recovery_phrase",
+        "recovery-phrase",
+        "recoveryphrase",
+        "signature",
         "client_secret",
         "key",
     ]
@@ -146,7 +157,8 @@ struct SensitiveDataRedactor {
             state: transaction.state,
             timingInfo: transaction.timingInfo,
             webSocketConnection: transaction.webSocketConnection,
-            graphQLInfo: transaction.graphQLInfo
+            graphQLInfo: transaction.graphQLInfo,
+            web3RPCInfo: transaction.web3RPCInfo
         )
         redacted.measuredDuration = transaction.measuredDuration
         redacted.sourcePort = transaction.sourcePort
@@ -176,15 +188,38 @@ struct SensitiveDataRedactor {
         options: [.caseInsensitive]
     )
 
+    private static let bodySecretKeyPattern = [
+        "password",
+        "passwd",
+        "pwd",
+        "secret",
+        "client_secret",
+        "private_key",
+        "private-key",
+        "privatekey",
+        "seed",
+        "seed_phrase",
+        "seed-phrase",
+        "seedphrase",
+        "mnemonic",
+        "recovery_phrase",
+        "recovery-phrase",
+        "recoveryphrase",
+        "signature",
+        "credentials",
+    ].joined(separator: "|")
+
     private static let bodySecretPatternRegex: NSRegularExpression = try! NSRegularExpression(
-        pattern: #"("(?:password|passwd|pwd|secret|client_secret|private_key|credentials)")\s*:\s*\#(jsonScalarPattern)"#,
+        pattern: #"("(?:\#(bodySecretKeyPattern))")\s*:\s*\#(jsonScalarPattern)"#,
         options: [.caseInsensitive]
     )
 
     private static let xmlSensitivePatternRegex: NSRegularExpression = try! NSRegularExpression(
         pattern: """
         <(password|passwd|secret|token|access_token|api_key|apikey\
-        |client_secret|private_key|credentials)>([^<]*)</
+        |client_secret|private_key|private-key|privatekey|seed|seed_phrase|seed-phrase\
+        |seedphrase|mnemonic|recovery_phrase|recovery-phrase|recoveryphrase|signature\
+        |credentials)>([^<]*)</
         """,
         options: [.caseInsensitive]
     )
@@ -195,7 +230,7 @@ struct SensitiveDataRedactor {
     )
 
     private static let genericKeyValuePatternRegex: NSRegularExpression = try! NSRegularExpression(
-        pattern: #"(?i)((?:password|passwd|secret|token|api_key|apikey)[\s]*[:=][\s]*)\S+"#,
+        pattern: #"(?i)((?:password|passwd|secret|token|api_key|apikey|private_key|privatekey|seed_phrase|seedphrase|mnemonic|signature)[\s]*[:=][\s]*)\S+"#,
         options: []
     )
     // swiftlint:enable force_try

--- a/Rockxy/Models/Network/HTTPTransaction.swift
+++ b/Rockxy/Models/Network/HTTPTransaction.swift
@@ -7,7 +7,7 @@ import Foundation
 // MARK: - HTTPTransaction
 
 /// The central model for a proxied HTTP exchange — pairs a request with its response,
-/// lifecycle state, timing breakdown, and optional protocol-specific data (WebSocket, GraphQL).
+/// lifecycle state, timing breakdown, and optional protocol-specific data (WebSocket, GraphQL, Web3 RPC).
 /// Uses `@Observable` for SwiftUI reactivity; marked `@unchecked Sendable` because mutations
 /// only occur on the main actor after the proxy pipeline delivers completed transactions.
 @Observable
@@ -22,7 +22,8 @@ final class HTTPTransaction: Identifiable, @unchecked Sendable {
         state: TransactionState = .pending,
         timingInfo: TimingInfo? = nil,
         webSocketConnection: WebSocketConnection? = nil,
-        graphQLInfo: GraphQLInfo? = nil
+        graphQLInfo: GraphQLInfo? = nil,
+        web3RPCInfo: Web3RPCInfo? = nil
     ) {
         self.id = id
         self.timestamp = timestamp
@@ -32,6 +33,7 @@ final class HTTPTransaction: Identifiable, @unchecked Sendable {
         self.timingInfo = timingInfo
         self.webSocketConnection = webSocketConnection
         self.graphQLInfo = graphQLInfo
+        self.web3RPCInfo = web3RPCInfo
     }
 
     // MARK: Internal
@@ -45,6 +47,7 @@ final class HTTPTransaction: Identifiable, @unchecked Sendable {
     var measuredDuration: TimeInterval?
     var webSocketConnection: WebSocketConnection?
     var graphQLInfo: GraphQLInfo?
+    var web3RPCInfo: Web3RPCInfo?
     var sourcePort: UInt16?
     var clientApp: String?
     var comment: String?

--- a/Rockxy/Models/Network/SessionCodable.swift
+++ b/Rockxy/Models/Network/SessionCodable.swift
@@ -60,6 +60,8 @@ struct CodableTransaction: Codable {
             .map { CodableWebSocketConnection(from: $0) }
         self.graphQLInfo = transaction.graphQLInfo
             .map { CodableGraphQLInfo(from: $0) }
+        self.web3RPCInfo = transaction.web3RPCInfo
+            .map { CodableWeb3RPCInfo(from: $0) }
         self.sourcePort = transaction.sourcePort
         self.clientApp = transaction.clientApp
         self.comment = transaction.comment
@@ -85,6 +87,7 @@ struct CodableTransaction: Codable {
             CodableWebSocketConnection.self, forKey: .webSocketConnection
         )
         graphQLInfo = try container.decodeIfPresent(CodableGraphQLInfo.self, forKey: .graphQLInfo)
+        web3RPCInfo = try container.decodeIfPresent(CodableWeb3RPCInfo.self, forKey: .web3RPCInfo)
         sourcePort = try container.decodeIfPresent(UInt16.self, forKey: .sourcePort)
         clientApp = try container.decodeIfPresent(String.self, forKey: .clientApp)
         comment = try container.decodeIfPresent(String.self, forKey: .comment)
@@ -109,6 +112,7 @@ struct CodableTransaction: Codable {
         case timingInfo
         case webSocketConnection
         case graphQLInfo
+        case web3RPCInfo
         case sourcePort
         case clientApp
         case comment
@@ -130,6 +134,7 @@ struct CodableTransaction: Codable {
     let timingInfo: CodableTiming?
     let webSocketConnection: CodableWebSocketConnection?
     let graphQLInfo: CodableGraphQLInfo?
+    let web3RPCInfo: CodableWeb3RPCInfo?
     let sourcePort: UInt16?
     let clientApp: String?
     let comment: String?
@@ -151,7 +156,8 @@ struct CodableTransaction: Codable {
             state: TransactionState(rawValue: state) ?? .pending,
             timingInfo: timingInfo?.toLiveModel(),
             webSocketConnection: webSocketConnection?.toLiveModel(),
-            graphQLInfo: graphQLInfo?.toLiveModel()
+            graphQLInfo: graphQLInfo?.toLiveModel(),
+            web3RPCInfo: web3RPCInfo?.toLiveModel()
         )
         transaction.clientApp = clientApp
         transaction.sourcePort = sourcePort
@@ -381,6 +387,126 @@ struct CodableGraphQLInfo: Codable {
             query: query,
             variables: variables
         )
+    }
+}
+
+// MARK: - CodableWeb3RPCInfo
+
+struct CodableWeb3RPCInfo: Codable {
+    // MARK: Lifecycle
+
+    init(from info: Web3RPCInfo) {
+        self.family = info.family.rawValue
+        self.providerHost = info.providerHost
+        self.method = info.method
+        self.requestID = info.requestID
+        self.batch = info.batch.map { CodableWeb3RPCBatchSummary(from: $0) }
+        self.error = info.error.map { CodableWeb3RPCError(from: $0) }
+        self.chainHint = info.chainHint.map { CodableWeb3RPCChainHint(from: $0) }
+        self.transactionHash = info.transactionHash
+        self.blockIdentifier = info.blockIdentifier
+        self.requestPayloadSize = info.requestPayloadSize
+        self.responsePayloadSize = info.responsePayloadSize
+    }
+
+    // MARK: Internal
+
+    let family: String
+    let providerHost: String
+    let method: String?
+    let requestID: String?
+    let batch: CodableWeb3RPCBatchSummary?
+    let error: CodableWeb3RPCError?
+    let chainHint: CodableWeb3RPCChainHint?
+    let transactionHash: String?
+    let blockIdentifier: String?
+    let requestPayloadSize: Int?
+    let responsePayloadSize: Int?
+
+    func toLiveModel() -> Web3RPCInfo {
+        Web3RPCInfo(
+            family: Web3RPCFamily(rawValue: family) ?? .evm,
+            providerHost: providerHost,
+            method: method,
+            requestID: requestID,
+            batch: batch?.toLiveModel(),
+            error: error?.toLiveModel(),
+            chainHint: chainHint?.toLiveModel(),
+            transactionHash: transactionHash,
+            blockIdentifier: blockIdentifier,
+            requestPayloadSize: requestPayloadSize,
+            responsePayloadSize: responsePayloadSize
+        )
+    }
+}
+
+// MARK: - CodableWeb3RPCBatchSummary
+
+struct CodableWeb3RPCBatchSummary: Codable {
+    // MARK: Lifecycle
+
+    init(from summary: Web3RPCBatchSummary) {
+        self.requestCount = summary.requestCount
+        self.web3RequestCount = summary.web3RequestCount
+        self.responseCount = summary.responseCount
+        self.errorCount = summary.errorCount
+        self.methods = summary.methods
+    }
+
+    // MARK: Internal
+
+    let requestCount: Int
+    let web3RequestCount: Int
+    let responseCount: Int?
+    let errorCount: Int
+    let methods: [String]
+
+    func toLiveModel() -> Web3RPCBatchSummary {
+        Web3RPCBatchSummary(
+            requestCount: requestCount,
+            web3RequestCount: web3RequestCount,
+            responseCount: responseCount,
+            errorCount: errorCount,
+            methods: methods
+        )
+    }
+}
+
+// MARK: - CodableWeb3RPCError
+
+struct CodableWeb3RPCError: Codable {
+    // MARK: Lifecycle
+
+    init(from error: Web3RPCError) {
+        self.code = error.code
+        self.message = error.message
+    }
+
+    // MARK: Internal
+
+    let code: Int?
+    let message: String?
+
+    func toLiveModel() -> Web3RPCError {
+        Web3RPCError(code: code, message: message)
+    }
+}
+
+// MARK: - CodableWeb3RPCChainHint
+
+struct CodableWeb3RPCChainHint: Codable {
+    // MARK: Lifecycle
+
+    init(from hint: Web3RPCChainHint) {
+        self.chainID = hint.chainID
+    }
+
+    // MARK: Internal
+
+    let chainID: String?
+
+    func toLiveModel() -> Web3RPCChainHint {
+        Web3RPCChainHint(chainID: chainID)
     }
 }
 

--- a/Rockxy/Models/Network/Web3RPCInfo.swift
+++ b/Rockxy/Models/Network/Web3RPCInfo.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+// MARK: - Web3RPCInfo
+
+/// Derived Web3 JSON-RPC metadata extracted from visible HTTP request and response bodies.
+struct Web3RPCInfo: Equatable, Sendable {
+    let family: Web3RPCFamily
+    let providerHost: String
+    let method: String?
+    let requestID: String?
+    let batch: Web3RPCBatchSummary?
+    let error: Web3RPCError?
+    let chainHint: Web3RPCChainHint?
+    let transactionHash: String?
+    let blockIdentifier: String?
+    let requestPayloadSize: Int?
+    let responsePayloadSize: Int?
+}
+
+// MARK: - Web3RPCFamily
+
+enum Web3RPCFamily: String, Equatable, Sendable {
+    case evm
+    case solana
+}
+
+// MARK: - Web3RPCBatchSummary
+
+struct Web3RPCBatchSummary: Equatable, Sendable {
+    let requestCount: Int
+    let web3RequestCount: Int
+    let responseCount: Int?
+    let errorCount: Int
+    let methods: [String]
+}
+
+// MARK: - Web3RPCError
+
+struct Web3RPCError: Equatable, Sendable {
+    let code: Int?
+    let message: String?
+}
+
+// MARK: - Web3RPCChainHint
+
+struct Web3RPCChainHint: Equatable, Sendable {
+    let chainID: String?
+}

--- a/Rockxy/Models/UI/ProtocolFilter.swift
+++ b/Rockxy/Models/UI/ProtocolFilter.swift
@@ -8,6 +8,7 @@ enum ProtocolFilter: String, CaseIterable, Hashable {
     case http
     case https
     case websocket
+    case web3RPC
     case json
     case xml
     case js
@@ -28,7 +29,7 @@ enum ProtocolFilter: String, CaseIterable, Hashable {
     // MARK: Internal
 
     static var contentFilters: [ProtocolFilter] {
-        [.all, .http, .https, .websocket, .json, .xml, .js, .css, .graphql, .grpc, .document, .media, .form, .font, .other]
+        [.all, .http, .https, .websocket, .web3RPC, .json, .xml, .js, .css, .graphql, .grpc, .document, .media, .form, .font, .other]
     }
 
     static var statusFilters: [ProtocolFilter] {
@@ -41,6 +42,7 @@ enum ProtocolFilter: String, CaseIterable, Hashable {
         case .http: "HTTP"
         case .https: "HTTPS"
         case .websocket: "WebSocket"
+        case .web3RPC: "Web3/RPC"
         case .json: "JSON"
         case .xml: "XML"
         case .js: "JS"
@@ -83,6 +85,8 @@ enum ProtocolFilter: String, CaseIterable, Hashable {
             return transaction.request.url.scheme == "https"
         case .websocket:
             return transaction.webSocketConnection != nil
+        case .web3RPC:
+            return transaction.web3RPCInfo != nil
         case .json:
             return transaction.response?.contentType == .json || transaction.request.contentType == .json
         case .xml:

--- a/Rockxy/Models/UI/RequestListRow.swift
+++ b/Rockxy/Models/UI/RequestListRow.swift
@@ -9,7 +9,7 @@ import Foundation
 /// and enabling future `SessionStore`-backed windowed browsing.
 ///
 /// Supports all traffic classes that `HTTPTransaction` represents: plain HTTP, HTTPS,
-/// WebSocket, GraphQL, and TLS-failure transactions.
+/// WebSocket, GraphQL, Web3 JSON-RPC, and TLS-failure transactions.
 struct RequestListRow: Identifiable {
     enum SSLState: Int {
         case insecure
@@ -44,6 +44,10 @@ struct RequestListRow: Identifiable {
         aiTrafficSignal = AITrafficDetector.signal(transaction: transaction)
         graphQLOpName = transaction.graphQLInfo?.operationName
         graphQLOpType = transaction.graphQLInfo?.operationType.rawValue
+        isWeb3RPC = transaction.web3RPCInfo != nil
+        web3RPCMethod = Self.web3RPCMethodDescription(transaction.web3RPCInfo)
+        web3RPCProviderHost = transaction.web3RPCInfo?.providerHost
+        web3RPCErrorCode = transaction.web3RPCInfo?.error?.code
         isWebSocket = transaction.webSocketConnection != nil
         webSocketFrameCount = transaction.webSocketConnection?.frameCount ?? 0
         sourcePort = transaction.sourcePort
@@ -79,6 +83,10 @@ struct RequestListRow: Identifiable {
     let aiTrafficSignal: AITrafficSignal
     let graphQLOpName: String?
     let graphQLOpType: String?
+    let isWeb3RPC: Bool
+    let web3RPCMethod: String?
+    let web3RPCProviderHost: String?
+    let web3RPCErrorCode: Int?
     let isWebSocket: Bool
     let webSocketFrameCount: Int
     let sourcePort: UInt16?
@@ -193,9 +201,32 @@ extension RequestListRow {
         if lhs.isWebSocket, rhs.isWebSocket {
             return compareInt(lhs.webSocketFrameCount, rhs.webSocketFrameCount)
         }
-        let lhsDisplay = lhs.isWebSocket ? "\(lhs.webSocketFrameCount)" : (lhs.graphQLOpName ?? "")
-        let rhsDisplay = rhs.isWebSocket ? "\(rhs.webSocketFrameCount)" : (rhs.graphQLOpName ?? "")
+        let lhsDisplay = operationDisplayName(for: lhs)
+        let rhsDisplay = operationDisplayName(for: rhs)
         return lhsDisplay.localizedCompare(rhsDisplay)
+    }
+
+    private static func operationDisplayName(for row: RequestListRow) -> String {
+        if row.isWebSocket {
+            return "\(row.webSocketFrameCount)"
+        }
+        return row.web3RPCMethod ?? row.graphQLOpName ?? ""
+    }
+
+    private static func web3RPCMethodDescription(_ info: Web3RPCInfo?) -> String? {
+        guard let info else {
+            return nil
+        }
+        if let method = info.method {
+            return method
+        }
+        guard let batch = info.batch else {
+            return nil
+        }
+        if let first = batch.methods.first {
+            return batch.methods.count > 1 ? "\(first) + \(batch.methods.count - 1)" : first
+        }
+        return "\(batch.web3RequestCount) calls"
     }
 
     private static func compareInt(_ lhs: Int, _ rhs: Int) -> ComparisonResult {

--- a/Rockxy/Views/Inspector/ResponseInspectorView.swift
+++ b/Rockxy/Views/Inspector/ResponseInspectorView.swift
@@ -51,7 +51,7 @@ struct ResponseInspectorView: View {
     @Environment(\.appUIDisplayMetrics) private var metrics
 
     private var hasProtocolTab: Bool {
-        transaction.webSocketConnection != nil || transaction.graphQLInfo != nil
+        transaction.webSocketConnection != nil || transaction.web3RPCInfo != nil || transaction.graphQLInfo != nil
     }
 
     private var httpsPromptModel: HTTPSInspectionPromptModel? {
@@ -135,6 +135,17 @@ struct ResponseInspectorView: View {
             ) {
                 selectionIntent = .protocolSpecific
                 protocolTab = .websocket
+                selectedPreviewTab = nil
+            }
+        }
+
+        if transaction.web3RPCInfo != nil {
+            InspectorTabButton(
+                title: String(localized: "Web3/RPC"),
+                isActive: protocolTab == .web3
+            ) {
+                selectionIntent = .protocolSpecific
+                protocolTab = .web3
                 selectedPreviewTab = nil
             }
         }
@@ -306,6 +317,8 @@ struct ResponseInspectorView: View {
                 switch proto {
                 case .websocket:
                     WebSocketInspectorView(transaction: transaction)
+                case .web3:
+                    Web3RPCInspectorView(transaction: transaction)
                 case .graphql:
                     GraphQLInspectorView(transaction: transaction)
                 case .grpc:
@@ -797,6 +810,7 @@ struct HTTPSInspectionPromptModel: Equatable {
 /// Separate from ResponseInspectorTab to avoid showing protocol tabs for all transactions.
 enum ProtocolTabKind {
     case websocket
+    case web3
     case graphql
     case grpc
 
@@ -806,6 +820,9 @@ enum ProtocolTabKind {
     static func defaultFor(_ transaction: HTTPTransaction) -> ProtocolTabKind? {
         if transaction.webSocketConnection != nil {
             return .websocket
+        }
+        if transaction.web3RPCInfo != nil {
+            return .web3
         }
         if transaction.graphQLInfo != nil {
             return .graphql
@@ -820,6 +837,8 @@ enum ProtocolTabKind {
         switch tab {
         case .websocket:
             transaction.webSocketConnection != nil
+        case .web3:
+            transaction.web3RPCInfo != nil
         case .graphql:
             transaction.graphQLInfo != nil
         case .grpc:

--- a/Rockxy/Views/Inspector/Web3RPCInspectorView.swift
+++ b/Rockxy/Views/Inspector/Web3RPCInspectorView.swift
@@ -1,0 +1,355 @@
+import SwiftUI
+
+// MARK: - Web3RPCInspectorView
+
+/// Displays bounded Web3 JSON-RPC metadata extracted from visible HTTP request and response bodies.
+struct Web3RPCInspectorView: View {
+    // MARK: Internal
+
+    let transaction: HTTPTransaction
+
+    var body: some View {
+        if let info = transaction.web3RPCInfo {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 12) {
+                    callSummary(info)
+                    metadataGrid(info)
+                    batchSummary(info.batch)
+                    errorStrip(info.error)
+                }
+                .padding(12)
+                .frame(maxWidth: .infinity, alignment: .topLeading)
+            }
+            .background(Color(nsColor: .textBackgroundColor))
+        } else {
+            InspectorEmptyStateView(
+                String(localized: "No Web3 RPC Data"),
+                systemImage: "network",
+                description: String(localized: "This transaction does not include Web3 JSON-RPC metadata.")
+            )
+        }
+    }
+
+    // MARK: Private
+
+    @Environment(\.appUIDisplayMetrics) private var metrics
+
+    private func callSummary(_ info: Web3RPCInfo) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 6) {
+                badge(String(localized: "Web3 JSON-RPC"), color: .purple)
+                badge(info.family.displayName, color: .blue)
+                if let statusCode = transaction.response?.statusCode {
+                    badge(String(localized: "HTTP \(statusCode)"), color: statusCode < 400 ? .green : .red)
+                }
+                if let error = info.error {
+                    badge(error.code.map { String(localized: "RPC \($0)") } ?? String(localized: "RPC Error"), color: .red)
+                }
+                Spacer(minLength: 0)
+            }
+
+            VStack(alignment: .leading, spacing: 3) {
+                Text(String(localized: "Method"))
+                    .font(.system(size: metrics.metadataFontSize, weight: .medium))
+                    .foregroundStyle(.secondary)
+                Text(info.method ?? batchMethodSummary(info.batch))
+                    .font(.system(size: metrics.primaryFontSize, weight: .semibold, design: .monospaced))
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                    .textSelection(.enabled)
+            }
+
+            LazyVGrid(columns: summaryColumns, alignment: .leading, spacing: 8) {
+                metric(String(localized: "Provider"), value: info.providerHost, color: .primary)
+                metric(String(localized: "Request ID"), value: info.requestID ?? String(localized: "Batch"), color: .primary)
+                metric(String(localized: "Chain"), value: info.chainHint?.chainID ?? String(localized: "Unknown"), color: .primary)
+                metric(String(localized: "Payload"), value: payloadSummary(info), color: .primary)
+            }
+        }
+        .padding(12)
+        .background(Color(nsColor: .controlBackgroundColor).opacity(0.55))
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+        .overlay {
+            RoundedRectangle(cornerRadius: 8)
+                .stroke(Color(nsColor: .separatorColor), lineWidth: 0.5)
+        }
+    }
+
+    private var summaryColumns: [GridItem] {
+        [
+            GridItem(.adaptive(minimum: 140), spacing: 8, alignment: .leading),
+        ]
+    }
+
+    private func metadataGrid(_ info: Web3RPCInfo) -> some View {
+        ViewThatFits(in: .horizontal) {
+            HStack(alignment: .top, spacing: 12) {
+                callSection(info)
+                resultSection(info)
+            }
+            VStack(alignment: .leading, spacing: 12) {
+                callSection(info)
+                resultSection(info)
+            }
+        }
+    }
+
+    private func callSection(_ info: Web3RPCInfo) -> some View {
+        section(String(localized: "Call")) {
+            metadataRow(String(localized: "Family"), value: info.family.longDisplayName)
+            metadataRow(String(localized: "Method"), value: info.method ?? batchMethodSummary(info.batch))
+            metadataRow(String(localized: "Provider"), value: info.providerHost)
+            metadataRow(String(localized: "Request"), value: sizeText(info.requestPayloadSize))
+        }
+    }
+
+    private func resultSection(_ info: Web3RPCInfo) -> some View {
+        section(String(localized: "Result")) {
+            metadataRow(String(localized: "Status"), value: statusText(info), color: info.error == nil ? .green : .red)
+            metadataRow(String(localized: "Response"), value: sizeText(info.responsePayloadSize))
+            metadataRow(String(localized: "Block Hint"), value: info.blockIdentifier ?? String(localized: "Not captured"))
+            metadataRow(String(localized: "Tx Hash"), value: info.transactionHash ?? String(localized: "Not returned"))
+        }
+    }
+
+    @ViewBuilder
+    private func batchSummary(_ batch: Web3RPCBatchSummary?) -> some View {
+        if let batch {
+            section(String(localized: "Batch Calls"), badgeText: String(localized: "\(batch.web3RequestCount) calls")) {
+                VStack(spacing: 0) {
+                    batchHeaderRow
+                    Divider()
+                    batchMetricRow(
+                        String(localized: "Requests"),
+                        value: "\(batch.requestCount)",
+                        detail: String(localized: "\(batch.web3RequestCount) Web3 methods")
+                    )
+                    Divider()
+                    batchMetricRow(
+                        String(localized: "Responses"),
+                        value: batch.responseCount.map(String.init) ?? String(localized: "Not captured"),
+                        detail: batch.errorCount == 0 ? String(localized: "No RPC errors") : String(localized: "\(batch.errorCount) RPC errors")
+                    )
+                    if !batch.methods.isEmpty {
+                        Divider()
+                        batchMetricRow(
+                            String(localized: "Methods"),
+                            value: batch.methods.joined(separator: ", "),
+                            detail: batch.methods.count >= 6 ? String(localized: "First 6 shown") : String(localized: "Detected")
+                        )
+                    }
+                }
+                .background(Color(nsColor: .textBackgroundColor))
+                .clipShape(RoundedRectangle(cornerRadius: 6))
+                .overlay {
+                    RoundedRectangle(cornerRadius: 6)
+                        .stroke(Color(nsColor: .separatorColor), lineWidth: 0.5)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func errorStrip(_ error: Web3RPCError?) -> some View {
+        if let error {
+            HStack(alignment: .top, spacing: 10) {
+                badge(error.code.map { String(localized: "RPC \($0)") } ?? String(localized: "RPC Error"), color: .red)
+                Text(error.message ?? String(localized: "Provider returned a JSON-RPC error."))
+                    .font(.system(size: metrics.secondaryFontSize, weight: .medium))
+                    .foregroundStyle(.red)
+                    .fixedSize(horizontal: false, vertical: true)
+                Spacer(minLength: 0)
+            }
+            .padding(10)
+            .background(Color.red.opacity(0.10))
+            .clipShape(RoundedRectangle(cornerRadius: 8))
+            .overlay {
+                RoundedRectangle(cornerRadius: 8)
+                    .stroke(Color.red.opacity(0.35), lineWidth: 0.5)
+            }
+        }
+    }
+
+    private var batchHeaderRow: some View {
+        HStack(spacing: 0) {
+            headerCell(String(localized: "Field"), width: 112)
+            headerCell(String(localized: "Value"), width: nil)
+            headerCell(String(localized: "Detail"), width: 160)
+        }
+        .background(Color(nsColor: .controlBackgroundColor))
+    }
+
+    private func batchMetricRow(_ label: String, value: String, detail: String) -> some View {
+        HStack(spacing: 0) {
+            frameCell(label, width: 112, color: .secondary, monospaced: false)
+            frameCell(value, width: nil)
+            frameCell(detail, width: 160, color: .secondary, monospaced: false)
+        }
+    }
+
+    private func section<Content: View>(
+        _ title: String,
+        badgeText: String? = nil,
+        @ViewBuilder content: () -> Content
+    )
+        -> some View
+    {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack(spacing: 8) {
+                Text(title)
+                    .font(.system(size: metrics.primaryFontSize, weight: .semibold))
+                if let badgeText {
+                    badge(badgeText, color: .secondary)
+                }
+                Spacer(minLength: 0)
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 7)
+            .background(Color(nsColor: .controlBackgroundColor))
+
+            content()
+        }
+        .frame(maxWidth: .infinity, alignment: .topLeading)
+        .background(Color(nsColor: .textBackgroundColor))
+        .clipShape(RoundedRectangle(cornerRadius: 6))
+        .overlay {
+            RoundedRectangle(cornerRadius: 6)
+                .stroke(Color(nsColor: .separatorColor), lineWidth: 0.5)
+        }
+    }
+
+    private func metadataRow(_ label: String, value: String, color: Color = .primary) -> some View {
+        HStack(spacing: 0) {
+            Text(label)
+                .font(.system(size: metrics.metadataFontSize, weight: .semibold, design: .monospaced))
+                .foregroundStyle(.secondary)
+                .frame(width: 112, alignment: .leading)
+                .padding(.horizontal, 8)
+                .padding(.vertical, 6)
+            Divider()
+            Text(value)
+                .font(.system(size: metrics.metadataFontSize, design: .monospaced))
+                .foregroundStyle(color)
+                .lineLimit(1)
+                .truncationMode(.middle)
+                .textSelection(.enabled)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, 8)
+                .padding(.vertical, 6)
+        }
+    }
+
+    private func headerCell(_ text: String, width: CGFloat?) -> some View {
+        Text(text)
+            .font(.system(size: metrics.metadataFontSize, weight: .semibold))
+            .foregroundStyle(.secondary)
+            .frame(width: width, alignment: .leading)
+            .frame(maxWidth: width == nil ? .infinity : nil, alignment: .leading)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 6)
+    }
+
+    private func frameCell(
+        _ text: String,
+        width: CGFloat?,
+        color: Color = .primary,
+        monospaced: Bool = true
+    )
+        -> some View
+    {
+        Text(text)
+            .font(.system(size: metrics.metadataFontSize, design: monospaced ? .monospaced : .default))
+            .foregroundStyle(color)
+            .lineLimit(1)
+            .truncationMode(.middle)
+            .frame(width: width, alignment: .leading)
+            .frame(maxWidth: width == nil ? .infinity : nil, alignment: .leading)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 6)
+    }
+
+    private func badge(_ text: String, color: Color) -> some View {
+        Text(text)
+            .font(.system(size: metrics.badgeFontSize, weight: .semibold))
+            .lineLimit(1)
+            .padding(.horizontal, 7)
+            .padding(.vertical, 3)
+            .background(color.opacity(0.12), in: Capsule())
+            .foregroundStyle(color)
+    }
+
+    private func metric(_ label: String, value: String, color: Color) -> some View {
+        VStack(alignment: .leading, spacing: 3) {
+            Text(label)
+                .font(.system(size: metrics.badgeFontSize, weight: .medium))
+                .foregroundStyle(.tertiary)
+            Text(value)
+                .font(.system(size: metrics.secondaryFontSize, weight: .medium, design: .monospaced))
+                .foregroundStyle(color)
+                .lineLimit(1)
+                .truncationMode(.middle)
+                .textSelection(.enabled)
+        }
+        .padding(.horizontal, 9)
+        .padding(.vertical, 7)
+        .background(Color(nsColor: .textBackgroundColor), in: RoundedRectangle(cornerRadius: 6))
+        .overlay {
+            RoundedRectangle(cornerRadius: 6)
+                .stroke(Color(nsColor: .separatorColor), lineWidth: 0.5)
+        }
+    }
+
+    private func batchMethodSummary(_ batch: Web3RPCBatchSummary?) -> String {
+        guard let batch else {
+            return String(localized: "Unknown method")
+        }
+        if let first = batch.methods.first {
+            return batch.methods.count > 1 ? String(localized: "\(first) + \(batch.methods.count - 1)") : first
+        }
+        return String(localized: "\(batch.web3RequestCount) calls")
+    }
+
+    private func payloadSummary(_ info: Web3RPCInfo) -> String {
+        switch (info.requestPayloadSize, info.responsePayloadSize) {
+        case let (.some(request), .some(response)):
+            "\(SizeFormatter.format(bytes: request)) / \(SizeFormatter.format(bytes: response))"
+        case let (.some(request), .none):
+            SizeFormatter.format(bytes: request)
+        case let (.none, .some(response)):
+            SizeFormatter.format(bytes: response)
+        case (.none, .none):
+            String(localized: "Unknown")
+        }
+    }
+
+    private func sizeText(_ bytes: Int?) -> String {
+        bytes.map(SizeFormatter.format(bytes:)) ?? String(localized: "Not captured")
+    }
+
+    private func statusText(_ info: Web3RPCInfo) -> String {
+        if info.error != nil {
+            return String(localized: "RPC error")
+        }
+        return String(localized: "Success")
+    }
+}
+
+private extension Web3RPCFamily {
+    var displayName: String {
+        switch self {
+        case .evm:
+            "EVM"
+        case .solana:
+            "Solana"
+        }
+    }
+
+    var longDisplayName: String {
+        switch self {
+        case .evm:
+            "EVM JSON-RPC"
+        case .solana:
+            "Solana JSON-RPC"
+        }
+    }
+}

--- a/Rockxy/Views/RequestList/RequestTableView.swift
+++ b/Rockxy/Views/RequestList/RequestTableView.swift
@@ -214,7 +214,7 @@ struct RequestTableView: NSViewRepresentable {
             ColumnSpec(id: "requestSize", title: String(localized: "Request"), width: 78, minWidth: 60),
             ColumnSpec(id: "responseSize", title: String(localized: "Response"), width: 78, minWidth: 60),
             ColumnSpec(id: "ssl", title: String(localized: "SSL"), width: 38, minWidth: 32),
-            ColumnSpec(id: "queryName", title: String(localized: "Query Name"), width: 100, minWidth: 60),
+            ColumnSpec(id: "queryName", title: String(localized: "Operation"), width: 110, minWidth: 70),
         ]
 
         return specs.map { spec in
@@ -685,10 +685,12 @@ extension RequestTableView {
                     text = rowData.responseSize.map { SizeFormatter.format(bytes: $0) } ?? "—"
                     font = .monospacedDigitSystemFont(ofSize: metrics.secondaryFontSize, weight: .regular)
                 case "queryName":
-                    // Unified display: WS rows show frame count, others show GraphQL op name
+                    // Unified display: WS rows show frame count, Web3 rows show RPC method, GraphQL rows show operation name.
                     if rowData.isWebSocket {
                         let count = rowData.webSocketFrameCount
                         text = "\(count) \(count == 1 ? "frame" : "frames")"
+                    } else if rowData.isWeb3RPC {
+                        text = rowData.web3RPCMethod ?? ""
                     } else {
                         text = rowData.graphQLOpName ?? ""
                     }
@@ -1540,7 +1542,7 @@ extension RequestTableView {
                 ("requestSize", String(localized: "Request")),
                 ("responseSize", String(localized: "Response")),
                 ("ssl", String(localized: "SSL")),
-                ("queryName", String(localized: "Query Name")),
+                ("queryName", String(localized: "Operation")),
             ]
 
             for col in builtInColumns {
@@ -2206,9 +2208,15 @@ extension RequestTableView {
                     let count = rowData.webSocketFrameCount
                     cell.stringValue = "\(count) \(count == 1 ? "frame" : "frames")"
                     cell.textColor = .tertiaryLabelColor
+                    cell.toolTip = nil
+                } else if rowData.isWeb3RPC {
+                    cell.stringValue = rowData.web3RPCMethod ?? ""
+                    cell.textColor = rowData.web3RPCErrorCode == nil ? .secondaryLabelColor : .systemRed
+                    cell.toolTip = rowData.web3RPCProviderHost
                 } else {
                     cell.stringValue = rowData.graphQLOpName ?? ""
                     cell.textColor = .secondaryLabelColor
+                    cell.toolTip = nil
                 }
 
             default:

--- a/RockxyTests/Core/Detection/DetectionTests.swift
+++ b/RockxyTests/Core/Detection/DetectionTests.swift
@@ -239,4 +239,225 @@ struct DetectionTests {
         #expect(frame.status == .truncatedPayload(expectedBytes: 4, actualBytes: 1))
         #expect(frame.heuristicTree == nil)
     }
+
+    // MARK: - Web3RPCDetector Tests
+
+    @Test("Web3RPCDetector detects eth_call metadata")
+    func detectWeb3EthCall() throws {
+        let request = try web3Request(
+            body: [
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "eth_call",
+                "params": [
+                    ["to": "0x1111111111111111111111111111111111111111", "data": "0x70a08231"],
+                    "latest",
+                ],
+            ]
+        )
+        let response = try web3Response(body: ["jsonrpc": "2.0", "id": 1, "result": "0x0"])
+
+        let info = try #require(Web3RPCDetector.detect(request: request, response: response))
+
+        #expect(info.family == .evm)
+        #expect(info.providerHost == "mainnet.infura.io")
+        #expect(info.method == "eth_call")
+        #expect(info.requestID == "1")
+        #expect(info.blockIdentifier == "latest")
+        #expect(info.requestPayloadSize == request.body?.count)
+        #expect(info.responsePayloadSize == response.body?.count)
+    }
+
+    @Test("Web3RPCDetector detects eth_estimateGas")
+    func detectWeb3EthEstimateGas() throws {
+        let request = try web3Request(
+            body: [
+                "jsonrpc": "2.0",
+                "id": "gas-1",
+                "method": "eth_estimateGas",
+                "params": [
+                    ["from": "0x2222222222222222222222222222222222222222", "to": "0x3333333333333333333333333333333333333333"],
+                    "pending",
+                ],
+            ]
+        )
+
+        let info = try #require(Web3RPCDetector.detect(request: request))
+
+        #expect(info.method == "eth_estimateGas")
+        #expect(info.requestID == "gas-1")
+        #expect(info.blockIdentifier == "pending")
+    }
+
+    @Test("Web3RPCDetector extracts eth_sendRawTransaction hash")
+    func detectWeb3EthSendRawTransaction() throws {
+        let txHash = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        let request = try web3Request(
+            body: [
+                "jsonrpc": "2.0",
+                "id": 7,
+                "method": "eth_sendRawTransaction",
+                "params": ["0xf86c808504a817c80082520894"],
+            ]
+        )
+        let response = try web3Response(body: ["jsonrpc": "2.0", "id": 7, "result": txHash])
+
+        let info = try #require(Web3RPCDetector.detect(request: request, response: response))
+
+        #expect(info.method == "eth_sendRawTransaction")
+        #expect(info.transactionHash == txHash)
+    }
+
+    @Test("Web3RPCDetector extracts eth_getLogs block and transaction hash")
+    func detectWeb3EthGetLogs() throws {
+        let txHash = "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        let request = try web3Request(
+            body: [
+                "jsonrpc": "2.0",
+                "id": 12,
+                "method": "eth_getLogs",
+                "params": [
+                    [
+                        "address": "0x4444444444444444444444444444444444444444",
+                        "fromBlock": "0x10",
+                        "toBlock": "0x20",
+                    ],
+                ],
+            ]
+        )
+        let response = try web3Response(
+            body: [
+                "jsonrpc": "2.0",
+                "id": 12,
+                "result": [
+                    ["blockNumber": "0x12", "transactionHash": txHash],
+                ],
+            ]
+        )
+
+        let info = try #require(Web3RPCDetector.detect(request: request, response: response))
+
+        #expect(info.method == "eth_getLogs")
+        #expect(info.blockIdentifier == "0x10...0x20")
+        #expect(info.transactionHash == txHash)
+    }
+
+    @Test("Web3RPCDetector extracts eth_chainId result")
+    func detectWeb3EthChainID() throws {
+        let request = try web3Request(body: ["jsonrpc": "2.0", "id": 4, "method": "eth_chainId", "params": []])
+        let response = try web3Response(body: ["jsonrpc": "2.0", "id": 4, "result": "0x1"])
+
+        let info = try #require(Web3RPCDetector.detect(request: request, response: response))
+
+        #expect(info.method == "eth_chainId")
+        #expect(info.chainHint?.chainID == "0x1")
+    }
+
+    @Test("Web3RPCDetector summarizes batches")
+    func detectWeb3BatchSummary() throws {
+        let request = try web3Request(
+            body: [
+                ["jsonrpc": "2.0", "id": 1, "method": "eth_chainId", "params": []],
+                ["jsonrpc": "2.0", "id": 2, "method": "eth_blockNumber", "params": []],
+            ]
+        )
+        let response = try web3Response(
+            body: [
+                ["jsonrpc": "2.0", "id": 1, "result": "0x1"],
+                ["jsonrpc": "2.0", "id": 2, "error": ["code": -32_000, "message": "rate limited"]],
+            ]
+        )
+
+        let info = try #require(Web3RPCDetector.detect(request: request, response: response))
+        let batch = try #require(info.batch)
+
+        #expect(info.method == nil)
+        #expect(info.requestID == nil)
+        #expect(batch.requestCount == 2)
+        #expect(batch.web3RequestCount == 2)
+        #expect(batch.responseCount == 2)
+        #expect(batch.errorCount == 1)
+        #expect(batch.methods == ["eth_chainId", "eth_blockNumber"])
+    }
+
+    @Test("Web3RPCDetector extracts provider error")
+    func detectWeb3ProviderError() throws {
+        let request = try web3Request(body: ["jsonrpc": "2.0", "id": 9, "method": "eth_call", "params": []])
+        let response = try web3Response(
+            body: [
+                "jsonrpc": "2.0",
+                "id": 9,
+                "error": ["code": -32_602, "message": "invalid argument 0"],
+            ]
+        )
+
+        let info = try #require(Web3RPCDetector.detect(request: request, response: response))
+
+        #expect(info.error?.code == -32_602)
+        #expect(info.error?.message == "invalid argument 0")
+    }
+
+    @Test("Web3RPCDetector ignores malformed JSON")
+    func detectWeb3MalformedPayload() throws {
+        let request = try HTTPRequestData(
+            method: "POST",
+            url: #require(URL(string: "https://mainnet.infura.io/v3/test")),
+            httpVersion: "HTTP/1.1",
+            headers: [HTTPHeader(name: "Content-Type", value: "application/json")],
+            body: Data(#"{"jsonrpc":"2.0","method":"eth_call""#.utf8),
+            contentType: .json
+        )
+
+        #expect(Web3RPCDetector.detect(request: request) == nil)
+    }
+
+    @Test("Web3RPCDetector ignores non-RPC JSON")
+    func detectWeb3NonRPCJSON() throws {
+        let request = try web3Request(
+            body: [
+                "method": "search",
+                "query": "eth_call examples",
+                "filters": ["chain": "mainnet"],
+            ]
+        )
+
+        #expect(Web3RPCDetector.detect(request: request) == nil)
+    }
+
+    @Test("Web3RPCDetector detects Solana JSON-RPC")
+    func detectWeb3SolanaRPC() throws {
+        let request = try web3Request(
+            url: "https://api.mainnet-beta.solana.com",
+            body: ["jsonrpc": "2.0", "id": 1, "method": "getLatestBlockhash", "params": []]
+        )
+
+        let info = try #require(Web3RPCDetector.detect(request: request))
+
+        #expect(info.family == .solana)
+        #expect(info.method == "getLatestBlockhash")
+        #expect(info.providerHost == "api.mainnet-beta.solana.com")
+    }
+
+    private func web3Request(url: String = "https://mainnet.infura.io/v3/test", body: Any) throws -> HTTPRequestData {
+        let data = try JSONSerialization.data(withJSONObject: body)
+        return try HTTPRequestData(
+            method: "POST",
+            url: #require(URL(string: url)),
+            httpVersion: "HTTP/1.1",
+            headers: [HTTPHeader(name: "Content-Type", value: "application/json")],
+            body: data,
+            contentType: .json
+        )
+    }
+
+    private func web3Response(body: Any) throws -> HTTPResponseData {
+        let data = try JSONSerialization.data(withJSONObject: body)
+        return HTTPResponseData(
+            statusCode: 200,
+            statusMessage: "OK",
+            headers: [HTTPHeader(name: "Content-Type", value: "application/json")],
+            body: data,
+            contentType: .json
+        )
+    }
 }

--- a/RockxyTests/Core/Plugins/GistPublishPayloadBuilderTests.swift
+++ b/RockxyTests/Core/Plugins/GistPublishPayloadBuilderTests.swift
@@ -34,7 +34,7 @@ struct GistPublishPayloadBuilderTests {
                 HTTPHeader(name: "Content-Type", value: "application/json"),
             ]
         )
-        request.body = #"{"password":"secret","name":"Ada"}"#.data(using: .utf8)
+        request.body = Data(#"{"password":"secret","name":"Ada"}"#.utf8)
         request.contentType = .json
         let transaction = HTTPTransaction(request: request, state: .completed)
         transaction.response = TestFixtures.makeResponse(statusCode: 200)
@@ -50,6 +50,31 @@ struct GistPublishPayloadBuilderTests {
         #expect(!serialized.contains(#""password":"secret""#))
         #expect(transaction.request.headers.first?.value == "Bearer secret")
         #expect(transaction.request.url.absoluteString.contains("api_key=secret"))
+    }
+
+    @Test("Redacts Web3 RPC wallet secrets before publishing")
+    func redactsWeb3RPCSecrets() throws {
+        let requestBody = Data(
+            #"{"jsonrpc":"2.0","id":1,"method":"eth_sendRawTransaction","params":[{"privateKey":"0xsecret","seedPhrase":"twelve words","signature":"0xsig"}]}"#.utf8
+        )
+        let responseBody = Data(#"{"jsonrpc":"2.0","id":1,"result":"0xhash","signature":"0xresponsesig"}"#.utf8)
+        let transaction = TestFixtures.makeWeb3RPCTransaction(
+            method: "eth_sendRawTransaction",
+            requestBody: requestBody,
+            responseBody: responseBody
+        )
+
+        let payload = try GistPublishPayloadBuilder().build(
+            transactions: [transaction],
+            options: GistPublishOptions(redactSensitiveData: true)
+        )
+        let serialized = payload.files.values.joined(separator: "\n")
+
+        #expect(!serialized.contains("0xsecret"))
+        #expect(!serialized.contains("twelve words"))
+        #expect(!serialized.contains("0xsig"))
+        #expect(!serialized.contains("0xresponsesig"))
+        #expect(serialized.contains("[REDACTED]"))
     }
 
     @Test("Includes WebSocket frames only when selected transactions contain frames")

--- a/RockxyTests/Core/Plugins/SessionSerializerTests.swift
+++ b/RockxyTests/Core/Plugins/SessionSerializerTests.swift
@@ -141,6 +141,32 @@ struct SessionSerializerTests {
         #expect(gql?.query == "{ users { id } }")
     }
 
+    @Test("Round-trip preserves Web3 RPC info")
+    func roundTripWeb3RPC() throws {
+        let transaction = TestFixtures.makeWeb3RPCTransaction(
+            method: nil,
+            batch: Web3RPCBatchSummary(
+                requestCount: 2,
+                web3RequestCount: 2,
+                responseCount: 2,
+                errorCount: 1,
+                methods: ["eth_chainId", "eth_blockNumber"]
+            ),
+            error: Web3RPCError(code: -32_000, message: "rate limited")
+        )
+        let metadata = SessionSerializer.makeMetadata(transactionCount: 1)
+        let data = try SessionSerializer.serialize(transactions: [transaction], metadata: metadata)
+        let session = try SessionSerializer.deserialize(from: data)
+
+        let info = session.transactions[0].toLiveModel().web3RPCInfo
+        #expect(info?.family == .evm)
+        #expect(info?.providerHost == "rpc.example.com")
+        #expect(info?.requestID == nil)
+        #expect(info?.batch?.methods == ["eth_chainId", "eth_blockNumber"])
+        #expect(info?.error?.code == -32_000)
+        #expect(info?.chainHint?.chainID == "0x1")
+    }
+
     @Test("Round-trip preserves log entries")
     func roundTripLogEntries() throws {
         let transactions = [TestFixtures.makeTransaction()]

--- a/RockxyTests/Core/Utilities/RequestCopyFormatterTests.swift
+++ b/RockxyTests/Core/Utilities/RequestCopyFormatterTests.swift
@@ -4,8 +4,6 @@ import Testing
 
 // Regression tests for `RequestCopyFormatter` in the core utilities layer.
 
-// swiftlint:disable force_unwrapping
-
 struct RequestCopyFormatterTests {
     // MARK: - URL
 
@@ -130,6 +128,13 @@ struct RequestCopyFormatterTests {
         let transaction = TestFixtures.makeGraphQLTransaction(operationName: "FetchUsers")
         let result = RequestCopyFormatter.cellValue(for: transaction, column: "queryName")
         #expect(result == "FetchUsers")
+    }
+
+    @Test("cellValue returns Web3 RPC method for queryName column")
+    func cellValueWeb3RPCMethod() {
+        let transaction = TestFixtures.makeWeb3RPCTransaction(method: "eth_getLogs")
+        let result = RequestCopyFormatter.cellValue(for: transaction, column: "queryName")
+        #expect(result == "eth_getLogs")
     }
 
     // MARK: - Headers
@@ -426,5 +431,3 @@ struct RequestCopyFormatterTests {
         #expect(result.contains("api.example.com"))
     }
 }
-
-// swiftlint:enable force_unwrapping

--- a/RockxyTests/Helpers/TestFixtures.swift
+++ b/RockxyTests/Helpers/TestFixtures.swift
@@ -183,6 +183,53 @@ enum TestFixtures {
         return transaction
     }
 
+    static func makeWeb3RPCTransaction(
+        method: String? = "eth_blockNumber",
+        batch: Web3RPCBatchSummary? = nil,
+        error: Web3RPCError? = nil,
+        requestBody: Data? = Data(#"{"jsonrpc":"2.0","id":1,"method":"eth_blockNumber","params":[]}"#.utf8),
+        responseBody: Data? = Data(#"{"jsonrpc":"2.0","id":1,"result":"0x1"}"#.utf8)
+    )
+        -> HTTPTransaction
+    {
+        guard let url = URL(string: "https://rpc.example.com") else {
+            preconditionFailure("Expected valid Web3 RPC fixture URL")
+        }
+        let request = HTTPRequestData(
+            method: "POST",
+            url: url,
+            httpVersion: "HTTP/1.1",
+            headers: [HTTPHeader(name: "Content-Type", value: "application/json")],
+            body: requestBody,
+            contentType: .json
+        )
+        let response = HTTPResponseData(
+            statusCode: 200,
+            statusMessage: "OK",
+            headers: [HTTPHeader(name: "Content-Type", value: "application/json")],
+            body: responseBody,
+            contentType: .json
+        )
+        return HTTPTransaction(
+            request: request,
+            response: response,
+            state: .completed,
+            web3RPCInfo: Web3RPCInfo(
+                family: .evm,
+                providerHost: "rpc.example.com",
+                method: method,
+                requestID: batch == nil ? "1" : nil,
+                batch: batch,
+                error: error,
+                chainHint: Web3RPCChainHint(chainID: "0x1"),
+                transactionHash: nil,
+                blockIdentifier: nil,
+                requestPayloadSize: requestBody?.count,
+                responsePayloadSize: responseBody?.count
+            )
+        )
+    }
+
     static func makeGRPCTransaction(
         requestBody: Data? = grpcFrame(payload: Data([0x08, 0x96, 0x01])),
         responseBody: Data? = grpcFrame(payload: Data([0x12, 0x07]) + Data("Stephen".utf8))

--- a/RockxyTests/Models/UI/ProtocolFilterTests.swift
+++ b/RockxyTests/Models/UI/ProtocolFilterTests.swift
@@ -29,6 +29,13 @@ struct ProtocolFilterTests {
         #expect(ProtocolFilter.websocket.matches(transaction))
     }
 
+    @Test("Web3 RPC filter matches transaction with Web3 metadata")
+    func web3RPCMatches() {
+        let transaction = TestFixtures.makeWeb3RPCTransaction()
+        #expect(ProtocolFilter.web3RPC.matches(transaction))
+        #expect(!ProtocolFilter.graphql.matches(transaction))
+    }
+
     @Test("gRPC filter matches transaction with gRPC metadata")
     func grpcMatches() {
         let transaction = TestFixtures.makeGRPCTransaction()

--- a/RockxyTests/Models/UI/RequestListRowTests.swift
+++ b/RockxyTests/Models/UI/RequestListRowTests.swift
@@ -69,6 +69,28 @@ struct RequestListRowTests {
         #expect(row.webSocketFrameCount == 0)
     }
 
+    @Test("Extracts Web3 RPC fields correctly")
+    func web3RPCFields() {
+        let transaction = TestFixtures.makeWeb3RPCTransaction(
+            method: nil,
+            batch: Web3RPCBatchSummary(
+                requestCount: 2,
+                web3RequestCount: 2,
+                responseCount: 2,
+                errorCount: 1,
+                methods: ["eth_chainId", "eth_blockNumber"]
+            ),
+            error: Web3RPCError(code: -32_000, message: "rate limited")
+        )
+
+        let row = RequestListRow(from: transaction)
+
+        #expect(row.isWeb3RPC == true)
+        #expect(row.web3RPCMethod == "eth_chainId + 1")
+        #expect(row.web3RPCProviderHost == "rpc.example.com")
+        #expect(row.web3RPCErrorCode == -32_000)
+    }
+
     @Test("Extracts WebSocket fields correctly")
     func webSocketFields() {
         let transaction = TestFixtures.makeWebSocketTransaction()
@@ -322,6 +344,16 @@ struct RequestListRowTests {
         // Numeric: 2 < 10 (lexicographic would put "10" before "2")
         #expect(RequestListRow.compare(ws2, ws10, using: descriptors) == true)
         #expect(RequestListRow.compare(ws10, ws2, using: descriptors) == false)
+    }
+
+    @Test("Web3 RPC method participates in operation sort")
+    func web3RPCOperationSort() {
+        let call = RequestListRow(from: TestFixtures.makeWeb3RPCTransaction(method: "eth_call"))
+        let logs = RequestListRow(from: TestFixtures.makeWeb3RPCTransaction(method: "eth_getLogs"))
+        let descriptors = [NSSortDescriptor(key: "queryName", ascending: true)]
+
+        #expect(RequestListRow.compare(call, logs, using: descriptors) == true)
+        #expect(RequestListRow.compare(logs, call, using: descriptors) == false)
     }
 
     // MARK: - Sequence Number Display

--- a/RockxyTests/Views/Inspector/InspectorRoutingTests.swift
+++ b/RockxyTests/Views/Inspector/InspectorRoutingTests.swift
@@ -189,11 +189,36 @@ struct InspectorRoutingTests {
         #expect(ProtocolTabKind.isSupported(.grpc, by: tx))
     }
 
+    @Test("Web3 RPC metadata defaults to .web3 protocol tab")
+    func web3RPCMetadataDefaultsToWeb3Tab() {
+        let tx = makeWeb3RPCTransaction()
+        let tab = ProtocolTabKind.defaultFor(tx)
+
+        #expect(tab == .web3)
+        #expect(ProtocolTabKind.isSupported(.web3, by: tx))
+    }
+
     @Test("Plain HTTP transaction defaults to nil protocol tab")
     func httpDefaultsToNilTab() {
         let tx = TestFixtures.makeTransaction()
         let tab = ProtocolTabKind.defaultFor(tx)
         #expect(tab == nil)
+    }
+
+    @Test("JSON-RPC shaped HTTP without Web3 metadata defaults to nil protocol tab")
+    func jsonRPCWithoutWeb3MetadataDefaultsToNilTab() {
+        let tx = makeJSONRPCTransaction(
+            body: #"{"jsonrpc":"2.0","id":1,"method":"eth_blockNumber","params":[]}"#
+        )
+
+        #expect(ProtocolTabKind.defaultFor(tx) == nil)
+    }
+
+    @Test("Malformed JSON-RPC HTTP without Web3 metadata falls back to nil protocol tab")
+    func malformedJSONRPCWithoutWeb3MetadataDefaultsToNilTab() {
+        let tx = makeJSONRPCTransaction(body: #"{"jsonrpc":"2.0","method":"eth_sendRawTransaction""#)
+
+        #expect(ProtocolTabKind.defaultFor(tx) == nil)
     }
 
     @Test("Plain HTTP transaction still supports empty gRPC tab")
@@ -212,6 +237,42 @@ struct InspectorRoutingTests {
         #expect(protocolTab == .websocket)
 
         // Then select HTTP
+        protocolTab = ProtocolTabKind.defaultFor(httpTx)
+        #expect(protocolTab == nil)
+    }
+
+    @Test("Switching GraphQL → HTTP clears protocol tab")
+    func graphQLToHttpClearsProtocol() {
+        let gqlTx = TestFixtures.makeGraphQLTransaction()
+        let httpTx = TestFixtures.makeTransaction()
+
+        var protocolTab = ProtocolTabKind.defaultFor(gqlTx)
+        #expect(protocolTab == .graphql)
+
+        protocolTab = ProtocolTabKind.defaultFor(httpTx)
+        #expect(protocolTab == nil)
+    }
+
+    @Test("Switching gRPC → HTTP clears protocol tab")
+    func grpcToHttpClearsProtocol() {
+        let grpcTx = TestFixtures.makeGRPCTransaction()
+        let httpTx = TestFixtures.makeTransaction()
+
+        var protocolTab = ProtocolTabKind.defaultFor(grpcTx)
+        #expect(protocolTab == .grpc)
+
+        protocolTab = ProtocolTabKind.defaultFor(httpTx)
+        #expect(protocolTab == nil)
+    }
+
+    @Test("Switching Web3 RPC → HTTP clears protocol tab")
+    func web3RPCToHttpClearsProtocol() {
+        let web3Tx = makeWeb3RPCTransaction()
+        let httpTx = TestFixtures.makeTransaction()
+
+        var protocolTab = ProtocolTabKind.defaultFor(web3Tx)
+        #expect(protocolTab == .web3)
+
         protocolTab = ProtocolTabKind.defaultFor(httpTx)
         #expect(protocolTab == nil)
     }
@@ -254,6 +315,30 @@ struct InspectorRoutingTests {
 
         tab = ProtocolTabKind.defaultFor(gql)
         #expect(tab == .graphql)
+    }
+
+    @Test("Switching WebSocket → Web3 RPC transitions protocol tab correctly")
+    func wsToWeb3RPCTransition() {
+        let ws = TestFixtures.makeWebSocketTransaction()
+        let web3 = makeWeb3RPCTransaction()
+
+        var tab = ProtocolTabKind.defaultFor(ws)
+        #expect(tab == .websocket)
+
+        tab = ProtocolTabKind.defaultFor(web3)
+        #expect(tab == .web3)
+    }
+
+    @Test("Web3 RPC metadata is preferred before GraphQL metadata")
+    func web3RPCPreferredBeforeGraphQL() {
+        let tx = makeWeb3RPCTransaction(graphQLInfo: GraphQLInfo(
+            operationName: "Example",
+            operationType: .query,
+            query: "query Example { blockNumber }",
+            variables: nil
+        ))
+
+        #expect(ProtocolTabKind.defaultFor(tx) == .web3)
     }
 
     @Test("Switching GraphQL → gRPC transitions protocol tab correctly")
@@ -416,6 +501,68 @@ struct InspectorRoutingTests {
             }
         }
         return crc ^ 0xFFFF_FFFF
+    }
+
+    private func makeWeb3RPCTransaction(graphQLInfo: GraphQLInfo? = nil) -> HTTPTransaction {
+        guard let url = URL(string: "https://rpc.example.com") else {
+            preconditionFailure("Expected valid Web3 RPC fixture URL")
+        }
+        let request = HTTPRequestData(
+            method: "POST",
+            url: url,
+            httpVersion: "HTTP/1.1",
+            headers: [HTTPHeader(name: "Content-Type", value: "application/json")],
+            body: Data(#"{"jsonrpc":"2.0","id":1,"method":"eth_blockNumber","params":[]}"#.utf8),
+            contentType: .json
+        )
+        let response = HTTPResponseData(
+            statusCode: 200,
+            statusMessage: "OK",
+            headers: [HTTPHeader(name: "Content-Type", value: "application/json")],
+            body: Data(#"{"jsonrpc":"2.0","id":1,"result":"0x1"}"#.utf8),
+            contentType: .json
+        )
+        return HTTPTransaction(
+            request: request,
+            response: response,
+            state: .completed,
+            graphQLInfo: graphQLInfo,
+            web3RPCInfo: Web3RPCInfo(
+                family: .evm,
+                providerHost: "rpc.example.com",
+                method: "eth_blockNumber",
+                requestID: "1",
+                batch: nil,
+                error: nil,
+                chainHint: Web3RPCChainHint(chainID: "0x1"),
+                transactionHash: nil,
+                blockIdentifier: nil,
+                requestPayloadSize: request.body?.count,
+                responsePayloadSize: response.body?.count
+            )
+        )
+    }
+
+    private func makeJSONRPCTransaction(body: String?) -> HTTPTransaction {
+        guard let url = URL(string: "https://rpc.example.com") else {
+            preconditionFailure("Expected valid JSON-RPC fixture URL")
+        }
+        let request = HTTPRequestData(
+            method: "POST",
+            url: url,
+            httpVersion: "HTTP/1.1",
+            headers: [HTTPHeader(name: "Content-Type", value: "application/json")],
+            body: body.map { Data($0.utf8) },
+            contentType: .json
+        )
+        let response = HTTPResponseData(
+            statusCode: 200,
+            statusMessage: "OK",
+            headers: [HTTPHeader(name: "Content-Type", value: "application/json")],
+            body: Data(#"{"jsonrpc":"2.0","id":1,"result":"0x1"}"#.utf8),
+            contentType: .json
+        )
+        return HTTPTransaction(request: request, response: response, state: .completed)
     }
 
     @Test("CONNECT tunnel with existing SSL rule shows disable guidance")


### PR DESCRIPTION
## Summary

- Add bounded Web3 JSON-RPC metadata detection for visible HTTP request/response traffic, including common EVM and Solana methods, batches, provider errors, chain hints, transaction hashes, block hints, and payload sizes.
- Add a native conditional Web3/RPC response inspector tab for selected traffic while keeping the existing raw, JSON, headers, timing, WebSocket, GraphQL, and gRPC views available.
- Improve Community workflow discoverability with a Web3/RPC quick filter, request-list operation summaries, provider tooltips, copy-format support, and session round-trip persistence.
- Strengthen shared redaction for wallet-shaped fields such as private keys, seed or recovery phrases, mnemonics, and signatures before captured traffic is exported or published.

## User Impact

Users debugging Web3 applications can now find selected JSON-RPC calls quickly, understand the method/error/provider context without scanning raw JSON, and preserve that metadata safely in Rockxy sessions. The implementation remains local-first and keeps protocol metadata edition-neutral.

## Scope Notes

This PR covers selected-flow HTTP JSON-RPC detection and inspection. Broader WebSocket subscription summaries, advanced smart search syntax, replay helpers, flow grouping, and larger protocol-lens budget work remain tracked separately.

## Validation

- `swiftlint lint --strict Rockxy/Core/Detection/Web3RPCDetector.swift Rockxy/Views/Inspector/Web3RPCInspectorView.swift Rockxy/Models/UI/ProtocolFilter.swift Rockxy/Models/UI/RequestListRow.swift Rockxy/Views/RequestList/RequestTableView.swift Rockxy/Core/Utilities/RequestCopyFormatter.swift Rockxy/Core/Utilities/SensitiveDataRedactor.swift RockxyTests/Helpers/TestFixtures.swift RockxyTests/Core/Detection/DetectionTests.swift RockxyTests/Models/UI/ProtocolFilterTests.swift RockxyTests/Models/UI/RequestListRowTests.swift RockxyTests/Core/Utilities/RequestCopyFormatterTests.swift RockxyTests/Core/Plugins/SessionSerializerTests.swift RockxyTests/Core/Plugins/GistPublishPayloadBuilderTests.swift`
- `xcodebuild -project Rockxy.xcodeproj -scheme Rockxy -destination 'platform=macOS' -only-testing:RockxyTests/DetectionTests -only-testing:RockxyTests/InspectorRoutingTests -only-testing:RockxyTests/ProtocolFilterTests -only-testing:RockxyTests/RequestListRowTests -only-testing:RockxyTests/RequestCopyFormatterTests -only-testing:RockxyTests/SessionSerializerTests -only-testing:RockxyTests/GistPublishPayloadBuilderTests test`

Fixes #158
Refs #157, #159, #169, #177, #178, #179
