### PR TITLE
Release protocol-aware AI and Web3 traffic inspection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Added AI traffic inspection for recognized model API traffic, including provider/model hints, streaming state, usage fields when present, tool-call summaries, retrieval hints, and warnings for unavailable fields.
+- Added Web3 JSON-RPC inspection for EVM and Solana-style HTTP RPC traffic, including provider host, request ID, method, batch summary, error, chain, transaction, payload, and debug-intent details.
+- Added x402-style payment-flow hints for payment-required and retry-oriented HTTP traffic.
+- Added a default Protocol column and protocol filters that make AI, Web3 RPC, gRPC, GraphQL, WebSocket, and HTTP traffic easier to scan in the request list.
 - Added a compact advanced filter builder with expanded request/response fields, AND/OR row connectors, saved presets, and inspector match highlighting for security/debugging workflows.
 - Added Upstream Proxy core support for routing outbound traffic through HTTP/HTTPS proxies, with Community caps for SOCKS5, authentication, and bypass-list size enforced by app policy.
 - Added WebSocket Protobuf heuristic decoding infrastructure for inspecting binary frame payloads without requiring schema uploads.
@@ -19,6 +23,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Improved sidebar grouping cleanup when selected domain/app groups disappear, keeping active filters and sidebar state aligned.
 
 ### Changed
+
+- Kept AI, Web3, and gRPC inspector tabs available at the end of the inspector tab row so protocol details are consistent with the existing Headers, Body, Set-Cookie, and Timeline workflow.
+- Clarified that existing rules and debugging tools still operate on URL, HTTP method, and headers rather than AI model names, tool calls, chain IDs, JSON-RPC methods, or batch subcalls.
 
 ## [0.28.0] - 2026-06-25
 

--- a/README.md
+++ b/README.md
@@ -77,10 +77,11 @@ See [CHANGELOG.md](CHANGELOG.md) for the full release history.
 - Upstream Proxy now includes free/core Automatic Proxy Configuration with PAC URL routing for `DIRECT`, HTTP, and HTTPS routes while preserving existing SOCKS5 and authentication policy boundaries.
 - Export workflows now cover OpenAPI YAML/HTML and selected-traffic Gist publishing with redaction-aware payload building.
 - Inspector tools now include JSONPath/key/value filtering and quick previews for selected payload text such as JWTs.
+- AI and Web3 traffic inspection now adds protocol labels, inspector tabs, and debug summaries for recognized model calls, JSON-RPC traffic, and x402-style payment hints.
 - Node.js Developer Setup now mirrors the selected client during validation and has a fuller localhost sample guide.
 - Developer Setup Hub now covers runtimes, browsers, clients, devices, frameworks, and environments with target-specific snippets, validation watchers, and honest guide content.
 - WebSocket Protobuf work continues as part of Rockxy's richer protocol inspection direction.
-- Public roadmap planning now includes protocol-aware debugging for AI traffic, Web3/RPC flows, x402-style payment flows, and safer redacted evidence sharing.
+- Public roadmap planning now focuses on deeper protocol-aware rules, replay, comparison, and safer redacted evidence sharing.
 
 ## Features
 
@@ -246,39 +247,39 @@ JS hooks on requests and responses for the cases a static rule can't cover — r
 
 `Request Hooks` · `Response Hooks` · `Programmatic Filtering` · `PII Redaction` · `Inline Error Feedback`
 
-## More Features Coming Soon
+## AI, Web3, and Future Protocol Work
 
-Future features are tracked publicly and ship only when the implementation, tests, privacy behavior, and documentation are ready.
+Rockxy is adding protocol-aware inspection while keeping the normal HTTP debugging workflow intact. Features ship only when the implementation, tests, privacy behavior, and documentation are ready.
 
-### AI Traffic Inspection `Coming Soon`
+### AI Traffic Inspection
 
-Make model traffic easier to debug inside the normal capture workflow. Detect AI requests, inspect selected model calls, diagnose streaming responses, compare prompt/output behavior, and understand tool-call chains without pasting sensitive payloads into another service.
+Make model traffic easier to debug inside the normal capture workflow. Detect recognized AI requests, inspect selected model calls, review streaming state, usage fields when present, warnings, retrieval hints, and tool-call summaries without pasting sensitive payloads into another service.
 
-`AI Requests` · `Model Inspector` · `Streaming Diagnostics` · `Tool Calls` · `Prompt Safety` · `Usage Signals`
+`AI Requests` · `Model Inspector` · `Streaming State` · `Tool Calls` · `Retrieval Hints` · `Usage Signals`
 
-### Web3/RPC Inspection `Coming Soon`
+### Web3/RPC Inspection
 
-Turn blockchain-era network calls into readable debugging evidence. Inspect JSON-RPC and Solana RPC traffic, group related calls into flows, explain common RPC errors, and replay selected requests without becoming a wallet or block explorer.
+Turn blockchain-era network calls into readable debugging evidence. Inspect EVM and Solana-style HTTP JSON-RPC traffic with provider host, request ID, method, batch summary, error, chain, transaction, payload, and debug-intent details without becoming a wallet or block explorer.
 
-`JSON-RPC` · `Solana RPC` · `Wallet Flows` · `RPC Errors` · `Replay Helpers` · `Network Evidence`
+`JSON-RPC` · `Solana RPC` · `Request ID` · `RPC Errors` · `Batch Summary` · `Network Evidence`
 
-### x402 Payment Flow Debugging `Coming Soon`
+### x402 Payment Flow Hints
 
-Understand payment-gated HTTP flows from the network layer. Highlight payment-required responses, follow the retry path, and keep the debugging evidence local and redaction-aware.
+Understand payment-gated HTTP flows from the network layer. Highlight payment-required and retry-oriented hints while keeping debugging evidence local and redaction-aware.
 
 `Payment Required` · `Retry Flow` · `Headers` · `Redaction` · `Local First`
+
+### Protocol-Aware Filters & Rules `Future`
+
+Rockxy can label and inspect AI and Web3 traffic today. Deeper rule matching by model, tool call, JSON-RPC method, chain, transaction hash, or batch subcall remains future work; current traffic modification tools still match URL, HTTP method, and headers.
+
+`Smart Filters` · `Request Badges` · `Protocol Column` · `Inspector Tabs` · `Future Rule Metadata`
 
 ### Redacted Evidence Bundles `Coming Soon`
 
 Share the facts needed to reproduce a bug without leaking secrets. Package selected traffic with protocol summaries, redaction previews, and source-backed context a teammate can audit.
 
 `Debug Bundles` · `Protocol Summary` · `Export Preview` · `Secret Redaction` · `Repro Context`
-
-### Protocol-Aware Filters & Rules `Coming Soon`
-
-Use AI and Web3 metadata where Rockxy already works: filters, badges, optional columns, comparison, rules, Developer Setup, and local MCP summaries.
-
-`Smart Filters` · `Request Badges` · `Optional Columns` · `Rules` · `Compare` · `Local MCP`
 
 ### Team Sharing & Collaboration `Coming Soon`
 
@@ -316,7 +317,7 @@ If you want to connect Rockxy to a local MCP client after installation, see the 
 | **MCP/local automation bridge** | Built in, token-authenticated, redaction by default | Not claimed in public docs reviewed | Not claimed in public docs reviewed |
 | **Open contribution path** | Public issues, discussions, roadmap, and PRs | Vendor-controlled product | Vendor-controlled product |
 
-On the roadmap: deeper replay/diff/rules/scripting workflows, improved WebSocket and GraphQL inspection, protocol-aware AI and Web3/RPC debugging, x402-style payment-flow visibility, and exploration of gRPC/Protobuf plus HTTP/2 and HTTP/3 support.
+On the roadmap: deeper replay/diff/rules/scripting workflows, improved WebSocket and GraphQL inspection, deeper protocol-aware AI and Web3/RPC debugging, x402-style payment-flow visibility, and exploration of gRPC/Protobuf plus HTTP/2 and HTTP/3 support.
 
 ## Security
 

--- a/Rockxy/Core/Detection/AITrafficDetector.swift
+++ b/Rockxy/Core/Detection/AITrafficDetector.swift
@@ -22,9 +22,20 @@ nonisolated enum AITrafficDetector {
 
     static func signal(snapshot: AITrafficSnapshot) -> AITrafficSignal {
         if let provider = provider(from: snapshot) {
-            return AITrafficSignal(isLikelyAI: true, provider: provider)
+            return AITrafficSignal(
+                isLikelyAI: true,
+                provider: provider,
+                kind: signalKind(for: snapshot),
+                evidence: evidence(for: snapshot)
+            )
         }
-        return AITrafficSignal(isLikelyAI: isLikelyAI(snapshot: snapshot), provider: nil)
+        let likely = isLikelyAI(snapshot: snapshot)
+        return AITrafficSignal(
+            isLikelyAI: likely,
+            provider: nil,
+            kind: likely ? .heuristic : .none,
+            evidence: likely ? evidence(for: snapshot) : []
+        )
     }
 
     static func isLikelyAI(snapshot: AITrafficSnapshot) -> Bool {
@@ -85,6 +96,8 @@ nonisolated enum AITrafficDetector {
 
         return AIInspection(
             provider: resolvedProvider,
+            kind: signalKind(for: snapshot),
+            evidence: evidence(for: snapshot),
             model: stringValue(forKey: "model", in: requestJSON)
                 ?? stringValue(forKey: "model", in: responseJSON),
             endpoint: snapshot.path.isEmpty ? snapshot.urlString : snapshot.path,
@@ -107,6 +120,18 @@ nonisolated enum AITrafficDetector {
         let path = snapshot.path.lowercased()
         let headerNames = snapshot.requestHeaders.map { $0.name.lowercased() }
 
+        if host == "chatgpt.com"
+            || host.hasSuffix(".chatgpt.com")
+            || host == "desktop.chat.openai.com"
+            || host.hasSuffix(".desktop.chat.openai.com")
+        {
+            return .chatGPT
+        }
+        if host == "claude.ai"
+            || host.hasSuffix(".claude.ai")
+        {
+            return .claude
+        }
         if host.contains("anthropic.com") || headerNames.contains("anthropic-version") {
             return .anthropic
         }
@@ -121,6 +146,71 @@ nonisolated enum AITrafficDetector {
             return .openAICompatible
         }
         return nil
+    }
+
+    private static func signalKind(for snapshot: AITrafficSnapshot) -> AITrafficSignalKind {
+        if hasVisibleAIAPIEvidence(snapshot) {
+            return .api
+        }
+        if isKnownNativeSession(snapshot) || hasHiddenTLSOnlyBody(snapshot) {
+            return .session
+        }
+        return .heuristic
+    }
+
+    private static func hasVisibleAIAPIEvidence(_ snapshot: AITrafficSnapshot) -> Bool {
+        let path = snapshot.path.lowercased()
+        if path.contains("/v1/responses")
+            || path.contains("/v1/chat/completions")
+            || path.contains("/v1/messages")
+            || path.contains("/v1/embeddings")
+            || path.contains("/chat/completions")
+            || path.contains("/embeddings")
+        {
+            return true
+        }
+
+        let requestPrefix = snapshot.requestBody
+            .flatMap { String(bytes: $0.prefix(maxQuickScanBytes), encoding: .utf8)?.lowercased() } ?? ""
+        let responsePrefix = snapshot.responseBody
+            .flatMap { String(bytes: $0.prefix(maxQuickScanBytes), encoding: .utf8)?.lowercased() } ?? ""
+        return requestPrefix.contains(#""model""#)
+            || responsePrefix.contains(#""usage""#)
+            || headerValue(named: "anthropic-version", in: snapshot.requestHeaders) != nil
+    }
+
+    private static func isKnownNativeSession(_ snapshot: AITrafficSnapshot) -> Bool {
+        let host = snapshot.host.lowercased()
+        return host == "chatgpt.com"
+            || host.hasSuffix(".chatgpt.com")
+            || host == "desktop.chat.openai.com"
+            || host.hasSuffix(".desktop.chat.openai.com")
+            || host == "claude.ai"
+            || host.hasSuffix(".claude.ai")
+    }
+
+    private static func hasHiddenTLSOnlyBody(_ snapshot: AITrafficSnapshot) -> Bool {
+        let method = snapshot.requestMethod.uppercased()
+        let scheme = snapshot.scheme.lowercased()
+        return method == "CONNECT"
+            || ((scheme == "https" || scheme == "wss") && snapshot.requestBody == nil && snapshot.responseBody == nil)
+    }
+
+    private static func evidence(for snapshot: AITrafficSnapshot) -> [String] {
+        var values: [String] = []
+        if provider(from: snapshot) != nil {
+            values.append("known host")
+        }
+        if hasVisibleAIAPIEvidence(snapshot) {
+            values.append("api fields")
+        }
+        if snapshot.scheme.lowercased() == "wss" || headerValue(named: "upgrade", in: snapshot.requestHeaders)?.lowercased() == "websocket" {
+            values.append("websocket")
+        }
+        if hasHiddenTLSOnlyBody(snapshot) {
+            values.append("body hidden")
+        }
+        return Array(NSOrderedSet(array: values).compactMap { $0 as? String })
     }
 
     private static func provider(from requestJSON: [String: Any]?, responseJSON: [String: Any]?) -> AIProvider? {
@@ -456,6 +546,7 @@ struct AITrafficSnapshot: Sendable {
     init(transaction: HTTPTransaction) {
         requestMethod = transaction.request.method
         urlString = transaction.request.url.absoluteString
+        scheme = transaction.request.url.scheme ?? ""
         host = transaction.request.host
         path = transaction.request.path
         requestHeaders = transaction.request.headers
@@ -468,6 +559,7 @@ struct AITrafficSnapshot: Sendable {
 
     let requestMethod: String
     let urlString: String
+    let scheme: String
     let host: String
     let path: String
     let requestHeaders: [HTTPHeader]
@@ -482,6 +574,8 @@ struct AITrafficSnapshot: Sendable {
 
 struct AIInspection: Equatable, Sendable {
     let provider: AIProvider
+    let kind: AITrafficSignalKind
+    let evidence: [String]
     let model: String?
     let endpoint: String
     let isStreaming: Bool
@@ -498,21 +592,46 @@ struct AIInspection: Equatable, Sendable {
 enum AIProvider: String, Sendable {
     case openAICompatible
     case anthropic
+    case chatGPT
+    case claude
 
     var displayName: String {
         switch self {
         case .openAICompatible: "OpenAI-compatible"
         case .anthropic: "Anthropic"
+        case .chatGPT: "ChatGPT"
+        case .claude: "Claude"
         }
     }
+}
+
+enum AITrafficSignalKind: String, Equatable, Sendable {
+    case none
+    case api
+    case session
+    case heuristic
 }
 
 struct AITrafficSignal: Equatable, Sendable {
     let isLikelyAI: Bool
     let provider: AIProvider?
+    let kind: AITrafficSignalKind
+    let evidence: [String]
 
     var tableLabel: String {
-        isLikelyAI ? "AI" : ""
+        guard isLikelyAI else {
+            return ""
+        }
+        switch kind {
+        case .api:
+            return "AI API"
+        case .session:
+            return "AI Session"
+        case .heuristic:
+            return "Likely AI"
+        case .none:
+            return "AI"
+        }
     }
 
     var accessibilityLabel: String {
@@ -520,9 +639,10 @@ struct AITrafficSignal: Equatable, Sendable {
             return ""
         }
         if let provider {
-            return "Likely AI model traffic: \(provider.displayName)"
+            let evidenceLabel = evidence.isEmpty ? "" : " (\(evidence.joined(separator: ", ")))"
+            return "\(tableLabel): \(provider.displayName)\(evidenceLabel)"
         }
-        return "Likely AI model traffic"
+        return tableLabel
     }
 }
 

--- a/Rockxy/Core/Detection/X402Detector.swift
+++ b/Rockxy/Core/Detection/X402Detector.swift
@@ -1,0 +1,220 @@
+import Foundation
+
+// MARK: - X402Detector
+
+/// Bounded detector for visible HTTP 402 and x402-like payment metadata.
+///
+/// The detector summarizes lifecycle hints without retaining payment proofs,
+/// challenges, receipts, or wallet/payment execution details.
+enum X402Detector {
+    // MARK: Internal
+
+    static let maxPayloadBytes = 256 * 1_024
+
+    static func detect(request: HTTPRequestData, response: HTTPResponseData? = nil) -> X402Info? {
+        guard request.method.caseInsensitiveCompare("CONNECT") != .orderedSame else {
+            return nil
+        }
+
+        let requestHeaders = HeaderLookup(request.headers)
+        let responseHeaders = HeaderLookup(response?.headers ?? [])
+        let responseStatus = response?.statusCode
+        let hasPaymentProof = requestHeaders.contains("x-payment")
+            || requestHeaders.contains("authorization")
+        let hasPaymentResponse = responseHeaders.contains("x-payment-response")
+        let bodySummary = summarizeBody(response?.body)
+        let isStatus402 = responseStatus == 402
+        let isX402Like = bodySummary.isX402Like
+            || requestHeaders.contains("x-payment")
+            || responseHeaders.contains("x-accept-payment")
+            || responseHeaders.contains("x-payment-response")
+
+        guard isStatus402 || isX402Like || hasPaymentResponse else {
+            return nil
+        }
+
+        let providerErrorPresent = bodySummary.providerErrorPresent
+        let stage = stage(
+            statusCode: responseStatus,
+            isX402Like: isX402Like,
+            hasPaymentProof: hasPaymentProof,
+            hasPaymentResponse: hasPaymentResponse,
+            providerErrorPresent: providerErrorPresent
+        )
+
+        return X402Info(
+            stage: stage,
+            isX402Like: isX402Like,
+            version: bodySummary.version,
+            paymentRequired: bodySummary.paymentRequired ?? (isStatus402 ? true : nil),
+            hasPaymentProof: hasPaymentProof,
+            hasChallenge: bodySummary.hasChallenge,
+            hasPaymentMetadata: bodySummary.hasPaymentMetadata || hasPaymentResponse,
+            providerErrorPresent: providerErrorPresent,
+            parseState: bodySummary.parseState,
+            redactionFields: redactionFields(
+                requestHeaders: requestHeaders,
+                responseHeaders: responseHeaders,
+                bodySummary: bodySummary
+            ),
+            requestPayloadSize: request.body?.count,
+            responsePayloadSize: response?.body?.count
+        )
+    }
+
+    // MARK: Private
+
+    private struct BodySummary {
+        let isX402Like: Bool
+        let version: String?
+        let paymentRequired: Bool?
+        let hasChallenge: Bool
+        let hasPaymentMetadata: Bool
+        let hasReceipt: Bool
+        let providerErrorPresent: Bool
+        let parseState: X402ParseState
+    }
+
+    private struct HeaderLookup {
+        private let names: Set<String>
+
+        init(_ headers: [HTTPHeader]) {
+            names = Set(headers.map { $0.name.lowercased() })
+        }
+
+        func contains(_ name: String) -> Bool {
+            names.contains(name.lowercased())
+        }
+    }
+
+    private static let emptyBodySummary = BodySummary(
+        isX402Like: false,
+        version: nil,
+        paymentRequired: nil,
+        hasChallenge: false,
+        hasPaymentMetadata: false,
+        hasReceipt: false,
+        providerErrorPresent: false,
+        parseState: .notApplicable
+    )
+
+    private static func summarizeBody(_ body: Data?) -> BodySummary {
+        guard let body, !body.isEmpty, body.count <= maxPayloadBytes else {
+            return emptyBodySummary
+        }
+
+        guard let object = try? JSONSerialization.jsonObject(with: body) as? [String: Any] else {
+            let prefix = String(bytes: body.prefix(8 * 1_024), encoding: .utf8)?.lowercased() ?? ""
+            let looksLikeX402 = prefix.contains("x402")
+                || prefix.contains("paymentrequired")
+                || prefix.contains("paymentmetadata")
+                || prefix.contains("challenge")
+            guard looksLikeX402 else {
+                return emptyBodySummary
+            }
+            return BodySummary(
+                isX402Like: true,
+                version: nil,
+                paymentRequired: prefix.contains("paymentrequired"),
+                hasChallenge: prefix.contains("challenge"),
+                hasPaymentMetadata: prefix.contains("paymentmetadata"),
+                hasReceipt: prefix.contains("receipt"),
+                providerErrorPresent: prefix.contains("\"error\"") || prefix.contains("error"),
+                parseState: .malformed
+            )
+        }
+
+        let hasPaymentMetadata = object["paymentMetadata"] != nil
+        let hasChallenge = object["challenge"] != nil
+        let hasReceipt = object["receipt"] != nil || (object["paymentMetadata"] as? [String: Any])?["receipt"] != nil
+        let paymentRequired = boolValue(object["paymentRequired"])
+        let version = stringValue(object["x402Version"])
+        let providerErrorPresent = object["error"] != nil
+        let isX402Like = version != nil
+            || paymentRequired != nil
+            || hasChallenge
+            || hasPaymentMetadata
+
+        return BodySummary(
+            isX402Like: isX402Like,
+            version: version,
+            paymentRequired: paymentRequired,
+            hasChallenge: hasChallenge,
+            hasPaymentMetadata: hasPaymentMetadata,
+            hasReceipt: hasReceipt,
+            providerErrorPresent: providerErrorPresent,
+            parseState: .parsed
+        )
+    }
+
+    private static func stage(
+        statusCode: Int?,
+        isX402Like: Bool,
+        hasPaymentProof: Bool,
+        hasPaymentResponse: Bool,
+        providerErrorPresent: Bool
+    ) -> X402Stage {
+        if providerErrorPresent {
+            return .providerError
+        }
+        if let statusCode, (200 ..< 300).contains(statusCode), hasPaymentProof || hasPaymentResponse {
+            return .paymentAccepted
+        }
+        if hasPaymentProof {
+            return .paymentProofSubmitted
+        }
+        if statusCode == 402, isX402Like {
+            return .paymentRequired
+        }
+        return .ordinaryPaymentRequired
+    }
+
+    private static func redactionFields(
+        requestHeaders: HeaderLookup,
+        responseHeaders: HeaderLookup,
+        bodySummary: BodySummary
+    ) -> [String] {
+        var fields: [String] = []
+        if requestHeaders.contains("authorization") {
+            fields.append("Authorization")
+        }
+        if requestHeaders.contains("x-payment") {
+            fields.append("X-Payment")
+        }
+        if responseHeaders.contains("x-payment-response") {
+            fields.append("X-Payment-Response")
+        }
+        if bodySummary.hasChallenge {
+            fields.append("challenge")
+        }
+        if bodySummary.hasPaymentMetadata {
+            fields.append("paymentMetadata")
+        }
+        if bodySummary.hasReceipt {
+            fields.append("receipt")
+        }
+        return fields
+    }
+
+    private static func stringValue(_ value: Any?) -> String? {
+        switch value {
+        case let string as String:
+            return string
+        case let number as NSNumber where CFGetTypeID(number) != CFBooleanGetTypeID():
+            return number.stringValue
+        default:
+            return nil
+        }
+    }
+
+    private static func boolValue(_ value: Any?) -> Bool? {
+        switch value {
+        case let bool as Bool:
+            return bool
+        case let number as NSNumber:
+            return number.boolValue
+        default:
+            return nil
+        }
+    }
+}

--- a/Rockxy/Core/MCPServer/MCPRedactionPolicy.swift
+++ b/Rockxy/Core/MCPServer/MCPRedactionPolicy.swift
@@ -225,8 +225,16 @@ struct MCPRedactionPolicy {
         options: [.caseInsensitive]
     )
 
+    private static let sensitiveBodyKeyAlternation: String = [
+        sensitiveBodyKeys,
+        sensitiveQueryParams.subtracting(["key"]),
+    ]
+    .flatMap { $0 }
+    .map { NSRegularExpression.escapedPattern(for: $0) }
+    .joined(separator: "|")
+
     private static let bodySecretPatternRegex: NSRegularExpression = try! NSRegularExpression(
-        pattern: #"("(?:password|passwd|pwd|secret|client_secret|private_key|credentials)")\s*:\s*\#(jsonScalarPattern)"#,
+        pattern: #"("(?:\#(sensitiveBodyKeyAlternation))")\s*:\s*\#(jsonScalarPattern)"#,
         options: [.caseInsensitive]
     )
 
@@ -236,10 +244,7 @@ struct MCPRedactionPolicy {
     )
 
     private static let xmlSensitivePatternRegex: NSRegularExpression = try! NSRegularExpression(
-        pattern: """
-        <(password|passwd|secret|token|access_token|api_key|apikey\
-        |client_secret|private_key|credentials)>([^<]*)</
-        """,
+        pattern: #"<(\#(sensitiveBodyKeyAlternation))>([^<]*)</"#,
         options: [.caseInsensitive]
     )
 
@@ -249,7 +254,7 @@ struct MCPRedactionPolicy {
     )
 
     private static let genericKeyValuePatternRegex: NSRegularExpression = try! NSRegularExpression(
-        pattern: #"(?i)((?:password|passwd|secret|token|api_key|apikey)[\s]*[:=][\s]*)\S+"#,
+        pattern: #"(?i)((?:\#(sensitiveBodyKeyAlternation))[\s]*[:=][\s]*)\S+"#,
         options: []
     )
     // swiftlint:enable force_try

--- a/Rockxy/Core/ProxyEngine/HTTPProxyHandler.swift
+++ b/Rockxy/Core/ProxyEngine/HTTPProxyHandler.swift
@@ -883,7 +883,8 @@ extension HTTPProxyHandler {
         let transaction = HTTPTransaction(
             request: requestData,
             response: responseData,
-            state: .completed
+            state: .completed,
+            x402Info: X402Detector.detect(request: requestData, response: responseData)
         )
         transaction.measuredDuration = requestElapsedDuration()
         transaction.sourcePort = clientSourcePort

--- a/Rockxy/Core/ProxyEngine/HTTPSProxyRelayHandler.swift
+++ b/Rockxy/Core/ProxyEngine/HTTPSProxyRelayHandler.swift
@@ -803,7 +803,8 @@ final class HTTPSProxyRelayHandler: ChannelInboundHandler, @unchecked Sendable {
         let transaction = HTTPTransaction(
             request: requestData,
             response: responseData,
-            state: .completed
+            state: .completed,
+            x402Info: X402Detector.detect(request: requestData, response: responseData)
         )
         transaction.measuredDuration = requestElapsedDuration()
         transaction.sourcePort = clientSourcePort

--- a/Rockxy/Core/ProxyEngine/UpstreamResponseHandler.swift
+++ b/Rockxy/Core/ProxyEngine/UpstreamResponseHandler.swift
@@ -676,7 +676,8 @@ final class UpstreamResponseHandler: ChannelInboundHandler, @unchecked Sendable 
             state: .completed,
             timingInfo: timing,
             graphQLInfo: graphQLInfo,
-            web3RPCInfo: Web3RPCDetector.detect(request: requestData, response: responseData)
+            web3RPCInfo: Web3RPCDetector.detect(request: requestData, response: responseData),
+            x402Info: X402Detector.detect(request: requestData, response: responseData)
         )
         transaction.sourcePort = sourcePort
         transaction.clientApp = Self.extractAppFromUserAgent(requestData.headers)

--- a/Rockxy/Core/Storage/SessionStore.swift
+++ b/Rockxy/Core/Storage/SessionStore.swift
@@ -83,6 +83,22 @@ actor SessionStore {
             Self.txGraphqlOpName <- transaction.graphQLInfo?.operationName,
             Self.txGraphqlOpType <- transaction.graphQLInfo?.operationType.rawValue,
             Self.txGraphqlQuery <- transaction.graphQLInfo?.query,
+            Self.txWeb3Family <- transaction.web3RPCInfo?.family.rawValue,
+            Self.txWeb3ProviderHost <- transaction.web3RPCInfo?.providerHost,
+            Self.txWeb3Method <- transaction.web3RPCInfo?.method,
+            Self.txWeb3RequestId <- transaction.web3RPCInfo?.requestID,
+            Self.txWeb3BatchRequestCount <- transaction.web3RPCInfo?.batch?.requestCount,
+            Self.txWeb3BatchRPCRequestCount <- transaction.web3RPCInfo?.batch?.web3RequestCount,
+            Self.txWeb3BatchResponseCount <- transaction.web3RPCInfo?.batch?.responseCount,
+            Self.txWeb3BatchErrorCount <- transaction.web3RPCInfo?.batch?.errorCount,
+            Self.txWeb3BatchMethods <- encodeWeb3BatchMethods(transaction.web3RPCInfo?.batch?.methods),
+            Self.txWeb3ErrorCode <- transaction.web3RPCInfo?.error?.code,
+            Self.txWeb3ErrorMessage <- transaction.web3RPCInfo?.error?.message,
+            Self.txWeb3ChainId <- transaction.web3RPCInfo?.chainHint?.chainID,
+            Self.txWeb3TransactionHash <- transaction.web3RPCInfo?.transactionHash,
+            Self.txWeb3BlockIdentifier <- transaction.web3RPCInfo?.blockIdentifier,
+            Self.txWeb3RequestPayloadSize <- transaction.web3RPCInfo?.requestPayloadSize,
+            Self.txWeb3ResponsePayloadSize <- transaction.web3RPCInfo?.responsePayloadSize,
             Self.txIsPinned <- (transaction.isPinned ? 1 : 0),
             Self.txIsSaved <- (transaction.isSaved ? 1 : 0),
             Self.txComment <- transaction.comment,
@@ -275,6 +291,22 @@ actor SessionStore {
     private static let txGraphqlOpName = SQLite.Expression<String?>("graphql_op_name")
     private static let txGraphqlOpType = SQLite.Expression<String?>("graphql_op_type")
     private static let txGraphqlQuery = SQLite.Expression<String?>("graphql_query")
+    private static let txWeb3Family = SQLite.Expression<String?>("web3_family")
+    private static let txWeb3ProviderHost = SQLite.Expression<String?>("web3_provider_host")
+    private static let txWeb3Method = SQLite.Expression<String?>("web3_method")
+    private static let txWeb3RequestId = SQLite.Expression<String?>("web3_request_id")
+    private static let txWeb3BatchRequestCount = SQLite.Expression<Int?>("web3_batch_request_count")
+    private static let txWeb3BatchRPCRequestCount = SQLite.Expression<Int?>("web3_batch_rpc_request_count")
+    private static let txWeb3BatchResponseCount = SQLite.Expression<Int?>("web3_batch_response_count")
+    private static let txWeb3BatchErrorCount = SQLite.Expression<Int?>("web3_batch_error_count")
+    private static let txWeb3BatchMethods = SQLite.Expression<String?>("web3_batch_methods")
+    private static let txWeb3ErrorCode = SQLite.Expression<Int?>("web3_error_code")
+    private static let txWeb3ErrorMessage = SQLite.Expression<String?>("web3_error_message")
+    private static let txWeb3ChainId = SQLite.Expression<String?>("web3_chain_id")
+    private static let txWeb3TransactionHash = SQLite.Expression<String?>("web3_transaction_hash")
+    private static let txWeb3BlockIdentifier = SQLite.Expression<String?>("web3_block_identifier")
+    private static let txWeb3RequestPayloadSize = SQLite.Expression<Int?>("web3_request_payload_size")
+    private static let txWeb3ResponsePayloadSize = SQLite.Expression<Int?>("web3_response_payload_size")
     private static let txIsPinned = SQLite.Expression<Int>("is_pinned")
     private static let txIsSaved = SQLite.Expression<Int>("is_saved")
     private static let txComment = SQLite.Expression<String?>("comment")
@@ -399,14 +431,14 @@ actor SessionStore {
     }
 
     private func migrateSchemaIfNeeded() throws {
-        let currentVersion = try schemaVersion()
+        var currentVersion = try schemaVersion()
 
         if currentVersion == 0 {
             let columns = try existingColumnNames(table: "transactions")
             if columns.contains("is_pinned") {
                 try setSchemaVersion(1)
+                currentVersion = 1
                 Self.logger.info("Schema version bootstrapped to v1 (columns already present)")
-                return
             }
         }
 
@@ -417,6 +449,24 @@ actor SessionStore {
                 "ALTER TABLE transactions ADD COLUMN comment TEXT",
                 "ALTER TABLE transactions ADD COLUMN highlight_color TEXT",
                 "ALTER TABLE transactions ADD COLUMN client_app TEXT",
+            ]),
+            (2, [
+                "ALTER TABLE transactions ADD COLUMN web3_family TEXT",
+                "ALTER TABLE transactions ADD COLUMN web3_provider_host TEXT",
+                "ALTER TABLE transactions ADD COLUMN web3_method TEXT",
+                "ALTER TABLE transactions ADD COLUMN web3_request_id TEXT",
+                "ALTER TABLE transactions ADD COLUMN web3_batch_request_count INTEGER",
+                "ALTER TABLE transactions ADD COLUMN web3_batch_rpc_request_count INTEGER",
+                "ALTER TABLE transactions ADD COLUMN web3_batch_response_count INTEGER",
+                "ALTER TABLE transactions ADD COLUMN web3_batch_error_count INTEGER",
+                "ALTER TABLE transactions ADD COLUMN web3_batch_methods TEXT",
+                "ALTER TABLE transactions ADD COLUMN web3_error_code INTEGER",
+                "ALTER TABLE transactions ADD COLUMN web3_error_message TEXT",
+                "ALTER TABLE transactions ADD COLUMN web3_chain_id TEXT",
+                "ALTER TABLE transactions ADD COLUMN web3_transaction_hash TEXT",
+                "ALTER TABLE transactions ADD COLUMN web3_block_identifier TEXT",
+                "ALTER TABLE transactions ADD COLUMN web3_request_payload_size INTEGER",
+                "ALTER TABLE transactions ADD COLUMN web3_response_payload_size INTEGER",
             ]),
         ]
 
@@ -618,6 +668,8 @@ actor SessionStore {
             )
         }
 
+        let web3RPCInfo = deserializeWeb3RPCInfo(from: row)
+
         let transaction = HTTPTransaction(
             id: id,
             timestamp: Date(timeIntervalSince1970: row[Self.txTimestamp]),
@@ -627,6 +679,7 @@ actor SessionStore {
         transaction.response = response
         transaction.timingInfo = timingInfo
         transaction.graphQLInfo = graphQLInfo
+        transaction.web3RPCInfo = web3RPCInfo
         transaction.isPinned = row[Self.txIsPinned] != 0
         transaction.isSaved = row[Self.txIsSaved] != 0
         transaction.comment = row[Self.txComment]
@@ -642,6 +695,59 @@ actor SessionStore {
         }
 
         return transaction
+    }
+
+    private func deserializeWeb3RPCInfo(from row: Row) -> Web3RPCInfo? {
+        guard let familyValue = row[Self.txWeb3Family],
+              let family = Web3RPCFamily(rawValue: familyValue),
+              let providerHost = row[Self.txWeb3ProviderHost]
+        else {
+            return nil
+        }
+
+        let batch = deserializeWeb3BatchSummary(from: row)
+        let error = deserializeWeb3Error(from: row)
+        let chainHint = row[Self.txWeb3ChainId].map { Web3RPCChainHint(chainID: $0) }
+
+        return Web3RPCInfo(
+            family: family,
+            providerHost: providerHost,
+            method: row[Self.txWeb3Method],
+            requestID: row[Self.txWeb3RequestId],
+            batch: batch,
+            error: error,
+            chainHint: chainHint,
+            transactionHash: row[Self.txWeb3TransactionHash],
+            blockIdentifier: row[Self.txWeb3BlockIdentifier],
+            requestPayloadSize: row[Self.txWeb3RequestPayloadSize],
+            responsePayloadSize: row[Self.txWeb3ResponsePayloadSize]
+        )
+    }
+
+    private func deserializeWeb3BatchSummary(from row: Row) -> Web3RPCBatchSummary? {
+        guard let requestCount = row[Self.txWeb3BatchRequestCount],
+              let web3RequestCount = row[Self.txWeb3BatchRPCRequestCount],
+              let errorCount = row[Self.txWeb3BatchErrorCount]
+        else {
+            return nil
+        }
+
+        return Web3RPCBatchSummary(
+            requestCount: requestCount,
+            web3RequestCount: web3RequestCount,
+            responseCount: row[Self.txWeb3BatchResponseCount],
+            errorCount: errorCount,
+            methods: decodeWeb3BatchMethods(row[Self.txWeb3BatchMethods])
+        )
+    }
+
+    private func deserializeWeb3Error(from row: Row) -> Web3RPCError? {
+        let code = row[Self.txWeb3ErrorCode]
+        let message = row[Self.txWeb3ErrorMessage]
+        guard code != nil || message != nil else {
+            return nil
+        }
+        return Web3RPCError(code: code, message: message)
     }
 
     // MARK: - Log Entry Deserialization
@@ -696,6 +802,28 @@ actor SessionStore {
             }
             return HTTPHeader(name: name, value: value)
         }
+    }
+
+    private func encodeWeb3BatchMethods(_ methods: [String]?) -> String? {
+        guard let methods else {
+            return nil
+        }
+        guard let data = try? JSONSerialization.data(withJSONObject: methods),
+              let json = String(data: data, encoding: .utf8) else
+        {
+            return nil
+        }
+        return json
+    }
+
+    private func decodeWeb3BatchMethods(_ json: String?) -> [String] {
+        guard let json,
+              let data = json.data(using: .utf8),
+              let methods = try? JSONSerialization.jsonObject(with: data) as? [String] else
+        {
+            return []
+        }
+        return methods
     }
 
     // MARK: - LogSource Encoding

--- a/Rockxy/Core/Utilities/SensitiveDataRedactor.swift
+++ b/Rockxy/Core/Utilities/SensitiveDataRedactor.swift
@@ -26,6 +26,8 @@ struct SensitiveDataRedactor {
         "x-access-token",
         "x-csrf-token",
         "x-xsrf-token",
+        "x-payment",
+        "x-payment-response",
     ]
 
     static let sensitiveQueryParams: Set<String> = [
@@ -53,6 +55,37 @@ struct SensitiveDataRedactor {
         "recoveryphrase",
         "signature",
         "client_secret",
+        "clientsecret",
+        "provider_key",
+        "provider-key",
+        "providerkey",
+        "rpc_key",
+        "rpc-key",
+        "rpckey",
+        "rpc_url",
+        "rpc-url",
+        "rpcurl",
+        "wallet_key",
+        "wallet-key",
+        "walletkey",
+        "wallet_secret",
+        "wallet-secret",
+        "walletsecret",
+        "payment",
+        "payment_payload",
+        "payment-payload",
+        "paymentpayload",
+        "payment_header",
+        "payment-header",
+        "paymentheader",
+        "payment_proof",
+        "payment-proof",
+        "paymentproof",
+        "x-payment",
+        "x-payment-response",
+        "maxamountrequired",
+        "max_amount_required",
+        "max-amount-required",
         "key",
     ]
 
@@ -61,6 +94,42 @@ struct SensitiveDataRedactor {
         .union([
             "credentials",
             "id_token",
+            "prompt",
+            "prompts",
+            "messages",
+            "input",
+            "instructions",
+            "system_prompt",
+            "system-prompt",
+            "systemprompt",
+            "developer_message",
+            "developer-message",
+            "developermessage",
+            "tools",
+            "tool",
+            "tool_calls",
+            "tool-calls",
+            "toolcalls",
+            "tool_call",
+            "tool-call",
+            "toolcall",
+            "function_call",
+            "function-call",
+            "functioncall",
+            "arguments",
+            "args",
+            "retrieved_context",
+            "retrieved-context",
+            "retrievedcontext",
+            "rag_context",
+            "rag-context",
+            "ragcontext",
+            "context",
+            "snippet",
+            "embedding",
+            "embeddings",
+            "vector",
+            "vectors",
         ])
 
     let isEnabled: Bool
@@ -189,25 +258,12 @@ struct SensitiveDataRedactor {
     )
 
     private static let bodySecretKeyPattern = [
-        "password",
-        "passwd",
-        "pwd",
-        "secret",
-        "client_secret",
-        "private_key",
-        "private-key",
-        "privatekey",
-        "seed",
-        "seed_phrase",
-        "seed-phrase",
-        "seedphrase",
-        "mnemonic",
-        "recovery_phrase",
-        "recovery-phrase",
-        "recoveryphrase",
-        "signature",
-        "credentials",
-    ].joined(separator: "|")
+        sensitiveBodyKeys,
+        sensitiveQueryParams.subtracting(["key"]),
+    ]
+    .flatMap { $0 }
+    .map { NSRegularExpression.escapedPattern(for: $0) }
+    .joined(separator: "|")
 
     private static let bodySecretPatternRegex: NSRegularExpression = try! NSRegularExpression(
         pattern: #"("(?:\#(bodySecretKeyPattern))")\s*:\s*\#(jsonScalarPattern)"#,
@@ -215,12 +271,7 @@ struct SensitiveDataRedactor {
     )
 
     private static let xmlSensitivePatternRegex: NSRegularExpression = try! NSRegularExpression(
-        pattern: """
-        <(password|passwd|secret|token|access_token|api_key|apikey\
-        |client_secret|private_key|private-key|privatekey|seed|seed_phrase|seed-phrase\
-        |seedphrase|mnemonic|recovery_phrase|recovery-phrase|recoveryphrase|signature\
-        |credentials)>([^<]*)</
-        """,
+        pattern: #"<(\#(bodySecretKeyPattern))>([^<]*)</"#,
         options: [.caseInsensitive]
     )
 
@@ -230,7 +281,7 @@ struct SensitiveDataRedactor {
     )
 
     private static let genericKeyValuePatternRegex: NSRegularExpression = try! NSRegularExpression(
-        pattern: #"(?i)((?:password|passwd|secret|token|api_key|apikey|private_key|privatekey|seed_phrase|seedphrase|mnemonic|signature)[\s]*[:=][\s]*)\S+"#,
+        pattern: #"(?i)((?:\#(bodySecretKeyPattern))[\s]*[:=][\s]*)\S+"#,
         options: []
     )
     // swiftlint:enable force_try

--- a/Rockxy/Models/Network/HTTPTransaction.swift
+++ b/Rockxy/Models/Network/HTTPTransaction.swift
@@ -23,7 +23,8 @@ final class HTTPTransaction: Identifiable, @unchecked Sendable {
         timingInfo: TimingInfo? = nil,
         webSocketConnection: WebSocketConnection? = nil,
         graphQLInfo: GraphQLInfo? = nil,
-        web3RPCInfo: Web3RPCInfo? = nil
+        web3RPCInfo: Web3RPCInfo? = nil,
+        x402Info: X402Info? = nil
     ) {
         self.id = id
         self.timestamp = timestamp
@@ -34,6 +35,7 @@ final class HTTPTransaction: Identifiable, @unchecked Sendable {
         self.webSocketConnection = webSocketConnection
         self.graphQLInfo = graphQLInfo
         self.web3RPCInfo = web3RPCInfo
+        self.x402Info = x402Info
     }
 
     // MARK: Internal
@@ -48,6 +50,7 @@ final class HTTPTransaction: Identifiable, @unchecked Sendable {
     var webSocketConnection: WebSocketConnection?
     var graphQLInfo: GraphQLInfo?
     var web3RPCInfo: Web3RPCInfo?
+    var x402Info: X402Info?
     var sourcePort: UInt16?
     var clientApp: String?
     var comment: String?

--- a/Rockxy/Models/Network/Web3RPCInfo.swift
+++ b/Rockxy/Models/Network/Web3RPCInfo.swift
@@ -15,6 +15,99 @@ struct Web3RPCInfo: Equatable, Sendable {
     let blockIdentifier: String?
     let requestPayloadSize: Int?
     let responsePayloadSize: Int?
+
+    var debugIntent: Web3RPCDebugIntent {
+        if batch != nil {
+            return .batch
+        }
+
+        guard let method = method?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !method.isEmpty else
+        {
+            return .unknown
+        }
+
+        let normalized = method.lowercased()
+
+        if Web3RPCDebugIntent.broadcastMethods.contains(normalized) {
+            return .broadcast
+        }
+        if Web3RPCDebugIntent.simulationMethods.contains(normalized) {
+            return .simulation
+        }
+        if Web3RPCDebugIntent.logMethods.contains(normalized) {
+            return .logs
+        }
+        if Web3RPCDebugIntent.subscriptionMethods.contains(where: { normalized.hasSuffix($0) }) {
+            return .subscription
+        }
+        if Web3RPCDebugIntent.providerMethods.contains(normalized) {
+            return .provider
+        }
+        if normalized.hasPrefix("eth_get") || normalized.hasPrefix("get") || normalized.hasPrefix("net_") {
+            return .read
+        }
+
+        return .unknown
+    }
+}
+
+// MARK: - Web3RPCDebugIntent
+
+enum Web3RPCDebugIntent: String, Equatable, Sendable {
+    case batch
+    case broadcast
+    case simulation
+    case logs
+    case subscription
+    case provider
+    case read
+    case unknown
+
+    fileprivate static let broadcastMethods: Set<String> = [
+        "eth_sendrawtransaction",
+        "eth_sendtransaction",
+        "wallet_sendcalls",
+        "wallet_sendsitepermission",
+        "personal_sign",
+        "eth_sign",
+        "eth_signtypeddata",
+        "eth_signtypeddata_v4",
+        "sendtransaction",
+        "requestairdrop",
+    ]
+
+    fileprivate static let simulationMethods: Set<String> = [
+        "eth_call",
+        "eth_estimategas",
+        "simulatetransaction",
+    ]
+
+    fileprivate static let logMethods: Set<String> = [
+        "eth_getlogs",
+        "eth_gettransactionreceipt",
+        "eth_gettransactionbyhash",
+        "gettransaction",
+        "getsignaturesforaddress",
+        "getsignaturestatuses",
+    ]
+
+    fileprivate static let providerMethods: Set<String> = [
+        "eth_chainid",
+        "eth_blocknumber",
+        "net_version",
+        "web3_clientversion",
+        "web3_sha3",
+        "getlatestblockhash",
+        "gethealth",
+        "getversion",
+        "getepochinfo",
+    ]
+
+    fileprivate static let subscriptionMethods = [
+        "subscribe",
+        "unsubscribe",
+    ]
 }
 
 // MARK: - Web3RPCFamily

--- a/Rockxy/Models/Network/X402Info.swift
+++ b/Rockxy/Models/Network/X402Info.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+// MARK: - X402Info
+
+/// Privacy-safe metadata for HTTP 402 and x402-like payment flows.
+///
+/// This model intentionally records only lifecycle hints and redaction field names.
+/// It must not hold payment proofs, challenges, receipts, wallet addresses, or payment execution state.
+struct X402Info: Equatable, Sendable {
+    let stage: X402Stage
+    let isX402Like: Bool
+    let version: String?
+    let paymentRequired: Bool?
+    let hasPaymentProof: Bool
+    let hasChallenge: Bool
+    let hasPaymentMetadata: Bool
+    let providerErrorPresent: Bool
+    let parseState: X402ParseState
+    let redactionFields: [String]
+    let requestPayloadSize: Int?
+    let responsePayloadSize: Int?
+}
+
+// MARK: - X402Stage
+
+enum X402Stage: String, Equatable, Sendable {
+    case ordinaryPaymentRequired
+    case paymentRequired
+    case paymentProofSubmitted
+    case paymentAccepted
+    case providerError
+}
+
+// MARK: - X402ParseState
+
+enum X402ParseState: String, Equatable, Sendable {
+    case notApplicable
+    case parsed
+    case malformed
+}

--- a/Rockxy/Models/UI/HeaderColumnStore.swift
+++ b/Rockxy/Models/UI/HeaderColumnStore.swift
@@ -214,7 +214,7 @@ final class HeaderColumnStore {
     private static let discoveredResKey = RockxyIdentity.current.defaultsKey("discoveredResHeaders")
     private static let hiddenColumnsKey = RockxyIdentity.current.defaultsKey("hiddenBuiltInColumns")
     private static let visibleDefaultHiddenColumnsKey = RockxyIdentity.current.defaultsKey("visibleDefaultHiddenBuiltInColumns")
-    private static let defaultHiddenBuiltInColumns: Set<String> = ["ai"]
+    private static let defaultHiddenBuiltInColumns: Set<String> = []
 
     // Internal dedup sets for O(1) membership checks during incremental discovery
     private var discoveredRequestHeaderSet: Set<String> = []

--- a/Rockxy/Models/UI/ProtocolFilter.swift
+++ b/Rockxy/Models/UI/ProtocolFilter.swift
@@ -8,7 +8,10 @@ enum ProtocolFilter: String, CaseIterable, Hashable {
     case http
     case https
     case websocket
+    case ai
+    case aiSession
     case web3RPC
+    case rpcError
     case json
     case xml
     case js
@@ -29,7 +32,7 @@ enum ProtocolFilter: String, CaseIterable, Hashable {
     // MARK: Internal
 
     static var contentFilters: [ProtocolFilter] {
-        [.all, .http, .https, .websocket, .web3RPC, .json, .xml, .js, .css, .graphql, .grpc, .document, .media, .form, .font, .other]
+        [.all, .http, .https, .websocket, .ai, .aiSession, .web3RPC, .rpcError, .json, .xml, .js, .css, .graphql, .grpc, .document, .media, .form, .font, .other]
     }
 
     static var statusFilters: [ProtocolFilter] {
@@ -42,7 +45,10 @@ enum ProtocolFilter: String, CaseIterable, Hashable {
         case .http: "HTTP"
         case .https: "HTTPS"
         case .websocket: "WebSocket"
-        case .web3RPC: "Web3/RPC"
+        case .ai: "AI API"
+        case .aiSession: "AI Session"
+        case .web3RPC: "Web3"
+        case .rpcError: "RPC Error"
         case .json: "JSON"
         case .xml: "XML"
         case .js: "JS"
@@ -85,8 +91,15 @@ enum ProtocolFilter: String, CaseIterable, Hashable {
             return transaction.request.url.scheme == "https"
         case .websocket:
             return transaction.webSocketConnection != nil
+        case .ai:
+            let signal = AITrafficDetector.signal(transaction: transaction)
+            return signal.isLikelyAI && signal.kind != .session
+        case .aiSession:
+            return AITrafficDetector.signal(transaction: transaction).kind == .session
         case .web3RPC:
             return transaction.web3RPCInfo != nil
+        case .rpcError:
+            return transaction.web3RPCInfo?.error != nil
         case .json:
             return transaction.response?.contentType == .json || transaction.request.contentType == .json
         case .xml:

--- a/Rockxy/Models/UI/RequestListRow.swift
+++ b/Rockxy/Models/UI/RequestListRow.swift
@@ -49,12 +49,30 @@ struct RequestListRow: Identifiable {
         web3RPCProviderHost = transaction.web3RPCInfo?.providerHost
         web3RPCErrorCode = transaction.web3RPCInfo?.error?.code
         isWebSocket = transaction.webSocketConnection != nil
+        isGraphQL = transaction.graphQLInfo != nil
+        isGRPC = GRPCDetector.isGRPC(transaction: transaction)
         webSocketFrameCount = transaction.webSocketConnection?.frameCount ?? 0
         sourcePort = transaction.sourcePort
         sequenceNumber = transaction.sequenceNumber
         requestHeaders = transaction.request.headers
         responseHeaders = transaction.response?.headers
         self.sslState = sslState ?? Self.defaultSSLState(forScheme: scheme)
+        smartBadgeText = Self.smartBadgeText(
+            aiTrafficSignal: aiTrafficSignal,
+            web3RPCInfo: transaction.web3RPCInfo,
+            isGRPC: isGRPC,
+            isGraphQL: isGraphQL,
+            isWebSocket: isWebSocket,
+            scheme: scheme
+        )
+        smartBadgeTooltip = Self.smartBadgeTooltip(
+            aiTrafficSignal: aiTrafficSignal,
+            web3RPCInfo: transaction.web3RPCInfo,
+            isGRPC: isGRPC,
+            isGraphQL: isGraphQL,
+            isWebSocket: isWebSocket,
+            scheme: scheme
+        )
     }
 
     // MARK: Internal
@@ -81,6 +99,8 @@ struct RequestListRow: Identifiable {
     let highlightColor: HighlightColor?
     let isTLSFailure: Bool
     let aiTrafficSignal: AITrafficSignal
+    let smartBadgeText: String
+    let smartBadgeTooltip: String?
     let graphQLOpName: String?
     let graphQLOpType: String?
     let isWeb3RPC: Bool
@@ -88,6 +108,8 @@ struct RequestListRow: Identifiable {
     let web3RPCProviderHost: String?
     let web3RPCErrorCode: Int?
     let isWebSocket: Bool
+    let isGraphQL: Bool
+    let isGRPC: Bool
     let webSocketFrameCount: Int
     let sourcePort: UInt16?
 
@@ -180,7 +202,7 @@ extension RequestListRow {
         case "ssl":
             compareInt(lhs.sslState.rawValue, rhs.sslState.rawValue)
         case "ai":
-            compareAISignal(lhs, rhs)
+            lhs.smartBadgeText.localizedCompare(rhs.smartBadgeText)
         case "queryName":
             compareQueryName(lhs, rhs)
         case "client":
@@ -229,6 +251,66 @@ extension RequestListRow {
         return "\(batch.web3RequestCount) calls"
     }
 
+    private static func smartBadgeText(
+        aiTrafficSignal: AITrafficSignal,
+        web3RPCInfo: Web3RPCInfo?,
+        isGRPC: Bool,
+        isGraphQL: Bool,
+        isWebSocket: Bool,
+        scheme: String
+    )
+        -> String
+    {
+        if aiTrafficSignal.isLikelyAI {
+            return aiTrafficSignal.tableLabel
+        }
+        if let web3RPCInfo {
+            return web3RPCInfo.error == nil ? "Web3" : "RPC ERR"
+        }
+        if isGRPC {
+            return "gRPC"
+        }
+        if isGraphQL {
+            return "GraphQL"
+        }
+        if isWebSocket {
+            return "WS"
+        }
+        return scheme.uppercased() == "HTTPS" ? "HTTPS" : "HTTP"
+    }
+
+    private static func smartBadgeTooltip(
+        aiTrafficSignal: AITrafficSignal,
+        web3RPCInfo: Web3RPCInfo?,
+        isGRPC: Bool,
+        isGraphQL: Bool,
+        isWebSocket: Bool,
+        scheme: String
+    )
+        -> String?
+    {
+        if !aiTrafficSignal.accessibilityLabel.isEmpty {
+            return aiTrafficSignal.accessibilityLabel
+        }
+        if let web3RPCInfo {
+            if let error = web3RPCInfo.error {
+                let code = error.code.map { " \($0)" } ?? ""
+                return "Web3 RPC error\(code) from \(web3RPCInfo.providerHost)"
+            }
+            return "Web3 RPC traffic from \(web3RPCInfo.providerHost)"
+        }
+        if isGRPC {
+            return "gRPC request"
+        }
+        if isGraphQL {
+            return "GraphQL request"
+        }
+        if isWebSocket {
+            return "WebSocket connection"
+        }
+        return "\(scheme.uppercased() == "HTTPS" ? "HTTPS" : "HTTP") request"
+    }
+
     private static func compareInt(_ lhs: Int, _ rhs: Int) -> ComparisonResult {
         if lhs < rhs {
             return .orderedAscending
@@ -262,27 +344,6 @@ extension RequestListRow {
             }
             return .orderedSame
         }
-    }
-
-    private static func compareBool(_ lhs: Bool, _ rhs: Bool) -> ComparisonResult {
-        switch (lhs, rhs) {
-        case (false, true):
-            .orderedAscending
-        case (true, false):
-            .orderedDescending
-        default:
-            .orderedSame
-        }
-    }
-
-    private static func compareAISignal(_ lhs: RequestListRow, _ rhs: RequestListRow) -> ComparisonResult {
-        let presence = compareBool(lhs.aiTrafficSignal.isLikelyAI, rhs.aiTrafficSignal.isLikelyAI)
-        if presence != .orderedSame {
-            return presence
-        }
-        let lhsProvider = lhs.aiTrafficSignal.provider?.displayName ?? ""
-        let rhsProvider = rhs.aiTrafficSignal.provider?.displayName ?? ""
-        return lhsProvider.localizedCompare(rhsProvider)
     }
 
     private static func defaultSSLState(forScheme scheme: String) -> SSLState {

--- a/Rockxy/Models/UI/ResponseInspectorTab.swift
+++ b/Rockxy/Models/UI/ResponseInspectorTab.swift
@@ -11,9 +11,9 @@ enum ResponseInspectorTab: String, CaseIterable {
 
     // MARK: Internal
 
-    static func availableTabs(hasAIInspection: Bool) -> [ResponseInspectorTab] {
+    static func availableTabs(hasAIInspection _: Bool) -> [ResponseInspectorTab] {
         allCases.filter { tab in
-            hasAIInspection || tab != .ai
+            tab != .ai
         }
     }
 

--- a/Rockxy/Models/UI/SmartTrafficFilter.swift
+++ b/Rockxy/Models/UI/SmartTrafficFilter.swift
@@ -1,0 +1,138 @@
+import Foundation
+
+/// Parses search-bar tokens such as `is:ai` and `rpc:eth_call` into metadata predicates.
+/// Unrecognized text remains available for the normal selected-field substring search.
+struct SmartTrafficFilter: Equatable {
+    enum Predicate: Equatable {
+        case isAI
+        case isAIAPI
+        case isAISession
+        case isWeb3
+        case rpcError(Bool)
+        case rpcMethod(String)
+        case provider(String)
+    }
+
+    let predicates: [Predicate]
+    let remainingSearchText: String
+
+    var hasPredicates: Bool {
+        !predicates.isEmpty
+    }
+
+    static func parse(_ searchText: String) -> SmartTrafficFilter {
+        var predicates: [Predicate] = []
+        var remainingTokens: [String] = []
+
+        for token in searchText.split(whereSeparator: \.isWhitespace).map(String.init) {
+            guard let parsed = parseToken(token) else {
+                remainingTokens.append(token)
+                continue
+            }
+            predicates.append(parsed)
+        }
+
+        return SmartTrafficFilter(
+            predicates: predicates,
+            remainingSearchText: remainingTokens.joined(separator: " ")
+        )
+    }
+
+    func matches(_ transaction: HTTPTransaction) -> Bool {
+        predicates.allSatisfy { predicate in
+            switch predicate {
+            case .isAI:
+                AITrafficDetector.signal(transaction: transaction).isLikelyAI
+            case .isAIAPI:
+                {
+                    let signal = AITrafficDetector.signal(transaction: transaction)
+                    return signal.isLikelyAI && signal.kind != .session
+                }()
+            case .isAISession:
+                AITrafficDetector.signal(transaction: transaction).kind == .session
+            case .isWeb3:
+                transaction.web3RPCInfo != nil
+            case let .rpcError(expected):
+                (transaction.web3RPCInfo?.error != nil) == expected
+            case let .rpcMethod(method):
+                rpcMethods(in: transaction).contains { $0.caseInsensitiveCompare(method) == .orderedSame }
+            case let .provider(provider):
+                providerValues(in: transaction).contains {
+                    $0.localizedCaseInsensitiveContains(provider)
+                }
+            }
+        }
+    }
+
+    private static func parseToken(_ token: String) -> Predicate? {
+        guard let separator = token.firstIndex(of: ":") else {
+            return nil
+        }
+
+        let key = token[..<separator].lowercased()
+        let value = String(token[token.index(after: separator)...])
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !value.isEmpty else {
+            return nil
+        }
+
+        switch key {
+        case "is":
+            switch value.lowercased() {
+            case "ai":
+                return .isAI
+            case "ai_api", "ai-api", "api_ai", "api-ai":
+                return .isAIAPI
+            case "ai_session", "ai-session", "session_ai", "session-ai":
+                return .isAISession
+            case "web3":
+                return .isWeb3
+            default:
+                return nil
+            }
+        case "rpc_error":
+            switch value.lowercased() {
+            case "true", "yes", "1":
+                return .rpcError(true)
+            case "false", "no", "0":
+                return .rpcError(false)
+            default:
+                return nil
+            }
+        case "rpc":
+            return .rpcMethod(value)
+        case "provider":
+            return .provider(value)
+        default:
+            return nil
+        }
+    }
+
+    private func rpcMethods(in transaction: HTTPTransaction) -> [String] {
+        guard let info = transaction.web3RPCInfo else {
+            return []
+        }
+
+        var methods: [String] = []
+        if let method = info.method {
+            methods.append(method)
+        }
+        if let batch = info.batch {
+            methods.append(contentsOf: batch.methods)
+        }
+        return methods
+    }
+
+    private func providerValues(in transaction: HTTPTransaction) -> [String] {
+        var values: [String] = []
+        if let info = transaction.web3RPCInfo {
+            values.append(info.providerHost)
+            values.append(info.family.rawValue)
+        }
+        if let provider = AITrafficDetector.signal(transaction: transaction).provider {
+            values.append(provider.rawValue)
+            values.append(provider.displayName)
+        }
+        return values
+    }
+}

--- a/Rockxy/Views/Certificate/CertificateStatusPanel.swift
+++ b/Rockxy/Views/Certificate/CertificateStatusPanel.swift
@@ -33,6 +33,7 @@ struct CertificateStatusPanel: View {
 
     let snapshot: RootCAStatusSnapshot?
     let isLoading: Bool
+    var pinsActionsToBottom = false
     let onAction: (CertificateAction) -> Void
 
     var body: some View {
@@ -41,14 +42,48 @@ struct CertificateStatusPanel: View {
             diagnosticsGrid
             expiryCallout
             errorCallout
+            if pinsActionsToBottom {
+                Spacer(minLength: 12)
+            }
             actionRow
         }
+        .frame(maxWidth: .infinity, maxHeight: pinsActionsToBottom ? .infinity : nil, alignment: .topLeading)
     }
 
     // MARK: Private
 
     private static let expiryWarningDays = 30
     private static let expiryWarningSeconds: TimeInterval = .init(expiryWarningDays) * 24 * 3_600
+
+    @Environment(\.appUIDisplayMetrics) private var appMetrics
+
+    private var settingsMetrics: SettingsDisplayMetrics {
+        SettingsDisplayMetrics(appMetrics: appMetrics)
+    }
+
+    private var titleFont: Font {
+        settingsMetrics.font(weight: .medium)
+    }
+
+    private var secondaryFont: Font {
+        settingsMetrics.secondaryFont()
+    }
+
+    private var secondaryMonospacedFont: Font {
+        settingsMetrics.secondaryFont(monospaced: true)
+    }
+
+    private var metadataFont: Font {
+        settingsMetrics.metadataFont()
+    }
+
+    private var actionFont: Font {
+        settingsMetrics.font()
+    }
+
+    private var summaryIconFontSize: CGFloat {
+        max(16, settingsMetrics.bodyFontSize + 3)
+    }
 
     private var state: PanelState {
         guard let snapshot else {
@@ -129,18 +164,19 @@ struct CertificateStatusPanel: View {
     // MARK: - Zone A: Summary Row
 
     private var summaryRow: some View {
-        HStack(spacing: Theme.Layout.controlSpacing) {
+        HStack(alignment: .top, spacing: Theme.Layout.controlSpacing) {
             Image(systemName: state.iconName)
                 .foregroundStyle(state.iconColor)
-                .font(.system(size: 16))
+                .font(.system(size: summaryIconFontSize))
+                .padding(.top, 2)
                 .accessibilityLabel(
                     String(localized: "Root CA status: \(state.accessibilityLabel)")
                 )
             VStack(alignment: .leading, spacing: 2) {
                 Text(state.title)
-                    .font(Theme.Typography.sectionTitle)
+                    .font(titleFont)
                 Text(state.subtitle)
-                    .font(.system(size: 11))
+                    .font(secondaryFont)
                     .foregroundStyle(.secondary)
             }
         }
@@ -215,9 +251,9 @@ struct CertificateStatusPanel: View {
             HStack(alignment: .top, spacing: 4) {
                 Image(systemName: "clock.badge.exclamationmark")
                     .foregroundStyle(tintColor)
-                    .font(.system(size: 10))
+                    .font(metadataFont)
                 Text(message)
-                    .font(.system(size: 10))
+                    .font(secondaryFont)
                     .foregroundStyle(tintColor)
             }
             .padding(6)
@@ -240,9 +276,9 @@ struct CertificateStatusPanel: View {
             HStack(alignment: .top, spacing: 4) {
                 Image(systemName: "exclamationmark.triangle.fill")
                     .foregroundStyle(.orange)
-                    .font(.system(size: 10))
+                    .font(metadataFont)
                 Text(message)
-                    .font(.system(size: 10))
+                    .font(secondaryFont)
                     .foregroundStyle(.red)
             }
             .padding(6)
@@ -324,6 +360,7 @@ struct CertificateStatusPanel: View {
                 .disabled(isLoading)
             }
         }
+        .font(actionFont)
     }
 
     private var shareCertificateButton: some View {
@@ -343,11 +380,11 @@ struct CertificateStatusPanel: View {
     {
         GridRow {
             Text(label)
-                .font(.system(size: 11))
+                .font(metadataFont)
                 .foregroundStyle(.secondary)
                 .gridColumnAlignment(.trailing)
             Text(value)
-                .font(.system(size: 11, design: .monospaced))
+                .font(secondaryMonospacedFont)
                 .foregroundStyle(color)
                 .accessibilityLabel(fullAccessibilityValue ?? value)
         }

--- a/Rockxy/Views/Inspector/AIInspectorView.swift
+++ b/Rockxy/Views/Inspector/AIInspectorView.swift
@@ -20,11 +20,15 @@ struct AIInspectorView: View {
                 VStack(spacing: 0) {
                     summaryStrip(inspection)
                     Divider()
-                    HSplitView {
-                        eventList(inspection)
-                            .frame(minWidth: 220, idealWidth: 280, maxWidth: 360)
-                        detailPane(inspection)
-                            .frame(minWidth: 280, maxWidth: .infinity)
+                    if inspection.kind == .session {
+                        sessionPane(inspection)
+                    } else {
+                        HSplitView {
+                            eventList(inspection)
+                                .frame(minWidth: 220, idealWidth: 280, maxWidth: 360)
+                            detailPane(inspection)
+                                .frame(minWidth: 280, maxWidth: .infinity)
+                        }
                     }
                 }
             } else {
@@ -78,11 +82,24 @@ struct AIInspectorView: View {
 
     private func summaryStrip(_ inspection: AIInspection) -> some View {
         VStack(alignment: .leading, spacing: 4) {
+            HStack(spacing: 8) {
+                badge(inspection.kind.displayName, color: inspection.kind == .session ? .teal : .accentColor)
+                if inspection.kind == .session {
+                    badge(String(localized: "TLS only"), color: .orange)
+                } else if inspection.isStreaming {
+                    badge(String(localized: "Stream"), color: .blue)
+                }
+                if !inspection.toolCalls.isEmpty {
+                    badge(String(localized: "Tool"), color: .orange)
+                }
+                Spacer(minLength: 0)
+            }
+
             HStack(spacing: 18) {
                 summaryItem(String(localized: "Provider"), value: inspection.provider.displayName)
                 summaryItem(String(localized: "Model"), value: inspection.model ?? String(localized: "Unavailable"))
                 summaryItem(String(localized: "Finish"), value: finishLabel(for: inspection))
-                summaryItem(String(localized: "Confidence"), value: confidenceLabel(for: inspection))
+                summaryItem(String(localized: "Evidence"), value: evidenceLabel(for: inspection))
             }
 
             Text(unavailableSummary(for: inspection))
@@ -95,6 +112,40 @@ struct AIInspectorView: View {
         .padding(.vertical, 8)
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(.quaternary.opacity(0.5))
+    }
+
+    private func sessionPane(_ inspection: AIInspection) -> some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 12) {
+                sectionCard {
+                    VStack(alignment: .leading, spacing: 10) {
+                        Text(String(localized: "Captured app session"))
+                            .font(.system(size: metrics.primaryFontSize, weight: .semibold))
+                        metadataPair(String(localized: "App"), value: transaction.clientApp ?? String(localized: "Unknown"))
+                        metadataPair(String(localized: "Host"), value: transaction.request.host)
+                        metadataPair(String(localized: "Transport"), value: sessionTransportLabel)
+                    }
+                }
+
+                warningCard(
+                    title: String(localized: "Body unavailable"),
+                    message: String(localized: "Rockxy can identify this AI app session, but model, tokens, and tools need decrypted API evidence."),
+                    color: .orange
+                )
+
+                sectionCard {
+                    VStack(alignment: .leading, spacing: 8) {
+                        sectionHeader(String(localized: "Suggested Check"))
+                        Text(String(localized: "Open SSL Proxying for this host or capture SDK traffic with HTTPS_PROXY when debugging local apps."))
+                            .font(.system(size: metrics.metadataFontSize))
+                            .foregroundStyle(.secondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
+            }
+            .padding(12)
+            .frame(maxWidth: .infinity, alignment: .topLeading)
+        }
     }
 
     private func summaryItem(_ label: String, value: String) -> some View {
@@ -167,6 +218,7 @@ struct AIInspectorView: View {
     private func detailPane(_ inspection: AIInspection) -> some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 14) {
+                debugFocusSection(inspection)
                 timingSection(inspection)
                 usageSection(inspection)
                 toolChainSection(inspection)
@@ -176,6 +228,20 @@ struct AIInspectorView: View {
             }
             .padding(12)
             .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    private func debugFocusSection(_ inspection: AIInspection) -> some View {
+        sectionCard {
+            VStack(alignment: .leading, spacing: 8) {
+                HStack(spacing: 8) {
+                    sectionHeader(String(localized: "Debug Focus"))
+                    badge(aiDebugFocusLabel(inspection), color: aiDebugFocusColor(inspection))
+                    Spacer(minLength: 0)
+                }
+                metadataPair(String(localized: "Outcome"), value: aiDebugOutcome(inspection))
+                metadataPair(String(localized: "Next Check"), value: aiDebugNextCheck(inspection))
+            }
         }
     }
 
@@ -316,6 +382,35 @@ struct AIInspectorView: View {
         }
     }
 
+    private func warningCard(title: String, message: String, color: Color) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(title)
+                .font(.system(size: metrics.secondaryFontSize, weight: .semibold))
+            Text(message)
+                .font(.system(size: metrics.metadataFontSize))
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .foregroundStyle(color)
+        .padding(10)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(color.opacity(0.10), in: RoundedRectangle(cornerRadius: 8))
+        .overlay {
+            RoundedRectangle(cornerRadius: 8)
+                .stroke(color.opacity(0.35), lineWidth: 0.5)
+        }
+    }
+
+    private func sectionCard<Content: View>(@ViewBuilder content: () -> Content) -> some View {
+        content()
+            .padding(10)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(Color(nsColor: .controlBackgroundColor).opacity(0.55), in: RoundedRectangle(cornerRadius: 8))
+            .overlay {
+                RoundedRectangle(cornerRadius: 8)
+                    .stroke(Color(nsColor: .separatorColor), lineWidth: 0.5)
+            }
+    }
+
     @ViewBuilder private var selectedEventSection: some View {
         if let selectedEvent {
             VStack(alignment: .leading, spacing: 8) {
@@ -352,6 +447,16 @@ struct AIInspectorView: View {
         .font(.system(size: metrics.metadataFontSize, design: .monospaced))
     }
 
+    private func badge(_ text: String, color: Color) -> some View {
+        Text(text)
+            .font(.system(size: metrics.badgeFontSize, weight: .semibold))
+            .lineLimit(1)
+            .padding(.horizontal, 7)
+            .padding(.vertical, 3)
+            .background(color.opacity(0.12), in: Capsule())
+            .foregroundStyle(color)
+    }
+
     private func unavailableText(_ text: String) -> some View {
         Text(text)
             .font(.system(size: metrics.metadataFontSize))
@@ -367,6 +472,81 @@ struct AIInspectorView: View {
         case .tools:
             events.filter { $0.category == .tool }
         }
+    }
+
+    private func aiDebugFocusLabel(_ inspection: AIInspection) -> String {
+        if inspection.warnings.contains(where: { $0.severity == .error }) {
+            return String(localized: "Provider Error")
+        }
+        if inspection.isStreaming, !inspection.toolCalls.isEmpty {
+            return String(localized: "Streaming Tool")
+        }
+        if inspection.isStreaming {
+            return String(localized: "Streaming")
+        }
+        if !inspection.toolCalls.isEmpty {
+            return String(localized: "Tool Call")
+        }
+        if !inspection.retrieval.isEmpty {
+            return String(localized: "Retrieval")
+        }
+        if inspection.usage == nil {
+            return String(localized: "Metadata Sparse")
+        }
+        return String(localized: "Completion")
+    }
+
+    private func aiDebugFocusColor(_ inspection: AIInspection) -> Color {
+        if inspection.warnings.contains(where: { $0.severity == .error }) {
+            return .red
+        }
+        if !inspection.toolCalls.isEmpty {
+            return .orange
+        }
+        if inspection.isStreaming {
+            return .blue
+        }
+        if !inspection.retrieval.isEmpty {
+            return .green
+        }
+        return .secondary
+    }
+
+    private func aiDebugOutcome(_ inspection: AIInspection) -> String {
+        if let warning = inspection.warnings.first(where: { $0.severity == .error }) {
+            return warning.message
+        }
+        if let statusCode = transaction.response?.statusCode,
+           statusCode >= 400
+        {
+            return String(localized: "HTTP \(statusCode) from provider")
+        }
+        if inspection.isStreaming {
+            return String(localized: "\(inspection.events.count) captured stream events, finish \(finishLabel(for: inspection))")
+        }
+        return String(localized: "Finish \(finishLabel(for: inspection))")
+    }
+
+    private func aiDebugNextCheck(_ inspection: AIInspection) -> String {
+        if inspection.warnings.contains(where: { $0.severity == .error }) {
+            return String(localized: "Check provider error body, request id, auth, rate-limit headers, and retry timing.")
+        }
+        if inspection.isStreaming, !inspection.toolCalls.isEmpty {
+            return String(localized: "Filter Tools and verify partial arguments, final tool call state, and stream completion.")
+        }
+        if inspection.isStreaming {
+            return String(localized: "Check event count, final event, interruption signs, and first-token/overall duration.")
+        }
+        if !inspection.toolCalls.isEmpty {
+            return String(localized: "Verify declared tool name, arguments, completion state, and app-side tool result follow-up.")
+        }
+        if !inspection.retrieval.isEmpty {
+            return String(localized: "Review retrieved sources, score, and sensitive-data risk before sharing traces.")
+        }
+        if inspection.usage == nil {
+            return String(localized: "Confirm provider adapter, response body visibility, and whether usage is omitted by this endpoint.")
+        }
+        return String(localized: "Compare model, tokens, finish reason, and latency against adjacent retries.")
     }
 
     private func durationLabel(_ duration: TimeInterval?) -> String {
@@ -400,6 +580,23 @@ struct AIInspectorView: View {
             : String(localized: "observed")
     }
 
+    private func evidenceLabel(for inspection: AIInspection) -> String {
+        if inspection.evidence.isEmpty {
+            return confidenceLabel(for: inspection)
+        }
+        return inspection.evidence.joined(separator: ", ")
+    }
+
+    private var sessionTransportLabel: String {
+        if transaction.webSocketConnection != nil || transaction.request.url.scheme?.lowercased() == "wss" {
+            return String(localized: "WebSocket / TLS")
+        }
+        if transaction.request.method.caseInsensitiveCompare("CONNECT") == .orderedSame {
+            return String(localized: "CONNECT / TLS")
+        }
+        return String(localized: "HTTPS / TLS")
+    }
+
     private func unavailableSummary(for inspection: AIInspection) -> String {
         if inspection.unavailableFields.isEmpty {
             return String(localized: "All displayed values come from visible captured traffic.")
@@ -414,4 +611,19 @@ private enum AIInspectorEventFilter: Hashable {
     case all
     case stream
     case tools
+}
+
+private extension AITrafficSignalKind {
+    var displayName: String {
+        switch self {
+        case .api:
+            String(localized: "AI API")
+        case .session:
+            String(localized: "AI Session")
+        case .heuristic:
+            String(localized: "Likely AI")
+        case .none:
+            String(localized: "AI")
+        }
+    }
 }

--- a/Rockxy/Views/Inspector/GRPCInspectorView.swift
+++ b/Rockxy/Views/Inspector/GRPCInspectorView.swift
@@ -17,9 +17,9 @@ struct GRPCInspectorView: View {
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
             case .unsupported:
                 InspectorEmptyStateView(
-                    String(localized: "Empty gRPC Data"),
+                    String(localized: "No gRPC Metadata"),
                     systemImage: "point.3.connected.trianglepath.dotted",
-                    description: String(localized: "This transaction does not include gRPC metadata or length-prefixed messages.")
+                    description: String(localized: "Open this tab when a request uses application/grpc metadata or length-prefixed gRPC messages.")
                 )
             case let .loaded(inspection):
                 inspectorContent(inspection)

--- a/Rockxy/Views/Inspector/ResponseInspectorView.swift
+++ b/Rockxy/Views/Inspector/ResponseInspectorView.swift
@@ -8,8 +8,8 @@ import SwiftUI
 /// Right half of the inspector split view. Provides tabbed access to response-side data:
 /// headers, body (with format picker), Set-Cookie headers, auth, and timing breakdown.
 /// Also supports optional body preview tabs from PreviewTabStore.
-/// Conditionally shows protocol-specific tabs (WebSocket, GraphQL, gRPC) when the selected
-/// transaction has protocol-specific data.
+/// Shows protocol-specific tabs alongside ordinary response tabs so multiple inspections can
+/// coexist for the same transaction.
 struct ResponseInspectorView: View {
     // MARK: Internal
 
@@ -50,8 +50,8 @@ struct ResponseInspectorView: View {
     @Environment(\.openWindow) private var openWindow
     @Environment(\.appUIDisplayMetrics) private var metrics
 
-    private var hasProtocolTab: Bool {
-        transaction.webSocketConnection != nil || transaction.web3RPCInfo != nil || transaction.graphQLInfo != nil
+    private var hasProtocolTabs: Bool {
+        !ProtocolTabKind.availableTabs(for: transaction).isEmpty
     }
 
     private var httpsPromptModel: HTTPSInspectionPromptModel? {
@@ -78,14 +78,6 @@ struct ResponseInspectorView: View {
 
     private var inspectorTabBar: some View {
         InspectorTabStrip {
-            if hasProtocolTab {
-                protocolTabButtons
-
-                Divider()
-                    .frame(height: max(14, metrics.controlFontSize + 2))
-                    .padding(.horizontal, 4)
-            }
-
             ForEach(ResponseInspectorTab.availableTabs(hasAIInspection: hasAIInspection), id: \.self) { tab in
                 InspectorTabButton(
                     title: tab.displayName,
@@ -97,8 +89,6 @@ struct ResponseInspectorView: View {
                     selectedTab = tab
                 }
             }
-
-            grpcTabButton
 
             if !previewTabStore.responseTabs.isEmpty {
                 Divider()
@@ -117,6 +107,14 @@ struct ResponseInspectorView: View {
                 }
             }
 
+            if hasProtocolTabs {
+                Divider()
+                    .frame(height: max(14, metrics.controlFontSize + 2))
+                    .padding(.horizontal, 4)
+
+                protocolTabButtons
+            }
+
             Divider()
                 .frame(height: max(14, metrics.controlFontSize + 2))
                 .padding(.horizontal, 4)
@@ -128,48 +126,15 @@ struct ResponseInspectorView: View {
     }
 
     @ViewBuilder private var protocolTabButtons: some View {
-        if transaction.webSocketConnection != nil {
+        ForEach(ProtocolTabKind.availableTabs(for: transaction), id: \.self) { tab in
             InspectorTabButton(
-                title: String(localized: "WebSocket"),
-                isActive: protocolTab == .websocket
+                title: tab.displayName,
+                isActive: protocolTab == tab
             ) {
                 selectionIntent = .protocolSpecific
-                protocolTab = .websocket
+                protocolTab = tab
                 selectedPreviewTab = nil
             }
-        }
-
-        if transaction.web3RPCInfo != nil {
-            InspectorTabButton(
-                title: String(localized: "Web3/RPC"),
-                isActive: protocolTab == .web3
-            ) {
-                selectionIntent = .protocolSpecific
-                protocolTab = .web3
-                selectedPreviewTab = nil
-            }
-        }
-
-        if transaction.graphQLInfo != nil {
-            InspectorTabButton(
-                title: String(localized: "GraphQL"),
-                isActive: protocolTab == .graphql
-            ) {
-                selectionIntent = .protocolSpecific
-                protocolTab = .graphql
-                selectedPreviewTab = nil
-            }
-        }
-    }
-
-    private var grpcTabButton: some View {
-        InspectorTabButton(
-            title: "gRPC",
-            isActive: protocolTab == .grpc
-        ) {
-            selectionIntent = .protocolSpecific
-            protocolTab = .grpc
-            selectedPreviewTab = nil
         }
     }
 
@@ -315,6 +280,8 @@ struct ResponseInspectorView: View {
         Group {
             if let proto = protocolTab {
                 switch proto {
+                case .ai:
+                    AIInspectorView(transaction: transaction)
                 case .websocket:
                     WebSocketInspectorView(transaction: transaction)
                 case .web3:
@@ -546,11 +513,6 @@ struct ResponseInspectorView: View {
     }
 
     private func syncInspectorStateForTransaction() {
-        let supportsAIInspection = hasAIInspection
-        if selectedTab == .ai, !supportsAIInspection {
-            selectedTab = .headers
-        }
-
         if let selectedPreviewTab,
            !previewTabStore.responseTabs.contains(where: { $0.id == selectedPreviewTab.id })
         {
@@ -561,15 +523,12 @@ struct ResponseInspectorView: View {
         switch selectionIntent {
         case .automatic:
             protocolTab = ProtocolTabKind.defaultFor(transaction)
-            if protocolTab == nil, supportsAIInspection {
-                selectedTab = .ai
-            }
         case .native,
              .preview:
             protocolTab = nil
         case .protocolSpecific:
             if let protocolTab,
-               ProtocolTabKind.isSupported(protocolTab, by: transaction)
+               ProtocolTabKind.hasDetectedSignal(protocolTab, in: transaction)
             {
                 return
             }
@@ -808,7 +767,8 @@ struct HTTPSInspectionPromptModel: Equatable {
 
 /// Protocol-specific tab selection for the response inspector.
 /// Separate from ResponseInspectorTab to avoid showing protocol tabs for all transactions.
-enum ProtocolTabKind {
+enum ProtocolTabKind: Hashable {
+    case ai
     case websocket
     case web3
     case graphql
@@ -816,8 +776,27 @@ enum ProtocolTabKind {
 
     // MARK: Internal
 
+    /// Returns the protocol/smart tabs that should be visible for a transaction.
+    /// AI and Web3 stay visible even without metadata so their inspectors can render empty states.
+    static func availableTabs(for transaction: HTTPTransaction) -> [ProtocolTabKind] {
+        var tabs: [ProtocolTabKind] = []
+        if transaction.webSocketConnection != nil {
+            tabs.append(.websocket)
+        }
+        if transaction.graphQLInfo != nil {
+            tabs.append(.graphql)
+        }
+        tabs.append(.ai)
+        tabs.append(.web3)
+        tabs.append(.grpc)
+        return tabs
+    }
+
     /// Returns the default protocol tab for a transaction, or nil for plain HTTP.
     static func defaultFor(_ transaction: HTTPTransaction) -> ProtocolTabKind? {
+        if AITrafficDetector.isLikelyAI(transaction: transaction) {
+            return .ai
+        }
         if transaction.webSocketConnection != nil {
             return .websocket
         }
@@ -835,6 +814,23 @@ enum ProtocolTabKind {
 
     static func isSupported(_ tab: ProtocolTabKind, by transaction: HTTPTransaction) -> Bool {
         switch tab {
+        case .ai:
+            true
+        case .websocket:
+            transaction.webSocketConnection != nil
+        case .web3:
+            true
+        case .graphql:
+            transaction.graphQLInfo != nil
+        case .grpc:
+            true
+        }
+    }
+
+    static func hasDetectedSignal(_ tab: ProtocolTabKind, in transaction: HTTPTransaction) -> Bool {
+        switch tab {
+        case .ai:
+            AITrafficDetector.isLikelyAI(transaction: transaction)
         case .websocket:
             transaction.webSocketConnection != nil
         case .web3:
@@ -842,7 +838,22 @@ enum ProtocolTabKind {
         case .graphql:
             transaction.graphQLInfo != nil
         case .grpc:
-            true
+            GRPCDetector.isGRPC(transaction: transaction)
+        }
+    }
+
+    var displayName: String {
+        switch self {
+        case .ai:
+            "AI"
+        case .websocket:
+            String(localized: "WebSocket")
+        case .web3:
+            String(localized: "Web3")
+        case .graphql:
+            String(localized: "GraphQL")
+        case .grpc:
+            "gRPC"
         }
     }
 }

--- a/Rockxy/Views/Inspector/Web3RPCInspectorView.swift
+++ b/Rockxy/Views/Inspector/Web3RPCInspectorView.swift
@@ -13,6 +13,7 @@ struct Web3RPCInspectorView: View {
             ScrollView {
                 VStack(alignment: .leading, spacing: 12) {
                     callSummary(info)
+                    debugIntentCard(info)
                     metadataGrid(info)
                     batchSummary(info.batch)
                     errorStrip(info.error)
@@ -23,9 +24,9 @@ struct Web3RPCInspectorView: View {
             .background(Color(nsColor: .textBackgroundColor))
         } else {
             InspectorEmptyStateView(
-                String(localized: "No Web3 RPC Data"),
+                String(localized: "No Web3 Detected"),
                 systemImage: "network",
-                description: String(localized: "This transaction does not include Web3 JSON-RPC metadata.")
+                description: String(localized: "Open this tab when a request carries JSON-RPC methods such as eth_call, sendTransaction, or getLatestBlockhash.")
             )
         }
     }
@@ -37,7 +38,7 @@ struct Web3RPCInspectorView: View {
     private func callSummary(_ info: Web3RPCInfo) -> some View {
         VStack(alignment: .leading, spacing: 10) {
             HStack(spacing: 6) {
-                badge(String(localized: "Web3 JSON-RPC"), color: .purple)
+                badge(String(localized: "Web3"), color: .green)
                 badge(info.family.displayName, color: .blue)
                 if let statusCode = transaction.response?.statusCode {
                     badge(String(localized: "HTTP \(statusCode)"), color: statusCode < 400 ? .green : .red)
@@ -59,12 +60,7 @@ struct Web3RPCInspectorView: View {
                     .textSelection(.enabled)
             }
 
-            LazyVGrid(columns: summaryColumns, alignment: .leading, spacing: 8) {
-                metric(String(localized: "Provider"), value: info.providerHost, color: .primary)
-                metric(String(localized: "Request ID"), value: info.requestID ?? String(localized: "Batch"), color: .primary)
-                metric(String(localized: "Chain"), value: info.chainHint?.chainID ?? String(localized: "Unknown"), color: .primary)
-                metric(String(localized: "Payload"), value: payloadSummary(info), color: .primary)
-            }
+            summaryMetrics(info)
         }
         .padding(12)
         .background(Color(nsColor: .controlBackgroundColor).opacity(0.55))
@@ -75,10 +71,38 @@ struct Web3RPCInspectorView: View {
         }
     }
 
-    private var summaryColumns: [GridItem] {
-        [
-            GridItem(.adaptive(minimum: 140), spacing: 8, alignment: .leading),
-        ]
+    private func summaryMetrics(_ info: Web3RPCInfo) -> some View {
+        let provider = summaryMetric(String(localized: "Provider"), value: info.providerHost, color: .primary)
+        let requestID = summaryMetric(String(localized: "Request ID"), value: info.requestID ?? String(localized: "Batch"), color: .primary)
+        let chain = summaryMetric(String(localized: "Chain"), value: info.chainHint?.chainID ?? String(localized: "Unknown"), color: .primary)
+        let payload = summaryMetric(String(localized: "Payload"), value: payloadSummary(info), color: .primary)
+
+        return ViewThatFits(in: .horizontal) {
+            HStack(alignment: .top, spacing: 8) {
+                provider
+                requestID
+                chain
+                payload
+            }
+
+            VStack(alignment: .leading, spacing: 8) {
+                HStack(alignment: .top, spacing: 8) {
+                    provider
+                    requestID
+                }
+                HStack(alignment: .top, spacing: 8) {
+                    chain
+                    payload
+                }
+            }
+
+            VStack(alignment: .leading, spacing: 8) {
+                provider
+                requestID
+                chain
+                payload
+            }
+        }
     }
 
     private func metadataGrid(_ info: Web3RPCInfo) -> some View {
@@ -90,6 +114,18 @@ struct Web3RPCInspectorView: View {
             VStack(alignment: .leading, spacing: 12) {
                 callSection(info)
                 resultSection(info)
+            }
+        }
+    }
+
+    private func debugIntentCard(_ info: Web3RPCInfo) -> some View {
+        section(String(localized: "Debug Intent"), badgeText: info.debugIntent.displayName) {
+            VStack(spacing: 0) {
+                metadataRow(String(localized: "Intent"), value: info.debugIntent.explanation, color: info.debugIntent.color)
+                Divider()
+                metadataRow(String(localized: "Outcome"), value: outcomeText(info), color: outcomeColor(info))
+                Divider()
+                metadataRow(String(localized: "Next Check"), value: nextCheckText(info), color: .primary)
             }
         }
     }
@@ -278,7 +314,7 @@ struct Web3RPCInspectorView: View {
             .foregroundStyle(color)
     }
 
-    private func metric(_ label: String, value: String, color: Color) -> some View {
+    private func summaryMetric(_ label: String, value: String, color: Color) -> some View {
         VStack(alignment: .leading, spacing: 3) {
             Text(label)
                 .font(.system(size: metrics.badgeFontSize, weight: .medium))
@@ -292,6 +328,7 @@ struct Web3RPCInspectorView: View {
         }
         .padding(.horizontal, 9)
         .padding(.vertical, 7)
+        .frame(minWidth: 136, maxWidth: .infinity, alignment: .leading)
         .background(Color(nsColor: .textBackgroundColor), in: RoundedRectangle(cornerRadius: 6))
         .overlay {
             RoundedRectangle(cornerRadius: 6)
@@ -332,6 +369,145 @@ struct Web3RPCInspectorView: View {
         }
         return String(localized: "Success")
     }
+
+    private func outcomeText(_ info: Web3RPCInfo) -> String {
+        if let error = info.error {
+            if let code = error.code, let message = error.message {
+                return String(localized: "RPC \(code): \(message)")
+            }
+            return error.message ?? String(localized: "Provider returned a JSON-RPC error")
+        }
+
+        if let statusCode = transaction.response?.statusCode,
+           statusCode >= 400
+        {
+            return String(localized: "HTTP \(statusCode) from provider")
+        }
+
+        if let batch = info.batch {
+            return batch.errorCount == 0 ?
+                String(localized: "\(batch.web3RequestCount) batch calls completed") :
+                String(localized: "\(batch.errorCount) of \(batch.web3RequestCount) batch calls failed")
+        }
+
+        return String(localized: "RPC completed")
+    }
+
+    private func outcomeColor(_ info: Web3RPCInfo) -> Color {
+        if info.error != nil {
+            return .red
+        }
+        if let statusCode = transaction.response?.statusCode,
+           statusCode >= 400
+        {
+            return .red
+        }
+        if let batch = info.batch,
+           batch.errorCount > 0
+        {
+            return .orange
+        }
+        return .green
+    }
+
+    private func nextCheckText(_ info: Web3RPCInfo) -> String {
+        if info.error != nil {
+            switch info.debugIntent {
+            case .broadcast:
+                return String(localized: "Check raw transaction/signature, wallet signer state, nonce, gas, and provider rejection details.")
+            case .batch:
+                return String(localized: "Open the raw response and match failed batch ids to their request methods.")
+            case .simulation:
+                return String(localized: "Compare call params, block tag, gas estimate, and revert message between attempts.")
+            default:
+                return String(localized: "Check provider error code/message, request id, auth headers, and retry timing.")
+            }
+        }
+
+        switch info.debugIntent {
+        case .batch:
+            return String(localized: "Verify each subcall belongs together and watch for mixed read/write calls in one request.")
+        case .broadcast:
+            return String(localized: "Follow the returned transaction hash/signature into receipt or confirmation polling.")
+        case .simulation:
+            return String(localized: "Compare block tag, calldata, gas, and returned value before sending a transaction.")
+        case .logs:
+            return String(localized: "Check block range, topic filters, returned tx hash, and receipt correlation.")
+        case .subscription:
+            return String(localized: "Follow subscribe id, notifications, unsubscribe, and any dropped WebSocket frames.")
+        case .provider:
+            return String(localized: "Use this as provider/chain baseline before comparing app calls.")
+        case .read:
+            return String(localized: "Compare account, commitment/block tag, and result size across providers or retries.")
+        case .unknown:
+            return String(localized: "Inspect raw JSON-RPC params and response body to classify this method.")
+        }
+    }
+}
+
+private extension Web3RPCDebugIntent {
+    var displayName: String {
+        switch self {
+        case .batch:
+            String(localized: "Batch")
+        case .broadcast:
+            String(localized: "Broadcast")
+        case .simulation:
+            String(localized: "Simulation")
+        case .logs:
+            String(localized: "Logs")
+        case .subscription:
+            String(localized: "Subscription")
+        case .provider:
+            String(localized: "Provider")
+        case .read:
+            String(localized: "Read")
+        case .unknown:
+            String(localized: "Unknown")
+        }
+    }
+
+    var explanation: String {
+        switch self {
+        case .batch:
+            String(localized: "Multiple JSON-RPC calls shipped together")
+        case .broadcast:
+            String(localized: "Write-like transaction/signature path")
+        case .simulation:
+            String(localized: "Dry-run or gas/compute estimation")
+        case .logs:
+            String(localized: "Event, receipt, or transaction lookup")
+        case .subscription:
+            String(localized: "Realtime subscription lifecycle")
+        case .provider:
+            String(localized: "Provider, chain, or node baseline")
+        case .read:
+            String(localized: "State read with no expected write")
+        case .unknown:
+            String(localized: "Method needs manual inspection")
+        }
+    }
+
+    var color: Color {
+        switch self {
+        case .broadcast:
+            .orange
+        case .simulation:
+            .blue
+        case .logs:
+            .purple
+        case .subscription:
+            .indigo
+        case .batch:
+            .teal
+        case .provider:
+            .secondary
+        case .read:
+            .green
+        case .unknown:
+            .secondary
+        }
+    }
 }
 
 private extension Web3RPCFamily {
@@ -347,9 +523,9 @@ private extension Web3RPCFamily {
     var longDisplayName: String {
         switch self {
         case .evm:
-            "EVM JSON-RPC"
+            "EVM RPC"
         case .solana:
-            "Solana JSON-RPC"
+            "Solana RPC"
         }
     }
 }

--- a/Rockxy/Views/Main/Extensions/MainContentCoordinator+Filtering.swift
+++ b/Rockxy/Views/Main/Extensions/MainContentCoordinator+Filtering.swift
@@ -91,6 +91,7 @@ extension MainContentCoordinator {
             deriveFilteredRows()
             return
         }
+        let smartFilter = SmartTrafficFilter.parse(filterCriteria.searchText)
         filteredTransactions = baseList.filter { transaction in
             if transaction.isTLSFailure {
                 return false
@@ -114,10 +115,15 @@ extension MainContentCoordinator {
                 }
             }
             if filterCriteria.isSearchEnabled, !filterCriteria.searchText.isEmpty {
-                let searchText = filterCriteria.searchText.lowercased()
-                let targetValue = fieldValue(for: filterCriteria.searchField, in: transaction)
-                guard targetValue.lowercased().contains(searchText) else {
+                guard smartFilter.matches(transaction) else {
                     return false
+                }
+                let searchText = smartFilter.remainingSearchText.lowercased()
+                if !searchText.isEmpty {
+                    let targetValue = fieldValue(for: filterCriteria.searchField, in: transaction)
+                    guard targetValue.lowercased().contains(searchText) else {
+                        return false
+                    }
                 }
             }
             if !filterCriteria.methods.isEmpty {
@@ -251,6 +257,7 @@ extension MainContentCoordinator {
             deriveFilteredRows(for: workspace)
             return
         }
+        let smartFilter = SmartTrafficFilter.parse(workspace.filterCriteria.searchText)
         workspace.filteredTransactions = baseList.filter { transaction in
             if transaction.isTLSFailure {
                 return false
@@ -274,10 +281,15 @@ extension MainContentCoordinator {
                 }
             }
             if workspace.filterCriteria.isSearchEnabled, !workspace.filterCriteria.searchText.isEmpty {
-                let searchText = workspace.filterCriteria.searchText.lowercased()
-                let targetValue = fieldValue(for: workspace.filterCriteria.searchField, in: transaction)
-                guard targetValue.lowercased().contains(searchText) else {
+                guard smartFilter.matches(transaction) else {
                     return false
+                }
+                let searchText = smartFilter.remainingSearchText.lowercased()
+                if !searchText.isEmpty {
+                    let targetValue = fieldValue(for: workspace.filterCriteria.searchField, in: transaction)
+                    guard targetValue.lowercased().contains(searchText) else {
+                        return false
+                    }
                 }
             }
             if !workspace.filterCriteria.methods.isEmpty {

--- a/Rockxy/Views/RequestList/RequestTableView.swift
+++ b/Rockxy/Views/RequestList/RequestTableView.swift
@@ -202,7 +202,7 @@ struct RequestTableView: NSViewRepresentable {
     private static func makeColumns() -> [NSTableColumn] {
         let specs: [ColumnSpec] = [
             ColumnSpec(id: "status", title: "", width: 22, minWidth: 22),
-            ColumnSpec(id: "ai", title: String(localized: "AI"), width: 38, minWidth: 32),
+            ColumnSpec(id: "ai", title: String(localized: "Protocol"), width: 92, minWidth: 64),
             ColumnSpec(id: "row", title: String(localized: "ID"), width: 46, minWidth: 36),
             ColumnSpec(id: "url", title: String(localized: "URL"), width: 300, minWidth: 200),
             ColumnSpec(id: "client", title: String(localized: "Client"), width: 120, minWidth: 60),
@@ -232,7 +232,11 @@ struct RequestTableView: NSViewRepresentable {
                 column.resizingMask = []
                 column.maxWidth = 22
             } else if spec.id == "ai" {
-                column.maxWidth = 44
+                column.maxWidth = 112
+                column.sortDescriptorPrototype = NSSortDescriptor(
+                    key: spec.id,
+                    ascending: true
+                )
             } else if spec.id == "ssl" {
                 column.maxWidth = 42
             } else {
@@ -632,7 +636,7 @@ extension RequestTableView {
 
             switch columnID {
             case "status": return 22
-            case "ai": return 38
+            case "ai": return 92
             case "row": return 46
             case "ssl": return 38
             default: break
@@ -657,7 +661,7 @@ extension RequestTableView {
                     text = rowData.clientApp ?? ""
                     font = metrics.appKitFont()
                 case "ai":
-                    text = rowData.aiTrafficSignal.tableLabel
+                    text = rowData.smartBadgeText
                     font = metrics.appKitFont(weight: .semibold)
                 case "method":
                     text = rowData.method
@@ -1530,7 +1534,7 @@ extension RequestTableView {
             // Built-in column visibility
             let builtInColumns: [(id: String, title: String)] = [
                 ("status", String(localized: "Status Icon")),
-                ("ai", String(localized: "AI")),
+                ("ai", String(localized: "Protocol")),
                 ("row", "#"),
                 ("url", String(localized: "URL")),
                 ("client", String(localized: "Client")),
@@ -2126,12 +2130,10 @@ extension RequestTableView {
 
             case "ai":
                 cell.alignment = .center
-                cell.stringValue = rowData.aiTrafficSignal.tableLabel
-                cell.toolTip = rowData.aiTrafficSignal.accessibilityLabel.isEmpty
-                    ? nil
-                    : rowData.aiTrafficSignal.accessibilityLabel
+                cell.stringValue = rowData.smartBadgeText
+                cell.toolTip = rowData.smartBadgeTooltip
                 cell.font = metrics.appKitFont(weight: .semibold)
-                cell.textColor = rowData.aiTrafficSignal.isLikelyAI ? .controlAccentColor : .tertiaryLabelColor
+                cell.textColor = protocolTextColor(for: rowData)
 
             case "method":
                 cell.alignment = .center
@@ -2227,6 +2229,21 @@ extension RequestTableView {
                 } else {
                     cell.stringValue = ""
                 }
+            }
+        }
+
+        private func protocolTextColor(for row: RequestListRow) -> NSColor {
+            switch row.smartBadgeText {
+            case "RPC ERR":
+                .systemRed
+            case "Web3":
+                .systemGreen
+            case "AI API", "AI Session", "Likely AI":
+                .controlAccentColor
+            case "gRPC", "GraphQL", "WS":
+                .systemBlue
+            default:
+                .secondaryLabelColor
             }
         }
 

--- a/Rockxy/Views/Settings/GeneralSettingsTab.swift
+++ b/Rockxy/Views/Settings/GeneralSettingsTab.swift
@@ -12,62 +12,35 @@ struct GeneralSettingsTab: View {
 
     var body: some View {
         ScrollView {
-            VStack(alignment: .leading, spacing: 16) {
-                // Port Number
-                settingsRow(label: String(localized: "Port Number:")) {
-                    TextField("", value: $proxyPort, format: .number)
-                        .textFieldStyle(.roundedBorder)
-                        .font(settingsMetrics.font(monospaced: true))
-                        .frame(width: settingsMetrics.fieldWidth(80))
-                        .frame(minHeight: settingsMetrics.controlHeight)
+            VStack(alignment: .leading, spacing: 18) {
+                Text(String(localized: "Proxy"))
+                    .font(settingsMetrics.font(weight: .medium))
+
+                sectionCard {
+                    generalControlsSection
                 }
 
-                // Auto Start Recording
-                checkboxRow(
-                    isOn: $recordOnLaunch,
-                    title: String(localized: "Auto Start Recording Traffic at Launch"),
-                    description: String(
-                        localized: "Start capturing network traffic as soon as the app launches."
-                    )
-                )
+                Text(String(localized: "Root CA Certificate"))
+                    .font(settingsMetrics.font(weight: .medium))
 
-                // Advanced Proxy Setting button
-                HStack {
-                    Color.clear.frame(width: settingsMetrics.rowLeading)
-                    Button(String(localized: "Advanced Proxy Setting…")) {
-                        openWindow(id: "advancedProxySettings")
+                sectionCard {
+                    VStack(alignment: .leading, spacing: 12) {
+                        certificateSection
+
+                        if case let .success(message) = certificateStatus {
+                            certificateFeedbackRow(message: message, color: .green)
+                        } else if case let .error(message) = certificateStatus {
+                            certificateFeedbackRow(message: message, color: .red)
+                        }
                     }
                 }
-
-                sectionDivider
-
-                // Certificate section
-                certificateSection
-
-                // Certificate status feedback
-                if case let .success(message) = certificateStatus {
-                    HStack(spacing: 8) {
-                        Color.clear.frame(width: settingsMetrics.rowLeading)
-                        Text(message)
-                            .foregroundStyle(.green)
-                            .font(settingsMetrics.secondaryFont())
-                            .fixedSize(horizontal: false, vertical: true)
-                    }
-                } else if case let .error(message) = certificateStatus {
-                    HStack(spacing: 8) {
-                        Color.clear.frame(width: settingsMetrics.rowLeading)
-                        Text(message)
-                            .foregroundStyle(.red)
-                            .font(settingsMetrics.secondaryFont())
-                            .fixedSize(horizontal: false, vertical: true)
-                    }
-                }
-
-                Spacer()
             }
             .padding(.horizontal, settingsMetrics.contentPadding)
             .padding(.top, 20)
+            .padding(.bottom, 20)
+            .frame(maxWidth: .infinity, alignment: .topLeading)
         }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
         .onChange(of: proxyPort) { _, newValue in
             AppSettingsManager.shared.updateProxyPort(newValue)
         }
@@ -134,22 +107,65 @@ struct GeneralSettingsTab: View {
     @State private var certificateStatus: CertificateStatus = .idle
     @StateObject private var caShareController = CAShareController()
 
-    private var sectionDivider: some View {
-        Divider().padding(.horizontal, 0)
-    }
-
     private var settingsMetrics: SettingsDisplayMetrics {
         SettingsDisplayMetrics(appMetrics: appMetrics)
     }
 
-    private var certificateSection: some View {
-        settingsRow(label: String(localized: "Root CA Certificate:")) {
-            CertificateStatusPanel(
-                snapshot: certSnapshot,
-                isLoading: certLoading,
-                onAction: handleCertAction
-            )
+    private func sectionCard<Content: View>(
+        @ViewBuilder content: () -> Content
+    )
+        -> some View
+    {
+        VStack(alignment: .leading, spacing: 12) {
+            content()
         }
+        .padding(.horizontal, 18)
+        .padding(.vertical, 16)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            Color(nsColor: .controlBackgroundColor).opacity(0.82),
+            in: RoundedRectangle(cornerRadius: 8)
+        )
+        .overlay {
+            RoundedRectangle(cornerRadius: 8)
+                .stroke(Color(nsColor: .separatorColor).opacity(0.22), lineWidth: 0.5)
+        }
+    }
+
+    private var certificateSection: some View {
+        CertificateStatusPanel(
+            snapshot: certSnapshot,
+            isLoading: certLoading,
+            onAction: handleCertAction
+        )
+    }
+
+    private var generalControlsSection: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            settingsRow(label: String(localized: "Port Number:")) {
+                TextField("", value: $proxyPort, format: .number)
+                    .textFieldStyle(.roundedBorder)
+                    .font(settingsMetrics.font(monospaced: true))
+                    .frame(width: settingsMetrics.fieldWidth(80))
+                    .frame(minHeight: settingsMetrics.controlHeight)
+            }
+
+            checkboxRow(
+                isOn: $recordOnLaunch,
+                title: String(localized: "Auto Start Recording Traffic at Launch"),
+                description: String(
+                    localized: "Start capturing network traffic as soon as the app launches."
+                )
+            )
+
+            HStack {
+                Color.clear.frame(width: settingsMetrics.rowLeading)
+                Button(String(localized: "Advanced Proxy Setting…")) {
+                    openWindow(id: "advancedProxySettings")
+                }
+            }
+        }
+        .fixedSize(horizontal: false, vertical: true)
     }
 
     private func settingsRow(
@@ -186,6 +202,13 @@ struct GeneralSettingsTab: View {
                     .fixedSize(horizontal: false, vertical: true)
             }
         }
+    }
+
+    private func certificateFeedbackRow(message: String, color: Color) -> some View {
+        Text(message)
+            .foregroundStyle(color)
+            .font(settingsMetrics.secondaryFont())
+            .fixedSize(horizontal: false, vertical: true)
     }
 
     // MARK: - Certificate Actions

--- a/RockxyTests/Core/Detection/AITrafficDetectorTests.swift
+++ b/RockxyTests/Core/Detection/AITrafficDetectorTests.swift
@@ -30,6 +30,7 @@ struct AITrafficDetectorTests {
         let inspection = try #require(AITrafficDetector.detect(transaction: transaction))
 
         #expect(inspection.provider == .openAICompatible)
+        #expect(inspection.kind == .api)
         #expect(inspection.model == "gpt-4.1-mini")
         #expect(inspection.isStreaming)
         #expect(inspection.usage?.inputTokens == 920)
@@ -60,6 +61,26 @@ struct AITrafficDetectorTests {
         #expect(inspection.unavailableFields.contains("usage"))
     }
 
+    @Test("Known AI app session is detected without visible body metadata")
+    func nativeAISessionIsDetectedFromHostEvidence() throws {
+        let transaction = TestFixtures.makeTransaction(
+            method: "CONNECT",
+            url: "https://chatgpt.com/",
+            statusCode: nil
+        )
+        transaction.clientApp = "ChatGPT"
+
+        let signal = AITrafficDetector.signal(transaction: transaction)
+        let inspection = try #require(AITrafficDetector.detect(transaction: transaction))
+
+        #expect(signal.tableLabel == "AI Session")
+        #expect(signal.evidence.contains("body hidden"))
+        #expect(inspection.provider == .chatGPT)
+        #expect(inspection.kind == .session)
+        #expect(inspection.model == nil)
+        #expect(inspection.usage == nil)
+    }
+
     @Test("Ordinary HTTP traffic does not expose AI inspection")
     func ordinaryHTTPTrafficDoesNotExposeAIInspection() {
         let transaction = TestFixtures.makeTransaction(
@@ -82,7 +103,9 @@ struct AITrafficDetectorTests {
         )
 
         #expect(AITrafficDetector.isLikelyAI(transaction: transaction))
-        #expect(ResponseInspectorTab.availableTabs(hasAIInspection: true).contains(.ai))
+        #expect(!ResponseInspectorTab.availableTabs(hasAIInspection: true).contains(.ai))
+        #expect(ProtocolTabKind.availableTabs(for: transaction).contains(.ai))
+        #expect(ProtocolTabKind.defaultFor(transaction) == .ai)
     }
 
     private func makeTransaction(

--- a/RockxyTests/Core/Detection/DetectionTests.swift
+++ b/RockxyTests/Core/Detection/DetectionTests.swift
@@ -438,6 +438,43 @@ struct DetectionTests {
         #expect(info.providerHost == "api.mainnet-beta.solana.com")
     }
 
+    @Test("Web3RPCInfo classifies engineer debug intent")
+    func classifyWeb3DebugIntent() {
+        #expect(makeWeb3Info(method: "eth_call").debugIntent == .simulation)
+        #expect(makeWeb3Info(method: "eth_estimateGas").debugIntent == .simulation)
+        #expect(makeWeb3Info(method: "eth_sendRawTransaction").debugIntent == .broadcast)
+        #expect(makeWeb3Info(method: "sendTransaction", family: .solana).debugIntent == .broadcast)
+        #expect(makeWeb3Info(method: "eth_getLogs").debugIntent == .logs)
+        #expect(makeWeb3Info(method: "getTransaction", family: .solana).debugIntent == .logs)
+        #expect(makeWeb3Info(method: "eth_chainId").debugIntent == .provider)
+        #expect(makeWeb3Info(method: "getBalance", family: .solana).debugIntent == .read)
+    }
+
+    @Test("Web3RPCInfo classifies batch before method class")
+    func classifyWeb3BatchIntent() {
+        let info = Web3RPCInfo(
+            family: .evm,
+            providerHost: "rpc.example.com",
+            method: "eth_sendRawTransaction",
+            requestID: nil,
+            batch: Web3RPCBatchSummary(
+                requestCount: 2,
+                web3RequestCount: 2,
+                responseCount: 2,
+                errorCount: 1,
+                methods: ["eth_chainId", "eth_sendRawTransaction"]
+            ),
+            error: Web3RPCError(code: -32_000, message: "rejected"),
+            chainHint: nil,
+            transactionHash: nil,
+            blockIdentifier: nil,
+            requestPayloadSize: nil,
+            responsePayloadSize: nil
+        )
+
+        #expect(info.debugIntent == .batch)
+    }
+
     private func web3Request(url: String = "https://mainnet.infura.io/v3/test", body: Any) throws -> HTTPRequestData {
         let data = try JSONSerialization.data(withJSONObject: body)
         return try HTTPRequestData(
@@ -447,6 +484,22 @@ struct DetectionTests {
             headers: [HTTPHeader(name: "Content-Type", value: "application/json")],
             body: data,
             contentType: .json
+        )
+    }
+
+    private func makeWeb3Info(method: String, family: Web3RPCFamily = .evm) -> Web3RPCInfo {
+        Web3RPCInfo(
+            family: family,
+            providerHost: "rpc.example.com",
+            method: method,
+            requestID: "1",
+            batch: nil,
+            error: nil,
+            chainHint: nil,
+            transactionHash: nil,
+            blockIdentifier: nil,
+            requestPayloadSize: nil,
+            responsePayloadSize: nil
         )
     }
 

--- a/RockxyTests/Core/Detection/X402DetectorTests.swift
+++ b/RockxyTests/Core/Detection/X402DetectorTests.swift
@@ -1,0 +1,203 @@
+import Foundation
+@testable import Rockxy
+import Testing
+
+struct X402DetectorTests {
+    @Test("X402Detector detects payment-required metadata from fixture corpus")
+    func detectsPaymentRequiredMetadata() throws {
+        let exchange = try firstExchange(in: ProtocolFixture.x402ContractSmoke)
+        let responseMessage = try responseMessage(in: exchange)
+        let info = try detectedInfo(
+            request: try request(from: exchange.request),
+            response: try response(from: responseMessage)
+        )
+
+        #expect(info.stage == .paymentRequired)
+        #expect(info.isX402Like)
+        #expect(info.version == "1")
+        #expect(info.paymentRequired == true)
+        #expect(info.hasChallenge)
+        #expect(!info.hasPaymentProof)
+        #expect(info.parseState == .parsed)
+        #expect(info.redactionFields.contains("challenge"))
+    }
+
+    @Test("X402Detector detects retry success without retaining payment proof values")
+    func detectsRetrySuccessMetadata() throws {
+        let exchange = try secondExchange(in: ProtocolFixture.x402ContractSmoke)
+        let responseMessage = try responseMessage(in: exchange)
+        let info = try detectedInfo(
+            request: try request(from: exchange.request),
+            response: try response(from: responseMessage)
+        )
+
+        #expect(info.stage == .paymentAccepted)
+        #expect(info.isX402Like)
+        #expect(info.hasPaymentProof)
+        #expect(info.paymentRequired == nil)
+        #expect(info.redactionFields.contains("X-Payment"))
+        #expect(info.redactionFields.contains("receipt"))
+        #expect(!info.redactionFields.contains("synthetic-payment-proof"))
+    }
+
+    @Test("X402Detector reports malformed x402 challenge as bounded fallback")
+    func reportsMalformedChallenge() throws {
+        let exchange = try firstExchange(in: ProtocolFixture.x402MalformedAndMissingProofContractSmoke)
+        let responseMessage = try responseMessage(in: exchange)
+        let info = try detectedInfo(
+            request: try request(from: exchange.request),
+            response: try response(from: responseMessage)
+        )
+
+        #expect(info.stage == .paymentRequired)
+        #expect(info.isX402Like)
+        #expect(info.paymentRequired == true)
+        #expect(info.hasChallenge)
+        #expect(info.parseState == .malformed)
+        #expect(info.redactionFields.contains("challenge"))
+    }
+
+    @Test("X402Detector summarizes provider error metadata safely")
+    func summarizesProviderErrorMetadata() throws {
+        let exchange = try firstExchange(in: ProtocolFixture.x402ProviderErrorMetadataContractSmoke)
+        let responseMessage = try responseMessage(in: exchange)
+        let info = try detectedInfo(
+            request: try request(from: exchange.request),
+            response: try response(from: responseMessage)
+        )
+
+        #expect(info.stage == .providerError)
+        #expect(info.isX402Like)
+        #expect(info.hasPaymentProof)
+        #expect(info.hasPaymentMetadata)
+        #expect(info.providerErrorPresent)
+        #expect(info.redactionFields.contains("Authorization"))
+        #expect(info.redactionFields.contains("X-Payment"))
+        #expect(info.redactionFields.contains("paymentMetadata"))
+        #expect(info.redactionFields.contains("receipt"))
+    }
+
+    @Test("X402Detector keeps ordinary 402 responses inspectable without x402 inference")
+    func keepsOrdinary402Inspectable() throws {
+        let request = try HTTPRequestData(
+            method: "GET",
+            url: try url("https://api.example.com/paywall"),
+            httpVersion: "HTTP/1.1",
+            headers: [],
+            body: nil,
+            contentType: nil
+        )
+        let response = HTTPResponseData(
+            statusCode: 402,
+            statusMessage: "Payment Required",
+            headers: [],
+            body: nil,
+            contentType: nil
+        )
+
+        let info = try detectedInfo(request: request, response: response)
+
+        #expect(info.stage == .ordinaryPaymentRequired)
+        #expect(!info.isX402Like)
+        #expect(info.paymentRequired == true)
+        #expect(info.parseState == .notApplicable)
+        #expect(info.redactionFields.isEmpty)
+    }
+
+    @Test("X402Detector ignores ordinary successful traffic")
+    func ignoresOrdinarySuccessfulTraffic() throws {
+        let request = try HTTPRequestData(
+            method: "GET",
+            url: try url("https://api.example.com/status"),
+            httpVersion: "HTTP/1.1",
+            headers: [],
+            body: nil,
+            contentType: nil
+        )
+        let response = HTTPResponseData(
+            statusCode: 200,
+            statusMessage: "OK",
+            headers: [],
+            body: Data(#"{"ok":true}"#.utf8),
+            contentType: .json
+        )
+
+        #expect(X402Detector.detect(request: request, response: response) == nil)
+    }
+
+    private func request(from message: ProtocolFixtureMessage) throws -> HTTPRequestData {
+        let headers = message.headers.map { HTTPHeader(name: $0.name, value: $0.value) }
+        let body = message.body.map { Data($0.utf8) }
+        return try HTTPRequestData(
+            method: message.method,
+            url: try url(message.url),
+            httpVersion: "HTTP/1.1",
+            headers: headers,
+            body: body,
+            contentType: ContentTypeDetector.detect(headers: headers, body: body)
+        )
+    }
+
+    private func response(from message: ProtocolFixtureMessage) throws -> HTTPResponseData {
+        let headers = message.headers.map { HTTPHeader(name: $0.name, value: $0.value) }
+        let body = message.body.map { Data($0.utf8) }
+        return HTTPResponseData(
+            statusCode: try statusCode(from: message),
+            statusMessage: message.statusCode == 402 ? "Payment Required" : "OK",
+            headers: headers,
+            body: body,
+            contentType: ContentTypeDetector.detect(headers: headers, body: body)
+        )
+    }
+
+    private func detectedInfo(request: HTTPRequestData, response: HTTPResponseData) throws -> X402Info {
+        guard let info = X402Detector.detect(request: request, response: response) else {
+            throw X402TestError.missingDetection
+        }
+        return info
+    }
+
+    private func firstExchange(in fixture: ProtocolFixture) throws -> ProtocolFixtureExchange {
+        guard let exchange = fixture.traffic.exchanges.first else {
+            throw X402TestError.missingExchange
+        }
+        return exchange
+    }
+
+    private func secondExchange(in fixture: ProtocolFixture) throws -> ProtocolFixtureExchange {
+        let exchanges = fixture.traffic.exchanges
+        guard exchanges.count > 1 else {
+            throw X402TestError.missingExchange
+        }
+        return exchanges[1]
+    }
+
+    private func responseMessage(in exchange: ProtocolFixtureExchange) throws -> ProtocolFixtureMessage {
+        guard let response = exchange.response else {
+            throw X402TestError.missingResponse
+        }
+        return response
+    }
+
+    private func statusCode(from message: ProtocolFixtureMessage) throws -> Int {
+        guard let statusCode = message.statusCode else {
+            throw X402TestError.missingStatusCode
+        }
+        return statusCode
+    }
+
+    private func url(_ string: String) throws -> URL {
+        guard let url = URL(string: string) else {
+            throw X402TestError.invalidURL
+        }
+        return url
+    }
+
+    private enum X402TestError: Error {
+        case invalidURL
+        case missingDetection
+        case missingExchange
+        case missingResponse
+        case missingStatusCode
+    }
+}

--- a/RockxyTests/Core/MCPServer/MCPRedactionPolicyTests.swift
+++ b/RockxyTests/Core/MCPServer/MCPRedactionPolicyTests.swift
@@ -173,6 +173,50 @@ struct MCPRedactionPolicyTests {
         #expect(redacted.contains("public"))
     }
 
+    @Test("Redacts AI prompt, tool, and retrieval JSON fields")
+    func redactAIProtocolJSONFields() {
+        let body = """
+        {
+          "model": "debug-model",
+          "messages": [{"role": "user", "content": "customer secret prompt"}],
+          "tool_calls": [{"function": {"arguments": "{\\"token\\":\\"tool-secret\\"}"}}],
+          "retrieved_context": "RAG snippet with private customer context",
+          "embedding": [0.1, 0.2, 0.3]
+        }
+        """
+
+        let redacted = enabledPolicy.redactJSONBody(body)
+
+        #expect(redacted.contains(#""model":"debug-model""#) || redacted.contains(#""model": "debug-model""#))
+        #expect(!redacted.contains("customer secret prompt"))
+        #expect(!redacted.contains("tool-secret"))
+        #expect(!redacted.contains("private customer context"))
+        #expect(!redacted.contains("0.1"))
+        #expect(redacted.contains("[REDACTED]"))
+    }
+
+    @Test("Redacts x402 payment metadata JSON fields")
+    func redactX402PaymentJSONFields() {
+        let body = """
+        {
+          "x-payment": "payment-header-secret",
+          "paymentPayload": "encoded-payment-payload",
+          "paymentProof": "proof-secret",
+          "maxAmountRequired": "1000",
+          "asset": "USDC"
+        }
+        """
+
+        let redacted = enabledPolicy.redactJSONBody(body)
+
+        #expect(!redacted.contains("payment-header-secret"))
+        #expect(!redacted.contains("encoded-payment-payload"))
+        #expect(!redacted.contains("proof-secret"))
+        #expect(!redacted.contains("1000"))
+        #expect(redacted.contains("USDC"))
+        #expect(redacted.contains("[REDACTED]"))
+    }
+
     @Test("Leaves generic key fields intact in JSON bodies")
     func preserveGenericJSONKeyField() throws {
         let body = #"{"items":[{"key":"foo","value":"bar"}]}"#
@@ -318,6 +362,23 @@ struct MCPRedactionPolicyTests {
         #expect(!redacted.contains(">secret<"))
         #expect(redacted.contains("[REDACTED]"))
         #expect(redacted.contains("<user>john</user>"))
+    }
+
+    @Test("Redacts protocol-sensitive XML and generic text")
+    func redactProtocolSensitiveXMLAndText() {
+        let policy = MCPRedactionPolicy(isEnabled: true)
+        let xml = "<root><prompt>private prompt</prompt><paymentProof>proof-secret</paymentProof><mode>debug</mode></root>"
+        let text = "tool_calls={\"arguments\":\"secret-args\"}\npayment_payload=encoded-payment\nstatus=ok"
+
+        let redactedXML = policy.redactXMLBody(xml)
+        let redactedText = policy.redactGenericText(text)
+
+        #expect(!redactedXML.contains("private prompt"))
+        #expect(!redactedXML.contains("proof-secret"))
+        #expect(redactedXML.contains("<mode>debug</mode>"))
+        #expect(!redactedText.contains("secret-args"))
+        #expect(!redactedText.contains("encoded-payment"))
+        #expect(redactedText.contains("status=ok"))
     }
 
     @Test("Redacts generic text Bearer tokens")

--- a/RockxyTests/Core/Plugins/GistPublishPayloadBuilderTests.swift
+++ b/RockxyTests/Core/Plugins/GistPublishPayloadBuilderTests.swift
@@ -77,6 +77,54 @@ struct GistPublishPayloadBuilderTests {
         #expect(serialized.contains("[REDACTED]"))
     }
 
+    @Test("Redacts AI prompt, RAG, tool args, and x402 metadata before publishing")
+    func redactsAIAndPaymentEvidence() throws {
+        var request = TestFixtures.makeRequest(
+            method: "POST",
+            url: "https://api.example.com/v1/responses?payment_payload=query-payment-secret",
+            headers: [
+                HTTPHeader(name: "Content-Type", value: "application/json"),
+                HTTPHeader(name: "X-Payment", value: "header-payment-secret"),
+            ]
+        )
+        request.body = Data(
+            """
+            {
+              "model": "debug-model",
+              "messages": [{"role": "user", "content": "sensitive prompt text"}],
+              "tool_calls": [{"function": {"arguments": "{\\"api_key\\":\\"tool-secret\\"}"}}],
+              "retrieved_context": "private RAG snippet",
+              "paymentProof": "payment-proof-secret"
+            }
+            """.utf8
+        )
+        request.contentType = .json
+        let transaction = HTTPTransaction(request: request, state: .completed)
+        var response = TestFixtures.makeResponse(
+            statusCode: 200,
+            body: Data(#"{"snippet":"private retrieved response","x-payment-response":"payment-response-secret"}"#.utf8)
+        )
+        response.contentType = .json
+        transaction.response = response
+
+        let payload = try GistPublishPayloadBuilder().build(
+            transactions: [transaction],
+            options: GistPublishOptions(redactSensitiveData: true)
+        )
+        let serialized = payload.files.values.joined(separator: "\n")
+
+        #expect(!serialized.contains("query-payment-secret"))
+        #expect(!serialized.contains("header-payment-secret"))
+        #expect(!serialized.contains("sensitive prompt text"))
+        #expect(!serialized.contains("tool-secret"))
+        #expect(!serialized.contains("private RAG snippet"))
+        #expect(!serialized.contains("payment-proof-secret"))
+        #expect(!serialized.contains("private retrieved response"))
+        #expect(!serialized.contains("payment-response-secret"))
+        #expect(serialized.contains("debug-model"))
+        #expect(serialized.contains("[REDACTED]"))
+    }
+
     @Test("Includes WebSocket frames only when selected transactions contain frames")
     func includesWebSocketFramesWhenPresent() throws {
         let http = TestFixtures.makeTransaction()

--- a/RockxyTests/Core/Storage/SessionStoreMigrationTests.swift
+++ b/RockxyTests/Core/Storage/SessionStoreMigrationTests.swift
@@ -31,7 +31,7 @@ struct SessionStoreMigrationTests {
         let store = try SessionStore(directory: dir)
         let version = try await store.schemaVersion()
 
-        #expect(version >= 1)
+        #expect(version >= 2)
     }
 
     @Test("Second initialization skips migration")
@@ -57,7 +57,7 @@ struct SessionStoreMigrationTests {
         let store = try SessionStore(directory: dir)
         let version = try await store.schemaVersion()
 
-        #expect(version >= 1)
+        #expect(version >= 2)
     }
 
     @Test("Save and load transaction after migration")
@@ -78,6 +78,44 @@ struct SessionStoreMigrationTests {
         #expect(loaded[0].comment == "test comment")
     }
 
+    @Test("Save and load preserves Web3 RPC metadata")
+    func saveLoadPreservesWeb3RPCMetadata() async throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let store = try SessionStore(directory: dir)
+        let transaction = TestFixtures.makeWeb3RPCTransaction(
+            method: nil,
+            batch: Web3RPCBatchSummary(
+                requestCount: 2,
+                web3RequestCount: 2,
+                responseCount: 2,
+                errorCount: 1,
+                methods: ["eth_chainId", "eth_blockNumber"]
+            ),
+            error: Web3RPCError(code: -32_000, message: "rate limited")
+        )
+
+        try await store.saveTransaction(transaction)
+        let loaded = try await store.loadTransaction(byID: transaction.id)
+        let info = try #require(loaded?.web3RPCInfo)
+
+        #expect(info.family == .evm)
+        #expect(info.providerHost == "rpc.example.com")
+        #expect(info.method == nil)
+        #expect(info.requestID == nil)
+        #expect(info.batch?.requestCount == 2)
+        #expect(info.batch?.web3RequestCount == 2)
+        #expect(info.batch?.responseCount == 2)
+        #expect(info.batch?.errorCount == 1)
+        #expect(info.batch?.methods == ["eth_chainId", "eth_blockNumber"])
+        #expect(info.error?.code == -32_000)
+        #expect(info.error?.message == "rate limited")
+        #expect(info.chainHint?.chainID == "0x1")
+        #expect(info.requestPayloadSize == transaction.web3RPCInfo?.requestPayloadSize)
+        #expect(info.responsePayloadSize == transaction.web3RPCInfo?.responsePayloadSize)
+    }
+
     @Test("Migrated columns have correct defaults")
     func migratedColumnDefaults() async throws {
         let dir = try makeTempDir()
@@ -95,6 +133,7 @@ struct SessionStoreMigrationTests {
         #expect(loaded[0].comment == nil)
         #expect(loaded[0].highlightColor == nil)
         #expect(loaded[0].clientApp == nil)
+        #expect(loaded[0].web3RPCInfo == nil)
     }
 
     // MARK: Private

--- a/RockxyTests/Models/UI/HeaderColumnStoreTests.swift
+++ b/RockxyTests/Models/UI/HeaderColumnStoreTests.swift
@@ -194,18 +194,18 @@ struct HeaderColumnStoreTests {
         #expect(store.isBuiltInColumnVisible("url"))
     }
 
-    @Test("AI built-in column is hidden by default but can be enabled")
-    func aiBuiltInColumnDefaultVisibility() {
+    @Test("Protocol built-in column is visible by default and can be hidden")
+    func protocolBuiltInColumnDefaultVisibility() {
         let store = makeCleanStore()
 
-        #expect(!store.isBuiltInColumnVisible("ai"))
-        store.toggleBuiltInColumn("ai")
         #expect(store.isBuiltInColumnVisible("ai"))
+        store.toggleBuiltInColumn("ai")
+        #expect(!store.isBuiltInColumnVisible("ai"))
 
         let store2 = HeaderColumnStore()
-        #expect(store2.isBuiltInColumnVisible("ai"))
-        store2.toggleBuiltInColumn("ai")
         #expect(!store2.isBuiltInColumnVisible("ai"))
+        store2.toggleBuiltInColumn("ai")
+        #expect(store2.isBuiltInColumnVisible("ai"))
     }
 
     @Test("Hidden built-in columns persist")

--- a/RockxyTests/Models/UI/ProtocolFilterTests.swift
+++ b/RockxyTests/Models/UI/ProtocolFilterTests.swift
@@ -29,11 +29,43 @@ struct ProtocolFilterTests {
         #expect(ProtocolFilter.websocket.matches(transaction))
     }
 
+    @Test("AI filter matches likely AI traffic")
+    func aiMatches() {
+        let transaction = TestFixtures.makeTransaction(
+            method: "POST",
+            url: "https://api.openai.com/v1/responses"
+        )
+        #expect(ProtocolFilter.ai.matches(transaction))
+        #expect(!ProtocolFilter.ai.matches(TestFixtures.makeTransaction()))
+    }
+
+    @Test("AI Session filter matches known app session hosts")
+    func aiSessionMatches() {
+        let transaction = TestFixtures.makeTransaction(
+            method: "CONNECT",
+            url: "https://chatgpt.com/",
+            statusCode: nil
+        )
+
+        #expect(ProtocolFilter.aiSession.matches(transaction))
+        #expect(!ProtocolFilter.ai.matches(transaction))
+        #expect(!ProtocolFilter.aiSession.matches(TestFixtures.makeTransaction()))
+    }
+
     @Test("Web3 RPC filter matches transaction with Web3 metadata")
     func web3RPCMatches() {
         let transaction = TestFixtures.makeWeb3RPCTransaction()
         #expect(ProtocolFilter.web3RPC.matches(transaction))
         #expect(!ProtocolFilter.graphql.matches(transaction))
+    }
+
+    @Test("RPC error filter matches Web3 transactions with provider errors")
+    func rpcErrorMatches() {
+        let transaction = TestFixtures.makeWeb3RPCTransaction(
+            error: Web3RPCError(code: -32_000, message: "rate limited")
+        )
+        #expect(ProtocolFilter.rpcError.matches(transaction))
+        #expect(!ProtocolFilter.rpcError.matches(TestFixtures.makeWeb3RPCTransaction()))
     }
 
     @Test("gRPC filter matches transaction with gRPC metadata")

--- a/RockxyTests/Models/UI/RequestListRowTests.swift
+++ b/RockxyTests/Models/UI/RequestListRowTests.swift
@@ -133,7 +133,56 @@ struct RequestListRowTests {
 
         #expect(row.aiTrafficSignal.isLikelyAI)
         #expect(row.aiTrafficSignal.provider == .openAICompatible)
-        #expect(row.aiTrafficSignal.tableLabel == "AI")
+        #expect(row.aiTrafficSignal.kind == .api)
+        #expect(row.aiTrafficSignal.tableLabel == "AI API")
+        #expect(row.smartBadgeText == "AI API")
+        #expect(row.smartBadgeTooltip?.contains("OpenAI-compatible") == true)
+    }
+
+    @Test("AI session signal is extracted from known native app hosts")
+    func aiSessionTrafficSignal() {
+        let transaction = TestFixtures.makeTransaction(
+            method: "CONNECT",
+            url: "https://chatgpt.com/",
+            statusCode: nil
+        )
+        transaction.clientApp = "ChatGPT"
+
+        let row = RequestListRow(from: transaction)
+
+        #expect(row.aiTrafficSignal.isLikelyAI)
+        #expect(row.aiTrafficSignal.provider == .chatGPT)
+        #expect(row.aiTrafficSignal.kind == .session)
+        #expect(row.smartBadgeText == "AI Session")
+        #expect(row.smartBadgeTooltip?.contains("body hidden") == true)
+    }
+
+    @Test("Smart badge text summarizes Web3 RPC metadata")
+    func web3SmartBadgeText() {
+        let normal = RequestListRow(from: TestFixtures.makeWeb3RPCTransaction())
+        let error = RequestListRow(from: TestFixtures.makeWeb3RPCTransaction(
+            error: Web3RPCError(code: -32_000, message: "rate limited")
+        ))
+
+        #expect(normal.smartBadgeText == "Web3")
+        #expect(normal.smartBadgeTooltip?.contains("rpc.example.com") == true)
+        #expect(error.smartBadgeText == "RPC ERR")
+        #expect(error.smartBadgeTooltip?.contains("-32000") == true)
+    }
+
+    @Test("Protocol column labels ordinary and structured traffic")
+    func protocolColumnFallbackLabels() {
+        let http = RequestListRow(from: TestFixtures.makeTransaction(url: "http://example.com/test"))
+        let https = RequestListRow(from: TestFixtures.makeTransaction(url: "https://example.com/test"))
+        let webSocket = RequestListRow(from: TestFixtures.makeWebSocketTransaction())
+        let graphQL = RequestListRow(from: TestFixtures.makeGraphQLTransaction())
+        let grpc = RequestListRow(from: TestFixtures.makeGRPCTransaction())
+
+        #expect(http.smartBadgeText == "HTTP")
+        #expect(https.smartBadgeText == "HTTPS")
+        #expect(webSocket.smartBadgeText == "WS")
+        #expect(graphQL.smartBadgeText == "GraphQL")
+        #expect(grpc.smartBadgeText == "gRPC")
     }
 
     @Test("Body sizes extracted from request and response")
@@ -241,14 +290,16 @@ struct RequestListRowTests {
         #expect(RequestListRow.compare(https, http, using: descriptors) == false)
     }
 
-    @Test("Sort by AI groups ordinary traffic before AI traffic")
+    @Test("Sort by protocol label")
     func sortByAI() {
-        let ordinary = makeRow(host: "example.com")
         let ai = makeRow(host: "api.openai.com", path: "/v1/responses")
+        let ordinary = makeRow(host: "example.com")
         let descriptors = [NSSortDescriptor(key: "ai", ascending: true)]
 
-        #expect(RequestListRow.compare(ordinary, ai, using: descriptors) == true)
-        #expect(RequestListRow.compare(ai, ordinary, using: descriptors) == false)
+        #expect(ai.smartBadgeText == "AI API")
+        #expect(ordinary.smartBadgeText == "HTTPS")
+        #expect(RequestListRow.compare(ai, ordinary, using: descriptors) == true)
+        #expect(RequestListRow.compare(ordinary, ai, using: descriptors) == false)
     }
 
     @Test("SSL state can represent intercepted HTTPS separately from tunneled HTTPS")

--- a/RockxyTests/Views/Inspector/InspectorRoutingTests.swift
+++ b/RockxyTests/Views/Inspector/InspectorRoutingTests.swift
@@ -227,6 +227,49 @@ struct InspectorRoutingTests {
         #expect(ProtocolTabKind.isSupported(.grpc, by: tx))
     }
 
+    @Test("Plain HTTP transaction exposes empty AI and Web3 tabs")
+    func httpExposesEmptyAIAndWeb3Tabs() {
+        let tx = TestFixtures.makeTransaction()
+        let tabs = ProtocolTabKind.availableTabs(for: tx)
+
+        #expect(tabs == [.ai, .web3, .grpc])
+        #expect(!tabs.contains(.websocket))
+        #expect(!tabs.contains(.graphql))
+        #expect(ProtocolTabKind.defaultFor(tx) == nil)
+        #expect(ProtocolTabKind.isSupported(.ai, by: tx))
+        #expect(ProtocolTabKind.isSupported(.web3, by: tx))
+        #expect(!ProtocolTabKind.hasDetectedSignal(.ai, in: tx))
+        #expect(!ProtocolTabKind.hasDetectedSignal(.web3, in: tx))
+    }
+
+    @Test("AI and Web3 tabs coexist when both signals are present")
+    func aiAndWeb3TabsCoexist() {
+        let tx = TestFixtures.makeTransaction(
+            method: "POST",
+            url: "https://api.openai.com/v1/responses"
+        )
+        tx.web3RPCInfo = makeWeb3RPCTransaction().web3RPCInfo
+
+        let tabs = ProtocolTabKind.availableTabs(for: tx)
+
+        #expect(tabs.contains(.ai))
+        #expect(tabs.contains(.web3))
+        #expect(ProtocolTabKind.defaultFor(tx) == .ai)
+    }
+
+    @Test("Detected dynamic tabs stay before always-visible AI Web3 gRPC tail")
+    func protocolTabOrderKeepsAlwaysVisibleTabsAtEnd() {
+        let tx = TestFixtures.makeWebSocketTransaction()
+        tx.graphQLInfo = GraphQLInfo(
+            operationName: "SubscribeBlocks",
+            operationType: .subscription,
+            query: "subscription SubscribeBlocks { block { number } }",
+            variables: nil
+        )
+
+        #expect(ProtocolTabKind.availableTabs(for: tx) == [.websocket, .graphql, .ai, .web3, .grpc])
+    }
+
     @Test("Switching WS → HTTP clears protocol tab")
     func wsToHttpClearsProtocol() {
         let wsTx = TestFixtures.makeWebSocketTransaction()

--- a/RockxyTests/Views/Main/FilteringTests.swift
+++ b/RockxyTests/Views/Main/FilteringTests.swift
@@ -162,6 +162,25 @@ struct FilteringTests {
         #expect(coordinator.filteredTransactions[0].id == httpsOk.id)
     }
 
+    @Test("AI and RPC error protocol filters match captured metadata")
+    func smartProtocolFilters() {
+        let coordinator = MainContentCoordinator()
+        let ai = TestFixtures.makeTransaction(
+            method: "POST",
+            url: "https://api.openai.com/v1/responses"
+        )
+        let rpcError = TestFixtures.makeWeb3RPCTransaction(
+            error: Web3RPCError(code: -32_000, message: "rate limited")
+        )
+        let ordinary = TestFixtures.makeTransaction(url: "https://example.com/test")
+        coordinator.transactions = [ai, rpcError, ordinary]
+
+        coordinator.filterCriteria.activeProtocolFilters = [.ai, .rpcError]
+        coordinator.recomputeFilteredTransactions()
+
+        #expect(coordinator.filteredTransactions.map(\.id) == [ai.id, rpcError.id])
+    }
+
     // MARK: - Sidebar Filters
 
     @Test("Sidebar domain filters by suffix match")
@@ -358,6 +377,72 @@ struct FilteringTests {
         ]
         coordinator.recomputeFilteredTransactions()
         #expect(coordinator.filteredTransactions.count == coordinator.transactions.count)
+    }
+
+    // MARK: - Smart Search Tokens
+
+    @Test("Smart search filters AI traffic and applies remaining text")
+    func smartSearchAIWithRemainingText() {
+        let coordinator = MainContentCoordinator()
+        let match = TestFixtures.makeTransaction(
+            method: "POST",
+            url: "https://api.openai.com/v1/responses"
+        )
+        let wrongPath = TestFixtures.makeTransaction(
+            method: "POST",
+            url: "https://api.anthropic.com/v1/messages"
+        )
+        let ordinary = TestFixtures.makeTransaction(url: "https://api.example.com/reports/responses")
+        coordinator.transactions = [match, wrongPath, ordinary]
+        coordinator.filterCriteria.searchField = .path
+        coordinator.filterCriteria.searchText = "is:ai responses"
+
+        coordinator.recomputeFilteredTransactions()
+
+        #expect(coordinator.filteredTransactions.map(\.id) == [match.id])
+    }
+
+    @Test("Smart search filters Web3 RPC method, provider, and errors")
+    func smartSearchWeb3Metadata() {
+        let coordinator = MainContentCoordinator()
+        let match = TestFixtures.makeWeb3RPCTransaction(
+            method: nil,
+            batch: Web3RPCBatchSummary(
+                requestCount: 2,
+                web3RequestCount: 2,
+                responseCount: 2,
+                errorCount: 1,
+                methods: ["eth_chainId", "eth_getLogs"]
+            ),
+            error: Web3RPCError(code: -32_000, message: "rate limited")
+        )
+        let wrongMethod = TestFixtures.makeWeb3RPCTransaction(
+            method: "eth_blockNumber",
+            error: Web3RPCError(code: -32_000, message: "rate limited")
+        )
+        let noError = TestFixtures.makeWeb3RPCTransaction(method: "eth_getLogs")
+        coordinator.transactions = [match, wrongMethod, noError]
+        coordinator.filterCriteria.searchText = "is:web3 rpc_error:true rpc:eth_getLogs provider:rpc.example.com"
+
+        coordinator.recomputeFilteredTransactions()
+
+        #expect(coordinator.filteredTransactions.map(\.id) == [match.id])
+    }
+
+    @Test("Smart provider search matches AI provider names")
+    func smartSearchAIProviderName() {
+        let coordinator = MainContentCoordinator()
+        let ai = TestFixtures.makeTransaction(
+            method: "POST",
+            url: "https://api.openai.com/v1/responses"
+        )
+        let ordinary = TestFixtures.makeTransaction(url: "https://api.example.com/test")
+        coordinator.transactions = [ai, ordinary]
+        coordinator.filterCriteria.searchText = "provider:openai"
+
+        coordinator.recomputeFilteredTransactions()
+
+        #expect(coordinator.filteredTransactions.map(\.id) == [ai.id])
     }
 
     // MARK: - New Field Cases

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -6,6 +6,21 @@ rss: true
 
 # Changelog
 
+<Update label="Unreleased" description="AI, Web3, and protocol inspection">
+  ### Added
+
+  - Added AI traffic inspection for recognized model API traffic, including provider/model hints, streaming state, usage fields when present, tool-call summaries, retrieval hints, and warnings for unavailable fields.
+  - Added Web3 JSON-RPC inspection for EVM and Solana-style HTTP RPC traffic, including provider host, request ID, method, batch summary, error, chain, transaction, payload, and debug-intent details.
+  - Added x402-style payment-flow hints for payment-required and retry-oriented HTTP traffic.
+  - Added a default Protocol column and protocol filters that make AI, Web3 RPC, gRPC, GraphQL, WebSocket, and HTTP traffic easier to scan in the request list.
+
+  ### Changed
+
+  - Kept AI, Web3, and gRPC inspector tabs available at the end of the inspector tab row so protocol details are consistent with the existing Headers, Body, Set-Cookie, and Timeline workflow.
+  - Clarified that existing rules and debugging tools still operate on URL, HTTP method, and headers rather than AI model names, tool calls, chain IDs, JSON-RPC methods, or batch subcalls.
+
+</Update>
+
 <Update label="June 2026" description="v0.28.0">
   ### Added
 

--- a/docs/core-features/filters-and-search.mdx
+++ b/docs/core-features/filters-and-search.mdx
@@ -31,6 +31,7 @@ This is the fastest way to move from “everything” to “the part of the syst
 Use toolbar filters when you want to refine within the current scope:
 
 - protocol,
+- AI, Web3 RPC, gRPC, WebSocket, or GraphQL traffic families when detected,
 - content family,
 - status-code range,
 - or a more advanced filter expression.
@@ -60,6 +61,13 @@ Use search when you already know a clue:
 1. scope to the relevant API host,
 2. filter to GraphQL or JSON-oriented traffic,
 3. inspect operation names and payloads in the request body.
+
+### Isolate AI or Web3 traffic
+
+1. scope to the client app or provider domain,
+2. filter to AI or Web3 RPC traffic,
+3. inspect the protocol-specific tab for provider, model, stream, tool-call, JSON-RPC method, batch, chain, or error hints,
+4. switch back to Headers, Body, Raw, or Timeline for the underlying HTTP evidence.
 
 ### Clean up mobile device noise
 
@@ -93,6 +101,9 @@ That distinction keeps the debugging loop clear.
 <CardGroup cols={2}>
   <Card title="Traffic Capture" icon="radar" href="/features/traffic-capture">
     Learn the broader capture model around filtering and selection.
+  </Card>
+  <Card title="AI and Web3 Inspection" icon="sparkles" href="/features/ai-web3-inspection">
+    Use protocol-aware labels and inspector tabs for model and RPC traffic.
   </Card>
   <Card title="Workspaces" icon="table-columns" href="/features/workspaces">
     Keep multiple filtered investigations open at once.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -34,6 +34,7 @@
           "features/traffic-capture",
           "core-features/filters-and-search",
           "features/https-interception",
+          "features/ai-web3-inspection",
           "features/websocket",
           "features/websocket-protobuf",
           "features/graphql",

--- a/docs/features/ai-web3-inspection.mdx
+++ b/docs/features/ai-web3-inspection.mdx
@@ -1,0 +1,127 @@
+---
+title: "AI and Web3 Inspection"
+description: "Detect and inspect AI model calls, Web3 JSON-RPC traffic, and x402-style payment hints inside Rockxy's native macOS traffic debugger."
+---
+
+# AI and Web3 Inspection
+
+Rockxy can highlight AI and Web3 traffic inside the same capture, filter, request list, and inspector workflow you already use for HTTP debugging.
+
+The goal is visibility first: identify the request, understand what kind of protocol behavior it represents, and keep the underlying request and response available in the normal inspector tabs.
+
+## What Rockxy Detects
+
+| Traffic type | What appears in Rockxy |
+|--------------|------------------------|
+| AI model APIs | Provider, model when visible, streaming hints, usage fields when present, warnings, retrieval hints, and tool-call summaries |
+| Native AI app sessions | AI session labeling when the request is recognizable but full payload details are not visible |
+| Web3 JSON-RPC | Provider host, request ID, RPC family, method, batch summary, error, chain hint, transaction hash, and payload sizes when visible |
+| x402-style flows | Payment-required and retry-flow hints from HTTP status, headers, and response body shape |
+| gRPC | Dedicated gRPC inspector tab for unary and streaming protobuf-style traffic |
+
+<Note>
+AI and Web3 inspection is passive. Rockxy does not become a wallet, model gateway, block explorer, prompt manager, or hosted observability service.
+</Note>
+
+## Request List Signals
+
+The request list can show protocol-aware labels so noisy sessions are easier to scan:
+
+- **Protocol** column labels AI, Web3 RPC, gRPC, GraphQL, WebSocket, and normal HTTP traffic.
+- Protocol filters help narrow a session to the traffic family you are investigating.
+- Rows keep the original method, host, path, status, size, and duration fields visible so protocol context does not replace the normal HTTP evidence.
+
+## AI Inspector
+
+When Rockxy recognizes AI model traffic, the AI inspector focuses on the debugging facts that are safe and useful to read:
+
+- provider and model when available,
+- request kind and endpoint shape,
+- streaming state,
+- usage fields when the provider returns them,
+- tool-call summaries,
+- retrieval hints,
+- warnings for incomplete or unavailable fields.
+
+Use the regular **Headers**, **Body**, **Raw**, **Timeline**, and **Comments** tabs alongside the AI tab when you need the full request context.
+
+## Web3 Inspector
+
+For Web3 JSON-RPC traffic, the Web3 inspector summarizes the call without hiding the raw JSON:
+
+- RPC family such as EVM or Solana,
+- provider host,
+- JSON-RPC request ID,
+- method,
+- batch request and response counts,
+- error code and message when present,
+- chain and transaction hints when visible,
+- payload size and debug intent.
+
+Debug intent helps you quickly tell whether a call looks like a read, simulation, provider check, log lookup, subscription, batch, or broadcast-style request.
+
+## Working With Existing Debugging Tools
+
+AI and Web3 requests remain normal captured HTTP transactions. Existing Rockxy tools still apply:
+
+- use **Breakpoint** to pause a request or response and inspect or edit it before continuing;
+- use **Map Local** to return a saved response snapshot for a matching request;
+- use **Map Remote** to redirect traffic to another provider, staging gateway, local model server, or local RPC node;
+- use **Modify Headers** to test request or response header behavior;
+- use **Block List** to make an endpoint fail and test fallback behavior;
+- use **Network Conditions** to test slower provider responses and retry behavior.
+
+<Warning>
+Traffic rules currently match URL, HTTP method, and headers. They do not yet match individual AI model names, tool calls, JSON-RPC methods, chain IDs, wallet addresses, transaction hashes, or batch subcalls.
+</Warning>
+
+## Practical Workflows
+
+### Debug AI API behavior
+
+1. Capture the real client request.
+2. Filter to AI traffic or search for the provider host.
+3. Open the AI inspector to check provider, model, stream, usage, and tool-call hints.
+4. Use the Body or Raw tab for the exact request and response payload.
+5. Use Breakpoints, Map Local, Map Remote, or Modify Headers only when you need to change the next run.
+
+### Debug Web3 RPC behavior
+
+1. Capture the wallet, dApp, backend, or CLI traffic.
+2. Filter to Web3 RPC traffic or scope to the provider domain.
+3. Open the Web3 inspector to check method, request ID, batch state, chain hint, error, and transaction hash.
+4. Use the raw JSON body for any detail not summarized by the inspector.
+5. Use Breakpoints for write or broadcast-style calls when you need to inspect the payload before it leaves the machine.
+
+### Check x402-style payment flows
+
+1. Capture the payment-gated HTTP request.
+2. Look for payment-required status and header/body hints.
+3. Compare the first response with the retry request or follow-up response.
+4. Keep sensitive headers and payloads local unless you explicitly export or publish selected traffic.
+
+## Current Scope
+
+Rockxy focuses on inspection and local debugging evidence:
+
+- AI and Web3 metadata is derived from visible captured HTTP traffic.
+- Encrypted HTTPS payloads require normal Rockxy certificate trust and SSL proxying setup.
+- WebSocket frames are still inspected through the WebSocket tools; Web3 JSON-RPC detection currently focuses on HTTP request and response bodies.
+- Batch JSON-RPC requests are summarized instead of split into separate editable subcalls.
+
+## Related Pages
+
+<CardGroup cols={2}>
+  <Card title="Traffic Capture" icon="radar" href="/features/traffic-capture">
+    Capture HTTP, HTTPS, WebSocket, GraphQL, AI, and Web3 traffic from real clients.
+  </Card>
+  <Card title="Traffic Rules" icon="filter" href="/features/rules">
+    Use existing Rockxy tools to pause, map, redirect, block, or slow matching requests.
+  </Card>
+  <Card title="Request Replay" icon="rotate" href="/features/request-replay">
+    Re-send selected HTTP requests while iterating on headers, body, query, or method.
+  </Card>
+  <Card title="MCP Integration" icon="plug" href="/features/mcp">
+    Share redacted captured traffic with local MCP clients when you choose to.
+  </Card>
+</CardGroup>

--- a/docs/features/rules.mdx
+++ b/docs/features/rules.mdx
@@ -86,6 +86,8 @@ Most Rockxy traffic modification tools work best when you scope them to:
 - HTTP method,
 - or a small regex that maps cleanly to the endpoint you are testing.
 
+For AI and Web3 traffic, start with the same matching strategy. Rockxy can label and inspect model calls, JSON-RPC traffic, and x402-style payment hints, but traffic rules still match the HTTP layer: URL, method, and headers. They do not currently match individual AI model names, tool calls, JSON-RPC methods, chain IDs, wallet addresses, transaction hashes, or batch subcalls.
+
 <Note>
 URL patterns use standard regular expressions. To match a literal dot in a domain name, escape it with a backslash: `api\.example\.com`. To match any path under a domain, use `https://api\.example\.com/.*`.
 </Note>

--- a/docs/features/traffic-capture.mdx
+++ b/docs/features/traffic-capture.mdx
@@ -55,7 +55,7 @@ Above the request list, the main content switcher gives you different perspectiv
 
 The toolbar supports protocol filters, URL search, and an optional advanced filter bar:
 
-- **Protocol filters** — narrow to HTTP, HTTPS, WebSocket, GraphQL, and related traffic classes.
+- **Protocol filters** — narrow to HTTP, HTTPS, WebSocket, GraphQL, AI, Web3 RPC, gRPC, and related traffic classes.
 - **URL search** — search the selected field from the search bar.
 - **Advanced filters** — combine structured rules such as method, status, domain, path, client app, or request state.
 - **Sidebar scope** — selecting an app, domain, pinned item, or saved item scopes the request list.
@@ -66,7 +66,7 @@ Combine multiple filters to isolate exactly the traffic you need. For example, f
 
 ## Request Inspector
 
-Select any request in the traffic list to open the inspector panel. The inspector splits into a request side (Headers, Query, Body, Cookies, Raw, Synopsis, Comments) and a response side (Headers, Body, Set-Cookie, Auth, Timeline — plus WebSocket and GraphQL when applicable). Switch tabs to inspect each part of the transaction:
+Select any request in the traffic list to open the inspector panel. The inspector splits into a request side (Headers, Query, Body, Cookies, Raw, Synopsis, Comments) and a response side (Headers, Body, Set-Cookie, Auth, Timeline — plus WebSocket, GraphQL, AI, Web3, and gRPC when applicable). Switch tabs to inspect each part of the transaction:
 
 ### Headers
 
@@ -106,6 +106,10 @@ On the response side, shows the frame list for any connection that completed an 
 
 On the response side, shows the parsed operation with query text and variables for any detected GraphQL request. See [GraphQL Support](/features/graphql) for details.
 
+### AI and Web3
+
+On the response side, protocol-specific tabs summarize recognized AI model calls, Web3 JSON-RPC requests, and x402-style payment-flow hints while keeping the original headers, bodies, raw payload, and timing available in the normal inspector tabs. See [AI and Web3 Inspection](/features/ai-web3-inspection) for details.
+
 ## Session Management
 
 Rockxy stores active traffic in an in-memory ring buffer with a default capacity of 50,000 transactions. When the buffer exceeds the limit, the oldest entries are evicted from the active workspace so the UI stays responsive.
@@ -124,6 +128,9 @@ When the live buffer reaches capacity, older active rows are evicted automatical
 | HTTPS | Full | Via CONNECT tunnel with MITM certificate generation |
 | WebSocket | Full | Frame-level capture after HTTP upgrade |
 | GraphQL-over-HTTP | Auto-detected | POST requests to `/graphql` endpoints with `query` field |
+| AI model APIs | Auto-detected | Provider/model, stream, usage, tool-call, retrieval, and warning hints when visible |
+| Web3 JSON-RPC | Auto-detected | EVM and Solana-style HTTP RPC request ID, method, batch, error, chain, and transaction hints |
+| gRPC | Inspector support | Dedicated protocol tab for unary and streaming protobuf-style traffic |
 
 ## Allow List
 
@@ -200,6 +207,9 @@ See [Sessions & HAR](/features/sessions) for full details on save/export workflo
   </Card>
   <Card title="GraphQL Detection" icon="diagram-project" href="/features/graphql">
     Automatic GraphQL-over-HTTP operation detection and inspection
+  </Card>
+  <Card title="AI and Web3 Inspection" icon="sparkles" href="/features/ai-web3-inspection">
+    Detect and inspect model calls, JSON-RPC traffic, and x402-style payment hints.
   </Card>
   <Card title="Traffic Rules" icon="filter" href="/features/rules">
     Block, redirect, throttle, or modify requests with rules

--- a/docs/use-cases/api-debugging-on-macos.mdx
+++ b/docs/use-cases/api-debugging-on-macos.mdx
@@ -16,6 +16,8 @@ Rockxy is most useful when you need to debug the request that the real client se
 5. add a rule only if you need to change behavior,
 6. export HAR or cURL once you have isolated the issue.
 
+For AI and Web3 work, the same loop applies: capture the real model or RPC request, use protocol filters and the Protocol column to find it, then inspect the AI or Web3 tab alongside Headers, Body, Raw, and Timeline.
+
 ## Why a system-level proxy debugger helps
 
 Browser DevTools and API clients are helpful, but they do not always show:
@@ -30,6 +32,7 @@ Rockxy fills that gap.
 ## Best pages to keep open together
 
 - [Traffic Capture](/features/traffic-capture)
+- [AI and Web3 Inspection](/features/ai-web3-inspection)
 - [Filters and Search](/core-features/filters-and-search)
 - [Request Replay](/features/request-replay)
 - [Sessions and HAR](/features/sessions)
@@ -42,5 +45,8 @@ Rockxy fills that gap.
   </Card>
   <Card title="MCP Integration" icon="plug" href="/features/mcp">
     Bring real captured API traffic into Claude.
+  </Card>
+  <Card title="AI and Web3 Inspection" icon="sparkles" href="/features/ai-web3-inspection">
+    Understand model calls, JSON-RPC traffic, and payment-flow hints without leaving the normal inspector.
   </Card>
 </CardGroup>


### PR DESCRIPTION
## Summary

Promotes the current `develop` branch to `main` with native protocol-aware traffic inspection and certificate-settings polish.

## Included changes

- detect and classify recognized AI API traffic, native AI sessions, EVM and Solana-style JSON-RPC calls, and x402-style payment flows
- add detailed AI and Web3 inspector surfaces for provider, model, streaming, usage, tool-call, retrieval, RPC, chain, transaction, batch, error, payload, and payment hints when available
- add protocol labels, a default Protocol column, smart traffic filters, richer search metadata, and stable inspector routing
- persist protocol metadata with migration coverage and extend privacy redaction across local summaries and export payloads
- publish user-facing AI/Web3 inspection documentation, filtering guidance, changelog entries, and explicit current rule limitations
- polish the General settings certificate status layout and actions

## User impact

Rockxy users can scan mixed captures by protocol, isolate modern AI and Web3 traffic quickly, and inspect useful protocol context without leaving the existing HTTP workflow. Sensitive protocol values remain covered by local redaction paths, and older saved sessions remain compatible through the updated storage migration.

## Issue evidence

### Implemented release slices

- #143 — protocol metadata architecture across transaction models, storage, filtering, request rows, and inspector routing
- #144 — privacy-aware handling and redaction for AI, Web3, MCP-safe, and exported payloads
- #147 — AI provider and traffic detection
- #148 — AI inspector presentation
- #149 — streaming-state diagnostics
- #150 — captured tool-call summaries
- #152 — usage and reliability fields when present
- #156 — retrieval and RAG hints when visible
- #157 — Web3 JSON-RPC detection
- #158 — Web3/RPC inspector presentation
- #159 — Solana-style HTTP RPC inspection
- #162 — captured RPC error details
- #164 — x402 payment-required and retry-flow hints
- #169 — smart AI/Web3 protocol filters
- #170 — compact request-list protocol labels
- #171 — request-list protocol column support
- #176 — fixture-backed AI, Web3, and x402 validation foundation
- #177 — bounded protocol parsing and quick-scan limits
- #178 — session persistence and migration compatibility
- #179 — inspector routing regression coverage
- #182 — public AI inspection documentation
- #183 — public Web3/RPC inspection documentation

### Supporting validation evidence

- #186 — protocol fixture schema and loader
- #187 — protocol UX contract expectations
- #188 — AI streaming and tool-call fixtures
- #189 — embeddings, RAG, and retrieval fixtures
- #190 — EVM JSON-RPC fixtures
- #191 — Solana RPC fixtures
- #192 — x402 payment-flow fixtures
- #193 — malformed and large-payload fixtures
- #194 — fixture secret-scanning and public-safety gates
- #195 — fixture-to-feature roadmap traceability

### Related follow-up roadmap

- #137 — richer local MCP context for protocol summaries
- #145 and #146 — redacted evidence bundles and export preview
- #151 — deeper AI security warnings
- #153, #154, and #155 — Python Probe and local trace correlation
- #160 and #161 — wallet/provider interaction patterns and grouped Web3 flows
- #163 — deeper Web3 security warnings
- #165 and #166 — JSON-RPC replay and simulation handoff
- #167 and #168 — optional TypeScript trace bridge
- #172 — protocol-aware rule predicates
- #173 — successful/failed workflow comparison
- #174 — redacted protocol summaries through local MCP
- #175 — Developer Setup presets for AI/Web3 workflows
- #180 — dedicated large-session metadata performance coverage
- #181 — public product positioning for modern protocol debugging
- #184 — evidence-bundle documentation after implementation

Issues are referenced as implementation evidence or roadmap traceability rather than automatically closed. Several contain broader acceptance criteria or future capabilities beyond this release slice.

## Validation

- `git diff --check origin/main...origin/develop`
- full macOS test suite built and exercised the feature changes
- all feature-related detection, redaction, storage migration, filtering, request-row, and inspector-routing tests passed
- one existing breakpoint concurrency case timed out during the parallel full-suite run and passed on immediate isolated rerun
- pull request #208 completed repository checks before merge into `develop`

## Release notes

- This is a branch-promotion PR; it introduces no additional source changes beyond the commits already merged into `develop`.
- Existing protocol-aware rules, replay helpers, workflow comparison, deeper MCP summaries, and large-session performance work remain tracked separately.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added AI traffic inspection with provider, model, streaming, usage, tool-call, retrieval, and evidence details.
  * Added Web3 RPC inspection for EVM and Solana traffic, including debug intent and error information.
  * Added x402-style payment-flow hints and protocol-aware detection.
  * Added a Protocol column, AI/RPC filters, and smart search tokens.
  * Added dedicated AI and Web3 inspector views with improved debugging guidance.

* **Bug Fixes**
  * Improved sensitive-data redaction for AI, Web3, and payment-related fields.
  * Preserved Web3 metadata when saving and restoring captured transactions.

* **Documentation**
  * Added guidance for AI, Web3, RPC, payment-flow inspection, and current rule-matching limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->