### PR TITLE
docs: align support links and React Native setup

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -22,7 +22,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           path-to-signatures: 'signatures/cla.json'
-          path-to-document: 'https://github.com/LocNguyenHuu/Rockxy/blob/main/CLA.md'
+          path-to-document: 'https://github.com/RockxyApp/Rockxy/blob/main/CLA.md'
           branch: 'main'
           allowlist: 'bot*,dependabot[bot],renovate[bot],github-actions[bot]'
           custom-pr-sign-comment: 'I have read the CLA Document and I hereby sign the CLA'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -254,7 +254,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
-- Developer Setup Hub now includes Flutter and React Native mobile setup flows, with licensed Android automation for supported workflows.
+- Developer Setup Hub now includes Flutter and React Native mobile setup flows with manual platform guidance, validation probes, and setup snippets for supported workflows.
 - Favorite request context menus now include richer actions, including opening favorites in new tabs.
 - Developer Setup Hub can now be opened directly from the toolbar.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ By participating in this project, you agree to abide by our [Code of Conduct](CO
 You'll need macOS 14.0+, Xcode 16+, [SwiftLint](https://github.com/realm/SwiftLint), and [SwiftFormat](https://github.com/nicklockwood/SwiftFormat).
 
 ```bash
-git clone https://github.com/LocNguyenHuu/Rockxy.git
+git clone https://github.com/RockxyApp/Rockxy.git
 cd Rockxy
 git checkout develop
 ```
@@ -85,7 +85,7 @@ docs/                  # Mintlify docs site
 
 ## Reporting Bugs
 
-Open a [GitHub issue](https://github.com/LocNguyenHuu/Rockxy/issues) with your macOS version, Rockxy version, and reproduction steps.
+Open a [GitHub issue](https://github.com/RockxyApp/Rockxy/issues) with your macOS version, Rockxy version, and reproduction steps.
 
 ## Contributor License Agreement
 

--- a/Rockxy/Views/Settings/PrivacySettingsTab.swift
+++ b/Rockxy/Views/Settings/PrivacySettingsTab.swift
@@ -111,7 +111,7 @@ struct PrivacySettingsTab: View {
             }
 
             Button(String(localized: "Privacy Policy")) {
-                if let url = URL(string: "https://github.com/LocNguyenHuu/Rockxy/wiki/Privacy") {
+                if let url = URL(string: "https://www.rockxy.io/privacy") {
                     NSWorkspace.shared.open(url)
                 }
             }

--- a/RockxyTests/ViewModels/DeveloperSetupFeatureNeutralityTests.swift
+++ b/RockxyTests/ViewModels/DeveloperSetupFeatureNeutralityTests.swift
@@ -40,6 +40,33 @@ struct DeveloperSetupFeatureNeutralityTests {
         #expect(violations.isEmpty, "Developer Setup files must stay free of packaging and entitlement language: \(violations)")
     }
 
+    @Test("Public React Native docs do not claim unsupported Android automation")
+    func publicReactNativeDocsStaySourceBacked() throws {
+        let root = try resolveProjectRoot()
+        let docs = [
+            root.appendingPathComponent("docs/setup-guides/react-native.mdx"),
+            root.appendingPathComponent("docs/getting-started/developer-setup-hub.mdx"),
+            root.appendingPathComponent("docs/index.mdx"),
+            root.appendingPathComponent("docs/troubleshooting/faq.mdx"),
+            root.appendingPathComponent("docs/changelog.mdx"),
+            root.appendingPathComponent("CHANGELOG.md"),
+        ]
+        let unsupportedClaims = [
+            "React Native Android automation",
+            "Pro automation exists for the React Native Android workflow",
+            "licensed Android automation",
+        ]
+
+        let violations = try docs.flatMap { url -> [String] in
+            let raw = try String(contentsOf: url, encoding: .utf8)
+            return unsupportedClaims.compactMap { claim in
+                raw.localizedCaseInsensitiveContains(claim) ? "\(url.lastPathComponent): \(claim)" : nil
+            }
+        }
+
+        #expect(violations.isEmpty, "React Native docs must match the shipped manual/hybrid implementation: \(violations)")
+    }
+
     // MARK: Private
 
     private enum ResolveError: Error, CustomStringConvertible {

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,7 +14,7 @@
 
 If you discover a security vulnerability in Rockxy, please report it responsibly through one of these channels:
 
-1. **GitHub Security Advisories** (preferred): Go to the [Security tab](https://github.com/LocNguyenHuu/Rockxy/security/advisories) and click "Report a vulnerability."
+1. **GitHub Security Advisories** (preferred): Go to the [Security tab](https://github.com/RockxyApp/Rockxy/security/advisories) and click "Report a vulnerability."
 2. **Email**: Send details to [rockxyapp@gmail.com](mailto:rockxyapp@gmail.com) with the subject line "Rockxy Security Report".
 
 ### What to include

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -259,7 +259,7 @@ rss: true
 <Update label="April 2026" description="v0.15.0">
   ### Added
 
-  - Developer Setup Hub now includes Flutter and React Native mobile setup flows, with licensed Android automation for supported workflows.
+  - Developer Setup Hub now includes Flutter and React Native mobile setup flows with manual platform guidance, validation probes, and setup snippets for supported workflows.
   - Favorite request context menus now include richer actions, including opening favorites in new tabs.
   - Developer Setup Hub can now be opened directly from the toolbar.
 

--- a/docs/getting-started/developer-setup-hub.mdx
+++ b/docs/getting-started/developer-setup-hub.mdx
@@ -166,13 +166,13 @@ Some targets are intentionally documented as guide-only because the platform sti
 
 That is not incomplete documentation. It is the product being explicit about where Rockxy helps and where the platform still requires manual work.
 
-## Rockxy Pro note
+## Product scope note
 
 Developer Setup Hub itself is not a Pro-only feature.
 
-The current paid addition in this area is the in-app **React Native Android Setup** automation workflow for supported Android targets. Without Pro, the manual setup path remains available.
+In the current public build, React Native is a manual/hybrid framework target: Rockxy provides platform guidance, a fetch validation probe, Android debug XML guidance, and Metro troubleshooting. Android setup for React Native remains manual in this build.
 
-For the full license breakdown, see [Pro Features](/features/pro-features) and [License Management](/features/license-management).
+For the current policy and roadmap breakdown, see [Pro Features](/features/pro-features).
 
 ## Why this matters for the docs IA
 
@@ -224,7 +224,7 @@ If Rockxy is already capturing the traffic you care about and you are past setup
     Follow the client-specific setup path for Firefox, Postman, Insomnia, and Paw.
   </Card>
   <Card title="Pro Features" icon="sparkles" href="/features/pro-features">
-    See where paid automation fits into the broader product.
+    See current Community caps and planned Pro extension points.
   </Card>
   <Card title="License Management" icon="key" href="/features/license-management">
     Review activation and updates coverage for paid features.

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -83,7 +83,7 @@ Use native session files when you want to preserve Rockxy-specific context, or H
     Connect Rockxy to Claude through a local MCP bridge.
   </Card>
   <Card title="Rockxy Pro" icon="key" href="/features/pro-features">
-    See what Pro unlocks today and where it adds value over Community.
+    See current Community caps and planned Pro extension points.
   </Card>
   <Card title="License Management" icon="id-card" href="/features/license-management">
     Understand perpetual licensing, updates coverage, activation, deactivation, and transfer.
@@ -96,7 +96,7 @@ Use native session files when you want to preserve Rockxy-specific context, or H
 - Inspect HTTPS traffic from apps, devices, and local runtimes
 - Replay, modify, compare, and export API traffic without leaving your machine
 - Local-first developer tooling with no account requirement
-- Optional Pro upgrade for unlimited caps, Advanced Diff, and React Native Android automation
+- App-policy capacity model with planned Pro extension points
 
 ## System Requirements
 

--- a/docs/setup-guides/react-native.mdx
+++ b/docs/setup-guides/react-native.mdx
@@ -10,7 +10,7 @@ React Native traffic still runs through the underlying iOS or Android network st
 ## Support in Rockxy
 
 - Manual setup available
-- Pro automation exists for the React Native Android workflow
+- Manual Android debug setup guidance available
 - Certificate sharing support available
 
 ## What Rockxy currently provides
@@ -27,6 +27,6 @@ React Native traffic still runs through the underlying iOS or Android network st
     Return to the frameworks hub.
   </Card>
   <Card title="Pro Features" icon="sparkles" href="/features/pro-features">
-    See how React Native Android automation fits into Rockxy Pro.
+    See current Community caps and planned Pro extension points.
   </Card>
 </CardGroup>

--- a/docs/troubleshooting/faq.mdx
+++ b/docs/troubleshooting/faq.mdx
@@ -25,9 +25,9 @@ Use replay when you want a fast resend. Use a breakpoint when you need to pause 
 
 Use HAR for cross-tool sharing. Use Rockxy's native session format when you want to preserve Rockxy-specific context and fidelity.
 
-## What does Rockxy Pro include today?
+## What does the current open-source build include today?
 
-Rockxy Pro currently unlocks unlimited usage caps, Advanced Diff, and the React Native Android automation workflow in Developer Setup Hub. Community keeps the core capture, inspection, replay, rules, sessions, and manual setup flows.
+The current open-source build includes core capture, inspection, replay, rules, sessions, manual setup flows, runtime-oriented automatic setup, and the DefaultAppPolicy capacity caps documented in [Pro Features](/features/pro-features). React Native is currently manual/hybrid setup with a fetch probe, Android debug XML guidance, and Metro troubleshooting.
 
 ## What does a perpetual Rockxy Pro license mean?
 


### PR DESCRIPTION
## Summary

- Retarget stale repository, security advisory, and CLA links to `RockxyApp/Rockxy`.
- Update the in-app Privacy Policy button to the live `https://www.rockxy.io/privacy` page.
- Align React Native public docs with the shipped manual/hybrid Developer Setup implementation.
- Add regression coverage that prevents unsupported React Native Android automation claims from returning to public docs.

## Notes

This is a maintainer-owned replacement for the closed external PRs #106 and #128. Those PRs were closed because the required contribution checks were incomplete, so the fixes were reimplemented directly from the current source and issue requirements.

## Validation

- `rg -n "github.com/LocNguyenHuu/Rockxy|wiki/Privacy|Pro automation exists|licensed Android automation|React Native Android automation" README.md CONTRIBUTING.md CLA.md SECURITY.md .github Rockxy docs CHANGELOG.md`
- `git diff --check`
- `swiftlint lint --strict Rockxy/Views/Settings/PrivacySettingsTab.swift RockxyTests/ViewModels/DeveloperSetupFeatureNeutralityTests.swift`
- `xcodebuild -project Rockxy.xcodeproj -scheme Rockxy -destination 'platform=macOS' -only-testing:RockxyTests/DeveloperSetupFeatureNeutralityTests test`
- `curl -I -L https://www.rockxy.io/privacy`
- `curl -I -L https://github.com/RockxyApp/Rockxy/security/advisories`
- `curl -I -L https://github.com/RockxyApp/Rockxy/blob/main/CLA.md`

Fixes #8
Fixes #76
