### PR TITLE
fix(mac): harden assistant and workspace lifecycle

### DIFF
--- a/Rockxy/Core/Assistant/AnthropicAssistantProvider.swift
+++ b/Rockxy/Core/Assistant/AnthropicAssistantProvider.swift
@@ -146,7 +146,7 @@ struct AnthropicStreamDecoder {
             updateInputUsage(message?["usage"] as? [String: Any])
             return [.started(responseID: responseID)]
         case "content_block_start":
-            return startContentBlock(object)
+            return try startContentBlock(object)
         case "content_block_delta":
             return try contentDelta(object)
         case "content_block_stop":
@@ -194,7 +194,7 @@ struct AnthropicStreamDecoder {
         cachedInputTokens = usage?["cache_read_input_tokens"] as? Int ?? cachedInputTokens
     }
 
-    private mutating func startContentBlock(_ object: [String: Any]) -> [AssistantStreamEvent] {
+    private mutating func startContentBlock(_ object: [String: Any]) throws -> [AssistantStreamEvent] {
         guard let index = object["index"] as? Int,
               let block = object["content_block"] as? [String: Any],
               block["type"] as? String == "tool_use",
@@ -202,6 +202,9 @@ struct AnthropicStreamDecoder {
               let name = block["name"] as? String else
         {
             return []
+        }
+        guard tools[index] != nil || tools.count < AssistantExecutionLimits.maxToolCalls else {
+            throw AssistantProviderError.malformedResponse("Too many active Anthropic tool calls")
         }
         tools[index] = ToolBuffer(id: id, name: name, arguments: "")
         return [.toolCallDelta(id: id, name: name, argumentsDelta: "")]
@@ -221,10 +224,14 @@ struct AnthropicStreamDecoder {
         {
             return []
         }
-        guard tool.arguments.utf8.count + partial.utf8.count <= AssistantExecutionLimits.maxToolArgumentBytes else {
+        let updatedArguments = tool.arguments + partial
+        guard updatedArguments.utf8.count <= AssistantExecutionLimits.maxToolArgumentBytes,
+              aggregateToolArgumentBytes(replacing: index, with: updatedArguments)
+              <= AssistantExecutionLimits.maxAggregateToolArgumentBytes else
+        {
             throw AssistantProviderError.malformedResponse("Anthropic tool arguments exceeded Rockxy's size limit")
         }
-        tool.arguments += partial
+        tool.arguments = updatedArguments
         tools[index] = tool
         return [.toolCallDelta(id: tool.id, name: nil, argumentsDelta: partial)]
     }
@@ -238,5 +245,16 @@ struct AnthropicStreamDecoder {
             name: tool.name,
             arguments: tool.arguments
         ))]
+    }
+
+    private func aggregateToolArgumentBytes(
+        replacing index: Int,
+        with arguments: String
+    )
+        -> Int
+    {
+        tools.reduce(arguments.utf8.count) { partial, entry in
+            entry.key == index ? partial : partial + entry.value.arguments.utf8.count
+        }
     }
 }

--- a/Rockxy/Core/Assistant/AssistantHTTPTransport.swift
+++ b/Rockxy/Core/Assistant/AssistantHTTPTransport.swift
@@ -7,6 +7,19 @@ struct AssistantHTTPStream {
     let lines: AsyncThrowingStream<String, Error>
 }
 
+// MARK: - AssistantHTTPTransportLimits
+
+/// Provider-neutral network bounds shared by local and remote model adapters.
+/// Individual providers may impose tighter semantic limits after framing, but
+/// no adapter can make the transport allocate an unbounded response first.
+struct AssistantHTTPTransportLimits: Equatable, Sendable {
+    static let `default` = AssistantHTTPTransportLimits()
+
+    var maximumDataBytes = 2 * 1_024 * 1_024
+    var maximumStreamLineBytes = 256 * 1_024
+    var maximumBufferedLines = 32
+}
+
 // MARK: - AssistantHTTPTransport
 
 protocol AssistantHTTPTransport: Sendable {
@@ -19,8 +32,12 @@ protocol AssistantHTTPTransport: Sendable {
 final class URLSessionAssistantHTTPTransport: AssistantHTTPTransport, @unchecked Sendable {
     // MARK: Lifecycle
 
-    init(session: URLSession? = nil) {
+    init(
+        session: URLSession? = nil,
+        limits: AssistantHTTPTransportLimits = .default
+    ) {
         self.session = session ?? URLSession(configuration: Self.proxyBypassConfiguration())
+        self.limits = limits
     }
 
     // MARK: Internal
@@ -35,9 +52,30 @@ final class URLSessionAssistantHTTPTransport: AssistantHTTPTransport, @unchecked
     }
 
     func data(for request: URLRequest) async throws -> (Data, HTTPURLResponse) {
-        let (data, response) = try await session.data(for: request)
+        let (bytes, response) = try await session.bytes(for: request)
         guard let response = response as? HTTPURLResponse else {
             throw AssistantProviderError.malformedResponse("Missing HTTP response metadata")
+        }
+
+        if response.expectedContentLength > limits.maximumDataBytes {
+            throw AssistantProviderError.malformedResponse(
+                "The provider response exceeded Rockxy's \(limits.maximumDataBytes)-byte limit"
+            )
+        }
+
+        var data = Data()
+        data.reserveCapacity(min(
+            max(0, Int(response.expectedContentLength)),
+            limits.maximumDataBytes
+        ))
+        for try await byte in bytes {
+            try Task.checkCancellation()
+            guard data.count < limits.maximumDataBytes else {
+                throw AssistantProviderError.malformedResponse(
+                    "The provider response exceeded Rockxy's \(limits.maximumDataBytes)-byte limit"
+                )
+            }
+            data.append(byte)
         }
         return (data, response)
     }
@@ -47,12 +85,23 @@ final class URLSessionAssistantHTTPTransport: AssistantHTTPTransport, @unchecked
         guard let response = response as? HTTPURLResponse else {
             throw AssistantProviderError.malformedResponse("Missing HTTP response metadata")
         }
-        let lines = AsyncThrowingStream<String, Error> { continuation in
+        let lines = AsyncThrowingStream<String, Error>(
+            bufferingPolicy: .bufferingOldest(max(1, limits.maximumBufferedLines))
+        ) { continuation in
             let task = Task {
                 do {
-                    for try await line in bytes.lines {
+                    var framer = AssistantHTTPLineFramer(
+                        maximumLineBytes: limits.maximumStreamLineBytes
+                    )
+                    for try await byte in bytes {
                         try Task.checkCancellation()
-                        continuation.yield(line)
+                        guard let line = try framer.append(byte) else {
+                            continue
+                        }
+                        try Self.yield(line, to: continuation)
+                    }
+                    if let finalLine = try framer.finish() {
+                        try Self.yield(finalLine, to: continuation)
                     }
                     continuation.finish()
                 } catch is CancellationError {
@@ -69,6 +118,83 @@ final class URLSessionAssistantHTTPTransport: AssistantHTTPTransport, @unchecked
     // MARK: Private
 
     private let session: URLSession
+    private let limits: AssistantHTTPTransportLimits
+
+    private static func yield(
+        _ line: String,
+        to continuation: AsyncThrowingStream<String, Error>.Continuation
+    ) throws {
+        switch continuation.yield(line) {
+        case .enqueued:
+            break
+        case .dropped:
+            throw AssistantProviderError.malformedResponse(
+                "The provider stream produced data faster than Rockxy could safely process it"
+            )
+        case .terminated:
+            throw CancellationError()
+        @unknown default:
+            throw AssistantProviderError.malformedResponse("The provider stream ended unexpectedly")
+        }
+    }
+}
+
+// MARK: - AssistantHTTPLineFramer
+
+/// Incrementally frames UTF-8 lines without first constructing an unbounded
+/// `String`. This is deliberately independent of any provider's SSE/NDJSON
+/// grammar so future adapters inherit the same memory boundary.
+struct AssistantHTTPLineFramer {
+    // MARK: Lifecycle
+
+    init(maximumLineBytes: Int) {
+        self.maximumLineBytes = max(1, maximumLineBytes)
+    }
+
+    // MARK: Internal
+
+    mutating func append(_ byte: UInt8) throws -> String? {
+        guard byte != Self.lineFeed else {
+            return try consumeLine()
+        }
+        guard buffer.count < maximumLineBytes else {
+            throw AssistantProviderError.malformedResponse(
+                "A provider stream line exceeded Rockxy's \(maximumLineBytes)-byte limit"
+            )
+        }
+        buffer.append(byte)
+        return nil
+    }
+
+    mutating func finish() throws -> String? {
+        guard !buffer.isEmpty else {
+            return nil
+        }
+        return try consumeLine()
+    }
+
+    // MARK: Private
+
+    private static let carriageReturn: UInt8 = 0x0D
+    private static let lineFeed: UInt8 = 0x0A
+
+    private let maximumLineBytes: Int
+    private var buffer = Data()
+
+    private mutating func consumeLine() throws -> String {
+        if buffer.last == Self.carriageReturn {
+            buffer.removeLast()
+        }
+        defer {
+            buffer.removeAll(keepingCapacity: true)
+        }
+        guard let line = String(data: buffer, encoding: .utf8) else {
+            throw AssistantProviderError.malformedResponse(
+                "The provider stream contained invalid UTF-8"
+            )
+        }
+        return line
+    }
 }
 
 // MARK: - AssistantHTTPErrorMapper

--- a/Rockxy/Core/Assistant/InvestigationContextBuilder.swift
+++ b/Rockxy/Core/Assistant/InvestigationContextBuilder.swift
@@ -7,6 +7,7 @@ struct InvestigationContextBuilder {
 
     func build(
         snapshots: [InvestigationTransactionSnapshot],
+        requestedTransactionCount: Int? = nil,
         limits: InvestigationContextLimits = .default
     )
         throws -> InvestigationContextPack
@@ -41,12 +42,14 @@ struct InvestigationContextBuilder {
         guard let preview = String(bytes: payload, encoding: .utf8) else {
             throw InvestigationContextBuilderError.invalidEncoding
         }
-        let omitted = snapshots.count - included.count
+        let requestedCount = max(snapshots.count, requestedTransactionCount ?? snapshots.count)
+        let omitted = requestedCount - included.count
         let manifest = InvestigationContextManifest(
             requestCount: included.count,
             outboundBytes: payload.count,
             redactedHeaderCount: totals.redactedHeaderCount,
             redactedQueryCount: totals.redactedQueryCount,
+            redactedURLCredentialCount: totals.redactedURLCredentialCount,
             redactedBodyFieldCount: totals.redactedBodyFieldCount,
             truncatedBodyCount: totals.truncatedBodyCount,
             omittedBinaryBodyCount: totals.omittedBinaryBodyCount,
@@ -83,6 +86,7 @@ struct InvestigationContextBuilder {
             limits: limits
         )
         let originalQueryCount = sensitiveQueryCount(in: snapshot.request.url)
+        let originalURLCredentialCount = sensitiveURLCredentialCount(in: snapshot.request.url)
         let redactedURL = bounded(
             redactor.redactURL(snapshot.request.url).absoluteString,
             characters: limits.maxURLCharacters
@@ -115,6 +119,7 @@ struct InvestigationContextBuilder {
             manifest: ManifestAccumulator(
                 redactedHeaderCount: requestHeaders.redactedCount + responseHeaders.redactedCount,
                 redactedQueryCount: originalQueryCount,
+                redactedURLCredentialCount: originalURLCredentialCount,
                 redactedBodyFieldCount: requestBody.redactedCount + responseBody.redactedCount,
                 truncatedBodyCount: requestBody.wasTruncatedCount + responseBody.wasTruncatedCount,
                 omittedBinaryBodyCount: requestBody.wasBinaryCount + responseBody.wasBinaryCount
@@ -175,6 +180,13 @@ struct InvestigationContextBuilder {
             return 0
         }
         return items.count { SensitiveDataRedactor.sensitiveQueryParams.contains($0.name.lowercased()) }
+    }
+
+    private func sensitiveURLCredentialCount(in url: URL) -> Int {
+        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+            return 0
+        }
+        return (components.user == nil ? 0 : 1) + (components.password == nil ? 0 : 1)
     }
 
     private func encode(transactions: [PayloadTransaction]) throws -> Data {
@@ -325,6 +337,7 @@ private struct PayloadRecord {
 private struct ManifestAccumulator {
     var redactedHeaderCount = 0
     var redactedQueryCount = 0
+    var redactedURLCredentialCount = 0
     var redactedBodyFieldCount = 0
     var truncatedBodyCount = 0
     var omittedBinaryBodyCount = 0
@@ -332,6 +345,7 @@ private struct ManifestAccumulator {
     mutating func add(_ other: ManifestAccumulator) {
         redactedHeaderCount += other.redactedHeaderCount
         redactedQueryCount += other.redactedQueryCount
+        redactedURLCredentialCount += other.redactedURLCredentialCount
         redactedBodyFieldCount += other.redactedBodyFieldCount
         truncatedBodyCount += other.truncatedBodyCount
         omittedBinaryBodyCount += other.omittedBinaryBodyCount

--- a/Rockxy/Core/Assistant/OpenAIResponsesProvider.swift
+++ b/Rockxy/Core/Assistant/OpenAIResponsesProvider.swift
@@ -194,8 +194,11 @@ struct OpenAIResponsesStreamDecoder {
         let callID = item["call_id"] as? String ?? itemID
         let name = item["name"] as? String ?? ""
         let arguments = item["arguments"] as? String ?? ""
-        guard toolsByItemID.count < AssistantExecutionLimits.maxToolCalls,
-              arguments.utf8.count <= AssistantExecutionLimits.maxToolArgumentBytes else
+        guard toolsByItemID[itemID] != nil
+            || toolsByItemID.count < AssistantExecutionLimits.maxToolCalls,
+            arguments.utf8.count <= AssistantExecutionLimits.maxToolArgumentBytes,
+            aggregateToolArgumentBytes(replacing: itemID, with: arguments)
+            <= AssistantExecutionLimits.maxAggregateToolArgumentBytes else
         {
             throw AssistantProviderError.malformedResponse("Tool-call data exceeded Rockxy's size limit")
         }
@@ -206,14 +209,22 @@ struct OpenAIResponsesStreamDecoder {
     private mutating func toolArgumentsDelta(in object: [String: Any]) throws -> [AssistantStreamEvent] {
         let itemID = object["item_id"] as? String ?? ""
         let delta = object["delta"] as? String ?? ""
+        guard !itemID.isEmpty,
+              toolsByItemID[itemID] != nil
+              || toolsByItemID.count < AssistantExecutionLimits.maxToolCalls else
+        {
+            throw AssistantProviderError.malformedResponse("Too many active tool calls")
+        }
         var accumulator = toolsByItemID[itemID]
             ?? ToolAccumulator(callID: itemID, name: "", arguments: "")
-        guard accumulator.arguments.utf8.count + delta.utf8.count
-            <= AssistantExecutionLimits.maxToolArgumentBytes else
+        let updatedArguments = accumulator.arguments + delta
+        guard updatedArguments.utf8.count <= AssistantExecutionLimits.maxToolArgumentBytes,
+              aggregateToolArgumentBytes(replacing: itemID, with: updatedArguments)
+              <= AssistantExecutionLimits.maxAggregateToolArgumentBytes else
         {
             throw AssistantProviderError.malformedResponse("Tool-call arguments exceeded Rockxy's size limit")
         }
-        accumulator.arguments += delta
+        accumulator.arguments = updatedArguments
         toolsByItemID[itemID] = accumulator
         return [
             .toolCallDelta(
@@ -237,7 +248,10 @@ struct OpenAIResponsesStreamDecoder {
         guard !accumulator.callID.isEmpty, !accumulator.name.isEmpty else {
             throw AssistantProviderError.malformedResponse("A completed tool call is missing its ID or name")
         }
-        guard accumulator.arguments.utf8.count <= AssistantExecutionLimits.maxToolArgumentBytes else {
+        guard accumulator.arguments.utf8.count <= AssistantExecutionLimits.maxToolArgumentBytes,
+              aggregateToolArgumentBytes(replacing: itemID, with: accumulator.arguments)
+              <= AssistantExecutionLimits.maxAggregateToolArgumentBytes else
+        {
             throw AssistantProviderError.malformedResponse("Tool-call arguments exceeded Rockxy's size limit")
         }
         toolsByItemID.removeValue(forKey: itemID)
@@ -248,6 +262,17 @@ struct OpenAIResponsesStreamDecoder {
                 arguments: accumulator.arguments
             )),
         ]
+    }
+
+    private func aggregateToolArgumentBytes(
+        replacing itemID: String,
+        with arguments: String
+    )
+        -> Int
+    {
+        toolsByItemID.reduce(arguments.utf8.count) { partial, entry in
+            entry.key == itemID ? partial : partial + entry.value.arguments.utf8.count
+        }
     }
 
     private func completionEvents(in object: [String: Any]) -> [AssistantStreamEvent] {

--- a/Rockxy/Core/ProxyEngine/HelperConnection.swift
+++ b/Rockxy/Core/ProxyEngine/HelperConnection.swift
@@ -54,24 +54,62 @@ enum HelperConnectionError: LocalizedError {
 final class SigningPreflightCache {
     // MARK: Internal
 
-    var provider: () -> SigningDiagnostics.Result = { SigningDiagnostics.diagnose() }
+    var provider: @Sendable () -> SigningDiagnostics.Result = { SigningDiagnostics.diagnose() }
 
-    func evaluate() -> SigningDiagnostics.Result {
-        if let cached {
-            return cached
+    /// Return the memoized diagnosis, running the live provider off the main actor.
+    ///
+    /// Concurrent callers coalesce onto a single detached diagnosis per generation. If the
+    /// cache is invalidated while a diagnosis is in flight, that result is discarded and the
+    /// caller retries against the current generation so a stale result can never repopulate
+    /// the cache.
+    func evaluate() async -> SigningDiagnostics.Result {
+        while true {
+            if let cached {
+                return cached
+            }
+
+            let generationAtStart = generation
+            let task: Task<SigningDiagnostics.Result, Never>
+            if let inFlightTask, inFlightGeneration == generationAtStart {
+                task = inFlightTask
+            } else {
+                let provider = provider
+                let newTask = Task.detached(priority: .userInitiated) { provider() }
+                inFlightTask = newTask
+                inFlightGeneration = generationAtStart
+                task = newTask
+            }
+
+            let result = await task.value
+
+            guard generation == generationAtStart else {
+                // Invalidated while this diagnosis was in flight — discard the stale
+                // generation and retry against the current one.
+                continue
+            }
+
+            cached = result
+            if inFlightGeneration == generationAtStart {
+                inFlightTask = nil
+                inFlightGeneration = nil
+            }
+            return result
         }
-        let result = provider()
-        cached = result
-        return result
     }
 
     func invalidate() {
         cached = nil
+        generation += 1
+        inFlightTask = nil
+        inFlightGeneration = nil
     }
 
     // MARK: Private
 
     private var cached: SigningDiagnostics.Result?
+    private var generation = 0
+    private var inFlightTask: Task<SigningDiagnostics.Result, Never>?
+    private var inFlightGeneration: Int?
 }
 
 // MARK: - HelperConnection
@@ -170,7 +208,7 @@ final class HelperConnection {
 
     /// Override system HTTP and HTTPS proxy to 127.0.0.1 on the given port.
     func overrideSystemProxy(port: Int) async throws {
-        let proxy = try getProxy()
+        let proxy = try await getProxy()
         let ownerPID = Int32(ProcessInfo.processInfo.processIdentifier)
         Self.logger.info("Calling helper overrideSystemProxy for port \(port)")
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
@@ -215,7 +253,7 @@ final class HelperConnection {
 
     /// Restore the original system proxy settings that were saved before the override.
     func restoreSystemProxy() async throws {
-        let proxy = try getProxy()
+        let proxy = try await getProxy()
         Self.logger.info("Calling helper restoreSystemProxy")
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
             let resumed = OSAllocatedUnfairLock(initialState: false)
@@ -259,7 +297,7 @@ final class HelperConnection {
 
     /// Query structured helper info: version, build number, and protocol version.
     func getHelperInfo() async throws -> HelperInfo {
-        let proxy = try getProxy()
+        let proxy = try await getProxy()
         return try await withCheckedThrowingContinuation { continuation in
             let resumed = OSAllocatedUnfairLock(initialState: false)
 
@@ -299,7 +337,7 @@ final class HelperConnection {
 
     /// Query the current proxy status from the helper: (isOverridden, port).
     func getProxyStatus() async throws -> (isOverridden: Bool, port: Int) {
-        let proxy = try getProxy()
+        let proxy = try await getProxy()
         return try await withCheckedThrowingContinuation { continuation in
             let resumed = OSAllocatedUnfairLock(initialState: false)
 
@@ -336,7 +374,7 @@ final class HelperConnection {
     /// Tell the helper to restore proxy settings and prepare for removal,
     /// then invalidate the XPC connection.
     func uninstallHelper() async throws {
-        let proxy = try getProxy()
+        let proxy = try await getProxy()
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
             let resumed = OSAllocatedUnfairLock(initialState: false)
 
@@ -381,7 +419,7 @@ final class HelperConnection {
 
     /// Set the system proxy bypass domain list via the helper tool.
     func setBypassDomains(_ domains: [String]) async throws {
-        let proxy = try getProxy()
+        let proxy = try await getProxy()
         Self.logger.info("Calling helper setBypassDomains with \(domains.count) domain(s)")
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
             let resumed = OSAllocatedUnfairLock(initialState: false)
@@ -425,7 +463,7 @@ final class HelperConnection {
 
     /// Install a root CA certificate in the system keychain and trust it for SSL.
     func installRootCertificate(derData: Data) async throws {
-        let proxy = try getProxy()
+        let proxy = try await getProxy()
         Self.logger.info("Calling helper installRootCertificate (\(derData.count) bytes)")
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
             let resumed = OSAllocatedUnfairLock(initialState: false)
@@ -469,7 +507,7 @@ final class HelperConnection {
 
     /// Remove the Rockxy root CA certificate and trust settings from the system keychain.
     func removeRootCertificate() async throws {
-        let proxy = try getProxy()
+        let proxy = try await getProxy()
         Self.logger.info("Calling helper removeRootCertificate")
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
             let resumed = OSAllocatedUnfairLock(initialState: false)
@@ -513,7 +551,7 @@ final class HelperConnection {
 
     /// Verify that a certificate with the given SHA-256 fingerprint is trusted in the system keychain.
     func verifyRootCertificateTrusted(fingerprint: String) async throws -> Bool {
-        let proxy = try getProxy()
+        let proxy = try await getProxy()
         return try await withCheckedThrowingContinuation { continuation in
             let resumed = OSAllocatedUnfairLock(initialState: false)
 
@@ -550,7 +588,7 @@ final class HelperConnection {
     /// Remove stale Rockxy Root CA certificates from the system keychain,
     /// keeping only the one matching activeFingerprint. Returns count of removed certs.
     func cleanupStaleCertificates(activeFingerprint: String) async throws -> Int {
-        let proxy = try getProxy()
+        let proxy = try await getProxy()
         return try await withCheckedThrowingContinuation { continuation in
             let resumed = OSAllocatedUnfairLock(initialState: false)
 
@@ -606,8 +644,8 @@ final class HelperConnection {
 
     /// Evaluate the signing preflight cache and throw a typed error if the
     /// current app has a signing issue relative to the installed helper.
-    private func signingPreflight() throws {
-        let result = signingCache.evaluate()
+    private func signingPreflight() async throws {
+        let result = await signingCache.evaluate()
         switch result {
         case let .appSignatureInvalid(detail):
             throw HelperConnectionError.appSignatureInvalid(detail)
@@ -622,8 +660,8 @@ final class HelperConnection {
     }
 
     /// Create or reuse an NSXPCConnection to the helper's Mach service.
-    private func getProxy() throws -> any RockxyHelperProtocol {
-        try signingPreflight()
+    private func getProxy() async throws -> any RockxyHelperProtocol {
+        try await signingPreflight()
         let conn: NSXPCConnection
         if let existing = connection {
             conn = existing

--- a/Rockxy/Core/ProxyEngine/SigningDiagnostics.swift
+++ b/Rockxy/Core/ProxyEngine/SigningDiagnostics.swift
@@ -13,7 +13,7 @@ enum SigningDiagnostics {
 
     // MARK: - Result
 
-    enum Result: Equatable {
+    enum Result: Equatable, Sendable {
         /// App signature is valid, helper exists, certificate chains match.
         case healthy
         /// App bundle code signature is invalid (e.g., missing dylib after stale Xcode build).

--- a/Rockxy/Core/Utilities/SensitiveDataRedactor.swift
+++ b/Rockxy/Core/Utilities/SensitiveDataRedactor.swift
@@ -21,10 +21,13 @@ struct SensitiveDataRedactor {
         "set-cookie",
         "www-authenticate",
         "proxy-authenticate",
+        "api-key",
+        "ocp-apim-subscription-key",
         "x-api-key",
         "x-auth-token",
         "x-access-token",
         "x-csrf-token",
+        "x-goog-api-key",
         "x-xsrf-token",
         "x-payment",
         "x-payment-response",
@@ -154,19 +157,28 @@ struct SensitiveDataRedactor {
         guard isEnabled else {
             return url
         }
-        guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false),
-              let queryItems = components.queryItems,
-              !queryItems.isEmpty else {
+        guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
             return url
         }
 
-        components.queryItems = queryItems.map { item in
-            guard Self.sensitiveQueryParams.contains(item.name.lowercased()) else {
-                return item
-            }
-            return URLQueryItem(name: item.name, value: redactedPlaceholder)
+        var didRedact = false
+        if components.user != nil || components.password != nil {
+            components.user = nil
+            components.password = nil
+            didRedact = true
         }
-        return components.url ?? url
+
+        if let queryItems = components.queryItems, !queryItems.isEmpty {
+            components.queryItems = queryItems.map { item in
+                guard Self.sensitiveQueryParams.contains(item.name.lowercased()) else {
+                    return item
+                }
+                didRedact = true
+                return URLQueryItem(name: item.name, value: redactedPlaceholder)
+            }
+        }
+
+        return didRedact ? (components.url ?? url) : url
     }
 
     func redactBody(_ body: Data?, contentType: ContentType?) -> Data? {

--- a/Rockxy/Models/Assistant/AssistantProviderModels.swift
+++ b/Rockxy/Models/Assistant/AssistantProviderModels.swift
@@ -731,6 +731,7 @@ enum ModelInvestigationState: Equatable {
     case streaming(
         runID: UUID,
         provider: AssistantProviderKind,
+        executionLocation: AssistantExecutionLocation,
         model: String,
         endpointHost: String,
         text: String
@@ -745,6 +746,7 @@ enum AssistantExecutionLimits {
     static let maxOutputBytes = 256 * 1_024
     static let maxStreamEventBytes = 256 * 1_024
     static let maxToolArgumentBytes = 64 * 1_024
+    static let maxAggregateToolArgumentBytes = 256 * 1_024
     static let maxToolCalls = 16
     static let streamingUIUpdateInterval: TimeInterval = 0.25
 }

--- a/Rockxy/Models/Assistant/AssistantTrustPolicy.swift
+++ b/Rockxy/Models/Assistant/AssistantTrustPolicy.swift
@@ -7,6 +7,8 @@ enum AssistantTrafficScope: String, Equatable, Sendable {
     case selectedOnly
     case selectedAndRelated
 
+    // MARK: Internal
+
     var title: String {
         switch self {
         case .selectedOnly:
@@ -14,6 +16,34 @@ enum AssistantTrafficScope: String, Equatable, Sendable {
         case .selectedAndRelated:
             String(localized: "Selected and Related Traffic")
         }
+    }
+}
+
+// MARK: - DebugAssistantReviewSummary
+
+/// Review-time accounting of automatically discovered related traffic for a single investigation.
+/// Distinguishes Focus/Noise scope exclusion from context-bound (size/capacity) omission, which
+/// stays in `InvestigationContextManifest.omittedTransactionCount`.
+struct DebugAssistantReviewSummary: Equatable {
+    /// Raw related requests discovered near the selection, before Focus/Noise scoping.
+    var rawRelatedFound = 0
+    /// Related requests actually included in the reviewed context pack.
+    var relatedIncluded = 0
+    /// Related requests withheld by the active Focus Set or muted Noise sources. Reported for
+    /// transparency even after an override is applied — it never zeroes just because the excluded
+    /// traffic was included once.
+    var focusNoiseExcluded = 0
+    /// True once the user applied the one-time include-excluded override for this review.
+    var overrideApplied = false
+    /// True only when recomputing related traffic while ignoring Focus/Noise would actually change
+    /// the bounded reviewed related transaction-ID set. Merely having excluded raw candidates that
+    /// fall outside the context bound is not enough to make the override material.
+    var overrideExpandsReviewedSet = false
+
+    /// An override is offered only when it has not already been applied and it would materially
+    /// expand the bounded reviewed related set.
+    var canOverrideFocusNoise: Bool {
+        !overrideApplied && overrideExpandsReviewedSet
     }
 }
 
@@ -27,7 +57,11 @@ enum AssistantUserHandoff: String, CaseIterable, Identifiable, Sendable {
     case export
     case share
 
-    var id: String { rawValue }
+    // MARK: Internal
+
+    var id: String {
+        rawValue
+    }
 
     var title: String {
         switch self {

--- a/Rockxy/Models/Assistant/DebugAssistantModels.swift
+++ b/Rockxy/Models/Assistant/DebugAssistantModels.swift
@@ -159,6 +159,10 @@ struct DebugAssistantMessage: Identifiable, Equatable {
         return fragments.joined(separator: "\n")
     }
 
+    var retainedTextBytes: Int {
+        searchableText.utf8.count
+    }
+
     static func user(_ text: String) -> DebugAssistantMessage {
         DebugAssistantMessage(role: .user, text: text)
     }
@@ -188,6 +192,73 @@ struct DebugAssistantMessage: Identifiable, Equatable {
     }
 }
 
+// MARK: - DebugAssistantConversationContext
+
+/// Stable, bounded identity for the captured traffic attached to a conversation.
+/// Only the requests Rockxy can actually include are retained; the original count
+/// remains visible so a large selection is never represented as complete.
+struct DebugAssistantConversationContext: Equatable {
+    // MARK: Lifecycle
+
+    init(
+        primaryTransactionID: UUID,
+        selectedTransactionIDs: [UUID],
+        requestedSelectionCount: Int
+    ) {
+        var orderedIDs = [primaryTransactionID]
+        var seen: Set<UUID> = [primaryTransactionID]
+        for id in selectedTransactionIDs where seen.insert(id).inserted {
+            orderedIDs.append(id)
+        }
+        self.primaryTransactionID = primaryTransactionID
+        self.selectedTransactionIDs = Array(
+            orderedIDs.prefix(InvestigationContextLimits.default.maxTransactions)
+        )
+        self.requestedSelectionCount = max(requestedSelectionCount, self.selectedTransactionIDs.count)
+    }
+
+    // MARK: Internal
+
+    let primaryTransactionID: UUID
+    let selectedTransactionIDs: [UUID]
+    let requestedSelectionCount: Int
+
+    var summary: String {
+        if requestedSelectionCount == selectedTransactionIDs.count {
+            return String(localized: "\(selectedTransactionIDs.count) selected request(s)")
+        }
+        return String(
+            localized: "\(selectedTransactionIDs.count) of \(requestedSelectionCount) selected request(s)"
+        )
+    }
+
+    func matches(
+        primaryTransactionID: UUID?,
+        selectedTransactionIDs: [UUID],
+        requestedSelectionCount: Int
+    )
+        -> Bool
+    {
+        self.primaryTransactionID == primaryTransactionID
+            && Set(self.selectedTransactionIDs) == Set(selectedTransactionIDs)
+            && (
+                self.requestedSelectionCount == requestedSelectionCount
+                    || self.selectedTransactionIDs.count == requestedSelectionCount
+            )
+    }
+}
+
+// MARK: - DebugAssistantConversationLimits
+
+enum DebugAssistantConversationLimits {
+    static let maximumPromptBytes = 16 * 1_024
+    static let maximumMessagesPerConversation = 48
+    static let maximumConversationTextBytes = 2 * 1_024 * 1_024
+    static let maximumConversationsPerWorkspace = 32
+    static let maximumPinnedConversationsPerWorkspace = 8
+    static let maximumWorkspaceTextBytes = 8 * 1_024 * 1_024
+}
+
 // MARK: - DebugAssistantConversation
 
 /// A workspace-local assistant thread. Keeping the captured evidence snapshots in memory avoids
@@ -200,6 +271,7 @@ struct DebugAssistantConversation: Identifiable, Equatable {
         id: UUID = UUID(),
         title: String,
         messages: [DebugAssistantMessage],
+        context: DebugAssistantConversationContext? = nil,
         createdAt: Date = Date(),
         updatedAt: Date = Date(),
         isPinned: Bool = false
@@ -207,6 +279,7 @@ struct DebugAssistantConversation: Identifiable, Equatable {
         self.id = id
         self.title = title
         self.messages = messages
+        self.context = context
         self.createdAt = createdAt
         self.updatedAt = updatedAt
         self.isPinned = isPinned
@@ -217,6 +290,7 @@ struct DebugAssistantConversation: Identifiable, Equatable {
     let id: UUID
     var title: String
     var messages: [DebugAssistantMessage]
+    var context: DebugAssistantConversationContext?
     let createdAt: Date
     var updatedAt: Date
     var isPinned: Bool
@@ -224,6 +298,10 @@ struct DebugAssistantConversation: Identifiable, Equatable {
     var preview: String {
         messages.last(where: { !$0.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty })?.text
             ?? String(localized: "No messages yet")
+    }
+
+    var retainedTextBytes: Int {
+        title.utf8.count + messages.reduce(0) { $0 + $1.retainedTextBytes }
     }
 
     func matches(_ query: String) -> Bool {

--- a/Rockxy/Models/Assistant/InvestigationContextPack.swift
+++ b/Rockxy/Models/Assistant/InvestigationContextPack.swift
@@ -16,17 +16,44 @@ struct InvestigationContextLimits: Equatable {
 // MARK: - InvestigationContextManifest
 
 struct InvestigationContextManifest: Equatable {
+    // MARK: Lifecycle
+
+    init(
+        requestCount: Int,
+        outboundBytes: Int,
+        redactedHeaderCount: Int,
+        redactedQueryCount: Int,
+        redactedURLCredentialCount: Int = 0,
+        redactedBodyFieldCount: Int,
+        truncatedBodyCount: Int,
+        omittedBinaryBodyCount: Int,
+        omittedTransactionCount: Int
+    ) {
+        self.requestCount = requestCount
+        self.outboundBytes = outboundBytes
+        self.redactedHeaderCount = redactedHeaderCount
+        self.redactedQueryCount = redactedQueryCount
+        self.redactedURLCredentialCount = redactedURLCredentialCount
+        self.redactedBodyFieldCount = redactedBodyFieldCount
+        self.truncatedBodyCount = truncatedBodyCount
+        self.omittedBinaryBodyCount = omittedBinaryBodyCount
+        self.omittedTransactionCount = omittedTransactionCount
+    }
+
+    // MARK: Internal
+
     let requestCount: Int
     let outboundBytes: Int
     let redactedHeaderCount: Int
     let redactedQueryCount: Int
+    let redactedURLCredentialCount: Int
     let redactedBodyFieldCount: Int
     let truncatedBodyCount: Int
     let omittedBinaryBodyCount: Int
     let omittedTransactionCount: Int
 
     var redactedFieldCount: Int {
-        redactedHeaderCount + redactedQueryCount + redactedBodyFieldCount
+        redactedHeaderCount + redactedQueryCount + redactedURLCredentialCount + redactedBodyFieldCount
     }
 }
 

--- a/Rockxy/Models/UI/ToastMessage.swift
+++ b/Rockxy/Models/UI/ToastMessage.swift
@@ -7,6 +7,7 @@ import Foundation
 /// Visual style for transient toast notifications.
 enum ToastStyle {
     case success
+    case warning
     case error
 }
 

--- a/Rockxy/Models/UI/WorkspaceState.swift
+++ b/Rockxy/Models/UI/WorkspaceState.swift
@@ -1,12 +1,16 @@
 import Foundation
 import os
 
+// MARK: - ContextDockTab
+
 // Defines the UI state for a single workspace tab.
 
 enum ContextDockTab: Equatable {
     case details
     case aiAssistant
 }
+
+// MARK: - WorkspaceState
 
 @MainActor @Observable
 final class WorkspaceState: Identifiable {
@@ -55,6 +59,7 @@ final class WorkspaceState: Identifiable {
     var debugAssistantConversationTitle = String(localized: "New Conversation")
     var debugAssistantConversationCreatedAt = Date()
     var debugAssistantConversationUpdatedAt = Date()
+    var debugAssistantConversationContext: DebugAssistantConversationContext?
     var debugAssistantConversations: [DebugAssistantConversation] = []
     var debugAssistantUsesConfiguredModel = true
     var debugAssistantTrafficScope = AssistantTrustPolicy.defaultTrafficScope
@@ -63,7 +68,10 @@ final class WorkspaceState: Identifiable {
     var debugAssistantReviewConfiguration: AssistantProviderConfiguration?
     var debugAssistantReviewTrafficScope: AssistantTrafficScope?
     var debugAssistantReviewModelAccessEnabled = false
+    var debugAssistantReviewSummary: DebugAssistantReviewSummary?
+    var debugAssistantRequestedContextCount = 0
     var isPreparingDebugAssistantReview = false
+    var isPreparingDebugAssistantReviewOverride = false
     var isDebugAssistantComposerFocusRequested = false
     var focusNavigatorMode: FocusNavigatorMode = .browse
     var activeTrafficSignal: TrafficSignal?
@@ -123,6 +131,7 @@ final class WorkspaceState: Identifiable {
         debugAssistantConversationTitle = String(localized: "New Conversation")
         debugAssistantConversationCreatedAt = Date()
         debugAssistantConversationUpdatedAt = Date()
+        debugAssistantConversationContext = nil
         debugAssistantConversations.removeAll()
         debugAssistantTrafficScope = AssistantTrustPolicy.defaultTrafficScope
         debugAssistantReviewPack = nil
@@ -130,7 +139,10 @@ final class WorkspaceState: Identifiable {
         debugAssistantReviewConfiguration = nil
         debugAssistantReviewTrafficScope = nil
         debugAssistantReviewModelAccessEnabled = false
+        debugAssistantReviewSummary = nil
+        debugAssistantRequestedContextCount = 0
         isPreparingDebugAssistantReview = false
+        isPreparingDebugAssistantReviewOverride = false
         isDebugAssistantComposerFocusRequested = false
         domainTree.removeAll()
         totalDomainCount = 0

--- a/Rockxy/Views/Common/NativeWorkspaceWindowChrome.swift
+++ b/Rockxy/Views/Common/NativeWorkspaceWindowChrome.swift
@@ -20,14 +20,16 @@ enum NativeWorkspaceWindowChrome {
         window.titlebarAppearsTransparent = true
         window.styleMask.insert(.fullSizeContentView)
 
-        guard let workspaceSplitController,
-              let toolbarConfiguration else {
-            return
+        if let workspaceSplitController,
+           let toolbarConfiguration
+        {
+            workspaceSplitController.installToolbarIfNeeded(
+                window: window,
+                configuration: toolbarConfiguration
+            )
         }
-        workspaceSplitController.installToolbarIfNeeded(
-            window: window,
-            configuration: toolbarConfiguration
-        )
+
+        window.titleVisibility = .hidden
     }
 }
 

--- a/Rockxy/Views/Common/ToastView.swift
+++ b/Rockxy/Views/Common/ToastView.swift
@@ -51,6 +51,7 @@ struct ToastView: View {
     private var iconName: String {
         switch message.style {
         case .success: "checkmark.circle.fill"
+        case .warning: "exclamationmark.triangle.fill"
         case .error: "xmark.circle.fill"
         }
     }
@@ -58,6 +59,7 @@ struct ToastView: View {
     private var iconColor: Color {
         switch message.style {
         case .success: .green
+        case .warning: .orange
         case .error: .red
         }
     }

--- a/Rockxy/Views/Inspector/AssistantConversationComponents.swift
+++ b/Rockxy/Views/Inspector/AssistantConversationComponents.swift
@@ -70,6 +70,80 @@ struct AssistantProgressRow: View {
     @Environment(\.appUIDisplayMetrics) private var metrics
 }
 
+// MARK: - AssistantConversationContextMismatchBanner
+
+struct AssistantConversationContextMismatchBanner: View {
+    let context: DebugAssistantConversationContext?
+    let onRestore: () -> Void
+    let onStartNew: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 7) {
+            Label(
+                String(localized: "This conversation belongs to different traffic"),
+                systemImage: "arrow.trianglehead.branch"
+            )
+            .font(metrics.swiftUIFont(size: metrics.secondaryFontSize, weight: .semibold))
+
+            if let context {
+                Text(
+                    String(
+                        localized: "It was started with \(context.summary). Restore that selection or start a clean conversation for the traffic shown above."
+                    )
+                )
+                .font(metrics.swiftUIFont(size: metrics.metadataFontSize))
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+            }
+
+            HStack(spacing: 7) {
+                Button(String(localized: "Restore Traffic"), action: onRestore)
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+
+                Button(String(localized: "New Conversation"), action: onStartNew)
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.small)
+            }
+        }
+        .padding(10)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color.orange.opacity(0.08))
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel(String(localized: "Conversation traffic changed"))
+    }
+
+    @Environment(\.appUIDisplayMetrics) private var metrics
+}
+
+// MARK: - AssistantUserMessageBubble
+
+struct AssistantUserMessageBubble: View {
+    let text: String
+
+    var body: some View {
+        HStack {
+            Spacer(minLength: 44)
+            Text(text)
+                .font(metrics.swiftUIFont(size: metrics.primaryFontSize))
+                .foregroundStyle(.primary)
+                .textSelection(.enabled)
+                .padding(.horizontal, 10)
+                .padding(.vertical, 8)
+                .background(Color(nsColor: .controlBackgroundColor), in: RoundedRectangle(cornerRadius: 8))
+                .overlay {
+                    RoundedRectangle(cornerRadius: 8)
+                        .stroke(Color(nsColor: .separatorColor), lineWidth: 0.5)
+                }
+        }
+        .frame(maxWidth: .infinity, alignment: .trailing)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(String(localized: "You: \(text)"))
+    }
+
+    @Environment(\.appUIDisplayMetrics) private var metrics
+}
+
 // MARK: - AssistantResponseActionBar
 
 struct AssistantResponseActionBar: View {

--- a/Rockxy/Views/Inspector/ContextDockView.swift
+++ b/Rockxy/Views/Inspector/ContextDockView.swift
@@ -67,6 +67,14 @@ private struct AIAssistantDockView: View {
             Divider()
             attachedContextHeader
             Divider()
+            if conversationContextMismatch {
+                AssistantConversationContextMismatchBanner(
+                    context: coordinator.activeWorkspace.debugAssistantConversationContext,
+                    onRestore: coordinator.restoreDebugAssistantConversationContext,
+                    onStartNew: coordinator.startNewDebugAssistantConversationForCurrentSelection
+                )
+                Divider()
+            }
             conversationTranscript
             Divider()
             promptComposer
@@ -74,16 +82,12 @@ private struct AIAssistantDockView: View {
         .background(Color.clear)
         .accessibilityElement(children: .contain)
         .accessibilityLabel(String(localized: "Rockxy AI Assistant"))
-        .sheet(item: reviewPackBinding) { pack in
+        .sheet(item: reviewPackBinding) { _ in
             DebugAssistantReviewDataSheet(
-                pack: pack,
-                request: coordinator.activeWorkspace.debugAssistantReviewRequest,
-                configuration: coordinator.activeWorkspace.debugAssistantReviewConfiguration,
-                trafficScope: coordinator.activeWorkspace.debugAssistantReviewTrafficScope
-                    ?? AssistantTrustPolicy.defaultTrafficScope,
-                modelAccessEnabled: coordinator.activeWorkspace.debugAssistantReviewModelAccessEnabled,
+                coordinator: coordinator,
                 onSend: coordinator.sendDebugAssistantReview,
-                onDismiss: coordinator.dismissDebugAssistantReview
+                onDismiss: coordinator.dismissDebugAssistantReview,
+                onOverride: coordinator.applyDebugAssistantReviewFocusNoiseOverride
             )
         }
         .alert(
@@ -130,7 +134,11 @@ private struct AIAssistantDockView: View {
             }
             Button(String(localized: "Cancel"), role: .cancel) {}
         } message: {
-            Text(String(localized: "Rockxy will create an editable draft. Nothing is sent until you press Send in Compose."))
+            Text(
+                String(
+                    localized: "Rockxy will create an editable draft. Nothing is sent until you press Send in Compose."
+                )
+            )
         }
         .onAppear(perform: focusComposerIfRequested)
         .onChange(of: coordinator.activeWorkspace.isDebugAssistantComposerFocusRequested) {
@@ -263,8 +271,19 @@ private struct AIAssistantDockView: View {
         min(selectedTransactions.count, InvestigationContextLimits.default.maxTransactions)
     }
 
+    private var selectedContextLabel: String {
+        guard selectedContextCount < selectedTransactions.count else {
+            return selectedContextCount.formatted()
+        }
+        return String(localized: "\(selectedContextCount) of \(selectedTransactions.count)")
+    }
+
     private var conversationIsEmpty: Bool {
         coordinator.activeWorkspace.debugAssistantMessages.isEmpty
+    }
+
+    private var conversationContextMismatch: Bool {
+        coordinator.debugAssistantConversationHasContextMismatch()
     }
 
     private var isBusy: Bool {
@@ -282,12 +301,13 @@ private struct AIAssistantDockView: View {
 
     private var canSendDraft: Bool {
         !isBusy
+            && !conversationContextMismatch
             && !coordinator.activeWorkspace.debugAssistantDraft
             .trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 
     private var streamingText: String {
-        guard case let .streaming(_, _, _, _, text) = coordinator.activeWorkspace.modelInvestigationState else {
+        guard case let .streaming(_, _, _, _, _, text) = coordinator.activeWorkspace.modelInvestigationState else {
             return ""
         }
         return text
@@ -401,7 +421,7 @@ private struct AIAssistantDockView: View {
                         coordinator.setDebugAssistantTrafficScope(.selectedOnly)
                     } label: {
                         Label(
-                            String(localized: "Selected Traffic Only (\(selectedContextCount))"),
+                            String(localized: "Selected Traffic Only (\(selectedContextLabel))"),
                             systemImage: coordinator.activeWorkspace.debugAssistantTrafficScope == .selectedOnly
                                 ? "checkmark" : "circle"
                         )
@@ -559,54 +579,12 @@ private struct AIAssistantDockView: View {
         }
     }
 
-    @ViewBuilder private func currentResultTurn(_ result: InvestigationResult) -> some View {
-        switch coordinator.activeWorkspace.modelInvestigationState {
-        case .streaming,
-             .failed:
-            modelAssistantTurn
-        case .completed:
-            EmptyView()
-        case .idle:
-            if resultIsInTranscript(result) {
-                EmptyView()
-            } else if coordinator.activeWorkspace.isPreparingDebugAssistantReview {
-                assistantBubble {
-                    AssistantProgressRow(
-                        title: String(localized: "Selected traffic inspected"),
-                        systemImage: "checkmark.circle.fill",
-                        color: .green
-                    )
-                    AssistantProgressRow(
-                        title: String(localized: "Redacting sensitive fields"),
-                        showsProgress: true
-                    )
-                    Text(String(localized: "Preparing the exact request for Review Data."))
-                        .font(assistantFont(appMetrics.metadataFontSize))
-                        .foregroundStyle(.secondary)
-                }
-            } else if coordinator.activeWorkspace.debugAssistantReviewPack != nil {
-                assistantBubble {
-                    AssistantProgressRow(
-                        title: String(localized: "Waiting for Review Data"),
-                        systemImage: "lock.shield",
-                        color: .secondary
-                    )
-                    Text(String(localized: "Confirm the redacted traffic and conversation before the model runs."))
-                        .font(assistantFont(appMetrics.metadataFontSize))
-                        .foregroundStyle(.secondary)
-                }
-            } else {
-                reviewReadyTurn(result)
-            }
-        }
-    }
-
     @ViewBuilder private var modelAssistantTurn: some View {
         switch coordinator.activeWorkspace.modelInvestigationState {
         case .idle,
              .completed:
             EmptyView()
-        case let .streaming(_, provider, model, endpointHost, text):
+        case let .streaming(_, provider, executionLocation, model, endpointHost, text):
             assistantBubble {
                 HStack(spacing: 7) {
                     ProgressView()
@@ -622,9 +600,13 @@ private struct AIAssistantDockView: View {
                     .controlSize(.mini)
                 }
                 if text.isEmpty {
-                    Text(String(localized: "The local model is reading the reviewed request context."))
-                        .font(assistantFont(appMetrics.metadataFontSize))
-                        .foregroundStyle(.secondary)
+                    Text(
+                        executionLocation.isLocal
+                            ? String(localized: "The local model is reading the reviewed request context.")
+                            : String(localized: "The configured provider is processing the reviewed request context.")
+                    )
+                    .font(assistantFont(appMetrics.metadataFontSize))
+                    .foregroundStyle(.secondary)
                 } else {
                     AssistantStreamingText(source: text)
                 }
@@ -667,7 +649,11 @@ private struct AIAssistantDockView: View {
 
     private var promptComposer: some View {
         VStack(alignment: .leading, spacing: 6) {
-            if primaryTransaction != nil, !isBusy, conversationIsEmpty {
+            if primaryTransaction != nil,
+               !isBusy,
+               !conversationContextMismatch,
+               conversationIsEmpty
+            {
                 ScrollView(.horizontal, showsIndicators: false) {
                     HStack(spacing: 6) {
                         ForEach(DebugAssistantRecipe.allCases.prefix(2)) { recipe in
@@ -695,7 +681,7 @@ private struct AIAssistantDockView: View {
                 .lineLimit(1 ... 4)
                 .focused($isComposerFocused)
                 .onSubmit(sendDraft)
-                .disabled(isBusy)
+                .disabled(isBusy || conversationContextMismatch)
 
                 Button(action: sendDraft) {
                     Image(systemName: "arrow.up")
@@ -719,7 +705,7 @@ private struct AIAssistantDockView: View {
             }
             .contentShape(Rectangle())
             .onTapGesture {
-                guard !isBusy else {
+                guard !isBusy, !conversationContextMismatch else {
                     return
                 }
                 isComposerFocused = true
@@ -792,6 +778,49 @@ private struct AIAssistantDockView: View {
         .background(Color.clear)
     }
 
+    @ViewBuilder
+    private func currentResultTurn(_ result: InvestigationResult) -> some View {
+        switch coordinator.activeWorkspace.modelInvestigationState {
+        case .streaming,
+             .failed:
+            modelAssistantTurn
+        case .completed:
+            EmptyView()
+        case .idle:
+            if resultIsInTranscript(result) {
+                EmptyView()
+            } else if coordinator.activeWorkspace.isPreparingDebugAssistantReview {
+                assistantBubble {
+                    AssistantProgressRow(
+                        title: String(localized: "Selected traffic inspected"),
+                        systemImage: "checkmark.circle.fill",
+                        color: .green
+                    )
+                    AssistantProgressRow(
+                        title: String(localized: "Redacting sensitive fields"),
+                        showsProgress: true
+                    )
+                    Text(String(localized: "Preparing the exact request for Review Data."))
+                        .font(assistantFont(appMetrics.metadataFontSize))
+                        .foregroundStyle(.secondary)
+                }
+            } else if coordinator.activeWorkspace.debugAssistantReviewPack != nil {
+                assistantBubble {
+                    AssistantProgressRow(
+                        title: String(localized: "Waiting for Review Data"),
+                        systemImage: "lock.shield",
+                        color: .secondary
+                    )
+                    Text(String(localized: "Confirm the redacted traffic and conversation before the model runs."))
+                        .font(assistantFont(appMetrics.metadataFontSize))
+                        .foregroundStyle(.secondary)
+                }
+            } else {
+                reviewReadyTurn(result)
+            }
+        }
+    }
+
     private func conversationHistoryRow(_ conversation: DebugAssistantConversation) -> some View {
         Button {
             coordinator.selectDebugAssistantConversation(conversation.id)
@@ -861,7 +890,7 @@ private struct AIAssistantDockView: View {
     private func conversationMessage(_ message: DebugAssistantMessage) -> some View {
         switch message.role {
         case .user:
-            userBubble(message.text)
+            AssistantUserMessageBubble(text: message.text)
         case .assistant:
             VStack(alignment: .leading, spacing: 8) {
                 if let investigation = message.investigation {
@@ -893,26 +922,6 @@ private struct AIAssistantDockView: View {
         }
     }
 
-    private func userBubble(_ text: String) -> some View {
-        HStack {
-            Spacer(minLength: 44)
-            Text(text)
-                .font(assistantFont(appMetrics.primaryFontSize))
-                .foregroundStyle(.primary)
-                .textSelection(.enabled)
-                .padding(.horizontal, 10)
-                .padding(.vertical, 8)
-                .background(Color(nsColor: .controlBackgroundColor), in: RoundedRectangle(cornerRadius: 8))
-                .overlay {
-                    RoundedRectangle(cornerRadius: 8)
-                        .stroke(Color(nsColor: .separatorColor), lineWidth: 0.5)
-                }
-        }
-        .frame(maxWidth: .infinity, alignment: .trailing)
-        .accessibilityElement(children: .combine)
-        .accessibilityLabel(String(localized: "You: \(text)"))
-    }
-
     private func assistantBubble(@ViewBuilder content: () -> some View) -> some View {
         AssistantResponseCard(content: content)
     }
@@ -921,7 +930,9 @@ private struct AIAssistantDockView: View {
         text: String,
         investigation: InvestigationResult?,
         canRetryModel: Bool
-    ) -> some View {
+    )
+        -> some View
+    {
         let requestID = investigation?.selectedTransactionID
         return AssistantResponseActionBar(
             canCopy: !text.isEmpty,
@@ -1114,7 +1125,9 @@ private struct AIAssistantDockView: View {
         title: String,
         detail: String,
         cancel: @escaping () -> Void
-    ) -> some View {
+    )
+        -> some View
+    {
         assistantBubble {
             HStack(spacing: 8) {
                 ProgressView()
@@ -1185,47 +1198,6 @@ private struct AIAssistantDockView: View {
         }
     }
 
-    private func requestSummary(for transaction: HTTPTransaction) -> String {
-        let status = transaction.response.map { String($0.statusCode) } ?? "—"
-        return "\(transaction.request.method) \(status)  \(transaction.request.host)\(transaction.request.path)"
-    }
-
-    private func evidenceColor(_ kind: InvestigationEvidenceKind) -> Color {
-        switch kind {
-        case .observed: .blue
-        case .derived: .purple
-        case .inferred: .orange
-        case .unknown: .secondary
-        }
-    }
-
-    private func statusColor(for transaction: HTTPTransaction) -> Color {
-        guard let status = transaction.response?.statusCode else {
-            return transaction.state == .failed ? .red : .secondary
-        }
-        switch status {
-        case 200 ..< 300: return .green
-        case 300 ..< 400: return .blue
-        case 400 ..< 500: return .orange
-        case 500...: return .red
-        default: return .secondary
-        }
-    }
-
-    private func relativeDateLabel(_ date: Date) -> String {
-        let interval = max(0, Date().timeIntervalSince(date))
-        if interval < 60 {
-            return String(localized: "Now")
-        }
-        if interval < 3_600 {
-            return String(localized: "\(Int(interval / 60))m")
-        }
-        if Calendar.current.isDateInToday(date) {
-            return date.formatted(date: .omitted, time: .shortened)
-        }
-        return date.formatted(.dateTime.weekday(.abbreviated))
-    }
-
     private func assistantFont(
         _ size: CGFloat,
         weight: Font.Weight = .regular,
@@ -1262,5 +1234,46 @@ private extension AIAssistantDockView {
         coordinator.activeWorkspace.debugAssistantMessages.contains {
             $0.investigation == result
         }
+    }
+
+    func requestSummary(for transaction: HTTPTransaction) -> String {
+        let status = transaction.response.map { String($0.statusCode) } ?? "—"
+        return "\(transaction.request.method) \(status)  \(transaction.request.host)\(transaction.request.path)"
+    }
+
+    func evidenceColor(_ kind: InvestigationEvidenceKind) -> Color {
+        switch kind {
+        case .observed: .blue
+        case .derived: .purple
+        case .inferred: .orange
+        case .unknown: .secondary
+        }
+    }
+
+    func statusColor(for transaction: HTTPTransaction) -> Color {
+        guard let status = transaction.response?.statusCode else {
+            return transaction.state == .failed ? .red : .secondary
+        }
+        switch status {
+        case 200 ..< 300: return .green
+        case 300 ..< 400: return .blue
+        case 400 ..< 500: return .orange
+        case 500...: return .red
+        default: return .secondary
+        }
+    }
+
+    func relativeDateLabel(_ date: Date) -> String {
+        let interval = max(0, Date().timeIntervalSince(date))
+        if interval < 60 {
+            return String(localized: "Now")
+        }
+        if interval < 3_600 {
+            return String(localized: "\(Int(interval / 60))m")
+        }
+        if Calendar.current.isDateInToday(date) {
+            return date.formatted(date: .omitted, time: .shortened)
+        }
+        return date.formatted(.dateTime.weekday(.abbreviated))
     }
 }

--- a/Rockxy/Views/Inspector/DebugAssistantReviewDataSheet.swift
+++ b/Rockxy/Views/Inspector/DebugAssistantReviewDataSheet.swift
@@ -1,16 +1,17 @@
 import SwiftUI
 
+// MARK: - DebugAssistantReviewDataSheet
+
 /// Exact, read-only view of the redacted context pack shown before an outbound request.
+/// Reads live review state from the coordinator so the one-time Focus/Noise override can
+/// recompute the reviewed pack in place without dismissing and reopening the sheet.
 struct DebugAssistantReviewDataSheet: View {
     // MARK: Internal
 
-    let pack: InvestigationContextPack
-    let request: AssistantCompletionRequest?
-    let configuration: AssistantProviderConfiguration?
-    let trafficScope: AssistantTrafficScope
-    let modelAccessEnabled: Bool
+    let coordinator: MainContentCoordinator
     let onSend: () -> Void
     let onDismiss: () -> Void
+    let onOverride: () -> Void
 
     var body: some View {
         VStack(spacing: 0) {
@@ -31,6 +32,38 @@ struct DebugAssistantReviewDataSheet: View {
 
     @Environment(\.appUIDisplayMetrics) private var appMetrics
 
+    private var workspace: WorkspaceState {
+        coordinator.activeWorkspace
+    }
+
+    private var pack: InvestigationContextPack? {
+        workspace.debugAssistantReviewPack
+    }
+
+    private var request: AssistantCompletionRequest? {
+        workspace.debugAssistantReviewRequest
+    }
+
+    private var configuration: AssistantProviderConfiguration? {
+        workspace.debugAssistantReviewConfiguration
+    }
+
+    private var trafficScope: AssistantTrafficScope {
+        workspace.debugAssistantReviewTrafficScope ?? AssistantTrustPolicy.defaultTrafficScope
+    }
+
+    private var modelAccessEnabled: Bool {
+        workspace.debugAssistantReviewModelAccessEnabled
+    }
+
+    private var reviewSummary: DebugAssistantReviewSummary {
+        workspace.debugAssistantReviewSummary ?? DebugAssistantReviewSummary()
+    }
+
+    private var isPreparingOverride: Bool {
+        workspace.isPreparingDebugAssistantReviewOverride
+    }
+
     private var toolMetrics: ToolWindowDisplayMetrics {
         ToolWindowDisplayMetrics(appMetrics: appMetrics)
     }
@@ -44,7 +77,7 @@ struct DebugAssistantReviewDataSheet: View {
     }
 
     private var canSend: Bool {
-        modelAccessEnabled && configuration?.isComplete == true && request != nil
+        modelAccessEnabled && configuration?.isComplete == true && request != nil && !isPreparingOverride
     }
 
     private var isLocalExecution: Bool {
@@ -61,6 +94,10 @@ struct DebugAssistantReviewDataSheet: View {
         return settings
     }
 
+    private var showsScopeSummary: Bool {
+        trafficScope == .selectedAndRelated && reviewSummary.rawRelatedFound > 0
+    }
+
     private var headerSubtitle: String {
         if isLocalExecution {
             return String(localized: "Confirm the redacted traffic and conversation before local inference begins.")
@@ -73,6 +110,9 @@ struct DebugAssistantReviewDataSheet: View {
     }
 
     private var footerStatus: String {
+        if isPreparingOverride {
+            return String(localized: "Rebuilding the reviewed context with the excluded traffic")
+        }
         if !modelAccessEnabled {
             return String(localized: "Model access is disabled in AI Assistant Settings")
         }
@@ -85,16 +125,294 @@ struct DebugAssistantReviewDataSheet: View {
         return String(localized: "Only reviewed content and required provider metadata will be sent")
     }
 
-    private var scopeDescription: String {
-        switch trafficScope {
-        case .selectedOnly:
-            String(localized: "\(pack.manifest.requestCount) selected request(s)")
-        case .selectedAndRelated:
-            String(localized: "\(pack.manifest.requestCount) selected and opted-in related request(s)")
+    private var header: some View {
+        HStack(alignment: .top, spacing: 10) {
+            Image(systemName: isLocalExecution ? "lock.shield" : "arrow.up.forward.app")
+                .font(.system(size: toolMetrics.compactIconFontSize, weight: .medium))
+                .foregroundStyle(.secondary)
+                .frame(width: 20)
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(String(localized: "Review Data"))
+                    .font(.system(size: max(15, toolMetrics.bodyFontSize + 2), weight: .semibold))
+                Text(headerSubtitle)
+                    .font(toolMetrics.secondaryFont())
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, toolMetrics.contentHorizontalPadding)
+        .padding(.top, toolMetrics.headerTopPadding)
+        .padding(.bottom, toolMetrics.headerBottomPadding)
+    }
+
+    @ViewBuilder private var content: some View {
+        if let pack {
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 16) {
+                    destinationSection(pack)
+                    if showsScopeSummary {
+                        scopeSummarySection
+                    }
+                    redactionSection(pack)
+                    previewSection(pack)
+                }
+                .padding(.horizontal, toolMetrics.contentHorizontalPadding)
+                .padding(.vertical, toolMetrics.formVerticalPadding)
+            }
+        } else {
+            Spacer(minLength: 0)
         }
     }
 
-    private var reviewDetails: [ReviewDetail] {
+    private var actionBar: some View {
+        HStack(spacing: toolMetrics.controlSpacing) {
+            Label(footerStatus, systemImage: canSend ? "checkmark.shield" : "lock.shield")
+                .font(toolMetrics.secondaryFont())
+                .foregroundStyle(.secondary)
+                .lineLimit(2)
+
+            Spacer(minLength: 12)
+
+            Button(String(localized: "Cancel"), action: onDismiss)
+                .keyboardShortcut(.cancelAction)
+
+            Button(primaryActionTitle, action: onSend)
+                .buttonStyle(.borderedProminent)
+                .keyboardShortcut(.defaultAction)
+                .disabled(!canSend)
+        }
+        .padding(.horizontal, toolMetrics.contentHorizontalPadding)
+        .padding(.vertical, toolMetrics.footerTopPadding)
+        .frame(minHeight: toolMetrics.footerControlHeight + 20)
+        .background(Color(nsColor: .windowBackgroundColor))
+    }
+
+    private var scopeSummarySection: some View {
+        reviewSection(String(localized: "Related Traffic Scope")) {
+            VStack(alignment: .leading, spacing: 10) {
+                Grid(alignment: .leading, horizontalSpacing: 24, verticalSpacing: 9) {
+                    GridRow {
+                        manifestRow(
+                            String(localized: "Related found"),
+                            value: reviewSummary.rawRelatedFound,
+                            systemImage: "magnifyingglass",
+                            color: .secondary
+                        )
+                        manifestRow(
+                            String(localized: "Included in review"),
+                            value: reviewSummary.relatedIncluded,
+                            systemImage: "checkmark.circle.fill",
+                            color: .green
+                        )
+                    }
+                    GridRow {
+                        manifestRow(
+                            String(localized: "Normally excluded by Focus / Noise"),
+                            value: reviewSummary.focusNoiseExcluded,
+                            systemImage: "eye.slash",
+                            color: reviewSummary.focusNoiseExcluded == 0 ? .secondary : .orange
+                        )
+                        Color.clear.frame(height: 0)
+                    }
+                }
+
+                if reviewSummary.overrideApplied {
+                    Label(
+                        String(localized: "Focus and Noise were ignored once for this review."),
+                        systemImage: "checkmark.circle"
+                    )
+                    .font(toolMetrics.secondaryFont())
+                    .foregroundStyle(.secondary)
+                } else if reviewSummary.canOverrideFocusNoise {
+                    overrideControl
+                }
+            }
+        }
+    }
+
+    private var overrideControl: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            if isPreparingOverride {
+                HStack(spacing: 8) {
+                    ProgressView()
+                        .controlSize(.small)
+                    Text(String(localized: "Including excluded traffic…"))
+                        .font(toolMetrics.secondaryFont())
+                        .foregroundStyle(.secondary)
+                }
+            } else {
+                Button(String(localized: "Include Excluded Traffic Once"), action: onOverride)
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+                    .accessibilityLabel(String(localized: "Include Excluded Traffic Once"))
+                    .help(String(localized: "Focus and Noise settings will not change."))
+            }
+            Text(
+                String(
+                    localized: "Adds the \(reviewSummary.focusNoiseExcluded) request(s) hidden by Focus or Noise to this review only. Your Focus and Noise settings will not change."
+                )
+            )
+            .font(toolMetrics.metadataFont())
+            .foregroundStyle(.secondary)
+            .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    private func destinationSection(_ pack: InvestigationContextPack) -> some View {
+        reviewSection(String(localized: "Request Summary")) {
+            LazyVGrid(
+                columns: [
+                    GridItem(.adaptive(minimum: 150), alignment: .topLeading),
+                ],
+                alignment: .leading,
+                spacing: 12
+            ) {
+                ForEach(reviewDetails(pack)) { detail in
+                    VStack(alignment: .leading, spacing: 3) {
+                        Text(detail.title)
+                            .font(toolMetrics.metadataFont(weight: .medium))
+                            .foregroundStyle(.secondary)
+                        Text(detail.value)
+                            .font(toolMetrics.font())
+                            .lineLimit(2)
+                            .textSelection(.enabled)
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                }
+            }
+        }
+    }
+
+    private func redactionSection(_ pack: InvestigationContextPack) -> some View {
+        reviewSection(String(localized: "Redaction Manifest")) {
+            Grid(alignment: .leading, horizontalSpacing: 24, verticalSpacing: 9) {
+                GridRow {
+                    manifestRow(
+                        String(localized: "Sensitive fields redacted"),
+                        value: pack.manifest.redactedFieldCount,
+                        systemImage: "checkmark.shield.fill",
+                        color: .green
+                    )
+                    manifestRow(
+                        String(localized: "Payloads truncated"),
+                        value: pack.manifest.truncatedBodyCount,
+                        systemImage: "scissors",
+                        color: pack.manifest.truncatedBodyCount == 0 ? .secondary : .orange
+                    )
+                }
+                GridRow {
+                    manifestRow(
+                        String(localized: "Binary payloads omitted"),
+                        value: pack.manifest.omittedBinaryBodyCount,
+                        systemImage: "nosign",
+                        color: pack.manifest.omittedBinaryBodyCount == 0 ? .secondary : .orange
+                    )
+                    manifestRow(
+                        String(localized: "Requests outside the bound"),
+                        value: pack.manifest.omittedTransactionCount,
+                        systemImage: "square.stack.3d.down.right",
+                        color: pack.manifest.omittedTransactionCount == 0 ? .secondary : .orange
+                    )
+                }
+            }
+        }
+    }
+
+    private func previewSection(_ pack: InvestigationContextPack) -> some View {
+        VStack(alignment: .leading, spacing: 7) {
+            HStack {
+                Text(String(localized: "Exact Reviewed Content"))
+                    .font(toolMetrics.font(weight: .semibold))
+                Spacer()
+                let totalRequestCount = pack.manifest.requestCount + pack.manifest.omittedTransactionCount
+                Text(
+                    pack.manifest.omittedTransactionCount == 0
+                        ? String(localized: "\(pack.manifest.requestCount) requests")
+                        : String(localized: "\(pack.manifest.requestCount) of \(totalRequestCount) requests")
+                )
+                .font(toolMetrics.metadataFont())
+                .foregroundStyle(.secondary)
+            }
+
+            InspectorBodyTextEditor(
+                text: request?.reviewedContentPreview ?? pack.preview,
+                editorID: "debug-assistant-review-\((request?.reviewedContentPreview ?? pack.preview).hashValue)",
+                editorSettings: previewEditorSettings,
+                isEditable: false
+            )
+            .frame(minHeight: 210, idealHeight: 260)
+            .overlay {
+                Rectangle()
+                    .stroke(Color(nsColor: .separatorColor), lineWidth: 0.5)
+            }
+        }
+    }
+
+    private func reviewSection(
+        _ title: String,
+        @ViewBuilder content: () -> some View
+    )
+        -> some View
+    {
+        VStack(alignment: .leading, spacing: 7) {
+            Text(title)
+                .font(toolMetrics.font(weight: .semibold))
+
+            content()
+                .padding(12)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(
+                    Color(nsColor: .controlBackgroundColor),
+                    in: RoundedRectangle(cornerRadius: 8)
+                )
+                .overlay {
+                    RoundedRectangle(cornerRadius: 8)
+                        .stroke(Color(nsColor: .separatorColor), lineWidth: 0.5)
+                }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func manifestRow(
+        _ title: String,
+        value: Int,
+        systemImage: String,
+        color: Color
+    )
+        -> some View
+    {
+        HStack(spacing: 8) {
+            Image(systemName: systemImage)
+                .foregroundStyle(color)
+                .frame(width: 16)
+            Text(title)
+                .font(toolMetrics.secondaryFont())
+            Spacer(minLength: 8)
+            Text(value.formatted())
+                .font(toolMetrics.secondaryFont())
+                .monospacedDigit()
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func scopeDescription(_ pack: InvestigationContextPack) -> String {
+        let totalRequestCount = pack.manifest.requestCount + pack.manifest.omittedTransactionCount
+        let countDescription = pack.manifest.omittedTransactionCount == 0
+            ? pack.manifest.requestCount.formatted()
+            : String(localized: "\(pack.manifest.requestCount) of \(totalRequestCount)")
+        return switch trafficScope {
+        case .selectedOnly:
+            String(localized: "\(countDescription) selected request(s)")
+        case .selectedAndRelated:
+            String(localized: "\(countDescription) selected and opted-in related request(s)")
+        }
+    }
+
+    private func reviewDetails(_ pack: InvestigationContextPack) -> [ReviewDetail] {
         var details = [
             ReviewDetail(
                 title: String(localized: "Provider"),
@@ -110,7 +428,7 @@ struct DebugAssistantReviewDataSheet: View {
             ),
             ReviewDetail(
                 title: String(localized: "Scope"),
-                value: scopeDescription
+                value: scopeDescription(pack)
             ),
             ReviewDetail(
                 title: String(localized: "Redaction"),
@@ -158,198 +476,9 @@ struct DebugAssistantReviewDataSheet: View {
         }
         return details
     }
-
-    private var header: some View {
-        HStack(alignment: .top, spacing: 10) {
-            Image(systemName: isLocalExecution ? "lock.shield" : "arrow.up.forward.app")
-                .font(.system(size: toolMetrics.compactIconFontSize, weight: .medium))
-                .foregroundStyle(.secondary)
-                .frame(width: 20)
-
-            VStack(alignment: .leading, spacing: 4) {
-                Text(String(localized: "Review Data"))
-                    .font(.system(size: max(15, toolMetrics.bodyFontSize + 2), weight: .semibold))
-                Text(headerSubtitle)
-                    .font(toolMetrics.secondaryFont())
-                    .foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
-            }
-
-            Spacer(minLength: 0)
-        }
-        .padding(.horizontal, toolMetrics.contentHorizontalPadding)
-        .padding(.top, toolMetrics.headerTopPadding)
-        .padding(.bottom, toolMetrics.headerBottomPadding)
-    }
-
-    private var content: some View {
-        ScrollView {
-            LazyVStack(alignment: .leading, spacing: 16) {
-                destinationSection
-                redactionSection
-                previewSection
-            }
-            .padding(.horizontal, toolMetrics.contentHorizontalPadding)
-            .padding(.vertical, toolMetrics.formVerticalPadding)
-        }
-    }
-
-    private var destinationSection: some View {
-        reviewSection(String(localized: "Request Summary")) {
-            LazyVGrid(
-                columns: [
-                    GridItem(.adaptive(minimum: 150), alignment: .topLeading),
-                ],
-                alignment: .leading,
-                spacing: 12
-            ) {
-                ForEach(reviewDetails) { detail in
-                    VStack(alignment: .leading, spacing: 3) {
-                        Text(detail.title)
-                            .font(toolMetrics.metadataFont(weight: .medium))
-                            .foregroundStyle(.secondary)
-                        Text(detail.value)
-                            .font(toolMetrics.font())
-                            .lineLimit(2)
-                            .textSelection(.enabled)
-                    }
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                }
-            }
-        }
-    }
-
-    private var redactionSection: some View {
-        reviewSection(String(localized: "Redaction Manifest")) {
-            Grid(alignment: .leading, horizontalSpacing: 24, verticalSpacing: 9) {
-                GridRow {
-                    manifestRow(
-                        String(localized: "Sensitive fields redacted"),
-                        value: pack.manifest.redactedFieldCount,
-                        systemImage: "checkmark.shield.fill",
-                        color: .green
-                    )
-                    manifestRow(
-                        String(localized: "Payloads truncated"),
-                        value: pack.manifest.truncatedBodyCount,
-                        systemImage: "scissors",
-                        color: pack.manifest.truncatedBodyCount == 0 ? .secondary : .orange
-                    )
-                }
-                GridRow {
-                    manifestRow(
-                        String(localized: "Binary payloads omitted"),
-                        value: pack.manifest.omittedBinaryBodyCount,
-                        systemImage: "nosign",
-                        color: pack.manifest.omittedBinaryBodyCount == 0 ? .secondary : .orange
-                    )
-                    manifestRow(
-                        String(localized: "Requests outside the bound"),
-                        value: pack.manifest.omittedTransactionCount,
-                        systemImage: "square.stack.3d.down.right",
-                        color: pack.manifest.omittedTransactionCount == 0 ? .secondary : .orange
-                    )
-                }
-            }
-        }
-    }
-
-    private var previewSection: some View {
-        VStack(alignment: .leading, spacing: 7) {
-            HStack {
-                Text(String(localized: "Exact Reviewed Content"))
-                    .font(toolMetrics.font(weight: .semibold))
-                Spacer()
-                Text(String(localized: "\(pack.manifest.requestCount) requests"))
-                    .font(toolMetrics.metadataFont())
-                    .foregroundStyle(.secondary)
-            }
-
-            InspectorBodyTextEditor(
-                text: request?.reviewedContentPreview ?? pack.preview,
-                editorID: "debug-assistant-review-\((request?.reviewedContentPreview ?? pack.preview).hashValue)",
-                editorSettings: previewEditorSettings,
-                isEditable: false
-            )
-            .frame(minHeight: 210, idealHeight: 260)
-            .overlay {
-                Rectangle()
-                    .stroke(Color(nsColor: .separatorColor), lineWidth: 0.5)
-            }
-        }
-    }
-
-    private var actionBar: some View {
-        HStack(spacing: toolMetrics.controlSpacing) {
-            Label(footerStatus, systemImage: canSend ? "checkmark.shield" : "lock.shield")
-                .font(toolMetrics.secondaryFont())
-                .foregroundStyle(.secondary)
-                .lineLimit(2)
-
-            Spacer(minLength: 12)
-
-            Button(String(localized: "Cancel"), action: onDismiss)
-                .keyboardShortcut(.cancelAction)
-
-            Button(primaryActionTitle, action: onSend)
-                .buttonStyle(.borderedProminent)
-                .keyboardShortcut(.defaultAction)
-                .disabled(!canSend)
-        }
-        .padding(.horizontal, toolMetrics.contentHorizontalPadding)
-        .padding(.vertical, toolMetrics.footerTopPadding)
-        .frame(minHeight: toolMetrics.footerControlHeight + 20)
-        .background(Color(nsColor: .windowBackgroundColor))
-    }
-
-    private func reviewSection<Content: View>(
-        _ title: String,
-        @ViewBuilder content: () -> Content
-    )
-        -> some View
-    {
-        VStack(alignment: .leading, spacing: 7) {
-            Text(title)
-                .font(toolMetrics.font(weight: .semibold))
-
-            content()
-                .padding(12)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .background(
-                    Color(nsColor: .controlBackgroundColor),
-                    in: RoundedRectangle(cornerRadius: 8)
-                )
-                .overlay {
-                    RoundedRectangle(cornerRadius: 8)
-                        .stroke(Color(nsColor: .separatorColor), lineWidth: 0.5)
-                }
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-    }
-
-    private func manifestRow(
-        _ title: String,
-        value: Int,
-        systemImage: String,
-        color: Color
-    )
-        -> some View
-    {
-        HStack(spacing: 8) {
-            Image(systemName: systemImage)
-                .foregroundStyle(color)
-                .frame(width: 16)
-            Text(title)
-                .font(toolMetrics.secondaryFont())
-            Spacer(minLength: 8)
-            Text(value.formatted())
-                .font(toolMetrics.secondaryFont())
-                .monospacedDigit()
-                .foregroundStyle(.secondary)
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-    }
 }
+
+// MARK: - ReviewDetail
 
 private struct ReviewDetail: Identifiable {
     let title: String

--- a/Rockxy/Views/Main/Extensions/MainContentCoordinator+DebugAssistant.swift
+++ b/Rockxy/Views/Main/Extensions/MainContentCoordinator+DebugAssistant.swift
@@ -9,6 +9,20 @@ extension MainContentCoordinator {
         guard !prompt.isEmpty else {
             return
         }
+        guard !debugAssistantConversationHasContextMismatch() else {
+            activeToast = ToastMessage(
+                style: .warning,
+                text: String(localized: "Restore this conversation's traffic or start a new conversation.")
+            )
+            return
+        }
+        guard prompt.utf8.count <= DebugAssistantConversationLimits.maximumPromptBytes else {
+            activeToast = ToastMessage(
+                style: .warning,
+                text: String(localized: "Shorten this message before sending it to the Assistant.")
+            )
+            return
+        }
         workspace.debugAssistantDraft = ""
         guard !debugAssistantSelectedTransactions().isEmpty else {
             if workspace.debugAssistantMessages.isEmpty {
@@ -76,6 +90,7 @@ extension MainContentCoordinator {
         workspace.debugAssistantConversationTitle = conversation.title
         workspace.debugAssistantConversationCreatedAt = conversation.createdAt
         workspace.debugAssistantConversationUpdatedAt = conversation.updatedAt
+        workspace.debugAssistantConversationContext = conversation.context
         workspace.debugAssistantMessages = conversation.messages
         workspace.debugAssistantDraft = ""
         let latestInvestigation = conversation.messages.compactMap(\.investigation).last
@@ -86,12 +101,7 @@ extension MainContentCoordinator {
         } ?? .idle
         workspace.modelInvestigationState = conversation.messages.compactMap(\.modelResult).last
             .map(ModelInvestigationState.completed) ?? .idle
-        workspace.debugAssistantReviewPack = nil
-        workspace.debugAssistantReviewRequest = nil
-        workspace.debugAssistantReviewConfiguration = nil
-        workspace.debugAssistantReviewTrafficScope = nil
-        workspace.debugAssistantReviewModelAccessEnabled = false
-        workspace.isPreparingDebugAssistantReview = false
+        resetDebugAssistantReviewState(workspace)
         workspace.debugAssistantTrafficScope = AssistantTrustPolicy.defaultTrafficScope
     }
 
@@ -120,6 +130,18 @@ extension MainContentCoordinator {
         guard let index = workspace.debugAssistantConversations.firstIndex(where: { $0.id == conversationID }) else {
             return
         }
+        if !workspace.debugAssistantConversations[index].isPinned,
+           workspace.debugAssistantConversations.count(where: \.isPinned)
+           >= DebugAssistantConversationLimits.maximumPinnedConversationsPerWorkspace
+        {
+            activeToast = ToastMessage(
+                style: .warning,
+                text: String(
+                    localized: "Unpin another Assistant conversation before pinning this one."
+                )
+            )
+            return
+        }
         workspace.debugAssistantConversations[index].isPinned.toggle()
     }
 
@@ -141,6 +163,23 @@ extension MainContentCoordinator {
             )
             return
         }
+        guard let conversationContext = currentDebugAssistantConversationContext() else {
+            return
+        }
+        if let existingContext = workspace.debugAssistantConversationContext,
+           !existingContext.matches(
+               primaryTransactionID: conversationContext.primaryTransactionID,
+               selectedTransactionIDs: conversationContext.selectedTransactionIDs,
+               requestedSelectionCount: conversationContext.requestedSelectionCount
+           )
+        {
+            activeToast = ToastMessage(
+                style: .warning,
+                text: String(localized: "Restore this conversation's traffic or start a new conversation.")
+            )
+            return
+        }
+        workspace.debugAssistantConversationContext = conversationContext
 
         if workspace.debugAssistantMessages.isEmpty {
             workspace.debugAssistantConversationTitle = debugAssistantConversationTitle(from: prompt)
@@ -149,16 +188,19 @@ extension MainContentCoordinator {
         workspace.debugAssistantMessages.append(.user(prompt))
         syncCurrentDebugAssistantConversation(workspace)
         cancelDebugAssistantTask(for: workspace.id)
-        let selected = selectedTransactions.map(InvestigationTransactionSnapshot.init(transaction:))
-        let session = debugAssistantContextTransactions()
+        let contextTransactions = debugAssistantContextTransactions()
+        let boundedSelected = Array(
+            selectedTransactions.prefix(InvestigationContextLimits.default.maxTransactions)
+        )
+        let selected = boundedSelected.map(InvestigationTransactionSnapshot.init(transaction:))
+        let session = contextTransactions
             .map(InvestigationTransactionSnapshot.init(transaction:))
         let runID = UUID()
-        workspace.debugAssistantReviewPack = nil
-        workspace.debugAssistantReviewRequest = nil
-        workspace.debugAssistantReviewConfiguration = nil
-        workspace.debugAssistantReviewTrafficScope = nil
-        workspace.debugAssistantReviewModelAccessEnabled = false
-        workspace.isPreparingDebugAssistantReview = false
+        resetDebugAssistantReviewState(workspace)
+        workspace.debugAssistantRequestedContextCount = selectedTransactions.count
+            + (workspace.debugAssistantTrafficScope == .selectedAndRelated
+                ? debugAssistantAvailableRelatedTransactionCount()
+                : 0)
         workspace.modelInvestigationState = .idle
         workspace.debugAssistantState = .investigating(runID: runID, recipe: recipe)
 
@@ -223,12 +265,7 @@ extension MainContentCoordinator {
         cancelDebugAssistantTask(for: workspace.id)
         workspace.debugAssistantState = .idle
         workspace.modelInvestigationState = .idle
-        workspace.debugAssistantReviewPack = nil
-        workspace.debugAssistantReviewRequest = nil
-        workspace.debugAssistantReviewConfiguration = nil
-        workspace.debugAssistantReviewTrafficScope = nil
-        workspace.debugAssistantReviewModelAccessEnabled = false
-        workspace.isPreparingDebugAssistantReview = false
+        resetDebugAssistantReviewState(workspace)
     }
 
     func backToDebugAssistantRecipes() {
@@ -236,12 +273,7 @@ extension MainContentCoordinator {
         cancelDebugAssistantTask(for: workspace.id)
         workspace.debugAssistantState = .idle
         workspace.modelInvestigationState = .idle
-        workspace.debugAssistantReviewPack = nil
-        workspace.debugAssistantReviewRequest = nil
-        workspace.debugAssistantReviewConfiguration = nil
-        workspace.debugAssistantReviewTrafficScope = nil
-        workspace.debugAssistantReviewModelAccessEnabled = false
-        workspace.isPreparingDebugAssistantReview = false
+        resetDebugAssistantReviewState(workspace)
     }
 
     func prepareDebugAssistantReview() {
@@ -268,8 +300,10 @@ extension MainContentCoordinator {
 
         cancelDebugAssistantTask(for: workspace.id)
         workspace.isPreparingDebugAssistantReview = true
+        workspace.isPreparingDebugAssistantReviewOverride = false
         workspace.debugAssistantReviewPack = nil
         workspace.debugAssistantReviewRequest = nil
+        workspace.debugAssistantReviewSummary = nil
         let settingsSnapshot = assistantSettingsProvider()
         workspace.debugAssistantReviewConfiguration = settingsSnapshot.assistantProviderConfiguration
         workspace.debugAssistantReviewTrafficScope = workspace.debugAssistantTrafficScope
@@ -278,10 +312,12 @@ extension MainContentCoordinator {
             AssistantContextBudgeter().contextLimits(for: $0)
         } ?? .default
         let selectedTransactionID = result.selectedTransactionID
+        let requestedTransactionCount = workspace.debugAssistantRequestedContextCount
         let worker = Task.detached(priority: .userInitiated) {
             try Task.checkCancellation()
             let pack = try InvestigationContextBuilder().build(
                 snapshots: snapshots,
+                requestedTransactionCount: requestedTransactionCount,
                 limits: contextLimits
             )
             try Task.checkCancellation()
@@ -318,6 +354,12 @@ extension MainContentCoordinator {
                             conversation: currentWorkspace.debugAssistantMessages
                         )
                     }
+                currentWorkspace.debugAssistantReviewSummary = self.makeDebugAssistantReviewSummary(
+                    result: currentResult,
+                    pack: pack,
+                    scope: currentWorkspace.debugAssistantTrafficScope,
+                    overrideApplied: false
+                )
             } catch is CancellationError {
                 return
             } catch {
@@ -336,15 +378,23 @@ extension MainContentCoordinator {
 
     func dismissDebugAssistantReview() {
         let workspace = activeWorkspace
+        if workspace.isPreparingDebugAssistantReviewOverride {
+            cancelDebugAssistantTask(for: workspace.id)
+        }
+        workspace.isPreparingDebugAssistantReviewOverride = false
         workspace.debugAssistantReviewPack = nil
         workspace.debugAssistantReviewRequest = nil
         workspace.debugAssistantReviewConfiguration = nil
         workspace.debugAssistantReviewTrafficScope = nil
         workspace.debugAssistantReviewModelAccessEnabled = false
+        workspace.debugAssistantReviewSummary = nil
     }
 
     func sendDebugAssistantReview() {
         let workspace = activeWorkspace
+        guard !workspace.isPreparingDebugAssistantReviewOverride else {
+            return
+        }
         guard case let .result(result) = workspace.debugAssistantState,
               let pack = workspace.debugAssistantReviewPack,
               let request = workspace.debugAssistantReviewRequest else
@@ -352,32 +402,11 @@ extension MainContentCoordinator {
             return
         }
 
-        let settings = assistantSettingsProvider()
-        guard workspace.debugAssistantReviewModelAccessEnabled,
-              settings.debugAssistantModelAccessEnabled else
-        {
-            workspace.modelInvestigationState = .failed(
-                message: String(localized: "Enable model access in AI Assistant Settings before sending data.")
-            )
-            return
-        }
-        guard let configuration = workspace.debugAssistantReviewConfiguration,
-              configuration.isComplete,
-              settings.assistantProviderConfiguration == configuration else
-        {
-            workspace.modelInvestigationState = .failed(
-                message: String(localized: "The provider configuration changed. Review the outbound data again.")
-            )
-            dismissDebugAssistantReview()
-            return
-        }
-        guard workspace.debugAssistantReviewTrafficScope == workspace.debugAssistantTrafficScope,
-              AssistantTrustPolicy.isReviewedScopeValid(pack, for: result) else
-        {
-            workspace.modelInvestigationState = .failed(
-                message: String(localized: "The traffic scope changed. Review the exact data again before model access.")
-            )
-            dismissDebugAssistantReview()
+        guard let configuration = validatedDebugAssistantReviewConfiguration(
+            workspace: workspace,
+            result: result,
+            pack: pack
+        ) else {
             return
         }
 
@@ -389,9 +418,12 @@ extension MainContentCoordinator {
         workspace.debugAssistantReviewConfiguration = nil
         workspace.debugAssistantReviewTrafficScope = nil
         workspace.debugAssistantReviewModelAccessEnabled = false
+        workspace.debugAssistantReviewSummary = nil
+        workspace.isPreparingDebugAssistantReviewOverride = false
         workspace.modelInvestigationState = .streaming(
             runID: runID,
             provider: configuration.kind,
+            executionLocation: configuration.executionLocation,
             model: configuration.model,
             endpointHost: configuration.endpointHost,
             text: ""
@@ -436,6 +468,7 @@ extension MainContentCoordinator {
                         workspace.modelInvestigationState = .streaming(
                             runID: runID,
                             provider: configuration.kind,
+                            executionLocation: configuration.executionLocation,
                             model: configuration.model,
                             endpointHost: configuration.endpointHost,
                             text: textBuffer.text
@@ -506,6 +539,128 @@ extension MainContentCoordinator {
         debugAssistantTasks[workspace.id] = DebugAssistantTaskHandle(id: taskID, task: task)
     }
 
+    /// One-time include-excluded override for the current review. Rebuilds the opted-in related
+    /// context from the unfiltered nearest set while leaving Focus/Noise settings untouched, then
+    /// atomically republishes the deterministic result, prompt, pack, and summary under the same id.
+    func applyDebugAssistantReviewFocusNoiseOverride() {
+        let workspace = activeWorkspace
+        guard case let .result(result) = workspace.debugAssistantState,
+              let previousPack = workspace.debugAssistantReviewPack,
+              workspace.debugAssistantReviewSummary?.canOverrideFocusNoise == true,
+              !workspace.isPreparingDebugAssistantReviewOverride,
+              workspace.debugAssistantTrafficScope == .selectedAndRelated,
+              let primary = transaction(for: result.selectedTransactionID),
+              selectedTransactionIDs.contains(primary.id) else
+        {
+            return
+        }
+
+        let boundedSelected = Array(
+            debugAssistantSelectedTransactions().prefix(InvestigationContextLimits.default.maxTransactions)
+        )
+        let rawRelatedCount = debugAssistantRawRelatedCandidates(for: primary).count
+        let overrideSnapshots = debugAssistantContextTransactions(ignoringFocusNoise: true)
+            .map(InvestigationTransactionSnapshot.init(transaction:))
+        let selectedSnapshots = Array(overrideSnapshots.prefix(boundedSelected.count))
+        let snapshotByID = Dictionary(
+            overrideSnapshots.map { ($0.id, $0) },
+            uniquingKeysWith: { first, _ in first }
+        )
+        let requestedCount = boundedSelected.count + rawRelatedCount
+
+        let settingsSnapshot = assistantSettingsProvider()
+        let configuration = settingsSnapshot.assistantProviderConfiguration
+        let contextLimits = configuration.map {
+            AssistantContextBudgeter().contextLimits(for: $0)
+        } ?? .default
+        let recipe = result.recipe
+        let previousPackID = previousPack.id
+        let scope = workspace.debugAssistantTrafficScope
+        let conversationID = workspace.debugAssistantConversationID
+        let selectedIDsAtStart = workspace.selectedTransactionIDs
+
+        cancelDebugAssistantTask(for: workspace.id)
+        workspace.isPreparingDebugAssistantReviewOverride = true
+        workspace.debugAssistantReviewConfiguration = configuration
+        workspace.debugAssistantReviewTrafficScope = scope
+        workspace.debugAssistantReviewModelAccessEnabled = settingsSnapshot.debugAssistantModelAccessEnabled
+
+        let worker = Task
+            .detached(priority: .userInitiated) { () -> (InvestigationResult, InvestigationContextPack) in
+                try Task.checkCancellation()
+                let newResult = try DebugAssistantEngine().investigate(
+                    recipe: recipe,
+                    selected: selectedSnapshots,
+                    session: overrideSnapshots
+                )
+                try Task.checkCancellation()
+                let scopeSnapshots = newResult.scopeTransactionIDs.compactMap { snapshotByID[$0] }
+                let builtPack = try InvestigationContextBuilder().build(
+                    snapshots: scopeSnapshots,
+                    requestedTransactionCount: requestedCount,
+                    limits: contextLimits
+                )
+                try Task.checkCancellation()
+                return (newResult, InvestigationContextPack(
+                    id: previousPackID,
+                    scopeTransactionIDs: builtPack.scopeTransactionIDs,
+                    payload: builtPack.payload,
+                    preview: builtPack.preview,
+                    manifest: builtPack.manifest
+                ))
+            }
+        let taskID = UUID()
+        let task = Task { [weak self] in
+            defer {
+                self?.clearDebugAssistantTask(for: workspace.id, matching: taskID)
+            }
+            do {
+                let (newResult, pack) = try await withTaskCancellationHandler {
+                    try await worker.value
+                } onCancel: {
+                    worker.cancel()
+                }
+                guard let self,
+                      self.debugAssistantTasks[workspace.id]?.id == taskID,
+                      let currentWorkspace = self.workspaceStore.workspaces.first(where: { $0.id == workspace.id }),
+                      case let .result(currentResult) = currentWorkspace.debugAssistantState,
+                      currentResult == result,
+                      currentWorkspace.debugAssistantTrafficScope == scope,
+                      currentWorkspace.debugAssistantConversationID == conversationID,
+                      currentWorkspace.selectedTransactionIDs == selectedIDsAtStart else
+                {
+                    return
+                }
+                self.publishDebugAssistantOverride(
+                    to: currentWorkspace,
+                    previousResult: result,
+                    newResult: newResult,
+                    pack: pack,
+                    requestedCount: requestedCount,
+                    scope: scope
+                )
+            } catch is CancellationError {
+                return
+            } catch {
+                guard let self,
+                      self.debugAssistantTasks[workspace.id]?.id == taskID,
+                      let currentWorkspace = self.workspaceStore.workspaces
+                      .first(where: { $0.id == workspace.id }) else
+                {
+                    return
+                }
+                currentWorkspace.isPreparingDebugAssistantReviewOverride = false
+                self.activeToast = ToastMessage(
+                    style: .warning,
+                    text: String(
+                        localized: "Rockxy could not include the excluded traffic. The reviewed data is unchanged."
+                    )
+                )
+            }
+        }
+        debugAssistantTasks[workspace.id] = DebugAssistantTaskHandle(id: taskID, task: task)
+    }
+
     func cancelDebugAssistantModelAnalysis() {
         let workspace = activeWorkspace
         cancelDebugAssistantTask(for: workspace.id)
@@ -514,6 +669,13 @@ extension MainContentCoordinator {
 
     func prepareDebugAssistantFollowUp(for result: InvestigationResult?) {
         let workspace = activeWorkspace
+        guard !debugAssistantConversationHasContextMismatch() else {
+            activeToast = ToastMessage(
+                style: .warning,
+                text: String(localized: "Restore this conversation's traffic before following up.")
+            )
+            return
+        }
         guard workspace.debugAssistantDraft
             .trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else
         {
@@ -537,8 +699,7 @@ extension MainContentCoordinator {
     }
 
     func revealDebugAssistantEvidence(_ evidence: InvestigationEvidence) {
-        guard let id = evidence.sourceTransactionID else
-        {
+        guard let id = evidence.sourceTransactionID else {
             return
         }
         revealDebugAssistantRequest(id: id)
@@ -576,12 +737,7 @@ extension MainContentCoordinator {
         workspace.debugAssistantTrafficScope = scope
         workspace.debugAssistantState = .idle
         workspace.modelInvestigationState = .idle
-        workspace.debugAssistantReviewPack = nil
-        workspace.debugAssistantReviewRequest = nil
-        workspace.debugAssistantReviewConfiguration = nil
-        workspace.debugAssistantReviewTrafficScope = nil
-        workspace.debugAssistantReviewModelAccessEnabled = false
-        workspace.isPreparingDebugAssistantReview = false
+        resetDebugAssistantReviewState(workspace)
     }
 
     func performUserInitiatedDebugAssistantHandoff(
@@ -626,7 +782,10 @@ extension MainContentCoordinator {
         return ordered
     }
 
-    func debugAssistantContextTransactions() -> [HTTPTransaction] {
+    /// Selected transactions (always first, unfiltered) plus automatically discovered related
+    /// requests. In normal mode related candidates obey the active Focus/Noise scope; the one-time
+    /// review override passes `ignoringFocusNoise: true` to reconsider the full nearest set.
+    func debugAssistantContextTransactions(ignoringFocusNoise: Bool = false) -> [HTTPTransaction] {
         let selected = debugAssistantSelectedTransactions()
         let maximumCount = InvestigationContextLimits.default.maxTransactions
         let boundedSelection = Array(selected.prefix(maximumCount))
@@ -637,9 +796,10 @@ extension MainContentCoordinator {
         }
         var values = boundedSelection
         var seen = Set(boundedSelection.map(\.id))
-        for transaction in debugAssistantRelatedTransactions(to: primary)
-            where seen.insert(transaction.id).inserted
-        {
+        let related = ignoringFocusNoise
+            ? debugAssistantRawRelatedCandidates(for: primary)
+            : debugAssistantRelatedPartition(for: primary).eligible
+        for transaction in related where seen.insert(transaction.id).inserted {
             guard values.count < maximumCount else {
                 break
             }
@@ -652,15 +812,47 @@ extension MainContentCoordinator {
         guard let primary = debugAssistantSelectedTransactions().first else {
             return 0
         }
-        let selectedIDs = selectedTransactionIDs
-        let availableCount = debugAssistantRelatedTransactions(to: primary)
-            .filter { !selectedIDs.contains($0.id) }
-            .count
+        let eligibleCount = debugAssistantRelatedPartition(for: primary).eligible.count
         let remainingCapacity = max(
             0,
             InvestigationContextLimits.default.maxTransactions - debugAssistantSelectedTransactions().count
         )
-        return min(availableCount, remainingCapacity)
+        return min(eligibleCount, remainingCapacity)
+    }
+
+    /// Raw nearest related candidates for the primary request, excluding explicitly selected IDs.
+    /// Selection identity always wins over Focus/Noise, so selected transactions are never here.
+    func debugAssistantRawRelatedCandidates(for primary: HTTPTransaction) -> [HTTPTransaction] {
+        let selectedIDs = selectedTransactionIDs
+        return debugAssistantRelatedTransactions(to: primary)
+            .filter { !selectedIDs.contains($0.id) }
+    }
+
+    /// Partitions raw related candidates into Focus/Noise-eligible versus scope-excluded, preserving
+    /// deterministic nearest ordering within each group.
+    func debugAssistantRelatedPartition(
+        for primary: HTTPTransaction
+    )
+        -> (eligible: [HTTPTransaction], scopeExcluded: [HTTPTransaction])
+    {
+        let workspace = activeWorkspace
+        var eligible: [HTTPTransaction] = []
+        var scopeExcluded: [HTTPTransaction] = []
+        for transaction in debugAssistantRawRelatedCandidates(for: primary) {
+            if isWithinFocusNoiseScope(transaction, workspace: workspace) {
+                eligible.append(transaction)
+            } else {
+                scopeExcluded.append(transaction)
+            }
+        }
+        return (eligible, scopeExcluded)
+    }
+
+    private func debugAssistantAvailableRelatedTransactionCount() -> Int {
+        guard let primary = debugAssistantSelectedTransactions().first else {
+            return 0
+        }
+        return debugAssistantRelatedPartition(for: primary).eligible.count
     }
 
     func resetDebugAssistantForSelectionChange() {
@@ -669,18 +861,192 @@ extension MainContentCoordinator {
         cancelDebugAssistantTask(for: workspace.id)
         workspace.debugAssistantState = .idle
         workspace.modelInvestigationState = .idle
+        resetDebugAssistantReviewState(workspace)
+        workspace.debugAssistantTrafficScope = AssistantTrustPolicy.defaultTrafficScope
+    }
+
+    func debugAssistantConversationHasContextMismatch() -> Bool {
+        guard let conversationContext = activeWorkspace.debugAssistantConversationContext else {
+            return false
+        }
+        guard let currentContext = currentDebugAssistantConversationContext() else {
+            return true
+        }
+        return !conversationContext.matches(
+            primaryTransactionID: currentContext.primaryTransactionID,
+            selectedTransactionIDs: currentContext.selectedTransactionIDs,
+            requestedSelectionCount: currentContext.requestedSelectionCount
+        )
+    }
+
+    func restoreDebugAssistantConversationContext() {
+        let workspace = activeWorkspace
+        guard let context = workspace.debugAssistantConversationContext,
+              let primary = transaction(for: context.primaryTransactionID) else
+        {
+            activeToast = ToastMessage(
+                style: .error,
+                text: String(localized: "The original captured traffic is no longer available.")
+            )
+            return
+        }
+        let availableIDs = Set(
+            context.selectedTransactionIDs.filter { transaction(for: $0) != nil }
+        )
+        guard availableIDs.contains(primary.id) else {
+            activeToast = ToastMessage(
+                style: .error,
+                text: String(localized: "The original captured traffic is no longer available.")
+            )
+            return
+        }
+        selectedTransactionIDs = availableIDs
+        selectTransaction(primary)
+    }
+
+    func startNewDebugAssistantConversationForCurrentSelection() {
+        newDebugAssistantConversation()
+        activeWorkspace.isDebugAssistantComposerFocusRequested = true
+    }
+
+    // MARK: Private
+
+    private func resetDebugAssistantReviewState(_ workspace: WorkspaceState) {
         workspace.debugAssistantReviewPack = nil
         workspace.debugAssistantReviewRequest = nil
         workspace.debugAssistantReviewConfiguration = nil
         workspace.debugAssistantReviewTrafficScope = nil
         workspace.debugAssistantReviewModelAccessEnabled = false
+        workspace.debugAssistantReviewSummary = nil
+        workspace.debugAssistantRequestedContextCount = 0
         workspace.isPreparingDebugAssistantReview = false
-        workspace.debugAssistantTrafficScope = AssistantTrustPolicy.defaultTrafficScope
+        workspace.isPreparingDebugAssistantReviewOverride = false
     }
 
-    // MARK: Private
+    private func validatedDebugAssistantReviewConfiguration(
+        workspace: WorkspaceState,
+        result: InvestigationResult,
+        pack: InvestigationContextPack
+    )
+        -> AssistantProviderConfiguration?
+    {
+        let settings = assistantSettingsProvider()
+        guard workspace.debugAssistantReviewModelAccessEnabled,
+              settings.debugAssistantModelAccessEnabled else
+        {
+            workspace.modelInvestigationState = .failed(
+                message: String(localized: "Enable model access in AI Assistant Settings before sending data.")
+            )
+            return nil
+        }
+        guard let configuration = workspace.debugAssistantReviewConfiguration,
+              configuration.isComplete,
+              settings.assistantProviderConfiguration == configuration else
+        {
+            workspace.modelInvestigationState = .failed(
+                message: String(localized: "The provider configuration changed. Review the outbound data again.")
+            )
+            dismissDebugAssistantReview()
+            return nil
+        }
+        guard workspace.debugAssistantReviewTrafficScope == workspace.debugAssistantTrafficScope,
+              AssistantTrustPolicy.isReviewedScopeValid(pack, for: result) else
+        {
+            workspace.modelInvestigationState = .failed(
+                message: String(
+                    localized: "The traffic scope changed. Review the exact data again before model access."
+                )
+            )
+            dismissDebugAssistantReview()
+            return nil
+        }
+        return configuration
+    }
 
-    private func cancelDebugAssistantTask(for workspaceID: UUID) {
+    private func publishDebugAssistantOverride(
+        to workspace: WorkspaceState,
+        previousResult: InvestigationResult,
+        newResult: InvestigationResult,
+        pack: InvestigationContextPack,
+        requestedCount: Int,
+        scope: AssistantTrafficScope
+    ) {
+        workspace.isPreparingDebugAssistantReviewOverride = false
+        workspace.debugAssistantState = .result(newResult)
+        workspace.debugAssistantRequestedContextCount = requestedCount
+        workspace.debugAssistantReviewPack = pack
+        workspace.debugAssistantReviewRequest = workspace.debugAssistantReviewConfiguration.map { configuration in
+            AssistantPromptBuilder().build(
+                result: newResult,
+                pack: pack,
+                configuration: configuration,
+                conversation: workspace.debugAssistantMessages
+            )
+        }
+        workspace.debugAssistantReviewSummary = makeDebugAssistantReviewSummary(
+            result: newResult,
+            pack: pack,
+            scope: scope,
+            overrideApplied: true
+        )
+        replaceLatestInvestigationMessage(in: workspace, matching: previousResult, with: newResult)
+    }
+
+    private func makeDebugAssistantReviewSummary(
+        result: InvestigationResult,
+        pack: InvestigationContextPack,
+        scope: AssistantTrafficScope,
+        overrideApplied: Bool
+    )
+        -> DebugAssistantReviewSummary
+    {
+        guard scope == .selectedAndRelated,
+              let primary = transaction(for: result.selectedTransactionID) else
+        {
+            return DebugAssistantReviewSummary(overrideApplied: overrideApplied)
+        }
+        let partition = debugAssistantRelatedPartition(for: primary)
+        let selectedIDs = Set(
+            debugAssistantSelectedTransactions()
+                .prefix(InvestigationContextLimits.default.maxTransactions)
+                .map(\.id)
+        )
+        let reviewedRelatedIDs = Set(pack.scopeTransactionIDs).subtracting(selectedIDs)
+        let unfilteredRelatedIDs = Set(
+            debugAssistantContextTransactions(ignoringFocusNoise: true).map(\.id)
+        ).subtracting(selectedIDs)
+        let overrideExpandsReviewedSet = !overrideApplied
+            && !partition.scopeExcluded.isEmpty
+            && unfilteredRelatedIDs != reviewedRelatedIDs
+        return DebugAssistantReviewSummary(
+            rawRelatedFound: partition.eligible.count + partition.scopeExcluded.count,
+            relatedIncluded: reviewedRelatedIDs.count,
+            focusNoiseExcluded: partition.scopeExcluded.count,
+            overrideApplied: overrideApplied,
+            overrideExpandsReviewedSet: overrideExpandsReviewedSet
+        )
+    }
+
+    private func replaceLatestInvestigationMessage(
+        in workspace: WorkspaceState,
+        matching old: InvestigationResult,
+        with new: InvestigationResult
+    ) {
+        guard let index = workspace.debugAssistantMessages.lastIndex(where: { $0.investigation == old }) else {
+            return
+        }
+        let message = workspace.debugAssistantMessages[index]
+        workspace.debugAssistantMessages[index] = DebugAssistantMessage(
+            id: message.id,
+            role: message.role,
+            text: message.modelResult == nil ? new.summary : message.text,
+            investigation: new,
+            modelResult: message.modelResult
+        )
+        syncCurrentDebugAssistantConversation(workspace)
+    }
+
+    func cancelDebugAssistantTask(for workspaceID: UUID) {
         debugAssistantTasks.removeValue(forKey: workspaceID)?.task.cancel()
     }
 
@@ -701,12 +1067,8 @@ extension MainContentCoordinator {
         workspace.debugAssistantConversationTitle = String(localized: "New Conversation")
         workspace.debugAssistantConversationCreatedAt = Date()
         workspace.debugAssistantConversationUpdatedAt = Date()
-        workspace.debugAssistantReviewPack = nil
-        workspace.debugAssistantReviewRequest = nil
-        workspace.debugAssistantReviewConfiguration = nil
-        workspace.debugAssistantReviewTrafficScope = nil
-        workspace.debugAssistantReviewModelAccessEnabled = false
-        workspace.isPreparingDebugAssistantReview = false
+        workspace.debugAssistantConversationContext = nil
+        resetDebugAssistantReviewState(workspace)
         workspace.debugAssistantTrafficScope = AssistantTrustPolicy.defaultTrafficScope
     }
 
@@ -714,6 +1076,9 @@ extension MainContentCoordinator {
         guard !workspace.debugAssistantMessages.isEmpty else {
             return
         }
+        workspace.debugAssistantMessages = boundedDebugAssistantMessages(
+            workspace.debugAssistantMessages
+        )
         let existingConversation = workspace.debugAssistantConversations.first {
             $0.id == workspace.debugAssistantConversationID
         }
@@ -724,6 +1089,7 @@ extension MainContentCoordinator {
             id: workspace.debugAssistantConversationID,
             title: workspace.debugAssistantConversationTitle,
             messages: workspace.debugAssistantMessages,
+            context: workspace.debugAssistantConversationContext,
             createdAt: workspace.debugAssistantConversationCreatedAt,
             updatedAt: workspace.debugAssistantConversationUpdatedAt,
             isPinned: existingConversation?.isPinned ?? false
@@ -733,6 +1099,7 @@ extension MainContentCoordinator {
         } else {
             workspace.debugAssistantConversations.append(conversation)
         }
+        enforceDebugAssistantConversationCapacity(workspace)
     }
 
     private func shouldAutomaticallyUseConfiguredModel(_ workspace: WorkspaceState) -> Bool {
@@ -755,6 +1122,67 @@ extension MainContentCoordinator {
         return String(normalized[..<cutoff]).trimmingCharacters(in: .whitespacesAndNewlines) + "…"
     }
 
+    private func currentDebugAssistantConversationContext() -> DebugAssistantConversationContext? {
+        let selected = debugAssistantSelectedTransactions()
+        guard let primary = selected.first else {
+            return nil
+        }
+        return DebugAssistantConversationContext(
+            primaryTransactionID: primary.id,
+            selectedTransactionIDs: Array(
+                selected.prefix(InvestigationContextLimits.default.maxTransactions)
+            ).map(\.id),
+            requestedSelectionCount: selected.count
+        )
+    }
+
+    private func boundedDebugAssistantMessages(
+        _ messages: [DebugAssistantMessage]
+    )
+        -> [DebugAssistantMessage]
+    {
+        var retained: [DebugAssistantMessage] = []
+        var retainedBytes = 0
+        for message in messages.reversed() {
+            guard retained.count < DebugAssistantConversationLimits.maximumMessagesPerConversation else {
+                break
+            }
+            let messageBytes = message.retainedTextBytes
+            guard retained.isEmpty
+                || retainedBytes + messageBytes
+                <= DebugAssistantConversationLimits.maximumConversationTextBytes else
+            {
+                break
+            }
+            retained.append(message)
+            retainedBytes += messageBytes
+        }
+        return retained.reversed()
+    }
+
+    private func enforceDebugAssistantConversationCapacity(_ workspace: WorkspaceState) {
+        func exceedsCapacity() -> Bool {
+            workspace.debugAssistantConversations.count
+                > DebugAssistantConversationLimits.maximumConversationsPerWorkspace
+                || workspace.debugAssistantConversations.reduce(0) { $0 + $1.retainedTextBytes }
+                > DebugAssistantConversationLimits.maximumWorkspaceTextBytes
+        }
+
+        while exceedsCapacity() {
+            let inactive = workspace.debugAssistantConversations.filter {
+                $0.id != workspace.debugAssistantConversationID
+            }
+            let candidate = inactive
+                .filter { !$0.isPinned }
+                .min(by: { $0.updatedAt < $1.updatedAt })
+                ?? inactive.min(by: { $0.updatedAt < $1.updatedAt })
+            guard let candidate else {
+                break
+            }
+            workspace.debugAssistantConversations.removeAll { $0.id == candidate.id }
+        }
+    }
+
     private func isCurrentModelRun(
         workspaceID: UUID,
         runID: UUID,
@@ -765,30 +1193,89 @@ extension MainContentCoordinator {
         guard let workspace = workspaceStore.workspaces.first(where: { $0.id == workspaceID }),
               case let .result(result) = workspace.debugAssistantState,
               result.selectedTransactionID == selectedTransactionID,
-              case let .streaming(currentRunID, _, _, _, _) = workspace.modelInvestigationState else
+              case let .streaming(currentRunID, _, _, _, _, _) = workspace.modelInvestigationState else
         {
             return false
         }
         return currentRunID == runID
     }
 
-    private func debugAssistantSessionTransactions() -> [HTTPTransaction] {
-        var values: [HTTPTransaction] = []
-        var seen: Set<UUID> = []
-        for transaction in transactions + persistedFavorites where seen.insert(transaction.id).inserted {
-            values.append(transaction)
+    private func debugAssistantRelatedTransactions(to primary: HTTPTransaction) -> [HTTPTransaction] {
+        ensureDebugAssistantTrafficIndex()
+        let cacheKey = DebugAssistantRelatedCacheKey(
+            primaryTransactionID: primary.id,
+            trafficIndexGeneration: debugAssistantTrafficIndexGeneration
+        )
+        if let cache = debugAssistantRelatedCache, cache.key == cacheKey {
+            return cache.transactions
         }
+
+        var nearest: [(distance: TimeInterval, transaction: HTTPTransaction)] = []
+        for transaction in debugAssistantTransactionsByHost[primary.request.host] ?? []
+            where transaction.id != primary.id
+        {
+            let candidate = (
+                distance: abs(transaction.timestamp.timeIntervalSince(primary.timestamp)),
+                transaction: transaction
+            )
+            if nearest.count < 20 {
+                nearest.append(candidate)
+                continue
+            }
+            guard let farthestIndex = nearest.indices.max(by: {
+                nearest[$0].distance < nearest[$1].distance
+            }), candidate.distance < nearest[farthestIndex].distance else {
+                continue
+            }
+            nearest[farthestIndex] = candidate
+        }
+        let values = nearest.sorted {
+            if $0.distance != $1.distance {
+                return $0.distance < $1.distance
+            }
+            return $0.transaction.timestamp < $1.transaction.timestamp
+        }.map(\.transaction)
+        debugAssistantRelatedCache = (cacheKey, values)
         return values
     }
 
-    private func debugAssistantRelatedTransactions(to primary: HTTPTransaction) -> [HTTPTransaction] {
-        debugAssistantSessionTransactions()
-            .filter { $0.id != primary.id && $0.request.host == primary.request.host }
-            .sorted {
-                abs($0.timestamp.timeIntervalSince(primary.timestamp))
-                    < abs($1.timestamp.timeIntervalSince(primary.timestamp))
-            }
-            .prefix(20)
-            .map { $0 }
+    func appendToDebugAssistantTrafficIndex(_ appended: [HTTPTransaction]) {
+        let expectedPreviousLiveCount = max(0, transactions.count - appended.count)
+        guard debugAssistantIndexedLiveCount == expectedPreviousLiveCount,
+              debugAssistantIndexedFavoriteCount == persistedFavorites.count else
+        {
+            rebuildDebugAssistantTrafficIndex()
+            return
+        }
+        for transaction in appended where debugAssistantIndexedTransactionIDs.insert(transaction.id).inserted {
+            debugAssistantTransactionsByHost[transaction.request.host, default: []].append(transaction)
+        }
+        debugAssistantIndexedLiveCount = transactions.count
+        debugAssistantIndexedFavoriteCount = persistedFavorites.count
+        debugAssistantTrafficIndexGeneration &+= 1
+        debugAssistantRelatedCache = nil
+    }
+
+    private func ensureDebugAssistantTrafficIndex() {
+        guard debugAssistantIndexedLiveCount != transactions.count
+            || debugAssistantIndexedFavoriteCount != persistedFavorites.count else
+        {
+            return
+        }
+        rebuildDebugAssistantTrafficIndex()
+    }
+
+    private func rebuildDebugAssistantTrafficIndex() {
+        var valuesByHost: [String: [HTTPTransaction]] = [:]
+        var seen: Set<UUID> = []
+        for transaction in transactions + persistedFavorites where seen.insert(transaction.id).inserted {
+            valuesByHost[transaction.request.host, default: []].append(transaction)
+        }
+        debugAssistantTransactionsByHost = valuesByHost
+        debugAssistantIndexedTransactionIDs = seen
+        debugAssistantIndexedLiveCount = transactions.count
+        debugAssistantIndexedFavoriteCount = persistedFavorites.count
+        debugAssistantTrafficIndexGeneration &+= 1
+        debugAssistantRelatedCache = nil
     }
 }

--- a/Rockxy/Views/Main/Extensions/MainContentCoordinator+Filtering.swift
+++ b/Rockxy/Views/Main/Extensions/MainContentCoordinator+Filtering.swift
@@ -329,7 +329,10 @@ extension MainContentCoordinator {
                     return false
                 }
             }
-            if !DomainGrouping.path(transaction.request.path, matchesPrefix: workspace.filterCriteria.sidebarPathPrefix) {
+            if !DomainGrouping.path(
+                transaction.request.path,
+                matchesPrefix: workspace.filterCriteria.sidebarPathPrefix
+            ) {
                 return false
             }
             if let sidebarApp = workspace.filterCriteria.sidebarApp {
@@ -407,12 +410,13 @@ extension MainContentCoordinator {
     }
 
     private func isVisibleInWorkspaceScope(_ transaction: HTTPTransaction, workspace: WorkspaceState) -> Bool {
-        if workspace.mutedTrafficSources.contains(where: { $0.matches(transaction) }) {
+        // Shared Focus/Noise gate (mute + Focus Set), then the request-list-only Traffic Signal lens.
+        guard isWithinFocusNoiseScope(transaction, workspace: workspace) else {
             return false
         }
         if let signal = workspace.activeTrafficSignal, !signal.matches(transaction) {
             return false
         }
-        return workspace.activeFocusSet?.matches(transaction) ?? true
+        return true
     }
 }

--- a/Rockxy/Views/Main/Extensions/MainContentCoordinator+FocusNavigator.swift
+++ b/Rockxy/Views/Main/Extensions/MainContentCoordinator+FocusNavigator.swift
@@ -81,6 +81,17 @@ extension MainContentCoordinator {
         transactions.count { source.matches($0) }
     }
 
+    /// Single Focus/Noise inclusion predicate shared by request-list workspace visibility and
+    /// Assistant related-traffic selection. Traffic Signals are intentionally excluded here so the
+    /// request list can layer its own signal lens on top without leaking that filter into the
+    /// Assistant's automatically discovered related context.
+    func isWithinFocusNoiseScope(_ transaction: HTTPTransaction, workspace: WorkspaceState) -> Bool {
+        if workspace.mutedTrafficSources.contains(where: { $0.matches(transaction) }) {
+            return false
+        }
+        return workspace.activeFocusSet?.matches(transaction) ?? true
+    }
+
     private func persistFocusSetsAcrossWorkspaces(_ focusSets: [FocusSet]) {
         FocusSetPersistence.save(focusSets)
         for workspace in workspaceStore.workspaces where workspace.id != activeWorkspace.id {

--- a/Rockxy/Views/Main/Extensions/MainContentCoordinator+ProxyControl.swift
+++ b/Rockxy/Views/Main/Extensions/MainContentCoordinator+ProxyControl.swift
@@ -408,6 +408,7 @@ extension MainContentCoordinator {
                 errorCount += 1
             }
         }
+        appendToDebugAssistantTrafficIndex(filteredBatch)
         appendObservedDomainsByApp(from: filteredBatch)
 
         updateAllWorkspaces(with: filteredBatch)

--- a/Rockxy/Views/Main/Extensions/MainContentCoordinator+Workspaces.swift
+++ b/Rockxy/Views/Main/Extensions/MainContentCoordinator+Workspaces.swift
@@ -6,6 +6,11 @@ import os
 // MARK: - MainContentCoordinator + Workspaces
 
 extension MainContentCoordinator {
+    func closeWorkspace(id: UUID) {
+        cancelDebugAssistantTask(for: id)
+        workspaceStore.closeWorkspace(id: id)
+    }
+
     // MARK: - All-Workspace Updates
 
     func recomputeAllWorkspaces() {

--- a/Rockxy/Views/Main/MainContentCoordinator.swift
+++ b/Rockxy/Views/Main/MainContentCoordinator.swift
@@ -94,6 +94,11 @@ final class MainContentCoordinator {
         let task: Task<Void, Never>
     }
 
+    struct DebugAssistantRelatedCacheKey: Equatable {
+        let primaryTransactionID: UUID
+        let trafficIndexGeneration: UInt
+    }
+
     static let logger = Logger(subsystem: RockxyIdentity.current.logSubsystem, category: "MainContentCoordinator")
 
     let policy: any AppPolicy
@@ -137,6 +142,13 @@ final class MainContentCoordinator {
     let readiness = ReadinessCoordinator.shared
 
     @ObservationIgnored var debugAssistantTasks: [UUID: DebugAssistantTaskHandle] = [:]
+    @ObservationIgnored var debugAssistantTransactionsByHost: [String: [HTTPTransaction]] = [:]
+    @ObservationIgnored var debugAssistantIndexedTransactionIDs: Set<UUID> = []
+    @ObservationIgnored var debugAssistantIndexedLiveCount = 0
+    @ObservationIgnored var debugAssistantIndexedFavoriteCount = 0
+    @ObservationIgnored var debugAssistantTrafficIndexGeneration: UInt = 0
+    @ObservationIgnored var debugAssistantRelatedCache:
+        (key: DebugAssistantRelatedCacheKey, transactions: [HTTPTransaction])?
 
     // MARK: - UI State — Logs
 

--- a/Rockxy/Views/Main/NativeWorkspaceSplitView.swift
+++ b/Rockxy/Views/Main/NativeWorkspaceSplitView.swift
@@ -47,6 +47,38 @@ struct NativeWorkspaceSplitView<Sidebar: View, Workspace: View, Inspector: View>
 
     // MARK: Internal
 
+    // MARK: - Coordinator
+
+    final class Coordinator {
+        // MARK: Internal
+
+        func recordInitialPresentation(sidebar: Bool, inspector: Bool) {
+            lastAppliedSidebarPresentation = sidebar
+            lastAppliedInspectorPresentation = inspector
+        }
+
+        func shouldApplySidebarPresentation(_ isPresented: Bool) -> Bool {
+            guard lastAppliedSidebarPresentation != isPresented else {
+                return false
+            }
+            lastAppliedSidebarPresentation = isPresented
+            return true
+        }
+
+        func shouldApplyInspectorPresentation(_ isPresented: Bool) -> Bool {
+            guard lastAppliedInspectorPresentation != isPresented else {
+                return false
+            }
+            lastAppliedInspectorPresentation = isPresented
+            return true
+        }
+
+        // MARK: Private
+
+        private var lastAppliedSidebarPresentation: Bool?
+        private var lastAppliedInspectorPresentation: Bool?
+    }
+
     @Binding var isSidebarPresented: Bool
     @Binding var isInspectorPresented: Bool
 
@@ -117,7 +149,9 @@ struct NativeWorkspaceSplitView<Sidebar: View, Workspace: View, Inspector: View>
         _ proposal: ProposedViewSize,
         nsViewController: NativeWorkspaceSplitViewController,
         context: Context
-    ) -> CGSize? {
+    )
+        -> CGSize?
+    {
         let naturalWidth = sidebarIdealWidth + workspaceMinimumWidth + inspectorIdealWidth
         let resolved = proposal.replacingUnspecifiedDimensions(
             by: CGSize(width: naturalWidth, height: MainWindowLayoutMetrics.defaultHeight)
@@ -132,7 +166,9 @@ struct NativeWorkspaceSplitView<Sidebar: View, Workspace: View, Inspector: View>
 
     private func hostingController<Content: View>(
         content: @escaping () -> Content
-    ) -> NSHostingController<NativeWorkspaceDeferredContent<Content>> {
+    )
+        -> NSHostingController<NativeWorkspaceDeferredContent<Content>>
+    {
         let controller = NSHostingController(
             rootView: NativeWorkspaceDeferredContent(content: content)
         )
@@ -156,34 +192,6 @@ struct NativeWorkspaceSplitView<Sidebar: View, Workspace: View, Inspector: View>
             }
             inspectorPresentation.wrappedValue = isVisible
         }
-    }
-
-    // MARK: - Coordinator
-
-    final class Coordinator {
-        func recordInitialPresentation(sidebar: Bool, inspector: Bool) {
-            lastAppliedSidebarPresentation = sidebar
-            lastAppliedInspectorPresentation = inspector
-        }
-
-        func shouldApplySidebarPresentation(_ isPresented: Bool) -> Bool {
-            guard lastAppliedSidebarPresentation != isPresented else {
-                return false
-            }
-            lastAppliedSidebarPresentation = isPresented
-            return true
-        }
-
-        func shouldApplyInspectorPresentation(_ isPresented: Bool) -> Bool {
-            guard lastAppliedInspectorPresentation != isPresented else {
-                return false
-            }
-            lastAppliedInspectorPresentation = isPresented
-            return true
-        }
-
-        private var lastAppliedSidebarPresentation: Bool?
-        private var lastAppliedInspectorPresentation: Bool?
     }
 }
 
@@ -210,6 +218,111 @@ struct NativeWorkspaceSplitLayout {
     let inspectorMaximumWidth: CGFloat
 }
 
+// MARK: - NativeWorkspaceSplitSizing
+
+/// Pure sizing math for the workspace split's initial layout pass.
+///
+/// Kept free of AppKit state so startup readiness and ideal-divider placement can be
+/// verified deterministically without a live window.
+enum NativeWorkspaceSplitSizing {
+    struct IdealPlacement: Equatable {
+        var leadingDividerPosition: CGFloat?
+        var trailingDividerPosition: CGFloat?
+    }
+
+    /// Bounds are usable once both dimensions are finite and strictly positive.
+    ///
+    /// Reads the raw stored size rather than `CGRect.width`/`.height`, which standardize a
+    /// negative size and report it as positive — a raw-negative provisional frame must be
+    /// rejected, not silently accepted.
+    static func isLayoutReady(_ bounds: CGRect) -> Bool {
+        let width = bounds.size.width
+        let height = bounds.size.height
+        return width.isFinite
+            && height.isFinite
+            && width > 0
+            && height > 0
+    }
+
+    /// Whether `totalWidth` can seat every currently requested presented pane at its declared
+    /// minimum thickness, including the workspace minimum and each active divider.
+    ///
+    /// A merely positive, finite width is not sufficient readiness: an early provisional AppKit
+    /// layout pass can report a positive-but-too-narrow width. Consuming pending visibility and
+    /// latching the initial layout there seats the panes at their minima and blocks the later,
+    /// correctly-sized pass from applying ideal widths.
+    static func canSeatRequestedMinima(
+        totalWidth: CGFloat,
+        dividerThickness: CGFloat,
+        sidebarPresented: Bool,
+        inspectorPresented: Bool,
+        sidebarMinimumWidth: CGFloat,
+        workspaceMinimumWidth: CGFloat,
+        inspectorMinimumWidth: CGFloat
+    )
+        -> Bool
+    {
+        guard totalWidth.isFinite, totalWidth > 0 else {
+            return false
+        }
+
+        let sidebarWidth = sidebarPresented ? sidebarMinimumWidth : 0
+        let inspectorWidth = inspectorPresented ? inspectorMinimumWidth : 0
+        let leadingDivider = sidebarPresented ? dividerThickness : 0
+        let trailingDivider = inspectorPresented ? dividerThickness : 0
+
+        let required = sidebarWidth
+            + inspectorWidth
+            + leadingDivider
+            + trailingDivider
+            + workspaceMinimumWidth
+        return totalWidth >= required
+    }
+
+    /// Ideal divider positions for the presented panes, or `nil` when the split view is too
+    /// narrow to seat every presented pane at its declared minimum thickness (dividers
+    /// included). Returning `nil` tells the caller to defer to AppKit constraints instead of
+    /// forcing a position that would drive a pane — and its geometry — negative.
+    static func idealPlacement(
+        totalWidth: CGFloat,
+        dividerThickness: CGFloat,
+        sidebarPresented: Bool,
+        inspectorPresented: Bool,
+        sidebarIdealWidth: CGFloat,
+        inspectorIdealWidth: CGFloat,
+        sidebarMinimumWidth: CGFloat,
+        workspaceMinimumWidth: CGFloat,
+        inspectorMinimumWidth: CGFloat
+    )
+        -> IdealPlacement?
+    {
+        guard totalWidth.isFinite, totalWidth > 0 else {
+            return nil
+        }
+
+        let sidebarWidth = sidebarPresented ? max(sidebarIdealWidth, sidebarMinimumWidth) : 0
+        let inspectorWidth = inspectorPresented ? max(inspectorIdealWidth, inspectorMinimumWidth) : 0
+        let leadingDivider = sidebarPresented ? dividerThickness : 0
+        let trailingDivider = inspectorPresented ? dividerThickness : 0
+
+        let workspaceWidth = totalWidth
+            - sidebarWidth
+            - inspectorWidth
+            - leadingDivider
+            - trailingDivider
+        guard workspaceWidth >= workspaceMinimumWidth else {
+            return nil
+        }
+
+        return IdealPlacement(
+            leadingDividerPosition: sidebarPresented ? sidebarWidth : nil,
+            trailingDividerPosition: inspectorPresented
+                ? totalWidth - inspectorWidth - trailingDivider
+                : nil
+        )
+    }
+}
+
 // MARK: - NativeWorkspaceSplitViewController
 
 @MainActor
@@ -219,12 +332,59 @@ final class NativeWorkspaceSplitViewController: NSSplitViewController {
     var onSidebarVisibilityChanged: ((Bool) -> Void)?
     var onInspectorVisibilityChanged: ((Bool) -> Void)?
 
+    var toolbarConfiguration: NativeWorkspaceToolbarConfiguration?
+
     var isSidebarPresented: Bool {
         sidebarItem.map { !$0.isCollapsed } ?? false
     }
 
     var isInspectorPresented: Bool {
         inspectorItem.map { !$0.isCollapsed } ?? false
+    }
+
+    override func viewDidLayout() {
+        super.viewDidLayout()
+        installWindowChromeIfNeeded()
+        guard !didApplyInitialLayout else {
+            return
+        }
+        let bounds = splitView.bounds
+        guard NativeWorkspaceSplitSizing.isLayoutReady(bounds),
+              NativeWorkspaceSplitSizing.canSeatRequestedMinima(
+                  totalWidth: bounds.width,
+                  dividerThickness: splitView.dividerThickness,
+                  sidebarPresented: requestedSidebarVisibility,
+                  inspectorPresented: requestedInspectorVisibility,
+                  sidebarMinimumWidth: sidebarMinimumWidth,
+                  workspaceMinimumWidth: workspaceMinimumWidth,
+                  inspectorMinimumWidth: inspectorMinimumWidth
+              ) else
+        {
+            return
+        }
+        didApplyInitialLayout = true
+
+        if let pendingInitialSidebarVisibility {
+            self.pendingInitialSidebarVisibility = nil
+            setSidebarPresented(pendingInitialSidebarVisibility, animated: false)
+        }
+        if let pendingInitialInspectorVisibility {
+            self.pendingInitialInspectorVisibility = nil
+            setInspectorPresented(pendingInitialInspectorVisibility, animated: false)
+        }
+
+        if !hasAutosavedFrames {
+            applyIdealInitialPositions(totalWidth: bounds.width)
+        }
+        isApplyingInitialState = false
+    }
+
+    override func viewDidAppear() {
+        super.viewDidAppear()
+        installWindowChromeIfNeeded()
+        DispatchQueue.main.async { [weak self] in
+            self?.installWindowChromeIfNeeded()
+        }
     }
 
     func configure(
@@ -273,14 +433,18 @@ final class NativeWorkspaceSplitViewController: NSSplitViewController {
         self.inspectorItem = inspectorItem
         self.sidebarIdealWidth = layout.sidebarIdealWidth
         self.inspectorIdealWidth = layout.inspectorIdealWidth
+        sidebarMinimumWidth = layout.sidebarMinimumWidth
+        workspaceMinimumWidth = layout.workspaceMinimumWidth
+        inspectorMinimumWidth = layout.inspectorMinimumWidth
         requestedSidebarVisibility = isSidebarPresented
         requestedInspectorVisibility = isInspectorPresented
         pendingInitialSidebarVisibility = isSidebarPresented
         pendingInitialInspectorVisibility = isInspectorPresented
         observeCollapseState(of: sidebarItem, isSidebar: true)
         observeCollapseState(of: inspectorItem, isSidebar: false)
-        setSidebarPresented(isSidebarPresented, animated: false)
-        setInspectorPresented(isInspectorPresented, animated: false)
+        // Initial collapse/divider state is deferred to the first valid layout pass
+        // (`viewDidLayout`). Applying it here, while the controller has zero-sized bounds,
+        // is what produced startup `Invalid view geometry` faults.
     }
 
     func setSidebarPresented(_ isPresented: Bool, animated: Bool) {
@@ -293,48 +457,23 @@ final class NativeWorkspaceSplitViewController: NSSplitViewController {
         set(item: inspectorItem, presented: isPresented, animated: animated)
     }
 
-    override func viewDidLayout() {
-        super.viewDidLayout()
-        installWindowChromeIfNeeded()
-        guard !didApplyInitialLayout else {
-            return
-        }
-        didApplyInitialLayout = true
-
-        if !hasAutosavedFrames {
-            if pendingInitialSidebarVisibility == true {
-                splitView.setPosition(sidebarIdealWidth, ofDividerAt: 0)
-            }
-            if pendingInitialInspectorVisibility == true,
-               splitView.bounds.width > sidebarIdealWidth + inspectorIdealWidth
-            {
-                splitView.setPosition(
-                    splitView.bounds.width - inspectorIdealWidth,
-                    ofDividerAt: 1
-                )
-            }
-        }
-
-        if let pendingInitialSidebarVisibility {
-            self.pendingInitialSidebarVisibility = nil
-            setSidebarPresented(pendingInitialSidebarVisibility, animated: false)
-        }
-        if let pendingInitialInspectorVisibility {
-            self.pendingInitialInspectorVisibility = nil
-            setInspectorPresented(pendingInitialInspectorVisibility, animated: false)
-        }
-        isApplyingInitialState = false
-    }
-
-    override func viewDidAppear() {
-        super.viewDidAppear()
-        installWindowChromeIfNeeded()
-        DispatchQueue.main.async { [weak self] in
-            self?.installWindowChromeIfNeeded()
-        }
-    }
-
     // MARK: Private
+
+    private weak var sidebarItem: NSSplitViewItem?
+    private weak var inspectorItem: NSSplitViewItem?
+    private var collapseObservations: [NSKeyValueObservation] = []
+    private var sidebarIdealWidth: CGFloat = 250
+    private var inspectorIdealWidth: CGFloat = 380
+    private var sidebarMinimumWidth: CGFloat = 0
+    private var workspaceMinimumWidth: CGFloat = 0
+    private var inspectorMinimumWidth: CGFloat = 0
+    private var requestedSidebarVisibility = true
+    private var requestedInspectorVisibility = false
+    private var pendingInitialSidebarVisibility: Bool?
+    private var pendingInitialInspectorVisibility: Bool?
+    private var hasAutosavedFrames = false
+    private var didApplyInitialLayout = false
+    private var isApplyingInitialState = true
 
     private func installWindowChromeIfNeeded() {
         guard let window = view.window else {
@@ -345,6 +484,31 @@ final class NativeWorkspaceSplitViewController: NSSplitViewController {
             workspaceSplitController: self,
             toolbarConfiguration: toolbarConfiguration
         )
+    }
+
+    private func applyIdealInitialPositions(totalWidth: CGFloat) {
+        guard let placement = NativeWorkspaceSplitSizing.idealPlacement(
+            totalWidth: totalWidth,
+            dividerThickness: splitView.dividerThickness,
+            sidebarPresented: isSidebarPresented,
+            inspectorPresented: isInspectorPresented,
+            sidebarIdealWidth: sidebarIdealWidth,
+            inspectorIdealWidth: inspectorIdealWidth,
+            sidebarMinimumWidth: sidebarMinimumWidth,
+            workspaceMinimumWidth: workspaceMinimumWidth,
+            inspectorMinimumWidth: inspectorMinimumWidth
+        ) else {
+            // The window is too narrow to seat every presented pane at its minimum.
+            // Skip ideal placement and let AppKit constraints choose a safe layout.
+            return
+        }
+
+        if let leading = placement.leadingDividerPosition {
+            splitView.setPosition(leading, ofDividerAt: 0)
+        }
+        if let trailing = placement.trailingDividerPosition {
+            splitView.setPosition(trailing, ofDividerAt: 1)
+        }
     }
 
     private func set(item: NSSplitViewItem?, presented: Bool, animated: Bool) {
@@ -392,18 +556,4 @@ final class NativeWorkspaceSplitViewController: NSSplitViewController {
             onInspectorVisibilityChanged?(isVisible)
         }
     }
-
-    private weak var sidebarItem: NSSplitViewItem?
-    private weak var inspectorItem: NSSplitViewItem?
-    var toolbarConfiguration: NativeWorkspaceToolbarConfiguration?
-    private var collapseObservations: [NSKeyValueObservation] = []
-    private var sidebarIdealWidth: CGFloat = 250
-    private var inspectorIdealWidth: CGFloat = 380
-    private var requestedSidebarVisibility = true
-    private var requestedInspectorVisibility = false
-    private var pendingInitialSidebarVisibility: Bool?
-    private var pendingInitialInspectorVisibility: Bool?
-    private var hasAutosavedFrames = false
-    private var didApplyInitialLayout = false
-    private var isApplyingInitialState = true
 }

--- a/Rockxy/Views/Main/WorkspaceWindowManager.swift
+++ b/Rockxy/Views/Main/WorkspaceWindowManager.swift
@@ -282,7 +282,7 @@ final class RockxyWorkspaceWindowManager: NSObject {
               workspace.isClosable else {
             return
         }
-        coordinator.workspaceStore.closeWorkspace(id: workspaceID)
+        coordinator.closeWorkspace(id: workspaceID)
         updateTabAccessory()
         updateWindowTitles(coordinator: coordinator)
     }

--- a/Rockxy/Views/RequestList/CenterContentView.swift
+++ b/Rockxy/Views/RequestList/CenterContentView.swift
@@ -200,10 +200,18 @@ struct CenterContentView: View {
             refreshToken: coordinator.refreshToken,
             isAppendOnly: coordinator.activeWorkspace.lastDeriveWasAppendOnly,
             selectedIDs: $selectedIDs,
-            onSelectionChanged: { ids in
+            onSelectionChanged: { ids, primaryID in
                 coordinator.selectedTransactionIDs = ids
-                if let firstID = ids.first,
-                   let transaction = coordinator.transaction(for: firstID)
+                if let primaryID,
+                   ids.contains(primaryID),
+                   let transaction = coordinator.transaction(for: primaryID)
+                {
+                    coordinator.selectTransaction(transaction)
+                } else if let firstVisibleID = coordinator.filteredRows
+                    .lazy
+                    .map(\.id)
+                    .first(where: ids.contains),
+                    let transaction = coordinator.transaction(for: firstVisibleID)
                 {
                     coordinator.selectTransaction(transaction)
                 } else {

--- a/Rockxy/Views/RequestList/NativeBottomInspectorSplitView.swift
+++ b/Rockxy/Views/RequestList/NativeBottomInspectorSplitView.swift
@@ -28,6 +28,31 @@ struct NativeBottomInspectorSplitView<Primary: View, Inspector: View>: NSViewCon
 
     // MARK: Internal
 
+    // MARK: - Coordinator
+
+    final class Coordinator {
+        // MARK: Internal
+
+        var primaryController: NSHostingController<NativeBottomDeferredContent<Primary>>?
+        var inspectorController: NSHostingController<NativeBottomDeferredContent<Inspector>>?
+
+        func recordInitialPresentation(_ isPresented: Bool) {
+            lastAppliedPresentation = isPresented
+        }
+
+        func shouldApplyPresentation(_ isPresented: Bool) -> Bool {
+            guard lastAppliedPresentation != isPresented else {
+                return false
+            }
+            lastAppliedPresentation = isPresented
+            return true
+        }
+
+        // MARK: Private
+
+        private var lastAppliedPresentation: Bool?
+    }
+
     @Binding var isInspectorPresented: Bool
 
     let autosaveName: String
@@ -89,7 +114,9 @@ struct NativeBottomInspectorSplitView<Primary: View, Inspector: View>: NSViewCon
         _ proposal: ProposedViewSize,
         nsViewController: NativeBottomInspectorSplitViewController,
         context: Context
-    ) -> CGSize? {
+    )
+        -> CGSize?
+    {
         NativeBottomInspectorSplitSizing.resolve(
             proposal,
             naturalHeight: primaryMinimumHeight + inspectorMinimumHeight
@@ -101,28 +128,11 @@ struct NativeBottomInspectorSplitView<Primary: View, Inspector: View>: NSViewCon
     private func updateVisibilityCallback(on controller: NativeBottomInspectorSplitViewController) {
         let presentation = $isInspectorPresented
         controller.onInspectorVisibilityChanged = { isVisible in
-            guard presentation.wrappedValue != isVisible else { return }
+            guard presentation.wrappedValue != isVisible else {
+                return
+            }
             presentation.wrappedValue = isVisible
         }
-    }
-
-    // MARK: - Coordinator
-
-    final class Coordinator {
-        var primaryController: NSHostingController<NativeBottomDeferredContent<Primary>>?
-        var inspectorController: NSHostingController<NativeBottomDeferredContent<Inspector>>?
-
-        func recordInitialPresentation(_ isPresented: Bool) {
-            lastAppliedPresentation = isPresented
-        }
-
-        func shouldApplyPresentation(_ isPresented: Bool) -> Bool {
-            guard lastAppliedPresentation != isPresented else { return false }
-            lastAppliedPresentation = isPresented
-            return true
-        }
-
-        private var lastAppliedPresentation: Bool?
     }
 }
 
@@ -147,8 +157,20 @@ enum NativeBottomInspectorSplitSizing {
         let resolved = proposal.replacingUnspecifiedDimensions(
             by: CGSize(width: 800, height: naturalHeight)
         )
-        guard resolved.width.isFinite, resolved.height.isFinite else { return nil }
+        guard resolved.width.isFinite, resolved.height.isFinite else {
+            return nil
+        }
         return resolved
+    }
+
+    /// The split view can safely consume its pending initial state once both dimensions are
+    /// finite and strictly positive. Collapsing or expanding into zero/insufficient bounds is
+    /// what produced startup `Invalid view geometry` faults.
+    static func isLayoutReady(_ bounds: CGRect) -> Bool {
+        bounds.width.isFinite
+            && bounds.height.isFinite
+            && bounds.width > 0
+            && bounds.height > 0
     }
 }
 
@@ -162,6 +184,24 @@ final class NativeBottomInspectorSplitViewController: NSSplitViewController {
 
     var isInspectorPresented: Bool {
         inspectorItem.map { !$0.isCollapsed } ?? false
+    }
+
+    override func viewDidLayout() {
+        super.viewDidLayout()
+        guard pendingInitialVisibility != nil else {
+            return
+        }
+        guard NativeBottomInspectorSplitSizing.isLayoutReady(splitView.bounds) else {
+            // Bounds are still zero/insufficient. Retain the requested state and wait for a
+            // valid layout pass rather than collapsing/expanding into negative geometry.
+            return
+        }
+        guard let pendingInitialVisibility else {
+            return
+        }
+        self.pendingInitialVisibility = nil
+        setInspectorPresented(pendingInitialVisibility, animated: false)
+        isApplyingInitialState = false
     }
 
     func configure(
@@ -196,12 +236,15 @@ final class NativeBottomInspectorSplitViewController: NSSplitViewController {
         requestedInspectorVisibility = isInspectorPresented
         pendingInitialVisibility = isInspectorPresented
         observeCollapseState(of: inspectorItem)
-        setInspectorPresented(isInspectorPresented, animated: false)
+        // Initial collapse state is deferred to the first valid layout pass. Applying it here,
+        // while the controller has zero-sized bounds, risks negative startup geometry.
     }
 
     func setInspectorPresented(_ isPresented: Bool, animated: Bool) {
         requestedInspectorVisibility = isPresented
-        guard let inspectorItem, inspectorItem.isCollapsed == isPresented else { return }
+        guard let inspectorItem, inspectorItem.isCollapsed == isPresented else {
+            return
+        }
 
         if animated, view.window != nil {
             NSAnimationContext.runAnimationGroup { context in
@@ -213,20 +256,20 @@ final class NativeBottomInspectorSplitViewController: NSSplitViewController {
         }
     }
 
-    override func viewDidLayout() {
-        super.viewDidLayout()
-        guard let pendingInitialVisibility else { return }
-        self.pendingInitialVisibility = nil
-        setInspectorPresented(pendingInitialVisibility, animated: false)
-        isApplyingInitialState = false
-    }
-
     // MARK: Private
+
+    private weak var inspectorItem: NSSplitViewItem?
+    private var collapseObservation: NSKeyValueObservation?
+    private var requestedInspectorVisibility = false
+    private var pendingInitialVisibility: Bool?
+    private var isApplyingInitialState = true
 
     private func observeCollapseState(of item: NSSplitViewItem) {
         collapseObservation = item.observe(\.isCollapsed, options: [.new]) { [weak self] _, _ in
             DispatchQueue.main.async { [weak self] in
-                guard let self else { return }
+                guard let self else {
+                    return
+                }
                 // Read the current value after AppKit finishes the collapse transaction.
                 // A queued KVO callback can otherwise publish an obsolete intermediate
                 // value and immediately reverse the SwiftUI binding.
@@ -236,15 +279,13 @@ final class NativeBottomInspectorSplitViewController: NSSplitViewController {
     }
 
     private func inspectorVisibilityDidChange(_ isVisible: Bool) {
-        guard !isApplyingInitialState else { return }
-        guard isVisible != requestedInspectorVisibility else { return }
+        guard !isApplyingInitialState else {
+            return
+        }
+        guard isVisible != requestedInspectorVisibility else {
+            return
+        }
         requestedInspectorVisibility = isVisible
         onInspectorVisibilityChanged?(isVisible)
     }
-
-    private weak var inspectorItem: NSSplitViewItem?
-    private var collapseObservation: NSKeyValueObservation?
-    private var requestedInspectorVisibility = false
-    private var pendingInitialVisibility: Bool?
-    private var isApplyingInitialState = true
 }

--- a/Rockxy/Views/RequestList/RequestTableView.swift
+++ b/Rockxy/Views/RequestList/RequestTableView.swift
@@ -23,7 +23,7 @@ struct RequestTableView: NSViewRepresentable {
     @Binding var selectedIDs: Set<UUID>
     @Environment(\.appUIDisplayMetrics) private var displayMetrics
 
-    var onSelectionChanged: ((Set<UUID>) -> Void)?
+    var onSelectionChanged: ((Set<UUID>, UUID?) -> Void)?
     var onDoubleClick: ((HTTPTransaction) -> Void)?
     var mainCoordinator: MainContentCoordinator?
 
@@ -385,6 +385,7 @@ extension RequestTableView {
         private var autosizeGeneration = 0
         private var lastAppliedRequestTableMetrics: RequestTableAppliedMetrics?
         private var pendingContextSelectionIDs: Set<UUID>?
+        private var pendingContextPrimaryID: UUID?
 
         /// Guard flag to prevent feedback loops: when we programmatically update NSTableView
         /// selection from SwiftUI state, we suppress the delegate callback that would
@@ -647,7 +648,13 @@ extension RequestTableView {
 
             lastSyncedSelectionIDs = ids
             parent.selectedIDs = ids
-            parent.onSelectionChanged?(ids)
+            let primaryRow = selected.contains(tableView.clickedRow)
+                ? tableView.clickedRow
+                : tableView.selectedRow
+            let primaryID = primaryRow >= 0 && primaryRow < rows.count
+                ? rows[primaryRow].id
+                : nil
+            parent.onSelectionChanged?(ids, primaryID)
         }
 
         func tableView(_ tableView: NSTableView, sizeToFitWidthOfColumn column: Int) -> CGFloat {
@@ -809,13 +816,15 @@ extension RequestTableView {
                 return
             }
             pendingContextSelectionIDs = nil
+            let primaryID = pendingContextPrimaryID
+            pendingContextPrimaryID = nil
             DispatchQueue.main.async { [weak self] in
                 guard let self else {
                     return
                 }
                 self.lastSyncedSelectionIDs = ids
                 self.parent.selectedIDs = ids
-                self.parent.onSelectionChanged?(ids)
+                self.parent.onSelectionChanged?(ids, primaryID)
             }
         }
 
@@ -1689,6 +1698,7 @@ extension RequestTableView {
             tableView.selectRowIndexes(selection, byExtendingSelection: false)
             isUpdatingSelection = false
             pendingContextSelectionIDs = ids
+            pendingContextPrimaryID = rows[clickedRow].id
         }
 
         // MARK: - Column Header Context Menu

--- a/Rockxy/Views/Settings/AssistantSettingsTab.swift
+++ b/Rockxy/Views/Settings/AssistantSettingsTab.swift
@@ -755,6 +755,22 @@ enum OllamaRuntimeState: Equatable {
     case unavailable(message: String)
 }
 
+// MARK: - AssistantSettingsManaging
+
+@MainActor
+protocol AssistantSettingsManaging: AnyObject {
+    var settings: AppSettings { get }
+
+    func updateAssistantConfiguration(
+        _ configuration: AssistantProviderConfiguration?,
+        enabled: Bool?
+    )
+    func selectAssistantConfiguration(_ configurationID: UUID)
+    func removeAssistantConfiguration(_ configurationID: UUID)
+}
+
+extension AppSettingsManager: AssistantSettingsManaging {}
+
 // MARK: - AssistantSettingsViewModel
 
 @MainActor @Observable
@@ -762,7 +778,7 @@ final class AssistantSettingsViewModel {
     // MARK: Lifecycle
 
     init(
-        manager: AppSettingsManager? = nil,
+        manager: (any AssistantSettingsManaging)? = nil,
         credentialStorage: any AssistantCredentialStorage = KeychainAssistantCredentialStorage(),
         runtime: any AssistantProviderRuntimeProtocol = AssistantProviderRuntime.shared,
         modelInstaller: any AssistantModelInstallerProtocol = OllamaModelInstaller.shared,
@@ -770,7 +786,7 @@ final class AssistantSettingsViewModel {
         runtimeInstaller: any AssistantLocalRuntimeInstalling = OllamaRuntimeInstaller.shared,
         applicationOpener: any AssistantRuntimeApplicationOpening = NSWorkspaceAssistantRuntimeApplicationOpener()
     ) {
-        let manager = manager ?? .shared
+        let manager = manager ?? AppSettingsManager.shared
         self.manager = manager
         self.credentialStorage = credentialStorage
         self.runtime = runtime
@@ -894,6 +910,7 @@ final class AssistantSettingsViewModel {
         guard configuration.kind != kind else {
             return
         }
+        invalidateConnectionAction()
         configuration = AssistantProviderConfiguration(kind: kind)
         credentialInput = ""
         hasStoredCredential = false
@@ -911,6 +928,7 @@ final class AssistantSettingsViewModel {
         guard let selected = savedConfigurations.first(where: { $0.id == configurationID }) else {
             return
         }
+        invalidateConnectionAction()
         manager.selectAssistantConfiguration(configurationID)
         savedConfiguration = selected
         configuration = selected
@@ -956,11 +974,10 @@ final class AssistantSettingsViewModel {
             return
         }
         isRefreshingProviderModels = true
-        startConnectionAction(requiresModel: false) { configuration in
-            defer { self.isRefreshingProviderModels = false }
+        startConnectionAction(requiresModel: false) { configuration, token in
             let previousModelID = self.configuration.model
             let values = try await self.runtime.discoverModels(configuration: configuration)
-            guard !Task.isCancelled else {
+            guard !Task.isCancelled, self.isCurrentConnectionAction(token) else {
                 return
             }
             self.models = values
@@ -1316,9 +1333,9 @@ final class AssistantSettingsViewModel {
     }
 
     func testConnection() {
-        startConnectionAction { configuration in
+        startConnectionAction { configuration, token in
             let result = try await self.runtime.testConnection(configuration: configuration)
-            guard !Task.isCancelled else {
+            guard !Task.isCancelled, self.isCurrentConnectionAction(token) else {
                 return
             }
             self.setSuccess(
@@ -1328,10 +1345,7 @@ final class AssistantSettingsViewModel {
     }
 
     func cancelConnection() {
-        connectionTask?.cancel()
-        connectionTask = nil
-        isBusy = false
-        isRefreshingProviderModels = false
+        invalidateConnectionAction()
         hasError = false
         statusMessage = String(localized: "Connection check cancelled.")
     }
@@ -1356,6 +1370,7 @@ final class AssistantSettingsViewModel {
             guard let removed = savedConfiguration else {
                 return
             }
+            invalidateConnectionAction()
             try credentialStorage.delete(providerID: removed.id)
             manager.removeAssistantConfiguration(removed.id)
             refreshSavedConfigurations()
@@ -1373,7 +1388,7 @@ final class AssistantSettingsViewModel {
 
     // MARK: Private
 
-    private let manager: AppSettingsManager
+    private let manager: any AssistantSettingsManaging
     private let credentialStorage: any AssistantCredentialStorage
     private let runtime: any AssistantProviderRuntimeProtocol
     private let modelInstaller: any AssistantModelInstallerProtocol
@@ -1384,6 +1399,7 @@ final class AssistantSettingsViewModel {
     @ObservationIgnored private var modelInstallTask: Task<Void, Never>?
     @ObservationIgnored private var runtimeInstallTask: Task<Void, Never>?
     private var lastInstalledRuntimeURL: URL?
+    private var connectionGeneration = UUID()
 
     private static var defaultRuntimeInstallDestination: URL {
         let fileManager = FileManager.default
@@ -1556,38 +1572,68 @@ final class AssistantSettingsViewModel {
 
     private func startConnectionAction(
         requiresModel: Bool = true,
-        _ operation: @escaping (AssistantProviderConfiguration) async throws -> Void
+        _ operation: @escaping (
+            AssistantProviderConfiguration,
+            AssistantProviderConnectionToken
+        ) async throws -> Void
     ) {
         guard !isBusy else {
             return
         }
         isBusy = true
         statusMessage = nil
+        connectionGeneration = UUID()
+        let generation = connectionGeneration
         connectionTask = Task { [weak self] in
             guard let self else {
                 return
             }
+            var operationToken: AssistantProviderConnectionToken?
             defer {
-                if !Task.isCancelled {
+                if self.connectionGeneration == generation {
                     self.isBusy = false
+                    self.isRefreshingProviderModels = false
                     self.connectionTask = nil
                 }
             }
             do {
                 try self.prepareDraft(requiresModel: requiresModel)
-                try await operation(self.configuration)
+                let configuration = self.configuration
+                let token = AssistantProviderConnectionToken(
+                    generation: generation,
+                    configuration: configuration
+                )
+                operationToken = token
+                try await operation(configuration, token)
             } catch is CancellationError {
                 return
             } catch AssistantProviderError.cancelled {
                 return
             } catch {
-                guard !Task.isCancelled else {
+                guard !Task.isCancelled,
+                      operationToken.map(self.isCurrentConnectionAction) ?? true else
+                {
                     return
                 }
                 self.setError(error)
                 self.isRefreshingProviderModels = false
             }
         }
+    }
+
+    private func invalidateConnectionAction() {
+        connectionGeneration = UUID()
+        connectionTask?.cancel()
+        connectionTask = nil
+        isBusy = false
+        isRefreshingProviderModels = false
+    }
+
+    private func isCurrentConnectionAction(_ token: AssistantProviderConnectionToken) -> Bool {
+        token.generation == connectionGeneration
+            && token.configurationID == configuration.id
+            && token.providerKind == configuration.kind
+            && token.baseURL == configuration.baseURL
     }
 
     private func setSuccess(_ message: String) {
@@ -1599,4 +1645,20 @@ final class AssistantSettingsViewModel {
         hasError = true
         statusMessage = error.localizedDescription
     }
+}
+
+// MARK: - AssistantProviderConnectionToken
+
+private struct AssistantProviderConnectionToken {
+    init(generation: UUID, configuration: AssistantProviderConfiguration) {
+        self.generation = generation
+        configurationID = configuration.id
+        providerKind = configuration.kind
+        baseURL = configuration.baseURL
+    }
+
+    let generation: UUID
+    let configurationID: UUID
+    let providerKind: AssistantProviderKind
+    let baseURL: String
 }

--- a/RockxyTests/Core/Assistant/InvestigationContextBuilderTests.swift
+++ b/RockxyTests/Core/Assistant/InvestigationContextBuilderTests.swift
@@ -48,6 +48,35 @@ struct InvestigationContextBuilderTests {
         #expect(!pack.preview.contains("body-secret"))
     }
 
+    @Test("URL credentials and provider API key headers never enter reviewed context")
+    func redactsURLCredentialsAndProviderHeaders() throws {
+        let request = try HTTPRequestData(
+            method: "GET",
+            url: #require(URL(string: "https://client:password@api.example.com/data?safe=1")),
+            httpVersion: "HTTP/2",
+            headers: [
+                HTTPHeader(name: "api-key", value: "azure-secret"),
+                HTTPHeader(name: "x-goog-api-key", value: "gemini-secret"),
+                HTTPHeader(name: "ocp-apim-subscription-key", value: "subscription-secret"),
+            ]
+        )
+        let transaction = HTTPTransaction(request: request, state: .completed)
+
+        let pack = try InvestigationContextBuilder().build(
+            snapshots: [InvestigationTransactionSnapshot(transaction: transaction)]
+        )
+
+        #expect(pack.manifest.redactedHeaderCount == 3)
+        #expect(pack.manifest.redactedURLCredentialCount == 2)
+        #expect(pack.manifest.redactedFieldCount == 5)
+        #expect(!pack.preview.contains("client:password"))
+        #expect(!pack.preview.contains("password@"))
+        #expect(!pack.preview.contains("azure-secret"))
+        #expect(!pack.preview.contains("gemini-secret"))
+        #expect(!pack.preview.contains("subscription-secret"))
+        #expect(pack.preview.contains("https://api.example.com/data?"))
+    }
+
     @Test("Context pack enforces request count, body, and binary bounds")
     func boundedContext() throws {
         let transactions = try (0 ..< 4).map { index -> HTTPTransaction in
@@ -76,6 +105,27 @@ struct InvestigationContextBuilderTests {
         #expect(pack.manifest.omittedBinaryBodyCount == 1)
         #expect(pack.manifest.truncatedBodyCount == 1)
         #expect(pack.payload.count <= limits.maxOutboundBytes)
+    }
+
+    @Test("Manifest preserves the user-requested count after early snapshot bounding")
+    func requestedCountSurvivesEarlyBounding() throws {
+        let transactions = try (0 ..< 2).map { index -> HTTPTransaction in
+            let request = HTTPRequestData(
+                method: "GET",
+                url: try #require(URL(string: "https://api.example.com/\(index)")),
+                httpVersion: "HTTP/2",
+                headers: []
+            )
+            return HTTPTransaction(request: request, state: .completed)
+        }
+
+        let pack = try InvestigationContextBuilder().build(
+            snapshots: transactions.map(InvestigationTransactionSnapshot.init(transaction:)),
+            requestedTransactionCount: 10
+        )
+
+        #expect(pack.manifest.requestCount == 2)
+        #expect(pack.manifest.omittedTransactionCount == 8)
     }
 
     @Test("Adversarial payloads remain inert while local context bounds stay enforceable")

--- a/RockxyTests/Core/Assistant/NativeAssistantProviderTests.swift
+++ b/RockxyTests/Core/Assistant/NativeAssistantProviderTests.swift
@@ -2,7 +2,11 @@ import Foundation
 @testable import Rockxy
 import Testing
 
+// MARK: - NativeAssistantProviderTests
+
 struct NativeAssistantProviderTests {
+    // MARK: Internal
+
     @Test("Default assistant networking bypasses the system HTTP proxy")
     func defaultTransportBypassesSystemProxy() {
         let dictionary = URLSessionAssistantHTTPTransport.proxyBypassConfiguration()
@@ -10,6 +14,45 @@ struct NativeAssistantProviderTests {
 
         #expect(dictionary?[kCFNetworkProxiesHTTPEnable as String] as? Bool == false)
         #expect(dictionary?[kCFNetworkProxiesHTTPSEnable as String] as? Bool == false)
+    }
+
+    @Test("Shared transport frames CRLF incrementally without leaking delimiters")
+    func boundedLineFraming() throws {
+        var framer = AssistantHTTPLineFramer(maximumLineBytes: 16)
+        var lines: [String] = []
+
+        for byte in Data("first\r\n\nlast".utf8) {
+            if let line = try framer.append(byte) {
+                lines.append(line)
+            }
+        }
+        if let line = try framer.finish() {
+            lines.append(line)
+        }
+
+        #expect(lines == ["first", "", "last"])
+    }
+
+    @Test("Shared transport rejects an oversized line before String allocation")
+    func oversizedLineFraming() throws {
+        var framer = AssistantHTTPLineFramer(maximumLineBytes: 4)
+
+        for byte in Data("four".utf8) {
+            #expect(try framer.append(byte) == nil)
+        }
+        #expect(throws: AssistantProviderError.self) {
+            _ = try framer.append(UInt8(ascii: "x"))
+        }
+    }
+
+    @Test("Shared transport rejects malformed UTF-8")
+    func malformedLineFraming() throws {
+        var framer = AssistantHTTPLineFramer(maximumLineBytes: 4)
+        _ = try framer.append(0xFF)
+
+        #expect(throws: AssistantProviderError.self) {
+            _ = try framer.append(0x0A)
+        }
     }
 
     @Test("Anthropic discovers models and streams text with usage")
@@ -26,8 +69,8 @@ struct NativeAssistantProviderTests {
                 #"data: {"type":"message_stop"}"#,
             ]
         )
-        let provider = AnthropicAssistantProvider(
-            baseURL: try #require(URL(string: "https://api.anthropic.com/v1")),
+        let provider = try AnthropicAssistantProvider(
+            baseURL: #require(URL(string: "https://api.anthropic.com/v1")),
             apiKey: "fixture-secret",
             transport: transport
         )
@@ -62,8 +105,8 @@ struct NativeAssistantProviderTests {
                     + #""cachedContentTokenCount":1}}"#,
             ]
         )
-        let provider = GeminiAssistantProvider(
-            baseURL: try #require(URL(string: "https://generativelanguage.googleapis.com/v1beta")),
+        let provider = try GeminiAssistantProvider(
+            baseURL: #require(URL(string: "https://generativelanguage.googleapis.com/v1beta")),
             apiKey: "fixture-secret",
             transport: transport
         )
@@ -81,7 +124,9 @@ struct NativeAssistantProviderTests {
 
         let requests = await transport.requests()
         let streamRequest = try #require(requests.last)
-        #expect(streamRequest.url?.absoluteString == "https://generativelanguage.googleapis.com/v1beta/models/gemini-fixture:streamGenerateContent?alt=sse")
+        #expect(streamRequest.url?
+            .absoluteString ==
+            "https://generativelanguage.googleapis.com/v1beta/models/gemini-fixture:streamGenerateContent?alt=sse")
         #expect(streamRequest.value(forHTTPHeaderField: "x-goog-api-key") == "fixture-secret")
         let body = try jsonBody(streamRequest)
         let generation = try #require(body["generationConfig"] as? [String: Any])
@@ -151,6 +196,117 @@ struct NativeAssistantProviderTests {
         #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer fixture-secret")
     }
 
+    @MainActor
+    @Test("Model discovery cannot overwrite a provider selected while discovery is in flight")
+    func staleModelDiscoveryIsIgnored() async throws {
+        let runtime = DelayedSettingsAssistantRuntime()
+        let manager = FixtureAssistantSettingsManager()
+        let viewModel = AssistantSettingsViewModel(
+            manager: manager,
+            credentialStorage: EmptyAssistantCredentialStorage(),
+            runtime: runtime
+        )
+
+        viewModel.fetchModels()
+        for _ in 0 ..< 500 {
+            if await runtime.hasStarted {
+                break
+            }
+            try await Task.sleep(for: .milliseconds(1))
+        }
+        #expect(await runtime.hasStarted)
+
+        viewModel.selectProvider(.openAICompatible)
+        await runtime.complete(with: [
+            AssistantModel(id: "stale-ollama-model", displayName: "Stale Ollama Model"),
+        ])
+        for _ in 0 ..< 10 {
+            await Task.yield()
+        }
+
+        #expect(viewModel.configuration.kind == .openAICompatible)
+        #expect(viewModel.models.isEmpty)
+        #expect(!viewModel.isBusy)
+        #expect(!viewModel.isRefreshingProviderModels)
+    }
+
+    @Test("Anthropic rejects a non-2xx streaming response with a typed error")
+    func anthropicStreamRejectsHTTPFailure() async throws {
+        let provider = try AnthropicAssistantProvider(
+            baseURL: #require(URL(string: "https://api.anthropic.com/v1")),
+            apiKey: "fixture-secret",
+            transport: NativeProviderFixtureTransport(
+                data: Data(),
+                lines: [#"{"error":{"message":"unauthorized"}}"#],
+                statusCode: 401
+            )
+        )
+
+        await expectStreamFailure(provider.stream(fixtureRequest(model: "claude-fixture"))) { error in
+            #expect(error == .authentication)
+        }
+    }
+
+    @Test("Anthropic stream without message_stop fails instead of presenting partial output")
+    func anthropicStreamRejectsPrematureEOF() async throws {
+        let provider = try AnthropicAssistantProvider(
+            baseURL: #require(URL(string: "https://api.anthropic.com/v1")),
+            apiKey: "fixture-secret",
+            transport: NativeProviderFixtureTransport(
+                data: Data(),
+                lines: [
+                    #"data: {"type":"message_start","message":{"id":"msg_partial"}}"#,
+                    #"data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"partial"}}"#,
+                ]
+            )
+        )
+
+        await expectStreamFailure(provider.stream(fixtureRequest(model: "claude-fixture"))) { error in
+            guard case .malformedResponse = error else {
+                Issue.record("Expected malformedResponse, got \(error)")
+                return
+            }
+        }
+    }
+
+    @Test("Gemini rejects a non-2xx streaming response with a typed error")
+    func geminiStreamRejectsHTTPFailure() async throws {
+        let provider = try GeminiAssistantProvider(
+            baseURL: #require(URL(string: "https://generativelanguage.googleapis.com/v1beta")),
+            apiKey: "fixture-secret",
+            transport: NativeProviderFixtureTransport(
+                data: Data(),
+                lines: [#"{"error":{"message":"unauthorized"}}"#],
+                statusCode: 401
+            )
+        )
+
+        await expectStreamFailure(provider.stream(fixtureRequest(model: "gemini-fixture"))) { error in
+            #expect(error == .authentication)
+        }
+    }
+
+    @Test("Gemini stream without a finish reason fails instead of presenting partial output")
+    func geminiStreamRejectsPrematureEOF() async throws {
+        let provider = try GeminiAssistantProvider(
+            baseURL: #require(URL(string: "https://generativelanguage.googleapis.com/v1beta")),
+            apiKey: "fixture-secret",
+            transport: NativeProviderFixtureTransport(
+                data: Data(),
+                lines: [#"data: {"candidates":[{"content":{"parts":[{"text":"partial"}]}}]}"#]
+            )
+        )
+
+        await expectStreamFailure(provider.stream(fixtureRequest(model: "gemini-fixture"))) { error in
+            guard case .malformedResponse = error else {
+                Issue.record("Expected malformedResponse, got \(error)")
+                return
+            }
+        }
+    }
+
+    // MARK: Private
+
     private func fixtureRequest(model: String) -> AssistantCompletionRequest {
         AssistantCompletionRequest(
             instructions: "System fixture",
@@ -163,12 +319,30 @@ struct NativeAssistantProviderTests {
 
     private func collect(
         _ stream: AsyncThrowingStream<AssistantStreamEvent, Error>
-    ) async throws -> [AssistantStreamEvent] {
+    )
+        async throws -> [AssistantStreamEvent]
+    {
         var events: [AssistantStreamEvent] = []
         for try await event in stream {
             events.append(event)
         }
         return events
+    }
+
+    private func expectStreamFailure(
+        _ stream: AsyncThrowingStream<AssistantStreamEvent, Error>,
+        _ validate: (AssistantProviderError) -> Void
+    )
+        async
+    {
+        do {
+            for try await _ in stream {}
+            Issue.record("Expected the stream to fail before completing normally")
+        } catch let error as AssistantProviderError {
+            validate(error)
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
     }
 
     private func jsonBody(_ request: URLRequest) throws -> [String: Any] {
@@ -177,16 +351,22 @@ struct NativeAssistantProviderTests {
     }
 }
 
+// MARK: - NativeProviderFixtureTransport
+
 private actor NativeProviderFixtureTransport: AssistantHTTPTransport {
+    // MARK: Lifecycle
+
     init(data: Data, lines: [String], statusCode: Int = 200) {
         fixtureData = data
         fixtureLines = lines
         self.statusCode = statusCode
     }
 
+    // MARK: Internal
+
     func data(for request: URLRequest) async throws -> (Data, HTTPURLResponse) {
         capturedRequests.append(request)
-        return (fixtureData, try response(for: request))
+        return try (fixtureData, response(for: request))
     }
 
     func lines(for request: URLRequest) async throws -> AssistantHTTPStream {
@@ -206,6 +386,8 @@ private actor NativeProviderFixtureTransport: AssistantHTTPTransport {
         capturedRequests
     }
 
+    // MARK: Private
+
     private let fixtureData: Data
     private let fixtureLines: [String]
     private let statusCode: Int
@@ -222,16 +404,101 @@ private actor NativeProviderFixtureTransport: AssistantHTTPTransport {
     }
 }
 
+// MARK: - EmptyAssistantCredentialStorage
+
 private struct EmptyAssistantCredentialStorage: AssistantCredentialStorage {
     func save(_: String, providerID _: UUID) throws {}
-    func load(providerID _: UUID) throws -> String? { nil }
+    func load(providerID _: UUID) throws -> String? {
+        nil
+    }
+
     func delete(providerID _: UUID) throws {}
 }
+
+// MARK: - FixtureAssistantCredentialStorage
 
 private struct FixtureAssistantCredentialStorage: AssistantCredentialStorage {
     let value: String
 
     func save(_: String, providerID _: UUID) throws {}
-    func load(providerID _: UUID) throws -> String? { value }
+    func load(providerID _: UUID) throws -> String? {
+        value
+    }
+
     func delete(providerID _: UUID) throws {}
+}
+
+// MARK: - FixtureAssistantSettingsManager
+
+@MainActor
+private final class FixtureAssistantSettingsManager: AssistantSettingsManaging {
+    var settings = AppSettings()
+
+    func updateAssistantConfiguration(
+        _ configuration: AssistantProviderConfiguration?,
+        enabled: Bool?
+    ) {
+        settings.assistantProviderConfiguration = configuration
+        if let enabled {
+            settings.debugAssistantModelAccessEnabled = enabled
+        }
+    }
+
+    func selectAssistantConfiguration(_ configurationID: UUID) {
+        settings.activeAssistantProviderID = configurationID
+    }
+
+    func removeAssistantConfiguration(_ configurationID: UUID) {
+        settings.assistantProviderConfigurations.removeAll { $0.id == configurationID }
+    }
+}
+
+// MARK: - DelayedSettingsAssistantRuntime
+
+private actor DelayedSettingsAssistantRuntime: AssistantProviderRuntimeProtocol {
+    // MARK: Internal
+
+    var hasStarted = false
+
+    func discoverModels(
+        configuration _: AssistantProviderConfiguration
+    )
+        async throws -> [AssistantModel]
+    {
+        hasStarted = true
+        return try await withCheckedThrowingContinuation { continuation in
+            discoveryContinuation = continuation
+        }
+    }
+
+    func testConnection(
+        configuration: AssistantProviderConfiguration
+    )
+        async throws -> AssistantConnectionTestResult
+    {
+        AssistantConnectionTestResult(
+            provider: configuration.kind.title,
+            endpointHost: configuration.endpointHost,
+            model: configuration.model,
+            discoveredModelCount: 0
+        )
+    }
+
+    func stream(
+        request _: AssistantCompletionRequest,
+        configuration _: AssistantProviderConfiguration
+    )
+        async throws -> AsyncThrowingStream<AssistantStreamEvent, Error>
+    {
+        AsyncThrowingStream { $0.finish() }
+    }
+
+    func complete(with models: [AssistantModel]) {
+        discoveryContinuation?.resume(returning: models)
+        discoveryContinuation = nil
+    }
+
+    // MARK: Private
+
+    private var discoveryContinuation: CheckedContinuation<[AssistantModel], Error>?
 }

--- a/RockxyTests/Core/Assistant/OpenAIResponsesProviderTests.swift
+++ b/RockxyTests/Core/Assistant/OpenAIResponsesProviderTests.swift
@@ -5,6 +5,8 @@ import Testing
 // MARK: - OpenAIResponsesProviderTests
 
 struct OpenAIResponsesProviderTests {
+    // MARK: Internal
+
     @Test("Responses adapter emits fixture text, tool call, usage, and exact request options")
     func fixtureStreamingFlow() async throws {
         let lines = [
@@ -281,9 +283,31 @@ struct OpenAIResponsesProviderTests {
                 "arguments": oversized,
             ],
         ])
-        let line = "data: " + (try #require(String(bytes: data, encoding: .utf8)))
+        let line = try "data: " + #require(String(bytes: data, encoding: .utf8))
         #expect(throws: (any Error).self) {
             _ = try toolDecoder.decode(line: line)
+        }
+
+        var activeToolDecoder = OpenAIResponsesStreamDecoder()
+        for index in 0 ..< AssistantExecutionLimits.maxToolCalls {
+            let delta = #"data: {"type":"response.function_call_arguments.delta","item_id":"item_\#(index)","delta":"x"}"#
+            _ = try activeToolDecoder.decode(line: delta)
+        }
+        #expect(throws: (any Error).self) {
+            _ = try activeToolDecoder.decode(
+                line: #"data: {"type":"response.function_call_arguments.delta","item_id":"overflow","delta":"x"}"#
+            )
+        }
+
+        var anthropicDecoder = AnthropicStreamDecoder()
+        for index in 0 ..< AssistantExecutionLimits.maxToolCalls {
+            let start = #"data: {"type":"content_block_start","index":\#(index),"content_block":{"type":"tool_use","id":"tool_\#(index)","name":"fixture"}}"#
+            _ = try anthropicDecoder.decode(line: start)
+        }
+        #expect(throws: (any Error).self) {
+            _ = try anthropicDecoder.decode(
+                line: #"data: {"type":"content_block_start","index":999,"content_block":{"type":"tool_use","id":"overflow","name":"fixture"}}"#
+            )
         }
     }
 
@@ -300,18 +324,18 @@ struct OpenAIResponsesProviderTests {
         }
         let modelError = Data(#"{"error":{"code":"model_not_found","message":"missing"}}"#.utf8)
 
-        #expect(AssistantHTTPErrorMapper.error(
-            response: try response(401),
+        #expect(try AssistantHTTPErrorMapper.error(
+            response: response(401),
             body: Data(),
             model: "fixture"
         ) == .authentication)
-        #expect(AssistantHTTPErrorMapper.error(
-            response: try response(403),
+        #expect(try AssistantHTTPErrorMapper.error(
+            response: response(403),
             body: Data(),
             model: "fixture"
         ) == .permission)
-        #expect(AssistantHTTPErrorMapper.error(
-            response: try response(404),
+        #expect(try AssistantHTTPErrorMapper.error(
+            response: response(404),
             body: modelError,
             model: "fixture"
         ) == .modelNotFound("fixture"))
@@ -322,6 +346,100 @@ struct OpenAIResponsesProviderTests {
         {
             Issue.record("Expected network classification")
             return
+        }
+    }
+
+    @Test("Compatible adapter rejects a non-2xx streaming response with a typed error")
+    func compatibleStreamRejectsHTTPFailure() async throws {
+        let provider = try OpenAICompatibleAssistantProvider(
+            baseURL: #require(URL(string: "http://127.0.0.1:1234/v1")),
+            apiKey: "",
+            transport: FixtureAssistantTransport(
+                streamStatus: 401,
+                streamLines: [#"{"error":{"message":"denied"}}"#]
+            )
+        )
+
+        await expectStreamFailure(provider.stream(fixtureRequest(model: "local-model"))) { error in
+            #expect(error == .authentication)
+        }
+    }
+
+    @Test("Compatible stream without data: [DONE] fails instead of presenting partial output")
+    func compatibleStreamRejectsPrematureEOF() async throws {
+        let provider = try OpenAICompatibleAssistantProvider(
+            baseURL: #require(URL(string: "http://127.0.0.1:1234/v1")),
+            apiKey: "",
+            transport: FixtureAssistantTransport(streamLines: [
+                #"data: {"choices":[{"delta":{"content":"partial"}}]}"#,
+            ])
+        )
+
+        await expectStreamFailure(provider.stream(fixtureRequest(model: "local-model"))) { error in
+            guard case .malformedResponse = error else {
+                Issue.record("Expected malformedResponse, got \(error)")
+                return
+            }
+        }
+    }
+
+    @Test("Ollama adapter rejects a non-2xx streaming response with a typed error")
+    func ollamaStreamRejectsHTTPFailure() async throws {
+        let provider = try OllamaAssistantProvider(
+            baseURL: #require(URL(string: "http://127.0.0.1:11434")),
+            transport: FixtureAssistantTransport(
+                streamStatus: 401,
+                streamLines: [#"{"error":"denied"}"#]
+            )
+        )
+
+        await expectStreamFailure(provider.stream(fixtureRequest(model: "qwen-fixture"))) { error in
+            #expect(error == .authentication)
+        }
+    }
+
+    @Test("Ollama stream without done=true fails instead of presenting partial output")
+    func ollamaStreamRejectsPrematureEOF() async throws {
+        let provider = try OllamaAssistantProvider(
+            baseURL: #require(URL(string: "http://127.0.0.1:11434")),
+            transport: FixtureAssistantTransport(streamLines: [
+                #"{"message":{"role":"assistant","content":"partial"},"done":false}"#,
+            ])
+        )
+
+        await expectStreamFailure(provider.stream(fixtureRequest(model: "qwen-fixture"))) { error in
+            guard case .malformedResponse = error else {
+                Issue.record("Expected malformedResponse, got \(error)")
+                return
+            }
+        }
+    }
+
+    // MARK: Private
+
+    private func fixtureRequest(model: String) -> AssistantCompletionRequest {
+        AssistantCompletionRequest(
+            instructions: "fixture system",
+            input: "fixture input",
+            model: model,
+            maxOutputTokens: 99,
+            storeResponse: false
+        )
+    }
+
+    private func expectStreamFailure(
+        _ stream: AsyncThrowingStream<AssistantStreamEvent, Error>,
+        _ validate: (AssistantProviderError) -> Void
+    )
+        async
+    {
+        do {
+            for try await _ in stream {}
+            Issue.record("Expected the stream to fail before completing normally")
+        } catch let error as AssistantProviderError {
+            validate(error)
+        } catch {
+            Issue.record("Unexpected error: \(error)")
         }
     }
 }
@@ -373,9 +491,9 @@ private actor FixtureAssistantTransport: AssistantHTTPTransport {
 
     func data(for request: URLRequest) async throws -> (Data, HTTPURLResponse) {
         requests.append(request)
-        return (
+        return try (
             dataBody,
-            try response(url: #require(request.url), status: dataStatus, headers: nil)
+            response(url: #require(request.url), status: dataStatus, headers: nil)
         )
     }
 
@@ -388,8 +506,8 @@ private actor FixtureAssistantTransport: AssistantHTTPTransport {
             }
             continuation.finish()
         }
-        return AssistantHTTPStream(
-            response: try response(
+        return try AssistantHTTPStream(
+            response: response(
                 url: #require(request.url),
                 status: streamStatus,
                 headers: streamHeaders

--- a/RockxyTests/Core/Assistant/SensitiveDataRedactorTests.swift
+++ b/RockxyTests/Core/Assistant/SensitiveDataRedactorTests.swift
@@ -1,0 +1,157 @@
+import Foundation
+@testable import Rockxy
+import Testing
+
+// Direct coverage for `SensitiveDataRedactor`, the shared vocabulary that scrubs
+// captured traffic before it leaves Rockxy. These tests exercise the real public
+// methods (no copied regexes) and assert both that secrets disappear and that
+// ordinary, non-sensitive data survives untouched.
+
+struct SensitiveDataRedactorTests {
+    // MARK: Internal
+
+    // MARK: - JSON body
+
+    @Test("Nested JSON redacts the AI payload vocabulary while keeping ordinary fields")
+    func nestedJSONRedactsAIVocabulary() throws {
+        let redactor = SensitiveDataRedactor()
+        let source = """
+        {
+          "model": "gpt-5",
+          "temperature": 0.5,
+          "messages": [{"role": "user", "content": "my SSN is 123-45-6789"}],
+          "input": "user secret input text",
+          "instructions": "hidden system prompt copy",
+          "tools": [{"type": "function", "function": {"name": "lookup", "key": "tool-secret"}}],
+          "embeddings": [0.11, 0.22, 0.33],
+          "metadata": {"trace_id": "abc-123", "details": {"region": "us-east-1"}}
+        }
+        """
+
+        let redactedText = redactor.redactBodyText(source, contentType: .json)
+        let object = try decodeJSON(redactedText)
+
+        for key in ["messages", "input", "instructions", "tools", "embeddings"] {
+            #expect(object[key] as? String == "[REDACTED]", "\(key) should collapse to the placeholder")
+        }
+
+        #expect(object["model"] as? String == "gpt-5")
+        #expect(object["temperature"] as? Double == 0.5)
+        let metadata = try #require(object["metadata"] as? [String: Any])
+        #expect(metadata["trace_id"] as? String == "abc-123")
+        let details = try #require(metadata["details"] as? [String: Any])
+        #expect(details["region"] as? String == "us-east-1")
+
+        for secret in [
+            "123-45-6789",
+            "user secret input text",
+            "hidden system prompt copy",
+            "tool-secret",
+            "0.22",
+        ] {
+            #expect(!redactedText.contains(secret), "\(secret) must not survive redaction")
+        }
+    }
+
+    // MARK: - Form body
+
+    @Test("Form body redacts a sensitive key and keeps an ordinary field")
+    func formBodyRedaction() {
+        let redactor = SensitiveDataRedactor()
+        let redacted = redactor.redactBodyText(
+            "username=alice&access_token=super-secret-value&scope=read",
+            contentType: .form
+        )
+
+        #expect(redacted.contains("username=alice"))
+        #expect(redacted.contains("scope=read"))
+        #expect(redacted.contains("access_token=[REDACTED]"))
+        #expect(!redacted.contains("super-secret-value"))
+    }
+
+    // MARK: - XML body
+
+    @Test("XML body redacts a sensitive element and keeps an ordinary element")
+    func xmlBodyRedaction() {
+        let redactor = SensitiveDataRedactor()
+        let redacted = redactor.redactBodyText(
+            "<config><password>hunter2</password><host>example.com</host></config>",
+            contentType: .xml
+        )
+
+        #expect(redacted.contains("<password>[REDACTED]</password>"))
+        #expect(redacted.contains("<host>example.com</host>"))
+        #expect(!redacted.contains("hunter2"))
+    }
+
+    // MARK: - URL
+
+    @Test("URL drops userinfo and sensitive query while keeping safe host, path, and query")
+    func urlRedaction() throws {
+        let redactor = SensitiveDataRedactor()
+        let url = try #require(URL(
+            string: "https://user:pass@api.example.com/v1/models?api_key=secret123&model=gpt-5"
+        ))
+
+        let redacted = redactor.redactURL(url)
+        let components = try #require(URLComponents(url: redacted, resolvingAgainstBaseURL: false))
+
+        #expect(components.user == nil)
+        #expect(components.password == nil)
+        #expect(components.host == "api.example.com")
+        #expect(components.path == "/v1/models")
+
+        let queryItems = try #require(components.queryItems)
+        #expect(queryItems.first { $0.name == "api_key" }?.value == "[REDACTED]")
+        #expect(queryItems.first { $0.name == "model" }?.value == "gpt-5")
+    }
+
+    // MARK: - Headers
+
+    @Test("Headers redact provider credentials while keeping safe metadata")
+    func headerRedaction() {
+        let redactor = SensitiveDataRedactor()
+        let redacted = redactor.redactHeaders([
+            HTTPHeader(name: "Authorization", value: "Bearer sk-live-secret"),
+            HTTPHeader(name: "X-Api-Key", value: "provider-key-123"),
+            HTTPHeader(name: "x-goog-api-key", value: "google-secret"),
+            HTTPHeader(name: "Content-Type", value: "application/json"),
+            HTTPHeader(name: "User-Agent", value: "Rockxy/1.0"),
+        ])
+
+        func value(_ name: String) -> String? {
+            redacted.first { $0.name == name }?.value
+        }
+
+        #expect(value("Authorization") == "[REDACTED]")
+        #expect(value("X-Api-Key") == "[REDACTED]")
+        #expect(value("x-goog-api-key") == "[REDACTED]")
+        #expect(value("Content-Type") == "application/json")
+        #expect(value("User-Agent") == "Rockxy/1.0")
+    }
+
+    // MARK: - Opt-out
+
+    @Test("Disabled redactor passes body, URL, and headers through untouched")
+    func disabledRedactionPassthrough() throws {
+        let redactor = SensitiveDataRedactor(isEnabled: false)
+        let body = #"{"messages":[{"content":"still visible"}],"access_token":"still-secret"}"#
+
+        #expect(redactor.redactBodyText(body, contentType: .json) == body)
+
+        let url = try #require(URL(string: "https://user:pass@api.example.com/v1?api_key=secret"))
+        #expect(redactor.redactURL(url) == url)
+
+        let headers = [HTTPHeader(name: "Authorization", value: "Bearer sk-secret")]
+        #expect(redactor.redactHeaders(headers) == headers)
+    }
+
+    // MARK: Private
+
+    // MARK: - Helpers
+
+    private func decodeJSON(_ text: String) throws -> [String: Any] {
+        let data = try #require(text.data(using: .utf8))
+        return try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+    }
+}

--- a/RockxyTests/Core/ProxyEngine/SigningDiagnosticsTests.swift
+++ b/RockxyTests/Core/ProxyEngine/SigningDiagnosticsTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import os
 @testable import Rockxy
 import Testing
 
@@ -42,7 +43,8 @@ private struct MockSigningEnvironment: SigningDiagnostics.Environment {
 struct SigningDiagnosticsClassifyTests {
     @Test("installed helper path is preferred over the bundled helper path")
     func helperExecutableCandidatesPreferInstalledHelper() {
-        let bundledHelperURL = URL(fileURLWithPath: "/Applications/Rockxy.app/Contents/Library/HelperTools/RockxyHelperTool")
+        let bundledHelperURL =
+            URL(fileURLWithPath: "/Applications/Rockxy.app/Contents/Library/HelperTools/RockxyHelperTool")
         let installedHelperURL = URL(fileURLWithPath: "/Library/PrivilegedHelperTools/com.amunx.rockxy.helper")
 
         let candidates = SigningDiagnostics.helperExecutableCandidates(
@@ -192,7 +194,9 @@ struct SigningDiagnosticsClassifyTests {
 struct SigningDiagnosticsLiveTests {
     @Test("LiveEnvironment validates test host app signature successfully")
     func liveAppSignatureValid() {
-        guard !TestIdentity.isRunningUnderRawXCTestTool else { return }
+        guard !TestIdentity.isRunningUnderRawXCTestTool else {
+            return
+        }
         let env = SigningDiagnostics.LiveEnvironment()
         guard env.validateAppSignature() == nil else {
             return
@@ -204,7 +208,9 @@ struct SigningDiagnosticsLiveTests {
 
     @Test("LiveEnvironment resolves the bundled helper executable from the app package")
     func liveBundledHelperExecutableDetected() {
-        guard !TestIdentity.isRunningUnderRawXCTestTool else { return }
+        guard !TestIdentity.isRunningUnderRawXCTestTool else {
+            return
+        }
         let bundledHelperURL = Bundle.main.bundleURL
             .appendingPathComponent("Contents/Library/HelperTools", isDirectory: true)
             .appendingPathComponent("RockxyHelperTool", isDirectory: false)
@@ -217,7 +223,9 @@ struct SigningDiagnosticsLiveTests {
 
     @Test("LiveEnvironment can extract app certificate chain from test host")
     func liveAppCertificateChainExtractable() {
-        guard !TestIdentity.isRunningUnderRawXCTestTool else { return }
+        guard !TestIdentity.isRunningUnderRawXCTestTool else {
+            return
+        }
         let env = SigningDiagnostics.LiveEnvironment()
         guard env.validateAppSignature() == nil else {
             return
@@ -230,7 +238,9 @@ struct SigningDiagnosticsLiveTests {
 
     @Test("LiveEnvironment handles helper certificate chain availability")
     func liveHelperCertificateChainAvailability() {
-        guard !TestIdentity.isRunningUnderRawXCTestTool else { return }
+        guard !TestIdentity.isRunningUnderRawXCTestTool else {
+            return
+        }
         let env = SigningDiagnostics.LiveEnvironment()
         guard env.validateAppSignature() == nil else {
             return
@@ -238,7 +248,7 @@ struct SigningDiagnosticsLiveTests {
 
         let chain = env.helperCertificateChain()
         if let chain {
-            #expect(chain.count > 0)
+            #expect(!chain.isEmpty)
         } else {
             #expect(SigningDiagnostics.classify(env) == .certificateChainUnavailable)
         }
@@ -246,7 +256,9 @@ struct SigningDiagnosticsLiveTests {
 
     @Test("Live classify returns healthy or helperBinaryNotFound depending on helper install state")
     func liveClassifyContract() {
-        guard !TestIdentity.isRunningUnderRawXCTestTool else { return }
+        guard !TestIdentity.isRunningUnderRawXCTestTool else {
+            return
+        }
         let env = SigningDiagnostics.LiveEnvironment()
         guard env.validateAppSignature() == nil else {
             return
@@ -275,33 +287,105 @@ struct SigningDiagnosticsLiveTests {
 
 // MARK: - SigningPreflightCacheTests
 
+@MainActor
 struct SigningPreflightCacheTests {
-    @Test("preflight cache invalidation triggers re-evaluation")
-    @MainActor
-    func preflightCacheInvalidation() {
+    @Test("async cache memoizes repeated calls until invalidated")
+    func preflightCacheInvalidation() async {
         let cache = SigningPreflightCache()
-        var callCount = 0
+        let callCount = OSAllocatedUnfairLock(initialState: 0)
 
         cache.provider = {
-            callCount += 1
-            if callCount == 1 {
+            let count = callCount.withLock { value -> Int in
+                value += 1
+                return value
+            }
+            if count == 1 {
                 return .signingIdentityMismatch(appSigner: "Dev", helperSigner: "Prod")
             }
             return .healthy
         }
 
-        let first = cache.evaluate()
+        let first = await cache.evaluate()
         #expect(first == .signingIdentityMismatch(appSigner: "Dev", helperSigner: "Prod"))
-        #expect(callCount == 1)
+        #expect(callCount.withLock { $0 } == 1)
 
-        let second = cache.evaluate()
+        let second = await cache.evaluate()
         #expect(second == .signingIdentityMismatch(appSigner: "Dev", helperSigner: "Prod"))
-        #expect(callCount == 1)
+        #expect(callCount.withLock { $0 } == 1)
 
         cache.invalidate()
 
-        let third = cache.evaluate()
+        let third = await cache.evaluate()
         #expect(third == .healthy)
-        #expect(callCount == 2)
+        #expect(callCount.withLock { $0 } == 2)
+    }
+
+    @Test("concurrent evaluations coalesce to a single provider invocation")
+    func concurrentEvaluationsCoalesce() async {
+        let cache = SigningPreflightCache()
+        let callCount = OSAllocatedUnfairLock(initialState: 0)
+
+        cache.provider = {
+            callCount.withLock { $0 += 1 }
+            // Hold the detached diagnosis open long enough for a second caller to attach to
+            // the same in-flight generation instead of starting its own.
+            Thread.sleep(forTimeInterval: 0.05)
+            return .healthy
+        }
+
+        async let first = cache.evaluate()
+        async let second = cache.evaluate()
+        let results = await [first, second]
+
+        #expect(results == [.healthy, .healthy])
+        #expect(callCount.withLock { $0 } == 1)
+    }
+
+    @Test("provider runs off the main thread")
+    func providerRunsOffMainThread() async {
+        let cache = SigningPreflightCache()
+        let ranOnMainThread = OSAllocatedUnfairLock(initialState: true)
+
+        cache.provider = {
+            ranOnMainThread.withLock { $0 = Thread.isMainThread }
+            return .healthy
+        }
+
+        _ = await cache.evaluate()
+
+        #expect(ranOnMainThread.withLock { $0 } == false)
+    }
+
+    @Test("invalidation during an in-flight evaluation returns the current generation")
+    func invalidationDuringFlightRetriesCurrentGeneration() async {
+        let cache = SigningPreflightCache()
+        let callCount = OSAllocatedUnfairLock(initialState: 0)
+
+        cache.provider = {
+            let count = callCount.withLock { value -> Int in
+                value += 1
+                return value
+            }
+            if count == 1 {
+                // The first (soon-to-be-stale) diagnosis blocks while it is invalidated.
+                Thread.sleep(forTimeInterval: 0.1)
+                return .signingIdentityMismatch(appSigner: "Stale", helperSigner: "Stale")
+            }
+            return .healthy
+        }
+
+        async let firstEvaluation = cache.evaluate()
+        // Let the first detached diagnosis start, then invalidate mid-flight.
+        try? await Task.sleep(nanoseconds: 30_000_000)
+        cache.invalidate()
+
+        let result = await firstEvaluation
+        #expect(result == .healthy)
+        #expect(callCount.withLock { $0 } == 2)
+
+        // The fresh result is now memoized; no further diagnosis runs.
+        let cached = await cache.evaluate()
+        #expect(cached == .healthy)
+        #expect(callCount.withLock { $0 } == 2)
     }
 }

--- a/RockxyTests/Views/Main/DebugAssistantCoordinatorTests.swift
+++ b/RockxyTests/Views/Main/DebugAssistantCoordinatorTests.swift
@@ -97,9 +97,78 @@ struct DebugAssistantCoordinatorTests {
         #expect(coordinator.activeWorkspace.debugAssistantMessages.count == 2)
     }
 
+    @Test("A conversation never silently follows a different traffic selection")
+    func conversationContextMismatchRequiresResolution() async throws {
+        let coordinator = MainContentCoordinator(assistantSettingsProvider: { AppSettings() })
+        let first = TestFixtures.makeTransaction(url: "https://api.example.com/first", statusCode: 500)
+        let second = TestFixtures.makeTransaction(url: "https://api.example.com/second", statusCode: 200)
+        coordinator.transactions = [first, second]
+        coordinator.selectedTransactionIDs = [first.id]
+        coordinator.selectTransaction(first)
+
+        coordinator.startDebugAssistant(.explainFailure)
+        try await waitUntil {
+            if case .result = coordinator.activeWorkspace.debugAssistantState {
+                return true
+            }
+            return false
+        }
+
+        let originalContext = try #require(
+            coordinator.activeWorkspace.debugAssistantConversationContext
+        )
+        #expect(originalContext.primaryTransactionID == first.id)
+        coordinator.selectedTransactionIDs = [second.id]
+        coordinator.selectTransaction(second)
+
+        #expect(coordinator.debugAssistantConversationHasContextMismatch())
+        coordinator.activeWorkspace.debugAssistantDraft = "Follow this request instead"
+        coordinator.sendDebugAssistantMessage()
+        #expect(coordinator.activeWorkspace.debugAssistantDraft == "Follow this request instead")
+
+        coordinator.restoreDebugAssistantConversationContext()
+        #expect(coordinator.selectedTransaction?.id == first.id)
+        #expect(!coordinator.debugAssistantConversationHasContextMismatch())
+
+        coordinator.selectedTransactionIDs = [second.id]
+        coordinator.selectTransaction(second)
+        coordinator.startNewDebugAssistantConversationForCurrentSelection()
+        #expect(coordinator.activeWorkspace.debugAssistantMessages.isEmpty)
+        #expect(coordinator.activeWorkspace.debugAssistantConversationContext == nil)
+        #expect(!coordinator.debugAssistantConversationHasContextMismatch())
+    }
+
+    @Test("Review Data reports selected requests omitted before snapshot creation")
+    func reviewReportsEarlySelectionBound() async throws {
+        let coordinator = MainContentCoordinator(assistantSettingsProvider: { AppSettings() })
+        let transactions = (0 ..< 10).map {
+            TestFixtures.makeTransaction(
+                url: "https://api.example.com/request-\($0)",
+                statusCode: 500
+            )
+        }
+        coordinator.transactions = transactions
+        coordinator.selectedTransactionIDs = Set(transactions.map(\.id))
+        coordinator.selectTransaction(transactions[0])
+
+        coordinator.startDebugAssistant(.explainFailure)
+        try await waitUntil {
+            if case .result = coordinator.activeWorkspace.debugAssistantState {
+                return true
+            }
+            return false
+        }
+        coordinator.prepareDebugAssistantReview()
+        try await waitUntil { coordinator.activeWorkspace.debugAssistantReviewPack != nil }
+
+        let manifest = try #require(coordinator.activeWorkspace.debugAssistantReviewPack?.manifest)
+        #expect(manifest.requestCount == InvestigationContextLimits.default.maxTransactions)
+        #expect(manifest.omittedTransactionCount == 5)
+    }
+
     @Test("Related traffic is included only after explicit opt-in")
     func relatedTrafficRequiresOptIn() async throws {
-        let coordinator = MainContentCoordinator()
+        let coordinator = MainContentCoordinator(assistantSettingsProvider: { AppSettings() })
         let selected = TestFixtures.makeTransaction(
             url: "https://api.example.com/failure",
             statusCode: 500
@@ -124,13 +193,78 @@ struct DebugAssistantCoordinatorTests {
             }
             return false
         }
-        #expect(coordinator.activeWorkspace.debugAssistantMessages.count == 1)
+        #expect(coordinator.activeWorkspace.debugAssistantMessages.count == 2)
         #expect(coordinator.activeWorkspace.debugAssistantMessages.first?.role == .user)
+        #expect(coordinator.activeWorkspace.debugAssistantMessages.last?.investigation != nil)
         coordinator.prepareDebugAssistantReview()
         try await waitUntil { coordinator.activeWorkspace.debugAssistantReviewPack != nil }
 
         #expect(coordinator.activeWorkspace.debugAssistantReviewPack?.manifest.requestCount == 2)
         #expect(coordinator.activeWorkspace.debugAssistantReviewTrafficScope == .selectedAndRelated)
+    }
+
+    @Test("Review Data reports related requests omitted by the context bound")
+    func reviewReportsRelatedTrafficBound() async throws {
+        let coordinator = MainContentCoordinator(assistantSettingsProvider: { AppSettings() })
+        let selected = TestFixtures.makeTransaction(
+            url: "https://api.example.com/failure",
+            statusCode: 500
+        )
+        let related = (0 ..< 10).map {
+            TestFixtures.makeTransaction(
+                url: "https://api.example.com/related-\($0)",
+                statusCode: 200
+            )
+        }
+        coordinator.transactions = [selected] + related
+        coordinator.selectedTransactionIDs = [selected.id]
+        coordinator.selectTransaction(selected)
+        coordinator.setDebugAssistantTrafficScope(.selectedAndRelated)
+
+        coordinator.startDebugAssistant(.explainFailure)
+        try await waitUntil {
+            if case .result = coordinator.activeWorkspace.debugAssistantState {
+                return true
+            }
+            return false
+        }
+        coordinator.prepareDebugAssistantReview()
+        try await waitUntil { coordinator.activeWorkspace.debugAssistantReviewPack != nil }
+
+        let manifest = try #require(coordinator.activeWorkspace.debugAssistantReviewPack?.manifest)
+        #expect(manifest.requestCount == InvestigationContextLimits.default.maxTransactions)
+        #expect(manifest.omittedTransactionCount == 6)
+    }
+
+    @Test("Related traffic lookup is cached for a high-volume session")
+    func relatedTrafficLookupCachesHighVolumeSession() {
+        let coordinator = MainContentCoordinator()
+        let selected = TestFixtures.makeTransaction(
+            url: "https://api.example.com/selected",
+            statusCode: 500
+        )
+        let traffic = (0 ..< 49_999).map { index in
+            let host = index.isMultiple(of: 10) ? "api.example.com" : "host-\(index).example"
+            return TestFixtures.makeTransaction(
+                url: "https://\(host)/request-\(index)",
+                statusCode: 200
+            )
+        }
+        coordinator.transactions = [selected] + traffic
+        coordinator.selectedTransactionIDs = [selected.id]
+        coordinator.selectTransaction(selected)
+        coordinator.setDebugAssistantTrafficScope(.selectedAndRelated)
+
+        let first = coordinator.debugAssistantContextTransactions()
+        let generation = coordinator.debugAssistantTrafficIndexGeneration
+        let cacheKey = coordinator.debugAssistantRelatedCache?.key
+
+        for _ in 0 ..< 100 {
+            #expect(coordinator.debugAssistantContextTransactions().map(\.id) == first.map(\.id))
+        }
+        #expect(first.count == InvestigationContextLimits.default.maxTransactions)
+        #expect(coordinator.debugAssistantTrafficIndexGeneration == generation)
+        #expect(coordinator.debugAssistantRelatedCache?.key == cacheKey)
     }
 
     @Test("A natural-language message selects a local investigation and can start a new chat")
@@ -196,6 +330,42 @@ struct DebugAssistantCoordinatorTests {
 
         coordinator.deleteDebugAssistantConversation(conversation.id)
         #expect(coordinator.activeWorkspace.debugAssistantConversations.isEmpty)
+    }
+
+    @Test("Workspace conversation history and messages remain capacity bounded")
+    func conversationCapacityIsBounded() {
+        let coordinator = MainContentCoordinator()
+
+        for index in 0 ..< (DebugAssistantConversationLimits.maximumConversationsPerWorkspace + 5) {
+            coordinator.activeWorkspace.debugAssistantDraft = "Conversation \(index)"
+            coordinator.sendDebugAssistantMessage()
+            coordinator.newDebugAssistantConversation()
+        }
+
+        #expect(
+            coordinator.activeWorkspace.debugAssistantConversations.count
+                <= DebugAssistantConversationLimits.maximumConversationsPerWorkspace
+        )
+
+        coordinator.activeWorkspace.debugAssistantMessages = (
+            0 ..< (DebugAssistantConversationLimits.maximumMessagesPerConversation + 12)
+        ).map {
+            .user("Message \($0)")
+        }
+        coordinator.newDebugAssistantConversation()
+
+        let latest = coordinator.activeWorkspace.debugAssistantConversations.max {
+            $0.updatedAt < $1.updatedAt
+        }
+        #expect(
+            latest?.messages.count
+                ?? 0
+                <= DebugAssistantConversationLimits.maximumMessagesPerConversation
+        )
+        let retainedBytes = coordinator.activeWorkspace.debugAssistantConversations.reduce(0) {
+            $0 + $1.retainedTextBytes
+        }
+        #expect(retainedBytes <= DebugAssistantConversationLimits.maximumWorkspaceTextBytes)
     }
 
     @Test("Response actions prepare a visible follow-up and reveal the captured request in Details")
@@ -324,6 +494,26 @@ struct DebugAssistantCoordinatorTests {
 
         #expect(coordinator.debugAssistantTasks[workspaceID]?.id == replacementID)
         replacementTask.cancel()
+    }
+
+    @Test("Closing a workspace cancels and releases its Assistant task")
+    func closingWorkspaceCancelsAssistantTask() async {
+        let coordinator = MainContentCoordinator()
+        let workspace = coordinator.workspaceStore.createWorkspace(title: "Assistant")
+        let taskID = UUID()
+        let task = Task<Void, Never> {
+            do {
+                try await Task.sleep(for: .seconds(30))
+            } catch {}
+        }
+        coordinator.debugAssistantTasks[workspace.id] = .init(id: taskID, task: task)
+
+        coordinator.closeWorkspace(id: workspace.id)
+        await Task.yield()
+
+        #expect(!coordinator.workspaceStore.workspaces.contains { $0.id == workspace.id })
+        #expect(coordinator.debugAssistantTasks[workspace.id] == nil)
+        #expect(task.isCancelled)
     }
 
     @Test("Model action requests are discarded without triggering native workflows")
@@ -497,6 +687,301 @@ struct DebugAssistantCoordinatorTests {
         #expect(await recorder.request == nil)
     }
 
+    @Test("A directly selected request stays eligible even when muted and outside the active Focus Set")
+    func selectedTrafficOverridesFocusNoise() {
+        let coordinator = MainContentCoordinator()
+        let selectedKeep = TestFixtures.makeTransaction(url: "https://api.example.com/keep", statusCode: 500)
+        let selectedMuted = TestFixtures.makeTransaction(url: "https://muted.example.com/secret", statusCode: 500)
+        coordinator.transactions = [selectedKeep, selectedMuted]
+        coordinator.selectedTransactionIDs = [selectedKeep.id, selectedMuted.id]
+        coordinator.selectTransaction(selectedKeep)
+
+        let focus = FocusSet(name: "API only", domain: "api.example.com")
+        coordinator.activeWorkspace.focusSets = [focus]
+        coordinator.activeWorkspace.activeFocusSetID = focus.id
+        coordinator.activeWorkspace.mutedTrafficSources = [.host("muted.example.com")]
+
+        let ids = Set(coordinator.debugAssistantContextTransactions().map(\.id))
+        #expect(ids.contains(selectedKeep.id))
+        #expect(ids.contains(selectedMuted.id))
+    }
+
+    @Test("Automatically related traffic obeys Focus and Noise but not an active Traffic Signal")
+    func relatedTrafficObeysFocusNoiseNotSignal() {
+        let coordinator = MainContentCoordinator()
+        let selected = TestFixtures.makeTransaction(url: "https://api.example.com/failure", statusCode: 500)
+        let relatedKeep = TestFixtures.makeTransaction(url: "https://api.example.com/keep", statusCode: 200)
+        let relatedMuted = TestFixtures.makeTransaction(url: "https://api.example.com/muted/list", statusCode: 200)
+        coordinator.transactions = [selected, relatedKeep, relatedMuted]
+        coordinator.selectedTransactionIDs = [selected.id]
+        coordinator.selectTransaction(selected)
+        coordinator.setDebugAssistantTrafficScope(.selectedAndRelated)
+
+        coordinator.activeWorkspace.mutedTrafficSources = [.pathPrefix("/muted")]
+        var ids = Set(coordinator.debugAssistantContextTransactions().map(\.id))
+        #expect(ids.contains(relatedKeep.id))
+        #expect(!ids.contains(relatedMuted.id))
+
+        coordinator.activeWorkspace.mutedTrafficSources = []
+        let focus = FocusSet(name: "Keep", pathPrefix: "/keep")
+        coordinator.activeWorkspace.focusSets = [focus]
+        coordinator.activeWorkspace.activeFocusSetID = focus.id
+        ids = Set(coordinator.debugAssistantContextTransactions().map(\.id))
+        #expect(ids.contains(relatedKeep.id))
+        #expect(!ids.contains(relatedMuted.id))
+
+        coordinator.activeWorkspace.focusSets = []
+        coordinator.activeWorkspace.activeFocusSetID = nil
+        coordinator.activeWorkspace.activeTrafficSignal = .errors
+        ids = Set(coordinator.debugAssistantContextTransactions().map(\.id))
+        #expect(ids.contains(relatedKeep.id))
+        #expect(ids.contains(relatedMuted.id))
+    }
+
+    @Test("Review summary reports raw/included/excluded and keeps scope exclusions out of the manifest")
+    func reviewSummaryReportsFocusNoiseExclusions() async throws {
+        let coordinator = MainContentCoordinator(assistantSettingsProvider: { AppSettings() })
+        let selected = TestFixtures.makeTransaction(url: "https://api.example.com/failure", statusCode: 500)
+        let relatedKeep = TestFixtures.makeTransaction(url: "https://api.example.com/keep", statusCode: 200)
+        let relatedMuted = TestFixtures.makeTransaction(url: "https://api.example.com/muted/list", statusCode: 200)
+        coordinator.transactions = [selected, relatedKeep, relatedMuted]
+        coordinator.selectedTransactionIDs = [selected.id]
+        coordinator.selectTransaction(selected)
+        coordinator.setDebugAssistantTrafficScope(.selectedAndRelated)
+        coordinator.activeWorkspace.mutedTrafficSources = [.pathPrefix("/muted")]
+
+        coordinator.startDebugAssistant(.explainFailure)
+        try await waitUntil {
+            if case .result = coordinator.activeWorkspace.debugAssistantState {
+                return true
+            }
+            return false
+        }
+        coordinator.prepareDebugAssistantReview()
+        try await waitUntil { coordinator.activeWorkspace.debugAssistantReviewPack != nil }
+
+        let summary = try #require(coordinator.activeWorkspace.debugAssistantReviewSummary)
+        #expect(summary.rawRelatedFound == 2)
+        #expect(summary.relatedIncluded == 1)
+        #expect(summary.focusNoiseExcluded == 1)
+        #expect(!summary.overrideApplied)
+
+        let manifest = try #require(coordinator.activeWorkspace.debugAssistantReviewPack?.manifest)
+        #expect(manifest.requestCount == 2)
+        #expect(manifest.omittedTransactionCount == 0)
+    }
+
+    @Test("One-time override includes excluded related traffic without changing Focus/Noise state")
+    func oneTimeOverrideIncludesExcludedTraffic() async throws {
+        let coordinator = MainContentCoordinator(assistantSettingsProvider: { AppSettings() })
+        let selected = TestFixtures.makeTransaction(url: "https://api.example.com/failure", statusCode: 500)
+        let relatedKeep = TestFixtures.makeTransaction(url: "https://api.example.com/keep", statusCode: 200)
+        let relatedMuted = TestFixtures.makeTransaction(url: "https://api.example.com/muted/list", statusCode: 200)
+        coordinator.transactions = [selected, relatedKeep, relatedMuted]
+        coordinator.selectedTransactionIDs = [selected.id]
+        coordinator.selectTransaction(selected)
+        coordinator.setDebugAssistantTrafficScope(.selectedAndRelated)
+        let muted: Set<MutedTrafficSource> = [.pathPrefix("/muted")]
+        coordinator.activeWorkspace.mutedTrafficSources = muted
+
+        coordinator.startDebugAssistant(.explainFailure)
+        try await waitUntil {
+            if case .result = coordinator.activeWorkspace.debugAssistantState {
+                return true
+            }
+            return false
+        }
+        coordinator.prepareDebugAssistantReview()
+        try await waitUntil { coordinator.activeWorkspace.debugAssistantReviewPack != nil }
+        #expect(
+            coordinator.activeWorkspace.debugAssistantReviewPack?.scopeTransactionIDs
+                .contains(relatedMuted.id) == false
+        )
+
+        coordinator.applyDebugAssistantReviewFocusNoiseOverride()
+        try await waitUntil {
+            coordinator.activeWorkspace.debugAssistantReviewSummary?.overrideApplied == true
+        }
+
+        let pack = try #require(coordinator.activeWorkspace.debugAssistantReviewPack)
+        #expect(pack.scopeTransactionIDs.contains(relatedMuted.id))
+        guard case let .result(result) = coordinator.activeWorkspace.debugAssistantState else {
+            Issue.record("Expected result state after override")
+            return
+        }
+        #expect(result.scopeTransactionIDs.contains(relatedMuted.id))
+        #expect(AssistantTrustPolicy.isReviewedScopeValid(pack, for: result))
+
+        let summary = try #require(coordinator.activeWorkspace.debugAssistantReviewSummary)
+        #expect(summary.overrideApplied)
+        #expect(!summary.canOverrideFocusNoise)
+        #expect(summary.focusNoiseExcluded == 1)
+        #expect(summary.relatedIncluded == 2)
+
+        #expect(coordinator.activeWorkspace.mutedTrafficSources == muted)
+        #expect(coordinator.activeWorkspace.activeFocusSetID == nil)
+        #expect(coordinator.activeWorkspace.focusSets.isEmpty)
+        #expect(!coordinator.activeWorkspace.isPreparingDebugAssistantReviewOverride)
+    }
+
+    @Test("A later investigation respects Focus and Noise again after a one-time override")
+    func overrideIsNotStickyForLaterInvestigations() async throws {
+        let coordinator = MainContentCoordinator(assistantSettingsProvider: { AppSettings() })
+        let selected = TestFixtures.makeTransaction(url: "https://api.example.com/failure", statusCode: 500)
+        let relatedKeep = TestFixtures.makeTransaction(url: "https://api.example.com/keep", statusCode: 200)
+        let relatedMuted = TestFixtures.makeTransaction(url: "https://api.example.com/muted/list", statusCode: 200)
+        coordinator.transactions = [selected, relatedKeep, relatedMuted]
+        coordinator.selectedTransactionIDs = [selected.id]
+        coordinator.selectTransaction(selected)
+        coordinator.setDebugAssistantTrafficScope(.selectedAndRelated)
+        coordinator.activeWorkspace.mutedTrafficSources = [.pathPrefix("/muted")]
+
+        coordinator.startDebugAssistant(.explainFailure)
+        try await waitUntil {
+            if case .result = coordinator.activeWorkspace.debugAssistantState {
+                return true
+            }
+            return false
+        }
+        coordinator.prepareDebugAssistantReview()
+        try await waitUntil { coordinator.activeWorkspace.debugAssistantReviewPack != nil }
+        coordinator.applyDebugAssistantReviewFocusNoiseOverride()
+        try await waitUntil {
+            coordinator.activeWorkspace.debugAssistantReviewSummary?.overrideApplied == true
+        }
+
+        coordinator.newDebugAssistantConversation()
+        coordinator.setDebugAssistantTrafficScope(.selectedAndRelated)
+        coordinator.startDebugAssistant(.explainFailure)
+        try await waitUntil {
+            if case .result = coordinator.activeWorkspace.debugAssistantState {
+                return true
+            }
+            return false
+        }
+
+        guard case let .result(result) = coordinator.activeWorkspace.debugAssistantState else {
+            Issue.record("Expected result state for the later investigation")
+            return
+        }
+        #expect(result.scopeTransactionIDs.contains(relatedKeep.id))
+        #expect(!result.scopeTransactionIDs.contains(relatedMuted.id))
+    }
+
+    @Test("Selection change during override preparation cannot publish a stale reviewed pack")
+    func overridePreparationRejectsStaleWrite() async throws {
+        let coordinator = MainContentCoordinator(assistantSettingsProvider: { AppSettings() })
+        let selected = TestFixtures.makeTransaction(url: "https://api.example.com/failure", statusCode: 500)
+        let relatedKeep = TestFixtures.makeTransaction(url: "https://api.example.com/keep", statusCode: 200)
+        let relatedMuted = TestFixtures.makeTransaction(url: "https://api.example.com/muted/list", statusCode: 200)
+        let other = TestFixtures.makeTransaction(url: "https://other.example.com/x", statusCode: 200)
+        coordinator.transactions = [selected, relatedKeep, relatedMuted, other]
+        coordinator.selectedTransactionIDs = [selected.id]
+        coordinator.selectTransaction(selected)
+        coordinator.setDebugAssistantTrafficScope(.selectedAndRelated)
+        coordinator.activeWorkspace.mutedTrafficSources = [.pathPrefix("/muted")]
+
+        coordinator.startDebugAssistant(.explainFailure)
+        try await waitUntil {
+            if case .result = coordinator.activeWorkspace.debugAssistantState {
+                return true
+            }
+            return false
+        }
+        coordinator.prepareDebugAssistantReview()
+        try await waitUntil { coordinator.activeWorkspace.debugAssistantReviewPack != nil }
+
+        coordinator.applyDebugAssistantReviewFocusNoiseOverride()
+        #expect(coordinator.activeWorkspace.isPreparingDebugAssistantReviewOverride)
+
+        coordinator.selectedTransactionIDs = [other.id]
+        coordinator.selectTransaction(other)
+        try await Task.sleep(nanoseconds: 80_000_000)
+
+        #expect(coordinator.activeWorkspace.debugAssistantState == .idle)
+        #expect(coordinator.activeWorkspace.debugAssistantReviewPack == nil)
+        #expect(!coordinator.activeWorkspace.isPreparingDebugAssistantReviewOverride)
+    }
+
+    @Test("No override is offered when excluded candidates fall outside the bounded related set")
+    func overrideRequiresMaterialExpansion() async throws {
+        let coordinator = MainContentCoordinator(assistantSettingsProvider: { AppSettings() })
+        let selected = (0 ..< 4).map {
+            TestFixtures.makeTransaction(url: "https://api.example.com/failure-\($0)", statusCode: 500)
+        }
+        let keep = TestFixtures.makeTransaction(url: "https://api.example.com/keep", statusCode: 200)
+        let muted = TestFixtures.makeTransaction(url: "https://api.example.com/muted/list", statusCode: 200)
+        coordinator.transactions = selected + [keep, muted]
+        coordinator.selectedTransactionIDs = Set(selected.map(\.id))
+        coordinator.selectTransaction(selected[0])
+        coordinator.setDebugAssistantTrafficScope(.selectedAndRelated)
+        coordinator.activeWorkspace.mutedTrafficSources = [.pathPrefix("/muted")]
+
+        coordinator.startDebugAssistant(.explainFailure)
+        try await waitUntil {
+            if case .result = coordinator.activeWorkspace.debugAssistantState {
+                return true
+            }
+            return false
+        }
+        coordinator.prepareDebugAssistantReview()
+        try await waitUntil { coordinator.activeWorkspace.debugAssistantReviewPack != nil }
+
+        // The single related slot holds `keep` with or without Focus/Noise, so including the
+        // excluded `muted` request would not change the bounded reviewed related set.
+        let summary = try #require(coordinator.activeWorkspace.debugAssistantReviewSummary)
+        #expect(summary.focusNoiseExcluded == 1)
+        #expect(!summary.overrideExpandsReviewedSet)
+        #expect(!summary.canOverrideFocusNoise)
+
+        coordinator.applyDebugAssistantReviewFocusNoiseOverride()
+        try await Task.sleep(nanoseconds: 40_000_000)
+
+        #expect(coordinator.activeWorkspace.debugAssistantReviewSummary?.overrideApplied == false)
+        #expect(!coordinator.activeWorkspace.isPreparingDebugAssistantReviewOverride)
+        #expect(
+            coordinator.activeWorkspace.debugAssistantReviewPack?.scopeTransactionIDs
+                .contains(muted.id) == false
+        )
+    }
+
+    @Test("Override preparation rejects a changed selection set even when the primary row is retained")
+    func overridePreparationRejectsChangedSelectionSet() async throws {
+        let coordinator = MainContentCoordinator(assistantSettingsProvider: { AppSettings() })
+        let selected = TestFixtures.makeTransaction(url: "https://api.example.com/failure", statusCode: 500)
+        let extra = TestFixtures.makeTransaction(url: "https://api.example.com/extra", statusCode: 200)
+        let relatedMuted = TestFixtures.makeTransaction(url: "https://api.example.com/muted/list", statusCode: 200)
+        coordinator.transactions = [selected, extra, relatedMuted]
+        coordinator.selectedTransactionIDs = [selected.id, extra.id]
+        coordinator.selectTransaction(selected)
+        coordinator.setDebugAssistantTrafficScope(.selectedAndRelated)
+        coordinator.activeWorkspace.mutedTrafficSources = [.pathPrefix("/muted")]
+
+        coordinator.startDebugAssistant(.explainFailure)
+        try await waitUntil {
+            if case .result = coordinator.activeWorkspace.debugAssistantState {
+                return true
+            }
+            return false
+        }
+        coordinator.prepareDebugAssistantReview()
+        try await waitUntil { coordinator.activeWorkspace.debugAssistantReviewPack != nil }
+        #expect(coordinator.activeWorkspace.debugAssistantReviewSummary?.canOverrideFocusNoise == true)
+
+        coordinator.applyDebugAssistantReviewFocusNoiseOverride()
+        #expect(coordinator.activeWorkspace.isPreparingDebugAssistantReviewOverride)
+
+        // The set changes but still retains the original primary row; exact-equality must reject it.
+        coordinator.activeWorkspace.selectedTransactionIDs = [selected.id, relatedMuted.id]
+        try await Task.sleep(nanoseconds: 80_000_000)
+
+        #expect(coordinator.activeWorkspace.debugAssistantReviewSummary?.overrideApplied != true)
+        #expect(
+            coordinator.activeWorkspace.debugAssistantReviewPack?.scopeTransactionIDs
+                .contains(relatedMuted.id) == false
+        )
+    }
+
     // MARK: Private
 
     private func waitUntil(
@@ -530,9 +1015,13 @@ private struct TestTimeout: Error {}
 
 @MainActor
 private final class DebugAssistantSettingsFixture {
+    // MARK: Lifecycle
+
     init(settings: AppSettings) {
         self.settings = settings
     }
+
+    // MARK: Internal
 
     var settings: AppSettings
 }

--- a/RockxyTests/Views/Main/NativeBottomInspectorSplitViewTests.swift
+++ b/RockxyTests/Views/Main/NativeBottomInspectorSplitViewTests.swift
@@ -5,6 +5,8 @@ import Testing
 
 @MainActor
 struct NativeBottomInspectorSplitViewTests {
+    // MARK: Internal
+
     @Test("Bottom inspector sizing preserves the proposed workspace size")
     func proposedSizeIsPreserved() throws {
         let resolved = try #require(NativeBottomInspectorSplitSizing.resolve(
@@ -54,18 +56,125 @@ struct NativeBottomInspectorSplitViewTests {
         #expect(coordinator.shouldApplyPresentation(true))
     }
 
+    // MARK: - Startup geometry readiness
+
+    @Test("Bottom inspector layout readiness rejects zero and non-finite bounds")
+    func layoutReadinessRejectsInvalidBounds() {
+        #expect(!NativeBottomInspectorSplitSizing.isLayoutReady(.zero))
+        #expect(!NativeBottomInspectorSplitSizing.isLayoutReady(
+            CGRect(x: 0, y: 0, width: 1_200, height: 0)
+        ))
+        #expect(!NativeBottomInspectorSplitSizing.isLayoutReady(
+            CGRect(x: 0, y: 0, width: 0, height: 700)
+        ))
+        #expect(!NativeBottomInspectorSplitSizing.isLayoutReady(
+            CGRect(x: 0, y: 0, width: 1_200, height: CGFloat.infinity)
+        ))
+        #expect(NativeBottomInspectorSplitSizing.isLayoutReady(
+            CGRect(x: 0, y: 0, width: 1_200, height: 700)
+        ))
+    }
+
+    @Test("Configuring the bottom inspector at zero bounds never produces negative geometry")
+    func zeroBoundsProducesNonNegativeGeometry() {
+        let autosaveName = uniqueAutosaveName()
+        let controller = makeConfiguredController(
+            isInspectorPresented: true,
+            autosaveName: autosaveName
+        )
+
+        layout(controller, at: .zero)
+
+        expectNonNegativeArrangedGeometry(controller)
+        removeSplitViewAutosaveDefaults(autosaveName)
+    }
+
+    @Test("Deferred initial collapse applies once bounds become sufficient")
+    func deferredCollapseAppliesAtSufficientBounds() {
+        let autosaveName = uniqueAutosaveName()
+        let controller = makeConfiguredController(
+            isInspectorPresented: false,
+            autosaveName: autosaveName
+        )
+
+        layout(controller, at: .zero)
+        layout(controller, at: CGRect(x: 0, y: 0, width: 1_200, height: 700))
+
+        #expect(!controller.isInspectorPresented)
+        expectNonNegativeArrangedGeometry(controller)
+        removeSplitViewAutosaveDefaults(autosaveName)
+    }
+
+    @Test("Insufficient height preserves inspector visibility without negative geometry")
+    func insufficientHeightPreservesVisibility() {
+        let autosaveName = uniqueAutosaveName()
+        let controller = makeConfiguredController(
+            isInspectorPresented: true,
+            autosaveName: autosaveName
+        )
+
+        // Positive but below the combined primary + inspector minimum height.
+        layout(controller, at: CGRect(x: 0, y: 0, width: 1_200, height: 400))
+
+        #expect(controller.isInspectorPresented)
+        expectNonNegativeArrangedGeometry(controller)
+        removeSplitViewAutosaveDefaults(autosaveName)
+    }
+
+    // MARK: Private
+
+    // MARK: - Helpers
+
     private func makeController(isInspectorPresented: Bool) -> NativeBottomInspectorSplitViewController {
+        let controller = makeConfiguredController(
+            isInspectorPresented: isInspectorPresented,
+            autosaveName: uniqueAutosaveName()
+        )
+        layout(controller, at: CGRect(x: 0, y: 0, width: 1_200, height: 700))
+        return controller
+    }
+
+    private func layout(_ controller: NativeBottomInspectorSplitViewController, at frame: CGRect) {
+        controller.view.frame = frame
+        controller.view.needsLayout = true
+        controller.view.layoutSubtreeIfNeeded()
+    }
+
+    private func makeConfiguredController(
+        isInspectorPresented: Bool,
+        autosaveName: String
+    )
+        -> NativeBottomInspectorSplitViewController
+    {
         let controller = NativeBottomInspectorSplitViewController()
         controller.configure(
             primaryController: NSHostingController(rootView: Color.clear),
             inspectorController: NSHostingController(rootView: Color.clear),
             isInspectorPresented: isInspectorPresented,
-            autosaveName: "NativeBottomInspectorSplitViewTests-\(UUID().uuidString)",
+            autosaveName: autosaveName,
             primaryMinimumHeight: 200,
             inspectorMinimumHeight: 320
         )
-        controller.view.frame = CGRect(x: 0, y: 0, width: 1_200, height: 700)
-        controller.view.layoutSubtreeIfNeeded()
         return controller
+    }
+
+    private func uniqueAutosaveName() -> String {
+        "NativeBottomInspectorSplitViewTests-\(UUID().uuidString)"
+    }
+
+    private func expectNonNegativeArrangedGeometry(
+        _ controller: NativeBottomInspectorSplitViewController
+    ) {
+        for item in controller.splitViewItems {
+            let frame = item.viewController.view.frame
+            #expect(frame.width.isFinite)
+            #expect(frame.height.isFinite)
+            #expect(frame.width >= 0)
+            #expect(frame.height >= 0)
+        }
+    }
+
+    private func removeSplitViewAutosaveDefaults(_ autosaveName: String) {
+        UserDefaults.standard.removeObject(forKey: "NSSplitView Subview Frames \(autosaveName)")
     }
 }

--- a/RockxyTests/Views/Main/NativeWorkspaceSplitViewTests.swift
+++ b/RockxyTests/Views/Main/NativeWorkspaceSplitViewTests.swift
@@ -5,6 +5,8 @@ import Testing
 
 @MainActor
 struct NativeWorkspaceSplitViewTests {
+    // MARK: Internal
+
     @Test("Sidebar and inspector share one balanced width policy")
     func balancedUtilityPaneWidths() {
         #expect(MainWindowLayoutMetrics.utilityPaneMinimumWidth == 300)
@@ -70,6 +72,7 @@ struct NativeWorkspaceSplitViewTests {
 
         #expect(window.styleMask.contains(.fullSizeContentView))
         #expect(window.titlebarAppearsTransparent)
+        #expect(window.titleVisibility == .hidden)
     }
 
     @Test("Main toolbar places the sidebar toggle before its tracking separator")
@@ -121,7 +124,8 @@ struct NativeWorkspaceSplitViewTests {
         guard let toggleItem = toolbar.managedToolbar.items.first(where: {
             $0.itemIdentifier == NativeWorkspaceToolbar.sidebarToggleIdentifier
         }),
-              let action = toggleItem.action else {
+            let action = toggleItem.action else
+        {
             Issue.record("Sidebar toolbar item was not installed")
             return
         }
@@ -133,10 +137,240 @@ struct NativeWorkspaceSplitViewTests {
         #expect(controller.isSidebarPresented)
     }
 
+    // MARK: - Startup geometry readiness
+
+    @Test("Layout readiness rejects zero, negative, and non-finite bounds")
+    func layoutReadinessRejectsInvalidBounds() {
+        #expect(!NativeWorkspaceSplitSizing.isLayoutReady(.zero))
+        #expect(!NativeWorkspaceSplitSizing.isLayoutReady(CGRect(x: 0, y: 0, width: 0, height: 700)))
+        #expect(!NativeWorkspaceSplitSizing.isLayoutReady(CGRect(x: 0, y: 0, width: 1_300, height: 0)))
+        #expect(!NativeWorkspaceSplitSizing.isLayoutReady(CGRect(x: 0, y: 0, width: -10, height: 700)))
+        #expect(!NativeWorkspaceSplitSizing.isLayoutReady(
+            CGRect(x: 0, y: 0, width: CGFloat.nan, height: 700)
+        ))
+        #expect(NativeWorkspaceSplitSizing.isLayoutReady(CGRect(x: 0, y: 0, width: 1_300, height: 700)))
+    }
+
+    @Test("Ideal placement seats every presented pane at or above its minimum")
+    func idealPlacementRespectsMinimums() throws {
+        let placement = try #require(NativeWorkspaceSplitSizing.idealPlacement(
+            totalWidth: 1_300,
+            dividerThickness: 1,
+            sidebarPresented: true,
+            inspectorPresented: true,
+            sidebarIdealWidth: 250,
+            inspectorIdealWidth: 380,
+            sidebarMinimumWidth: 200,
+            workspaceMinimumWidth: 600,
+            inspectorMinimumWidth: 300
+        ))
+
+        let sidebarWidth = try #require(placement.leadingDividerPosition)
+        let trailing = try #require(placement.trailingDividerPosition)
+        let inspectorWidth = 1_300 - trailing - 1
+        let workspaceWidth = trailing - (sidebarWidth + 1)
+
+        #expect(sidebarWidth >= 200)
+        #expect(inspectorWidth >= 300)
+        #expect(workspaceWidth >= 600)
+    }
+
+    @Test("Ideal placement is skipped when the window cannot seat the workspace minimum")
+    func idealPlacementSkippedWhenTooNarrow() {
+        let placement = NativeWorkspaceSplitSizing.idealPlacement(
+            totalWidth: 1_150,
+            dividerThickness: 1,
+            sidebarPresented: true,
+            inspectorPresented: true,
+            sidebarIdealWidth: 250,
+            inspectorIdealWidth: 380,
+            sidebarMinimumWidth: 200,
+            workspaceMinimumWidth: 600,
+            inspectorMinimumWidth: 300
+        )
+
+        #expect(placement == nil)
+    }
+
+    @Test("Ideal placement omits the divider for a collapsed pane")
+    func idealPlacementForSinglePresentedPane() throws {
+        let placement = try #require(NativeWorkspaceSplitSizing.idealPlacement(
+            totalWidth: 1_300,
+            dividerThickness: 1,
+            sidebarPresented: true,
+            inspectorPresented: false,
+            sidebarIdealWidth: 250,
+            inspectorIdealWidth: 380,
+            sidebarMinimumWidth: 200,
+            workspaceMinimumWidth: 600,
+            inspectorMinimumWidth: 300
+        ))
+
+        #expect(placement.leadingDividerPosition == 250)
+        #expect(placement.trailingDividerPosition == nil)
+    }
+
+    @Test("Configuring at zero bounds never produces negative arranged geometry")
+    func zeroBoundsProducesNonNegativeGeometry() {
+        let autosaveName = uniqueAutosaveName()
+        let controller = makeConfiguredController(
+            sidebarPresented: true,
+            inspectorPresented: true,
+            autosaveName: autosaveName
+        )
+
+        layout(controller, at: .zero)
+
+        expectNonNegativeArrangedGeometry(controller)
+        removeSplitViewAutosaveDefaults(autosaveName)
+    }
+
+    @Test("Moving from a zero frame to a sufficient frame applies pending visibility and ideal placement")
+    func deferredLayoutAppliesPendingVisibilityAndIdealPlacement() {
+        let autosaveName = uniqueAutosaveName()
+        removeSplitViewAutosaveDefaults(autosaveName)
+        let controller = makeConfiguredController(
+            sidebarPresented: true,
+            inspectorPresented: true,
+            autosaveName: autosaveName
+        )
+
+        layout(controller, at: .zero)
+        layout(controller, at: CGRect(x: 0, y: 0, width: 1_300, height: 700))
+
+        #expect(controller.isSidebarPresented)
+        #expect(controller.isInspectorPresented)
+
+        let sidebarWidth = controller.splitViewItems[0].viewController.view.frame.width
+        let inspectorWidth = controller.splitViewItems[2].viewController.view.frame.width
+        #expect(abs(sidebarWidth - 250) <= 2)
+        #expect(abs(inspectorWidth - 380) <= 2)
+        expectNonNegativeArrangedGeometry(controller)
+        removeSplitViewAutosaveDefaults(autosaveName)
+    }
+
+    @Test("Minima readiness rejects raw-invalid and too-narrow widths but accepts a minimum-capable width")
+    func minimaReadinessGuardsInitialLatch() {
+        // Raw-negative width must be rejected, not standardized to a positive value.
+        #expect(!NativeWorkspaceSplitSizing.canSeatRequestedMinima(
+            totalWidth: -1_300,
+            dividerThickness: 1,
+            sidebarPresented: true,
+            inspectorPresented: true,
+            sidebarMinimumWidth: 200,
+            workspaceMinimumWidth: 600,
+            inspectorMinimumWidth: 300
+        ))
+
+        // 200 + 600 + 300 + two dividers = 1_102 required; 900 cannot seat the minima.
+        #expect(!NativeWorkspaceSplitSizing.canSeatRequestedMinima(
+            totalWidth: 900,
+            dividerThickness: 1,
+            sidebarPresented: true,
+            inspectorPresented: true,
+            sidebarMinimumWidth: 200,
+            workspaceMinimumWidth: 600,
+            inspectorMinimumWidth: 300
+        ))
+
+        // 1_150 seats the minima (1_102) even though it cannot seat the ideals.
+        #expect(NativeWorkspaceSplitSizing.canSeatRequestedMinima(
+            totalWidth: 1_150,
+            dividerThickness: 1,
+            sidebarPresented: true,
+            inspectorPresented: true,
+            sidebarMinimumWidth: 200,
+            workspaceMinimumWidth: 600,
+            inspectorMinimumWidth: 300
+        ))
+
+        // A collapsed inspector drops its pane and divider from the requirement.
+        #expect(NativeWorkspaceSplitSizing.canSeatRequestedMinima(
+            totalWidth: 810,
+            dividerThickness: 1,
+            sidebarPresented: true,
+            inspectorPresented: false,
+            sidebarMinimumWidth: 200,
+            workspaceMinimumWidth: 600,
+            inspectorMinimumWidth: 300
+        ))
+    }
+
+    @Test("A provisional too-narrow pass defers latch until a pass that seats the requested minima")
+    func provisionalTooNarrowPassDefersLatchToIdealPlacement() {
+        let autosaveName = uniqueAutosaveName()
+        removeSplitViewAutosaveDefaults(autosaveName)
+        let controller = makeConfiguredController(
+            sidebarPresented: true,
+            inspectorPresented: true,
+            autosaveName: autosaveName
+        )
+
+        // Positive and finite, but too narrow to seat sidebar + workspace + inspector minima
+        // plus dividers. This pass must not consume pending visibility or latch the layout.
+        layout(controller, at: CGRect(x: 0, y: 0, width: 900, height: 700))
+        layout(controller, at: CGRect(x: 0, y: 0, width: 1_300, height: 700))
+
+        #expect(controller.isSidebarPresented)
+        #expect(controller.isInspectorPresented)
+
+        let sidebarWidth = controller.splitViewItems[0].viewController.view.frame.width
+        let inspectorWidth = controller.splitViewItems[2].viewController.view.frame.width
+        #expect(abs(sidebarWidth - 250) <= 2)
+        #expect(abs(inspectorWidth - 380) <= 2)
+        expectNonNegativeArrangedGeometry(controller)
+        removeSplitViewAutosaveDefaults(autosaveName)
+    }
+
+    @Test("A window too narrow for ideal placement preserves visibility without negative geometry")
+    func insufficientWidthPreservesVisibility() {
+        let autosaveName = uniqueAutosaveName()
+        let controller = makeConfiguredController(
+            sidebarPresented: true,
+            inspectorPresented: true,
+            autosaveName: autosaveName
+        )
+
+        layout(controller, at: CGRect(x: 0, y: 0, width: 1_150, height: 700))
+
+        #expect(controller.isSidebarPresented)
+        #expect(controller.isInspectorPresented)
+        expectNonNegativeArrangedGeometry(controller)
+        removeSplitViewAutosaveDefaults(autosaveName)
+    }
+
+    // MARK: Private
+
+    // MARK: - Helpers
+
     private func makeController(
         sidebarPresented: Bool,
         inspectorPresented: Bool
-    ) -> NativeWorkspaceSplitViewController {
+    )
+        -> NativeWorkspaceSplitViewController
+    {
+        let controller = makeConfiguredController(
+            sidebarPresented: sidebarPresented,
+            inspectorPresented: inspectorPresented,
+            autosaveName: uniqueAutosaveName()
+        )
+        layout(controller, at: CGRect(x: 0, y: 0, width: 1_300, height: 700))
+        return controller
+    }
+
+    private func layout(_ controller: NativeWorkspaceSplitViewController, at frame: CGRect) {
+        controller.view.frame = frame
+        controller.view.needsLayout = true
+        controller.view.layoutSubtreeIfNeeded()
+    }
+
+    private func makeConfiguredController(
+        sidebarPresented: Bool,
+        inspectorPresented: Bool,
+        autosaveName: String
+    )
+        -> NativeWorkspaceSplitViewController
+    {
         let controller = NativeWorkspaceSplitViewController()
         controller.configure(
             sidebarController: NSHostingController(rootView: Color.clear),
@@ -145,7 +379,7 @@ struct NativeWorkspaceSplitViewTests {
             isSidebarPresented: sidebarPresented,
             isInspectorPresented: inspectorPresented,
             layout: NativeWorkspaceSplitLayout(
-                autosaveName: "NativeWorkspaceSplitViewTests-\(UUID().uuidString)",
+                autosaveName: autosaveName,
                 sidebarMinimumWidth: 200,
                 sidebarIdealWidth: 250,
                 sidebarMaximumWidth: 350,
@@ -155,8 +389,24 @@ struct NativeWorkspaceSplitViewTests {
                 inspectorMaximumWidth: 520
             )
         )
-        controller.view.frame = CGRect(x: 0, y: 0, width: 1_300, height: 700)
-        controller.view.layoutSubtreeIfNeeded()
         return controller
+    }
+
+    private func uniqueAutosaveName() -> String {
+        "NativeWorkspaceSplitViewTests-\(UUID().uuidString)"
+    }
+
+    private func expectNonNegativeArrangedGeometry(_ controller: NativeWorkspaceSplitViewController) {
+        for item in controller.splitViewItems {
+            let frame = item.viewController.view.frame
+            #expect(frame.width.isFinite)
+            #expect(frame.height.isFinite)
+            #expect(frame.width >= 0)
+            #expect(frame.height >= 0)
+        }
+    }
+
+    private func removeSplitViewAutosaveDefaults(_ autosaveName: String) {
+        UserDefaults.standard.removeObject(forKey: "NSSplitView Subview Frames \(autosaveName)")
     }
 }

--- a/docs/core-features/filters-and-search.mdx
+++ b/docs/core-features/filters-and-search.mdx
@@ -69,11 +69,11 @@ Saved Focus Sets:
 - can be applied, edited, duplicated, expanded to inspect their rules, or deleted;
 - keep their active selection separate in each workspace.
 
-Applying a Focus Set only changes which rows are visible. Capture continues, and the underlying transactions remain available to other workspaces.
+Applying a Focus Set changes the current workspace's visible rows and the pool from which AI Assistant may automatically discover related traffic. Capture continues, the underlying transactions remain available to other workspaces, and requests you explicitly select remain eligible for Assistant review.
 
 ## Noise Control
 
-Noise Control hides traffic that should remain captured but stay out of the current workspace's working set.
+Noise Control hides traffic that should remain captured but stay out of the current workspace's visible working set and automatically discovered AI Assistant context.
 
 In the sidebar's **Focus** mode, choose **Configure** beside **Noise Control**, then mute either:
 
@@ -85,7 +85,7 @@ You can also right-click a domain in **Browse** and choose **Mute Source**.
 Muted sources apply throughout the current workspace, regardless of which Focus Set is active. Use **Unmute** for one source or **Unmute All** to restore them.
 
 <Note>
-Focus Set exclusions belong only to that Focus Set. Noise Control is workspace-wide. Neither feature deletes traffic or prevents it from being captured.
+Focus Set exclusions belong only to that Focus Set. Noise Control is workspace-wide. Neither feature deletes traffic or prevents it from being captured. Review Data can include normally excluded related traffic once without changing either setting.
 </Note>
 
 ## Practical debugging patterns

--- a/docs/features/ai-assistant.mdx
+++ b/docs/features/ai-assistant.mdx
@@ -69,6 +69,10 @@ You can explicitly opt in to **Selected and Related Traffic** when nearby reques
 
 Related traffic is never added silently. Changing the scope resets the current investigation so the new evidence can be reviewed from the beginning.
 
+Explicitly selected requests always remain in the investigation, even when they are outside the active Focus Set or match Noise Control. Automatically discovered related traffic follows the active Focus Set and Noise Control so hidden telemetry does not silently return through Assistant context. Traffic Signal rows such as Errors or Slow only filter the table; they do not narrow related Assistant evidence.
+
+Review Data reports how many related requests were found, included, and normally excluded by Focus or Noise. When including excluded traffic would materially change the bounded review, choose **Include Excluded Traffic Once** to rebuild that review without changing the workspace's Focus or Noise settings. The override applies only to the current review; later investigations use the normal scope again.
+
 ## Privacy and Trust Boundary
 
 Rockxy applies the following protections before configured-model access:


### PR DESCRIPTION
## Summary

- Hardens provider streaming with explicit HTTP status validation, bounded line framing, premature-EOF detection, cancellation, and stale-result protection across OpenAI, Anthropic, Gemini, compatible endpoints, and Ollama.
- Strengthens Review Data and assistant trust boundaries with URL-credential and provider-header redaction, exact scope accounting, bounded related-traffic expansion, one-time excluded-traffic review, and workspace-scoped conversation state.
- Stabilizes native macOS lifecycle behavior across workspace and bottom-inspector split initialization, request-table selection, helper signing preflight, provider setup actions, and main-window title visibility.
- Expands focused regression coverage and updates the public assistant and Focus Set documentation.

## Why

The assistant foundation now spans asynchronous provider streams, selected and related traffic, user-reviewed outbound context, workspace-local conversations, and multiple native split views. These paths need deterministic cancellation, exact scope reporting, strict redaction, and lifecycle-safe UI updates so stale work cannot change the active investigation and provisional AppKit geometry cannot corrupt the workspace layout.

This follow-up also keeps signing diagnostics off the main thread and removes the redundant application name from the main toolbar chrome.

## Impact

- Provider HTTP failures and truncated streams now fail explicitly instead of appearing as successful partial responses.
- Captured URL credentials and provider-specific authentication headers are removed from reviewed context.
- Selected traffic remains explicit; related traffic respects workspace noise controls, and excluded traffic requires a fresh one-time review before inclusion.
- Conversation capacity, context ownership, replacement-task cancellation, and provider-configuration changes are bounded and stale-safe.
- Initial split-view presentation waits for valid geometry, while toolbar and inspector visibility remain coordinated with the owning workspace state.
- Helper signing preflight work is coalesced, invalidatable, and performed away from the main actor.

## Related issues

Refs #214
Refs #215
Refs #216
Refs #217
Refs #218
Refs #226
Refs #227
Refs #228
Refs #229
Refs #235
Refs #236

## Validation

- Passed focused `xcodebuild` suites for investigation context, sensitive-data redaction, native providers, OpenAI Responses, signing diagnostics and preflight caching, Debug Assistant coordination, and the native bottom inspector split.
- Passed the focused main-window chrome regression test.
- Passed `git diff --check`.
- `swiftlint lint --strict` reports the existing repository baseline of seven violations in unchanged code: five superfluous disable commands and two file-length violations. No changed file adds a lint violation.
- Known local failure: the full `NativeWorkspaceSplitViewTests` suite still fails `deferredLayoutAppliesPendingVisibilityAndIdealPlacement` and `provisionalTooNarrowPassDefersLatchToIdealPlacement`; the remaining cases pass.
