### PR TITLE
release: promote native traffic inspection workflows

### DIFF
--- a/Rockxy/Core/Storage/SessionStore.swift
+++ b/Rockxy/Core/Storage/SessionStore.swift
@@ -146,11 +146,12 @@ actor SessionStore {
         return nil
     }
 
-    // MARK: - Load Pinned & Saved
+    // MARK: - Load Library Transactions
 
+    /// Loads every transaction retained by Library: pinned, saved, or carrying a user note.
     func loadPinnedAndSavedTransactions() throws -> [HTTPTransaction] {
         let query = Self.transactions
-            .filter(Self.txIsPinned == 1 || Self.txIsSaved == 1)
+            .filter(Self.txIsPinned == 1 || Self.txIsSaved == 1 || Self.txComment != nil)
             .order(Self.txTimestamp.desc)
 
         var results: [HTTPTransaction] = []

--- a/Rockxy/Models/Network/HTTPTransaction.swift
+++ b/Rockxy/Models/Network/HTTPTransaction.swift
@@ -69,6 +69,16 @@ final class HTTPTransaction: Identifiable, @unchecked Sendable {
     /// column sort. Must not be used by export, persistence, inspector, or replay.
     var sequenceNumber: Int = 0
 
+    /// Whether this transaction carries a user note. Membership in the Library's Notes
+    /// collection is derived from a non-empty, whitespace-trimmed `comment` — there is no
+    /// separate stored flag, unlike `isPinned` / `isSaved`.
+    var hasNote: Bool {
+        guard let comment else {
+            return false
+        }
+        return !comment.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
     func applyMatchedRuleMetadata(from rule: ProxyRule) {
         matchedRuleID = rule.id
         matchedRuleName = rule.name

--- a/Rockxy/Models/UI/AppUIDisplayMetrics.swift
+++ b/Rockxy/Models/UI/AppUIDisplayMetrics.swift
@@ -173,6 +173,49 @@ struct AppUIDisplayMetrics: Equatable {
     }
 }
 
+// MARK: - BottomInspectorLayoutMetrics
+
+/// Font-aware minimum heights for the request-list / bottom-inspector split.
+///
+/// Pure and value-typed so the sizing can be verified without a live window. Both minima are
+/// derived from `AppUIDisplayMetrics` so the split tracks the Rockxy app font size instead of
+/// pinning fixed point values.
+struct BottomInspectorLayoutMetrics: Equatable {
+    // MARK: Lifecycle
+
+    init(appMetrics: AppUIDisplayMetrics = AppUIDisplayMetrics()) {
+        self.appMetrics = appMetrics
+    }
+
+    // MARK: Internal
+
+    let appMetrics: AppUIDisplayMetrics
+
+    /// Minimum height that keeps roughly six request rows plus the compact table header and
+    /// surrounding chrome visible. ≈200pt at the default 13pt app font, scaling up with it.
+    var requestListMinimumHeight: CGFloat {
+        let rowHeight = appMetrics.tableRowHeight
+        let rows = rowHeight * Self.visibleRequestRows
+        let header = rowHeight
+        return (rows + header + Self.requestChromeInset).rounded()
+    }
+
+    /// Minimum height for a compact, native inspector: the tab strip plus a readable stack of
+    /// content lines and vertical chrome. ≈232pt at 13pt, scaling up for larger app fonts.
+    var inspectorMinimumHeight: CGFloat {
+        let tabStrip = appMetrics.inspectorTabHeight
+        let contentLines = appMetrics.tableTextHeight * Self.inspectorVisibleLines
+        return (tabStrip + contentLines + Self.inspectorChromeInset).rounded()
+    }
+
+    // MARK: Private
+
+    private static let visibleRequestRows: CGFloat = 6
+    private static let requestChromeInset: CGFloat = 4
+    private static let inspectorVisibleLines: CGFloat = 10
+    private static let inspectorChromeInset: CGFloat = 29
+}
+
 // MARK: - DeveloperSetupDisplayMetrics
 
 struct DeveloperSetupDisplayMetrics: Equatable {

--- a/Rockxy/Models/UI/BottomInspectorPresentation.swift
+++ b/Rockxy/Models/UI/BottomInspectorPresentation.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+// MARK: - BottomInspectorContent
+
+/// What the bottom payload inspector can present for the current selection.
+///
+/// Mirrors `InspectorPanelView`: multi-selection shows a selection summary, a single
+/// selection shows raw request/response payload, and an empty selection has nothing
+/// to inspect.
+enum BottomInspectorContent: Equatable {
+    /// No transaction selected — nothing to inspect.
+    case none
+    /// Exactly one transaction selected — raw request/response payload.
+    case single
+    /// Two or more transactions selected — selection summary.
+    case summary
+}
+
+// MARK: - BottomInspectorPresentation
+
+/// Pure resolver that separates the user's persisted bottom-inspector *preference*
+/// (`InspectorLayout` + automatic reveal) from the *effective* presentation shown for
+/// the current selection.
+///
+/// The bottom inspector is temporarily collapsed whenever there is nothing to inspect,
+/// so the request table reclaims the space. Collapsing here never mutates the persisted
+/// layout preference or the automatic-reveal flag — it is derived state only.
+enum BottomInspectorPresentation {
+    /// Resolves the content state from the current selection counts.
+    static func content(selectedCount: Int, hasSingleSelection: Bool) -> BottomInspectorContent {
+        if selectedCount > 1 {
+            return .summary
+        }
+        return hasSingleSelection ? .single : .none
+    }
+
+    /// Whether the native bottom split item should be expanded.
+    ///
+    /// Returns `false` for an empty selection regardless of the stored layout so the
+    /// table gets the space; otherwise honors the persisted `InspectorLayout` preference.
+    static func isPresented(layout: InspectorLayout, content: BottomInspectorContent) -> Bool {
+        guard content != .none else {
+            return false
+        }
+        return layout == .bottom
+    }
+
+    /// Whether a bottom-inspector show/hide control should be enabled.
+    ///
+    /// Toggling with nothing to inspect would only flip a hidden preference with no
+    /// visible result, so controls are disabled (and the toggle is a no-op) in that case.
+    static func allowsToggle(content: BottomInspectorContent) -> Bool {
+        content != .none
+    }
+}

--- a/Rockxy/Models/UI/ContextDockEmptyState.swift
+++ b/Rockxy/Models/UI/ContextDockEmptyState.swift
@@ -1,0 +1,83 @@
+import Foundation
+
+// MARK: - ContextDockEmptyState
+
+/// The reason the Context Dock has nothing to show for the current selection.
+///
+/// Kept as a pure decision so the empty-state copy stays honest about capture and
+/// filter state without embedding string comparisons in the view.
+enum ContextDockEmptyState: Equatable {
+    /// No traffic captured yet and capture is running — requests will arrive.
+    case waitingForTraffic
+    /// No traffic captured and capture is stopped — the user must start capture.
+    case captureStopped
+    /// Traffic has been captured, but the active filters hide every request.
+    case filteredNoResults
+    /// Visible traffic exists but nothing is selected — the user should pick a request.
+    case selectRequest
+
+    // MARK: Internal
+
+    /// Resolves the empty-state reason from coordinator data.
+    ///
+    /// - Parameters:
+    ///   - hasCapturedTraffic: any traffic captured in the current session.
+    ///   - hasVisibleResults: at least one request survives the active workspace scope/filters.
+    ///   - isCapturing: the proxy is currently running.
+    static func resolve(
+        hasCapturedTraffic: Bool,
+        hasVisibleResults: Bool,
+        isCapturing: Bool
+    )
+        -> ContextDockEmptyState
+    {
+        if hasVisibleResults {
+            return .selectRequest
+        }
+        guard hasCapturedTraffic else {
+            return isCapturing ? .waitingForTraffic : .captureStopped
+        }
+        return .filteredNoResults
+    }
+}
+
+// MARK: - ContextDockEmptyStateCopy
+
+/// User-facing copy for a `ContextDockEmptyState`, rendered through the shared
+/// `InspectorEmptyStateView` so every empty state keeps the same visual language.
+struct ContextDockEmptyStateCopy: Equatable {
+    // MARK: Lifecycle
+
+    init(_ state: ContextDockEmptyState) {
+        switch state {
+        case .waitingForTraffic:
+            title = String(localized: "Waiting for Traffic")
+            systemImage = "dot.radiowaves.left.and.right"
+            description = String(
+                localized: "Captured requests will appear here. Select one to inspect its context."
+            )
+        case .captureStopped:
+            title = String(localized: "Capture Stopped")
+            systemImage = "stop.circle"
+            description = String(
+                localized: "Start capture to record requests, then select one to inspect its context."
+            )
+        case .filteredNoResults:
+            title = String(localized: "No Matching Requests")
+            systemImage = "line.3.horizontal.decrease.circle"
+            description = String(
+                localized: "No captured requests match the current view. Adjust or clear its filters to see traffic here."
+            )
+        case .selectRequest:
+            title = String(localized: "No Selection")
+            systemImage = "doc.text.magnifyingglass"
+            description = String(localized: "Select a request to see diagnostics and related traffic.")
+        }
+    }
+
+    // MARK: Internal
+
+    let title: String
+    let systemImage: String
+    let description: String
+}

--- a/Rockxy/Models/UI/FavoriteTransactionContextMenu.swift
+++ b/Rockxy/Models/UI/FavoriteTransactionContextMenu.swift
@@ -7,9 +7,15 @@ import Foundation
 enum FavoriteTransactionSection: String, CaseIterable {
     case pinned
     case saved
+    case notes
 
     var deleteTitle: String {
-        String(localized: "Delete")
+        switch self {
+        case .pinned, .saved:
+            String(localized: "Delete")
+        case .notes:
+            String(localized: "Remove Note")
+        }
     }
 
     var displayName: String {
@@ -18,6 +24,8 @@ enum FavoriteTransactionSection: String, CaseIterable {
             String(localized: "Pinned")
         case .saved:
             String(localized: "Saved")
+        case .notes:
+            String(localized: "Notes")
         }
     }
 
@@ -27,6 +35,8 @@ enum FavoriteTransactionSection: String, CaseIterable {
             .pinnedTransaction(id: id)
         case .saved:
             .savedTransaction(id: id)
+        case .notes:
+            .noteTransaction(id: id)
         }
     }
 
@@ -36,6 +46,8 @@ enum FavoriteTransactionSection: String, CaseIterable {
             .allPinned
         case .saved:
             .allSaved
+        case .notes:
+            .allNotes
         }
     }
 }

--- a/Rockxy/Models/UI/FilterCriteria.swift
+++ b/Rockxy/Models/UI/FilterCriteria.swift
@@ -8,6 +8,7 @@ enum SidebarScope: Codable, Hashable {
     case allTraffic
     case saved
     case pinned
+    case notes
 }
 
 // MARK: - FilterCriteria

--- a/Rockxy/Models/UI/FilterField.swift
+++ b/Rockxy/Models/UI/FilterField.swift
@@ -39,7 +39,7 @@ enum FilterField: String, CaseIterable, Codable, Hashable {
         case .cookies: "Cookies"
         case .clientApp: "Client/App"
         case .contentType: "Content Type"
-        case .comment: "Comment"
+        case .comment: "Note"
         case .color: "Color"
         }
     }

--- a/Rockxy/Models/UI/InspectorTabOverflowPlan.swift
+++ b/Rockxy/Models/UI/InspectorTabOverflowPlan.swift
@@ -1,0 +1,77 @@
+import CoreGraphics
+
+// MARK: - InspectorTabLayoutItem
+
+/// A single tab competing for horizontal space in an inspector tab strip.
+///
+/// Pure and value-typed so the overflow distribution can be verified without a live
+/// window. `width` is the measured/estimated intrinsic width the tab needs when rendered
+/// directly in the strip (including any leading group separator it reserves).
+struct InspectorTabLayoutItem: Equatable {
+    let id: String
+    let width: CGFloat
+}
+
+// MARK: - InspectorTabOverflowPlan
+
+/// Result of distributing tabs between the directly-visible strip and the overflow menu.
+struct InspectorTabOverflowPlan: Equatable {
+    let visibleIDs: [String]
+    let overflowIDs: [String]
+
+    var hasOverflow: Bool {
+        !overflowIDs.isEmpty
+    }
+}
+
+// MARK: - InspectorTabOverflowPlanner
+
+/// Distributes inspector tabs between the visible strip and a native overflow menu.
+///
+/// Guarantees, for a given (`items`, `activeID`, `availableWidth`) triple:
+/// - visible tabs fit within `availableWidth` (minus the overflow affordance when overflow occurs),
+/// - the `activeID` tab is always visible, even at extremely narrow widths,
+/// - source order is preserved in both the visible strip and the overflow menu.
+///
+/// The function is pure: the same inputs always produce the same plan, so resize and font-size
+/// changes recompute deterministically without oscillation or selection changes.
+enum InspectorTabOverflowPlanner {
+    static func plan(
+        items: [InspectorTabLayoutItem],
+        activeID: String?,
+        availableWidth: CGFloat,
+        overflowAffordanceWidth: CGFloat
+    )
+        -> InspectorTabOverflowPlan
+    {
+        guard !items.isEmpty else {
+            return InspectorTabOverflowPlan(visibleIDs: [], overflowIDs: [])
+        }
+
+        let totalWidth = items.reduce(0) { $0 + $1.width }
+        if totalWidth <= availableWidth {
+            return InspectorTabOverflowPlan(visibleIDs: items.map(\.id), overflowIDs: [])
+        }
+
+        var remaining = max(0, availableWidth - overflowAffordanceWidth)
+        var visible = Set<String>()
+
+        // Reserve the active tab first so it is always directly reachable. In an extremely narrow
+        // strip this can drive `remaining` negative, which simply forces every other tab to overflow.
+        if let activeID, let active = items.first(where: { $0.id == activeID }) {
+            visible.insert(active.id)
+            remaining -= active.width
+        }
+
+        for item in items where !visible.contains(item.id) {
+            if item.width <= remaining {
+                visible.insert(item.id)
+                remaining -= item.width
+            }
+        }
+
+        let visibleIDs = items.filter { visible.contains($0.id) }.map(\.id)
+        let overflowIDs = items.filter { !visible.contains($0.id) }.map(\.id)
+        return InspectorTabOverflowPlan(visibleIDs: visibleIDs, overflowIDs: overflowIDs)
+    }
+}

--- a/Rockxy/Models/UI/ProtocolFilterSelection.swift
+++ b/Rockxy/Models/UI/ProtocolFilterSelection.swift
@@ -1,0 +1,141 @@
+import Foundation
+
+/// Pure, view-free selection and presentation logic for the adaptive protocol filter bar.
+///
+/// The bar shows a single line of `FilterPillButton`s plus an `ellipsis.circle` overflow menu.
+/// This type partitions the `ProtocolFilter` cases into stable, ordered groups (Transport /
+/// Protocol / Content / Status), decides which pills appear inline at each adaptive width tier,
+/// and derives the complementary overflow-menu contents. All matching semantics (OR within a
+/// group, AND across groups) live in `MainContentCoordinator+Filtering`; this type only decides
+/// what is shown and how a toggle mutates the active set. `.all` is a presentation-only sentinel —
+/// it is never stored as an active filter.
+enum ProtocolFilterSelection {
+    /// Transport section of the overflow menu, in stable display order.
+    static let transportFilters: [ProtocolFilter] = [.all, .http, .https, .websocket]
+
+    /// Smart / protocol section of the overflow menu, in stable display order.
+    static let protocolFilters: [ProtocolFilter] = [.ai, .aiSession, .web3RPC, .rpcError, .graphql, .grpc]
+
+    /// Content section of the overflow menu, in stable display order.
+    static let contentTypeFilters: [ProtocolFilter] = [
+        .json, .xml, .js, .css, .document, .media, .form, .font, .other,
+    ]
+
+    /// Status section of the overflow menu, in ascending range order.
+    static let statusFilters: [ProtocolFilter] = [.status1xx, .status2xx, .status3xx, .status4xx, .status5xx]
+
+    /// Stable pill sets shown at each adaptive width tier, widest first. Practical tiers keep both
+    /// traffic-type and status filters visible so the bar continues to advertise both capabilities
+    /// as it contracts. The last (`.all` only) is the safe fallback. Selection never changes these
+    /// arrays, so pills do not reorder when toggled. Keep the tier count in sync with
+    /// `ProtocolFilterBar`'s explicit `ViewThatFits` candidates.
+    static let inlinePillTiers: [[ProtocolFilter]] = [
+        [
+            .all,
+            .http,
+            .https,
+            .websocket,
+            .ai,
+            .aiSession,
+            .web3RPC,
+            .json,
+            .graphql,
+            .status2xx,
+            .status4xx,
+            .status5xx
+        ],
+        [.all, .http, .https, .websocket, .ai, .json, .status2xx, .status4xx, .status5xx],
+        [.all, .https, .websocket, .ai, .json, .status2xx, .status4xx],
+        [.all, .https, .ai, .status2xx, .status4xx],
+        [.all, .https, .status2xx, .status4xx],
+        [.all],
+    ]
+
+    /// Active, user-selectable traffic-type filters (excludes `.all` and status filters),
+    /// returned in `ProtocolFilter.allCases` order.
+    static func activeTypeFilters(in filters: Set<ProtocolFilter>) -> [ProtocolFilter] {
+        ProtocolFilter.allCases.filter { $0 != .all && !$0.isStatusFilter && filters.contains($0) }
+    }
+
+    /// Active status filters, returned in `ProtocolFilter.allCases` order.
+    static func activeStatusFilters(in filters: Set<ProtocolFilter>) -> [ProtocolFilter] {
+        ProtocolFilter.allCases.filter { $0.isStatusFilter && filters.contains($0) }
+    }
+
+    /// Inline pills shown at the given adaptive tier (0 = widest).
+    static func inlinePills(forTier tier: Int) -> [ProtocolFilter] {
+        let clamped = min(max(tier, 0), inlinePillTiers.count - 1)
+        return inlinePillTiers[clamped]
+    }
+
+    /// Members of `section` that are hidden at the current tier and therefore belong in the
+    /// overflow menu, in the section's stable order. `.all` is never an overflow toggle — it is a
+    /// pill at every tier.
+    static func overflowFilters(in section: [ProtocolFilter], visiblePills: [ProtocolFilter]) -> [ProtocolFilter] {
+        let visible = Set(visiblePills)
+        return section.filter { $0 != .all && !visible.contains($0) }
+    }
+
+    /// Whether any active filter is hidden at the current tier, so the overflow icon should signal
+    /// it. `.all` is never stored, so it never counts as a hidden active filter.
+    static func hasHiddenActiveFilter(
+        activeFilters: Set<ProtocolFilter>,
+        visiblePills: [ProtocolFilter]
+    )
+        -> Bool
+    {
+        let visible = Set(visiblePills)
+        return activeFilters.contains { !visible.contains($0) }
+    }
+
+    /// Whether the given filter reads as selected. `.all` is selected exactly when no traffic-type
+    /// filter is active.
+    static func isSelected(_ filter: ProtocolFilter, in filters: Set<ProtocolFilter>) -> Bool {
+        if filter == .all {
+            return activeTypeFilters(in: filters).isEmpty
+        }
+        return filters.contains(filter)
+    }
+
+    /// The set produced by toggling `filter`. Selecting `.all` clears traffic-type filters while
+    /// preserving status filters; every other toggle flips membership. `.all` is never stored.
+    static func toggling(_ filter: ProtocolFilter, in filters: Set<ProtocolFilter>) -> Set<ProtocolFilter> {
+        if filter == .all {
+            return clearingTypeFilters(in: filters)
+        }
+        var next = filters
+        if next.contains(filter) {
+            next.remove(filter)
+        } else {
+            next.insert(filter)
+            next.remove(.all)
+        }
+        return next
+    }
+
+    /// "All Traffic" action — removes traffic-type filters, preserves status filters.
+    static func clearingTypeFilters(in filters: Set<ProtocolFilter>) -> Set<ProtocolFilter> {
+        Set(filters.filter(\.isStatusFilter))
+    }
+
+    /// "Any Status" action — removes status filters, preserves traffic-type filters.
+    static func clearingStatusFilters(in filters: Set<ProtocolFilter>) -> Set<ProtocolFilter> {
+        Set(filters.filter { !$0.isStatusFilter && $0 != .all })
+    }
+
+    /// "Clear All" action — removes both traffic-type and status filters.
+    static func clearingAllFilters(in _: Set<ProtocolFilter>) -> Set<ProtocolFilter> {
+        []
+    }
+
+    /// Removable summary chips for the active filter bar, in `ProtocolFilter.allCases` order.
+    /// Excludes the `.all` sentinel.
+    static func summaryFilters(in filters: Set<ProtocolFilter>) -> [ProtocolFilter] {
+        ProtocolFilter.allCases.filter { $0 != .all && filters.contains($0) }
+    }
+
+    /// Menu row label. `.all` renders as "All Traffic"; everything else uses its display name.
+    static func menuLabel(for filter: ProtocolFilter) -> String {
+        filter == .all ? String(localized: "All Traffic") : filter.displayName
+    }
+}

--- a/Rockxy/Models/UI/RequestInspectorTab.swift
+++ b/Rockxy/Models/UI/RequestInspectorTab.swift
@@ -20,7 +20,7 @@ enum RequestInspectorTab: String, CaseIterable {
         case .cookies: "Cookies"
         case .raw: "Raw"
         case .synopsis: "Synopsis"
-        case .comments: "Comments"
+        case .comments: "Notes"
         }
     }
 }

--- a/Rockxy/Models/UI/RequestListEmptyState.swift
+++ b/Rockxy/Models/UI/RequestListEmptyState.swift
@@ -1,0 +1,212 @@
+import Foundation
+
+// MARK: - RequestListEmptyState
+
+/// The reason the main request list has no visible rows.
+///
+/// Kept as a pure decision so the overlay copy stays honest about capture, scope, and
+/// filter state without embedding branching logic in the view. Resolves to `nil` whenever
+/// visible rows exist — the table renders normally in that case.
+enum RequestListEmptyState: Equatable {
+    /// Candidate requests exist in the current scope but active filters hide every one.
+    /// Carries the available (non-TLS-failure) candidate count for truthful copy.
+    case filtered(availableCount: Int)
+    /// A Library collection (Saved / Pinned / Notes) is scoped but holds no requests.
+    case emptyCollection(SidebarScope)
+    /// The proxy is starting up; requests cannot arrive yet.
+    case proxyStarting
+    /// The proxy is stopped and nothing has been captured.
+    case proxyStopped
+    /// The proxy is running but recording is paused, so new requests are dropped from view.
+    case recordingPaused
+    /// The proxy is running and recording, but no traffic has arrived yet.
+    case waitingForTraffic
+
+    // MARK: Internal
+
+    /// Resolves the empty-state reason from current coordinator state.
+    ///
+    /// Precedence, top to bottom:
+    /// 1. Visible rows → `nil` (table renders).
+    /// 2. Empty Library collection (Saved / Pinned / Notes with zero candidates) — takes
+    ///    precedence over proxy state so an empty collection never claims "no matches" or
+    ///    "waiting for traffic".
+    /// 3. Filtered empty — candidates exist (>0) and active filters hide all of them.
+    /// 4. Proxy state (starting / stopped / paused / waiting).
+    ///
+    /// - Parameters:
+    ///   - hasVisibleRows: at least one row survives the active scope + filters.
+    ///   - availableCount: candidate (non-TLS-failure) request count for the current scope.
+    ///   - hasActiveFilters: any workspace filter, advanced rule, signal, focus set, or mute is active.
+    ///   - scope: the active sidebar scope.
+    ///   - proxyState: the live proxy display state.
+    static func resolve(
+        hasVisibleRows: Bool,
+        availableCount: Int,
+        hasActiveFilters: Bool,
+        scope: SidebarScope,
+        proxyState: ProxyDisplayState
+    )
+        -> RequestListEmptyState?
+    {
+        if hasVisibleRows {
+            return nil
+        }
+
+        // An empty Library collection is more specific than proxy state: never report
+        // "no matches" or "waiting" when the collection itself is simply empty.
+        if scope != .allTraffic, availableCount == 0 {
+            return .emptyCollection(scope)
+        }
+
+        // Only claim "no matches" when there are genuine candidates to match against.
+        if availableCount > 0, hasActiveFilters {
+            return .filtered(availableCount: availableCount)
+        }
+
+        switch proxyState {
+        case .starting:
+            return .proxyStarting
+        case .stopped:
+            return .proxyStopped
+        case .paused:
+            return .recordingPaused
+        case .running:
+            return .waitingForTraffic
+        }
+    }
+}
+
+// MARK: - RequestListEmptyStateAction
+
+/// The single safe recovery action offered for an empty state, if any. Every action routes
+/// through the coordinator so behavior cannot drift from the filter-summary reset.
+enum RequestListEmptyStateAction: Equatable {
+    case clearFilters
+    case showAllTraffic
+    case startProxy
+    case resumeRecording
+}
+
+// MARK: - RequestListEmptyStateCopy
+
+/// User-facing copy and recovery action for a `RequestListEmptyState`, rendered through a
+/// native `ContentUnavailableView`.
+struct RequestListEmptyStateCopy: Equatable {
+    // MARK: Lifecycle
+
+    init(_ state: RequestListEmptyState) {
+        switch state {
+        case let .filtered(availableCount):
+            title = String(localized: "No Matching Requests")
+            systemImage = "line.3.horizontal.decrease.circle"
+            description = Self.filteredDescription(availableCount: availableCount)
+            action = .clearFilters
+            actionTitle = String(localized: "Clear Filters")
+            actionHelp = String(localized: "Clear the active filters to show all captured traffic.")
+
+        case let .emptyCollection(scope):
+            let collection = Self.collectionCopy(for: scope)
+            title = collection.title
+            systemImage = collection.systemImage
+            description = collection.description
+            action = .showAllTraffic
+            actionTitle = String(localized: "Show All Traffic")
+            actionHelp = String(localized: "Leave this collection and show all captured traffic.")
+
+        case .proxyStarting:
+            title = String(localized: "Starting Proxy")
+            systemImage = "hourglass"
+            description = String(localized: "Rockxy is starting the proxy. Captured requests will appear here.")
+            action = nil
+            actionTitle = nil
+            actionHelp = nil
+
+        case .proxyStopped:
+            title = String(localized: "No Traffic Captured")
+            systemImage = "network.slash"
+            description = String(localized: "The proxy is stopped. Start it to begin capturing requests.")
+            action = .startProxy
+            actionTitle = String(localized: "Start Proxy")
+            actionHelp = String(localized: "Start the proxy to begin capturing network traffic.")
+
+        case .recordingPaused:
+            title = String(localized: "Recording Paused")
+            systemImage = "pause.circle"
+            description = String(
+                localized: "New requests are not being recorded. Resume recording to capture traffic."
+            )
+            action = .resumeRecording
+            actionTitle = String(localized: "Resume Recording")
+            actionHelp = String(localized: "Resume recording so new requests are captured.")
+
+        case .waitingForTraffic:
+            title = String(localized: "Waiting for Requests")
+            systemImage = "dot.radiowaves.left.and.right"
+            description = String(
+                localized: "Rockxy is capturing. Send a request through the proxy and it will appear here."
+            )
+            action = nil
+            actionTitle = nil
+            actionHelp = nil
+        }
+    }
+
+    // MARK: Internal
+
+    let title: String
+    let systemImage: String
+    let description: String
+    let action: RequestListEmptyStateAction?
+    let actionTitle: String?
+    let actionHelp: String?
+
+    // MARK: Private
+
+    private struct CollectionCopy {
+        let title: String
+        let systemImage: String
+        let description: String
+    }
+
+    private static func filteredDescription(availableCount: Int) -> String {
+        if availableCount == 1 {
+            return String(localized: "No requests match the active filters. 1 request is available before filtering.")
+        }
+        return String(
+            localized: "No requests match the active filters. \(availableCount) requests are available before filtering."
+        )
+    }
+
+    private static func collectionCopy(for scope: SidebarScope) -> CollectionCopy {
+        switch scope {
+        case .saved:
+            CollectionCopy(
+                title: String(localized: "No Saved Requests"),
+                systemImage: "bookmark",
+                description: String(
+                    localized: "Requests you save appear here. Save a request from its menu to keep it across sessions."
+                )
+            )
+        case .pinned:
+            CollectionCopy(
+                title: String(localized: "No Pinned Requests"),
+                systemImage: "pin",
+                description: String(localized: "Pin a request to keep it at hand. Pinned requests appear here.")
+            )
+        case .notes:
+            CollectionCopy(
+                title: String(localized: "No Requests with Notes"),
+                systemImage: "note.text",
+                description: String(localized: "Requests with notes appear here. Add a note to a request to track it.")
+            )
+        case .allTraffic:
+            // Not reachable — `.emptyCollection` is only resolved for Library scopes.
+            CollectionCopy(
+                title: String(localized: "No Requests"),
+                systemImage: "tray",
+                description: String(localized: "No requests to show.")
+            )
+        }
+    }
+}

--- a/Rockxy/Models/UI/SidebarItem.swift
+++ b/Rockxy/Models/UI/SidebarItem.swift
@@ -17,8 +17,10 @@ enum SidebarItem: Hashable, Codable {
     case logStream(id: UUID)
     case pinnedTransaction(id: UUID)
     case savedTransaction(id: UUID)
+    case noteTransaction(id: UUID)
     case allApps
     case allDomains
     case allPinned
     case allSaved
+    case allNotes
 }

--- a/Rockxy/RockxyApp.swift
+++ b/Rockxy/RockxyApp.swift
@@ -921,7 +921,7 @@ struct RockxyMenuCommands: Commands {
 
             Divider()
 
-            Button(String(localized: "Add Comment…")) {
+            Button(String(localized: "Add Note…")) {
                 actions?.addComment()
             }
             .disabled(actions?.hasSelectedTransaction != true)

--- a/Rockxy/RockxyApp.swift
+++ b/Rockxy/RockxyApp.swift
@@ -830,6 +830,7 @@ struct RockxyMenuCommands: Commands {
                 actions?.toggleInspectorBottom()
             }
             .keyboardShortcut("]", modifiers: [.command, .control])
+            .disabled(actions?.canToggleBottomInspector != true)
 
             Button(
                 actions?.isContextDockVisible == true

--- a/Rockxy/Views/Common/NativeWorkspaceWindowChrome.swift
+++ b/Rockxy/Views/Common/NativeWorkspaceWindowChrome.swift
@@ -91,6 +91,7 @@ final class NativeWorkspaceToolbar: NSObject, NSToolbarDelegate {
                 await withCheckedContinuation { continuation in
                     withObservationTracking {
                         _ = coordinator.isProxyRunning
+                        _ = coordinator.hasPayloadInspectorSelection
                     } onChange: {
                         continuation.resume()
                     }
@@ -161,6 +162,7 @@ final class NativeWorkspaceToolbar: NSObject, NSToolbarDelegate {
     ] = [:]
     private var observationTask: Task<Void, Never>?
     private weak var proxyToggleItem: NSToolbarItem?
+    private weak var bottomInspectorItem: NSToolbarItem?
 
     private func makeSidebarToggleItem() -> NSToolbarItem {
         let item = imageItem(
@@ -202,6 +204,9 @@ final class NativeWorkspaceToolbar: NSObject, NSToolbarDelegate {
             systemImage: "rectangle.split.1x2",
             action: #selector(toggleBottomInspector(_:))
         )
+        bottomInspectorItem.isEnabled = coordinator.canToggleBottomInspector
+        bottomInspectorItem.toolTip = bottomInspectorToolTip
+        self.bottomInspectorItem = bottomInspectorItem
         let contextDockItem = imageItem(
             identifier: NSToolbarItem.Identifier(
                 "\(Self.actionGroupIdentifier.rawValue).contextDock"
@@ -268,6 +273,14 @@ final class NativeWorkspaceToolbar: NSObject, NSToolbarDelegate {
             systemSymbolName: isRunning ? "stop.fill" : "play.fill",
             accessibilityDescription: label
         )
+        bottomInspectorItem?.isEnabled = coordinator.canToggleBottomInspector
+        bottomInspectorItem?.toolTip = bottomInspectorToolTip
+    }
+
+    private var bottomInspectorToolTip: String {
+        coordinator.canToggleBottomInspector
+            ? String(localized: "Show or hide the bottom inspector panel")
+            : String(localized: "Select a request to use the bottom inspector")
     }
 
     @objc

--- a/Rockxy/Views/Inspector/AssistantConversationComponents.swift
+++ b/Rockxy/Views/Inspector/AssistantConversationComponents.swift
@@ -1,6 +1,8 @@
 import AppKit
 import SwiftUI
 
+// MARK: - AssistantClipboard
+
 enum AssistantClipboard {
     static func copy(_ text: String) {
         let pasteboard = NSPasteboard.general
@@ -12,34 +14,28 @@ enum AssistantClipboard {
 // MARK: - AssistantResponseCard
 
 struct AssistantResponseCard<Content: View>: View {
-    let content: Content
+    // MARK: Internal
 
-    init(@ViewBuilder content: () -> Content) {
-        self.content = content()
-    }
+    @ViewBuilder let content: Content
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
+        VStack(alignment: .leading, spacing: 6) {
             HStack(spacing: 6) {
                 Image(systemName: "waveform.badge.magnifyingglass")
                     .foregroundStyle(.secondary)
                 Text(String(localized: "Rockxy Assistant"))
-                    .font(metrics.swiftUIFont(size: metrics.metadataFontSize, weight: .semibold))
+                    .font(.system(size: metrics.metadataFontSize, weight: .semibold))
                     .foregroundStyle(.secondary)
                 Spacer(minLength: 0)
             }
             content
         }
-        .padding(10)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .background(Color(nsColor: .controlBackgroundColor), in: RoundedRectangle(cornerRadius: 9))
-        .overlay {
-            RoundedRectangle(cornerRadius: 9)
-                .stroke(Color(nsColor: .separatorColor), lineWidth: 0.5)
-        }
         .accessibilityElement(children: .contain)
         .accessibilityLabel(String(localized: "AI Assistant Response"))
     }
+
+    // MARK: Private
 
     @Environment(\.appUIDisplayMetrics) private var metrics
 }
@@ -47,6 +43,8 @@ struct AssistantResponseCard<Content: View>: View {
 // MARK: - AssistantProgressRow
 
 struct AssistantProgressRow: View {
+    // MARK: Internal
+
     let title: String
     var systemImage: String?
     var color = Color.secondary
@@ -62,10 +60,12 @@ struct AssistantProgressRow: View {
                     .foregroundStyle(color)
             }
             Text(title)
-                .font(metrics.swiftUIFont(size: metrics.secondaryFontSize, weight: .medium))
+                .font(.system(size: metrics.secondaryFontSize, weight: .medium))
             Spacer(minLength: 0)
         }
     }
+
+    // MARK: Private
 
     @Environment(\.appUIDisplayMetrics) private var metrics
 }
@@ -73,6 +73,8 @@ struct AssistantProgressRow: View {
 // MARK: - AssistantConversationContextMismatchBanner
 
 struct AssistantConversationContextMismatchBanner: View {
+    // MARK: Internal
+
     let context: DebugAssistantConversationContext?
     let onRestore: () -> Void
     let onStartNew: () -> Void
@@ -83,7 +85,8 @@ struct AssistantConversationContextMismatchBanner: View {
                 String(localized: "This conversation belongs to different traffic"),
                 systemImage: "arrow.trianglehead.branch"
             )
-            .font(metrics.swiftUIFont(size: metrics.secondaryFontSize, weight: .semibold))
+            .font(.system(size: metrics.secondaryFontSize, weight: .semibold))
+            .foregroundStyle(.orange)
 
             if let context {
                 Text(
@@ -91,7 +94,7 @@ struct AssistantConversationContextMismatchBanner: View {
                         localized: "It was started with \(context.summary). Restore that selection or start a clean conversation for the traffic shown above."
                     )
                 )
-                .font(metrics.swiftUIFont(size: metrics.metadataFontSize))
+                .font(.system(size: metrics.metadataFontSize))
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
             }
@@ -106,40 +109,48 @@ struct AssistantConversationContextMismatchBanner: View {
                     .controlSize(.small)
             }
         }
-        .padding(10)
+        .padding(.horizontal, 10)
+        .padding(.vertical, 8)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .background(Color.orange.opacity(0.08))
         .accessibilityElement(children: .contain)
         .accessibilityLabel(String(localized: "Conversation traffic changed"))
     }
 
+    // MARK: Private
+
     @Environment(\.appUIDisplayMetrics) private var metrics
 }
 
-// MARK: - AssistantUserMessageBubble
+// MARK: - AssistantQueryRow
 
-struct AssistantUserMessageBubble: View {
+/// A user prompt rendered as a compact, full-width investigation query event — a labelled row that
+/// reads as part of the inspector's evidence trail, not a trailing chat bubble aligned to one side.
+struct AssistantQueryRow: View {
+    // MARK: Internal
+
     let text: String
 
     var body: some View {
-        HStack {
-            Spacer(minLength: 44)
+        HStack(alignment: .firstTextBaseline, spacing: 7) {
+            Image(systemName: "text.magnifyingglass")
+                .font(.system(size: metrics.metadataFontSize, weight: .semibold))
+                .foregroundStyle(.secondary)
+                .accessibilityHidden(true)
             Text(text)
-                .font(metrics.swiftUIFont(size: metrics.primaryFontSize))
+                .font(.system(size: metrics.secondaryFontSize, weight: .medium))
                 .foregroundStyle(.primary)
                 .textSelection(.enabled)
-                .padding(.horizontal, 10)
-                .padding(.vertical, 8)
-                .background(Color(nsColor: .controlBackgroundColor), in: RoundedRectangle(cornerRadius: 8))
-                .overlay {
-                    RoundedRectangle(cornerRadius: 8)
-                        .stroke(Color(nsColor: .separatorColor), lineWidth: 0.5)
-                }
+                .fixedSize(horizontal: false, vertical: true)
+            Spacer(minLength: 0)
         }
-        .frame(maxWidth: .infinity, alignment: .trailing)
+        .padding(.horizontal, 2)
+        .padding(.vertical, 4)
+        .frame(maxWidth: .infinity, alignment: .leading)
         .accessibilityElement(children: .combine)
-        .accessibilityLabel(String(localized: "You: \(text)"))
+        .accessibilityLabel(String(localized: "Investigation query: \(text)"))
     }
+
+    // MARK: Private
 
     @Environment(\.appUIDisplayMetrics) private var metrics
 }
@@ -147,6 +158,8 @@ struct AssistantUserMessageBubble: View {
 // MARK: - AssistantResponseActionBar
 
 struct AssistantResponseActionBar: View {
+    // MARK: Internal
+
     let canCopy: Bool
     let canRevealRequest: Bool
     let canRetry: Bool
@@ -191,10 +204,12 @@ struct AssistantResponseActionBar: View {
                 }
             }
         }
-        .font(metrics.swiftUIFont(size: metrics.metadataFontSize))
+        .font(.system(size: metrics.metadataFontSize))
         .foregroundStyle(.secondary)
         .padding(.top, 2)
     }
+
+    // MARK: Private
 
     @Environment(\.appUIDisplayMetrics) private var metrics
 
@@ -202,7 +217,9 @@ struct AssistantResponseActionBar: View {
         _ title: String,
         systemImage: String,
         action: @escaping () -> Void
-    ) -> some View {
+    )
+        -> some View
+    {
         Button(action: action) {
             Label(title, systemImage: systemImage)
                 .lineLimit(1)
@@ -217,7 +234,9 @@ struct AssistantResponseActionBar: View {
         _ title: String,
         systemImage: String,
         action: @escaping () -> Void
-    ) -> some View {
+    )
+        -> some View
+    {
         Button(action: action) {
             Image(systemName: systemImage)
                 .frame(minWidth: 18, minHeight: 18)
@@ -234,6 +253,8 @@ struct AssistantResponseActionBar: View {
 /// Renders common model Markdown as native SwiftUI text without exposing formatting markers.
 /// Block parsing runs away from the main actor and is retained by the view's stable message identity.
 struct AssistantMarkdownText: View {
+    // MARK: Internal
+
     let source: String
 
     var body: some View {
@@ -242,7 +263,7 @@ struct AssistantMarkdownText: View {
                 AssistantMarkdownDocumentView(document: document)
             } else {
                 Text(AssistantMarkdownInlineRenderer.render(source))
-                    .font(metrics.swiftUIFont(size: metrics.primaryFontSize))
+                    .font(.system(size: metrics.primaryFontSize))
                     .fixedSize(horizontal: false, vertical: true)
             }
         }
@@ -258,21 +279,29 @@ struct AssistantMarkdownText: View {
         }
     }
 
+    // MARK: Private
+
     @Environment(\.appUIDisplayMetrics) private var metrics
     @State private var document: AssistantMarkdownDocument?
 }
 
+// MARK: - AssistantStreamingText
+
 /// Streaming output deliberately stays plain and cheap. Completed messages are parsed into
 /// native Markdown once, after the provider finishes.
 struct AssistantStreamingText: View {
+    // MARK: Internal
+
     let source: String
 
     var body: some View {
         Text(source)
-            .font(metrics.swiftUIFont(size: metrics.primaryFontSize))
+            .font(.system(size: metrics.primaryFontSize))
             .textSelection(.enabled)
             .fixedSize(horizontal: false, vertical: true)
     }
+
+    // MARK: Private
 
     @Environment(\.appUIDisplayMetrics) private var metrics
 }
@@ -282,6 +311,8 @@ struct AssistantStreamingText: View {
 struct AssistantMarkdownDocument: Equatable, Sendable {
     let blocks: [AssistantMarkdownBlock]
 }
+
+// MARK: - AssistantMarkdownBlock
 
 enum AssistantMarkdownBlock: Equatable, Sendable {
     case heading(level: Int, text: String)
@@ -293,6 +324,8 @@ enum AssistantMarkdownBlock: Equatable, Sendable {
     case separator
 }
 
+// MARK: - AssistantMarkdownListItem
+
 struct AssistantMarkdownListItem: Equatable, Sendable {
     let number: Int
     let text: String
@@ -301,6 +334,8 @@ struct AssistantMarkdownListItem: Equatable, Sendable {
 // MARK: - AssistantMarkdownDocumentParser
 
 enum AssistantMarkdownDocumentParser {
+    // MARK: Internal
+
     static func parse(_ source: String) -> AssistantMarkdownDocument {
         let lines = source
             .replacingOccurrences(of: "\r\n", with: "\n")
@@ -440,6 +475,8 @@ enum AssistantMarkdownDocumentParser {
         return AssistantMarkdownDocument(blocks: blocks)
     }
 
+    // MARK: Private
+
     private static func heading(from line: String) -> (level: Int, text: String)? {
         let markerCount = line.prefix(while: { $0 == "#" }).count
         guard (1 ... 6).contains(markerCount),
@@ -488,6 +525,8 @@ enum AssistantMarkdownDocumentParser {
 // MARK: - AssistantMarkdownDocumentView
 
 private struct AssistantMarkdownDocumentView: View {
+    // MARK: Internal
+
     let document: AssistantMarkdownDocument
 
     var body: some View {
@@ -499,6 +538,8 @@ private struct AssistantMarkdownDocumentView: View {
         .frame(maxWidth: .infinity, alignment: .leading)
     }
 
+    // MARK: Private
+
     @Environment(\.appUIDisplayMetrics) private var metrics
 
     @ViewBuilder
@@ -506,15 +547,12 @@ private struct AssistantMarkdownDocumentView: View {
         switch block {
         case let .heading(level, text):
             Text(AssistantMarkdownInlineRenderer.render(text))
-                .font(metrics.swiftUIFont(
-                    size: headingFontSize(level),
-                    weight: .semibold
-                ))
+                .font(.system(size: headingFontSize(level), weight: .semibold))
                 .fixedSize(horizontal: false, vertical: true)
                 .padding(.top, level <= 2 ? 2 : 0)
         case let .paragraph(text):
             Text(AssistantMarkdownInlineRenderer.render(text))
-                .font(metrics.swiftUIFont(size: metrics.primaryFontSize))
+                .font(.system(size: metrics.primaryFontSize))
                 .fixedSize(horizontal: false, vertical: true)
         case let .unorderedList(items):
             VStack(alignment: .leading, spacing: 5) {
@@ -527,7 +565,7 @@ private struct AssistantMarkdownDocumentView: View {
                     }
                 }
             }
-            .font(metrics.swiftUIFont(size: metrics.primaryFontSize))
+            .font(.system(size: metrics.primaryFontSize))
             .padding(.leading, 4)
         case let .orderedList(items):
             VStack(alignment: .leading, spacing: 5) {
@@ -542,17 +580,17 @@ private struct AssistantMarkdownDocumentView: View {
                     }
                 }
             }
-            .font(metrics.swiftUIFont(size: metrics.primaryFontSize))
+            .font(.system(size: metrics.primaryFontSize))
         case let .code(language, text):
             VStack(alignment: .leading, spacing: 5) {
                 if let language {
-                    Text(language.uppercased())
-                        .font(metrics.swiftUIFont(size: metrics.metadataFontSize, weight: .medium))
+                    Text(language)
+                        .font(.system(size: metrics.metadataFontSize, weight: .medium, design: .monospaced))
                         .foregroundStyle(.secondary)
                 }
                 ScrollView(.horizontal) {
                     Text(text)
-                        .font(metrics.swiftUIFont(size: metrics.secondaryFontSize, monospaced: true))
+                        .font(.system(size: metrics.secondaryFontSize, design: .monospaced))
                         .textSelection(.enabled)
                         .frame(maxWidth: .infinity, alignment: .leading)
                 }
@@ -573,7 +611,7 @@ private struct AssistantMarkdownDocumentView: View {
                     .fill(Color(nsColor: .separatorColor))
                     .frame(width: 2)
                 Text(AssistantMarkdownInlineRenderer.render(text))
-                    .font(metrics.swiftUIFont(size: metrics.primaryFontSize))
+                    .font(.system(size: metrics.primaryFontSize))
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
             }

--- a/Rockxy/Views/Inspector/CommentsTabView.swift
+++ b/Rockxy/Views/Inspector/CommentsTabView.swift
@@ -1,9 +1,12 @@
 import SwiftUI
 
-/// Editable comments tab for annotating individual HTTP transactions.
+/// Editable Notes tab for annotating individual HTTP transactions. Routes edits through the
+/// coordinator's note seam so whitespace is normalized, the Library's Notes collection stays in sync,
+/// and persistence is debounced rather than rewriting the transaction row on every keystroke.
 struct CommentsTabView: View {
     // MARK: Internal
 
+    let coordinator: MainContentCoordinator
     let transaction: HTTPTransaction
 
     var body: some View {
@@ -12,17 +15,53 @@ struct CommentsTabView: View {
                 .font(.system(size: metrics.primaryFontSize))
                 .scrollContentBackground(.hidden)
                 .padding(8)
+                .accessibilityLabel(String(localized: "Request note"))
+
+            Divider()
+
+            HStack(spacing: 0) {
+                Spacer(minLength: 0)
+                Button(action: saveNote) {
+                    Image(systemName: "square.and.arrow.down")
+                }
+                .buttonStyle(.borderless)
+                .controlSize(.small)
+                .disabled(!isDirty)
+                .help(String(localized: "Save Note"))
+                .accessibilityLabel(String(localized: "Save Note"))
+            }
+            .padding(.horizontal, 8)
+            .padding(.vertical, 5)
         }
         .onAppear {
             commentText = transaction.comment ?? ""
+            lastExplicitlySavedNote = MainContentCoordinator.normalizedNote(commentText)
         }
         .onChange(of: commentText) { _, newValue in
-            transaction.comment = newValue.isEmpty ? nil : newValue
+            coordinator.updateNoteDraft(newValue, for: transaction)
+        }
+        .onDisappear {
+            coordinator.flushNotePersistence(for: transaction)
         }
     }
 
     // MARK: Private
 
     @State private var commentText: String = ""
+    @State private var lastExplicitlySavedNote: String?
     @Environment(\.appUIDisplayMetrics) private var metrics
+
+    /// Tracks changes since the user's last explicit save. Inline editing still keeps the existing
+    /// debounce and selection-change safety, while this state gives the Save action a stable lifecycle
+    /// even though the coordinator updates the in-memory transaction immediately.
+    private var isDirty: Bool {
+        MainContentCoordinator.normalizedNote(commentText) != lastExplicitlySavedNote
+    }
+
+    /// Commits the current draft immediately, cancelling the debounced write so the note is
+    /// persisted right away instead of waiting on the autosave timer.
+    private func saveNote() {
+        coordinator.setNote(commentText, for: transaction)
+        lastExplicitlySavedNote = MainContentCoordinator.normalizedNote(commentText)
+    }
 }

--- a/Rockxy/Views/Inspector/ContextDetailsView.swift
+++ b/Rockxy/Views/Inspector/ContextDetailsView.swift
@@ -73,6 +73,16 @@ struct ContextDetailsView: View {
         ]
     }
 
+    private var emptyStateCopy: ContextDockEmptyStateCopy {
+        ContextDockEmptyStateCopy(
+            ContextDockEmptyState.resolve(
+                hasCapturedTraffic: !coordinator.transactions.isEmpty,
+                hasVisibleResults: !coordinator.filteredTransactions.isEmpty,
+                isCapturing: coordinator.isProxyRunning
+            )
+        )
+    }
+
     @ViewBuilder private var contextContent: some View {
         if selectedTransactions.count > 1 {
             multiSelectionContent
@@ -85,11 +95,12 @@ struct ContextDetailsView: View {
     }
 
     private var noSelectionContent: some View {
-        VStack(spacing: 0) {
+        let copy = emptyStateCopy
+        return VStack(spacing: 0) {
             InspectorEmptyStateView(
-                requestSelectionDescription: coordinator.isProxyRunning
-                    ? String(localized: "Select a request to see diagnostics and related traffic.")
-                    : String(localized: "Start capture, then select a request to inspect its context.")
+                copy.title,
+                systemImage: copy.systemImage,
+                description: copy.description
             )
 
             WorkspaceFooterBar(horizontalPadding: 12) {

--- a/Rockxy/Views/Inspector/ContextDetailsView.swift
+++ b/Rockxy/Views/Inspector/ContextDetailsView.swift
@@ -1,8 +1,12 @@
 import SwiftUI
 
+// MARK: - ContextDetailsView
+
 /// Selection-aware request diagnostics shown in the Details tab of the Context Dock.
 /// Raw request and response payloads remain in the horizontal inspector below the traffic table.
 struct ContextDetailsView: View {
+    // MARK: Internal
+
     let coordinator: MainContentCoordinator
 
     var body: some View {
@@ -11,6 +15,8 @@ struct ContextDetailsView: View {
             .accessibilityElement(children: .contain)
             .accessibilityLabel(String(localized: "Inspector Details"))
     }
+
+    // MARK: Private
 
     private struct ContextInsight: Identifiable {
         let id: String
@@ -26,8 +32,48 @@ struct ContextDetailsView: View {
         let duration: TimeInterval
     }
 
-    @ViewBuilder
-    private var contextContent: some View {
+    @Environment(\.openWindow) private var openWindow
+    @Environment(\.appUIDisplayMetrics) private var metrics
+    @State private var isTimingExpanded = false
+    @State private var isRelatedExpanded = false
+
+    private var selectedTransactions: [HTTPTransaction] {
+        coordinator.resolveSelectedTransactions()
+    }
+
+    private var selectedErrorCount: Int {
+        selectedTransactions.count { ($0.response?.statusCode ?? 0) >= 400 || $0.state == .failed }
+    }
+
+    private var selectedTransferredText: String {
+        let bytes = selectedTransactions.reduce(Int64(0)) { partial, transaction in
+            partial + Int64(transaction.request.body?.count ?? 0)
+                + Int64(transaction.response?.body?.count ?? 0)
+        }
+        return ByteCountFormatter.string(fromByteCount: bytes, countStyle: .file)
+    }
+
+    private var multiSelectionFields: [ContextTableField] {
+        [
+            ContextTableField(label: String(localized: "Requests"), value: "\(selectedTransactions.count)"),
+            ContextTableField(
+                label: String(localized: "Hosts"),
+                value: "\(Set(selectedTransactions.map(\.request.host)).count)"
+            ),
+            ContextTableField(
+                label: String(localized: "Errors"),
+                value: "\(selectedErrorCount)",
+                color: selectedErrorCount > 0 ? .red : .primary
+            ),
+            ContextTableField(
+                label: String(localized: "Rules Hit"),
+                value: "\(selectedTransactions.count { $0.matchedRuleID != nil })"
+            ),
+            ContextTableField(label: String(localized: "Transferred"), value: selectedTransferredText),
+        ]
+    }
+
+    @ViewBuilder private var contextContent: some View {
         if selectedTransactions.count > 1 {
             multiSelectionContent
         } else if let transaction = coordinator.selectedTransaction {
@@ -56,8 +102,51 @@ struct ContextDetailsView: View {
                     )
                     Spacer()
                 }
-                .font(.caption)
+                .font(.system(size: metrics.secondaryFontSize))
                 .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    private var multiSelectionContent: some View {
+        VStack(spacing: 0) {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 10) {
+                    ContextInspectorFieldTable(
+                        title: String(localized: "Selection"),
+                        fields: multiSelectionFields
+                    )
+
+                    Text(String(localized: "Select one request to inspect payload and timing details."))
+                        .font(.system(size: metrics.secondaryFontSize))
+                        .foregroundStyle(.secondary)
+                }
+                .padding(.horizontal, 12)
+                .padding(.vertical, 12)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+
+            WorkspaceFooterBar(horizontalPadding: 10) {
+                HStack(spacing: 8) {
+                    Button {
+                        let transactions = selectedTransactions
+                        guard transactions.count == 2 else {
+                            return
+                        }
+                        coordinator.compareTransactions(transactions[0], transactions[1])
+                    } label: {
+                        Label(String(localized: "Compare"), systemImage: "arrow.left.arrow.right")
+                    }
+                    .disabled(selectedTransactions.count != 2)
+                    Spacer()
+                    Button {
+                        coordinator.presentSelectedExport(format: .har)
+                    } label: {
+                        Label(String(localized: "Export Selection"), systemImage: "square.and.arrow.up")
+                    }
+                    .disabled(selectedTransactions.isEmpty)
+                }
+                .controlSize(.small)
             }
         }
     }
@@ -67,16 +156,20 @@ struct ContextDetailsView: View {
             selectionHeader(transaction)
             Divider()
 
-            List {
-                overviewSection(transaction)
-                insightSection(transaction)
-                timingSection(transaction)
-                payloadSection(transaction)
-                relatedSection(transaction)
-                toolsSection(transaction)
+            ScrollView {
+                VStack(alignment: .leading, spacing: 10) {
+                    ruleImpactSection(transaction)
+                    overviewSection(transaction)
+                    payloadSection(transaction)
+                    insightSection(transaction)
+                    timingSection(transaction)
+                    relatedSection(transaction)
+                    notesSection(transaction)
+                }
+                .padding(.horizontal, 12)
+                .padding(.vertical, 12)
+                .frame(maxWidth: .infinity, alignment: .leading)
             }
-            .listStyle(.inset)
-            .scrollContentBackground(.hidden)
 
             singleSelectionActionBar(transaction)
         }
@@ -86,65 +179,55 @@ struct ContextDetailsView: View {
         HStack(alignment: .top, spacing: 9) {
             Circle()
                 .fill(statusColor(for: transaction))
-                .frame(width: 9, height: 9)
+                .frame(width: 8, height: 8)
                 .padding(.top, 5)
 
             VStack(alignment: .leading, spacing: 3) {
                 HStack(spacing: 6) {
                     Text(transaction.request.method)
-                        .font(.caption.weight(.semibold).monospaced())
+                        .font(.system(size: metrics.secondaryFontSize, weight: .semibold, design: .monospaced))
                     Text(transaction.response.map { String($0.statusCode) } ?? String(localized: "Pending"))
-                        .font(.caption.weight(.semibold).monospacedDigit())
+                        .font(.system(size: metrics.secondaryFontSize, weight: .semibold, design: .monospaced))
                         .foregroundStyle(statusColor(for: transaction))
                 }
                 Text(transaction.request.host)
-                    .font(.headline)
+                    .font(.system(size: metrics.primaryFontSize, weight: .semibold, design: .monospaced))
                     .lineLimit(1)
                     .truncationMode(.middle)
+                    .textSelection(.enabled)
                 Text(transaction.request.path)
-                    .font(.caption.monospaced())
+                    .font(.system(size: metrics.secondaryFontSize, design: .monospaced))
                     .foregroundStyle(.secondary)
                     .lineLimit(2)
                     .truncationMode(.middle)
+                    .textSelection(.enabled)
             }
             Spacer(minLength: 0)
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 10)
-        .background(Color.clear)
     }
 
     private func overviewSection(_ transaction: HTTPTransaction) -> some View {
-        Section(String(localized: "Overview")) {
-            nativeValueRow(String(localized: "Outcome"), outcomeText(for: transaction), color: statusColor(for: transaction))
-            nativeValueRow(String(localized: "Application"), transaction.clientApp ?? String(localized: "Unknown"))
-            nativeValueRow(String(localized: "Protocol"), transaction.request.httpVersion)
-            nativeValueRow(String(localized: "Transport"), transportText(for: transaction))
-            nativeValueRow(String(localized: "Duration"), durationText(for: transaction))
-            nativeValueRow(String(localized: "Transferred"), transferredText(for: transaction))
-            if let sourcePort = transaction.sourcePort {
-                nativeValueRow(String(localized: "Source Port"), String(sourcePort))
-            }
-        }
+        ContextInspectorFieldTable(
+            title: String(localized: "Details"),
+            fields: overviewFields(transaction)
+        )
     }
 
     private func insightSection(_ transaction: HTTPTransaction) -> some View {
-        Section(String(localized: "Insights")) {
-            ForEach(insights(for: transaction)) { insight in
-                HStack(alignment: .top, spacing: 8) {
-                    Image(systemName: insight.systemImage)
-                        .foregroundStyle(insight.color)
-                        .frame(width: 16)
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text(insight.title)
-                            .font(.subheadline.weight(.medium))
-                        Text(insight.detail)
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                            .fixedSize(horizontal: false, vertical: true)
-                    }
+        let values = insights(for: transaction)
+        return ContextInspectorTable(title: String(localized: "Insights")) {
+            ForEach(Array(values.enumerated()), id: \.element.id) { index, insight in
+                if index > 0 {
+                    Divider()
                 }
-                .listRowBackground(insight.color.opacity(0.08))
+                ContextInspectorInsightRow(
+                    systemImage: insight.systemImage,
+                    title: insight.title,
+                    detail: insight.detail,
+                    color: insight.color
+                )
             }
         }
     }
@@ -154,101 +237,187 @@ struct ContextDetailsView: View {
         if let timing = transaction.timingInfo {
             let phases = timingPhases(timing)
             let slowest = phases.max { $0.duration < $1.duration }
-            Section(String(localized: "Timing")) {
+            ContextInspectorDisclosureTable(
+                title: String(localized: "Timing"),
+                isExpanded: $isTimingExpanded,
+                summary: formatDuration(timing.totalDuration)
+            ) {
                 if let slowest {
-                    nativeValueRow(String(localized: "Slowest Phase"), slowest.title)
+                    ContextInspectorFieldRow(field: ContextTableField(
+                        label: String(localized: "Slowest Phase"),
+                        value: slowest.title,
+                        monospaced: false
+                    ))
+                    Divider()
                 }
-                ForEach(phases) { phase in
-                    LabeledContent(phase.title) {
-                        Text(phaseDurationText(phase.duration, total: timing.totalDuration))
-                            .monospacedDigit()
-                            .foregroundStyle(.secondary)
+                ForEach(Array(phases.enumerated()), id: \.element.id) { index, phase in
+                    if index > 0 {
+                        Divider()
                     }
-                    .font(.caption)
+                    ContextInspectorFieldRow(field: ContextTableField(
+                        label: phase.title,
+                        value: phaseDurationText(phase.duration, total: timing.totalDuration)
+                    ))
                 }
             }
         }
     }
 
     private func payloadSection(_ transaction: HTTPTransaction) -> some View {
-        Section(String(localized: "Payload")) {
-            nativeValueRow(
-                String(localized: "Request"),
-                payloadSummary(body: transaction.request.body, contentType: transaction.request.contentType)
-            )
-            nativeValueRow(
-                String(localized: "Response"),
-                payloadSummary(body: transaction.response?.body, contentType: transaction.response?.contentType)
-            )
-            nativeValueRow(String(localized: "Request Headers"), "\(transaction.request.headers.count)")
-            nativeValueRow(String(localized: "Response Headers"), "\(transaction.response?.headers.count ?? 0)")
+        ContextInspectorTable(title: String(localized: "Payload")) {
+            ContextInspectorFieldRow(field: ContextTableField(
+                label: String(localized: "Request"),
+                value: payloadSummary(body: transaction.request.body, contentType: transaction.request.contentType)
+            ))
+            Divider()
+            ContextInspectorFieldRow(field: ContextTableField(
+                label: String(localized: "Response"),
+                value: payloadSummary(
+                    body: transaction.response?.body,
+                    contentType: transaction.response?.contentType
+                )
+            ))
+            Divider()
+            ContextInspectorFieldRow(field: ContextTableField(
+                label: String(localized: "Request Headers"),
+                value: "\(transaction.request.headers.count)"
+            ))
+            Divider()
+            ContextInspectorFieldRow(field: ContextTableField(
+                label: String(localized: "Response Headers"),
+                value: "\(transaction.response?.headers.count ?? 0)"
+            ))
             if transaction.response?.bodyTruncated == true {
-                Label(String(localized: "Response body was truncated during capture"), systemImage: "scissors")
-                    .font(.caption)
+                Divider()
+                ContextInspectorFullRow {
+                    Label(
+                        String(localized: "Response body was truncated during capture"),
+                        systemImage: "scissors"
+                    )
+                    .font(.system(size: metrics.metadataFontSize))
                     .foregroundStyle(.orange)
+                }
             }
         }
     }
 
     private func relatedSection(_ transaction: HTTPTransaction) -> some View {
-        let related = relatedTransactions(to: transaction)
-        return Section(String(localized: "Related Requests")) {
+        let related = Array(relatedTransactions(to: transaction).prefix(6))
+        return ContextInspectorDisclosureTable(
+            title: String(localized: "Related Requests"),
+            isExpanded: $isRelatedExpanded,
+            summary: related.isEmpty ? nil : "\(related.count)"
+        ) {
             if related.isEmpty {
-                Text(String(localized: "No other requests to this host in the current session."))
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+                ContextInspectorFullRow {
+                    Text(String(localized: "No other requests to this host in the current session."))
+                        .font(.system(size: metrics.metadataFontSize))
+                        .foregroundStyle(.secondary)
+                }
             } else {
-                ForEach(related.prefix(6)) { item in
-                    Button {
-                        coordinator.selectedTransactionIDs = [item.id]
-                        coordinator.selectTransaction(item)
-                    } label: {
-                        HStack(spacing: 7) {
-                            Circle()
-                                .fill(statusColor(for: item))
-                                .frame(width: 6, height: 6)
-                            VStack(alignment: .leading, spacing: 1) {
-                                Text(item.request.path)
-                                    .lineLimit(1)
-                                    .truncationMode(.middle)
-                                Text(relativeTimeText(item.timestamp, from: transaction.timestamp))
-                                    .font(.caption2)
-                                    .foregroundStyle(.secondary)
-                            }
-                            Spacer(minLength: 6)
-                            Text(item.response.map { String($0.statusCode) } ?? "—")
-                                .monospacedDigit()
-                                .foregroundStyle(statusColor(for: item))
-                        }
-                        .font(.caption)
-                        .contentShape(Rectangle())
+                ForEach(Array(related.enumerated()), id: \.element.id) { index, item in
+                    if index > 0 {
+                        Divider()
                     }
-                    .buttonStyle(.plain)
+                    relatedRequestRow(item, reference: transaction)
                 }
             }
         }
     }
 
-    private func toolsSection(_ transaction: HTTPTransaction) -> some View {
-        Section(String(localized: "Rules & Tools")) {
-            if transaction.matchedRuleID != nil {
-                Label {
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text(transaction.matchedRuleName ?? String(localized: "Rule matched"))
-                        if let summary = transaction.matchedRuleActionSummary {
-                            Text(summary).font(.caption).foregroundStyle(.secondary)
-                        }
-                        if let pattern = transaction.matchedRulePattern {
-                            Text(pattern).font(.caption2.monospaced()).foregroundStyle(.tertiary)
-                        }
+    private func relatedRequestRow(_ item: HTTPTransaction, reference: HTTPTransaction) -> some View {
+        Button {
+            coordinator.selectedTransactionIDs = [item.id]
+            coordinator.selectTransaction(item)
+        } label: {
+            ContextInspectorFullRow {
+                HStack(spacing: 7) {
+                    Circle()
+                        .fill(statusColor(for: item))
+                        .frame(width: 6, height: 6)
+                    VStack(alignment: .leading, spacing: 1) {
+                        Text(item.request.path)
+                            .font(.system(size: metrics.metadataFontSize, design: .monospaced))
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                        Text(relativeTimeText(item.timestamp, from: reference.timestamp))
+                            .font(.system(size: metrics.metadataFontSize))
+                            .foregroundStyle(.secondary)
                     }
-                } icon: {
-                    Image(systemName: "checkmark.circle.fill").foregroundStyle(.green)
+                    Spacer(minLength: 6)
+                    Text(item.response.map { String($0.statusCode) } ?? "—")
+                        .font(.system(size: metrics.metadataFontSize, design: .monospaced))
+                        .foregroundStyle(statusColor(for: item))
+                }
+                .contentShape(Rectangle())
+            }
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func ruleImpactSection(_ transaction: HTTPTransaction) -> some View {
+        ContextInspectorTable(title: String(localized: "Rule Impact")) {
+            if transaction.matchedRuleID != nil {
+                ContextInspectorFieldRow(field: ContextTableField(
+                    label: String(localized: "Rule"),
+                    value: transaction.matchedRuleName ?? String(localized: "Rule matched"),
+                    monospaced: false,
+                    color: .green
+                ))
+                if let summary = transaction.matchedRuleActionSummary {
+                    Divider()
+                    ContextInspectorFieldRow(field: ContextTableField(
+                        label: String(localized: "Action"),
+                        value: summary,
+                        monospaced: false
+                    ))
+                }
+                if let pattern = transaction.matchedRulePattern {
+                    Divider()
+                    ContextInspectorFieldRow(field: ContextTableField(
+                        label: String(localized: "Pattern"),
+                        value: pattern
+                    ))
+                }
+                if let target = matchedRuleNavigationTarget(transaction), let windowID = target.windowID {
+                    Divider()
+                    openRuleActionRow(windowID: windowID, help: target.openHelp)
                 }
             } else {
-                Label(String(localized: "No rule modified this request"), systemImage: "minus.circle")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+                ContextInspectorFullRow {
+                    Label(String(localized: "No rule modified this request"), systemImage: "minus.circle")
+                        .font(.system(size: metrics.secondaryFontSize))
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+    }
+
+    private func openRuleActionRow(windowID: String, help: String?) -> some View {
+        Button {
+            openWindow(id: windowID)
+        } label: {
+            ContextInspectorFullRow {
+                HStack(spacing: 6) {
+                    Label(String(localized: "Open Rule"), systemImage: "arrow.up.forward.app")
+                        .font(.system(size: metrics.secondaryFontSize, weight: .medium))
+                        .foregroundStyle(Color.accentColor)
+                    Spacer(minLength: 6)
+                    Image(systemName: "chevron.right")
+                        .font(.system(size: metrics.metadataFontSize, weight: .semibold))
+                        .foregroundStyle(.secondary)
+                }
+                .contentShape(Rectangle())
+            }
+        }
+        .buttonStyle(.plain)
+        .help(help ?? String(localized: "Open the rule's editor window"))
+    }
+
+    private func notesSection(_ transaction: HTTPTransaction) -> some View {
+        ContextInspectorTable(title: String(localized: "Notes")) {
+            ContextInspectorFullRow {
+                ContextNotesEditor(coordinator: coordinator, transaction: transaction)
             }
         }
     }
@@ -285,74 +454,39 @@ struct ContextDetailsView: View {
         }
     }
 
-    private var multiSelectionContent: some View {
-        VStack(spacing: 0) {
-            List {
-                Section(String(localized: "Selection")) {
-                    nativeValueRow(String(localized: "Requests"), "\(selectedTransactions.count)")
-                    nativeValueRow(
-                        String(localized: "Hosts"),
-                        "\(Set(selectedTransactions.map { $0.request.host }).count)"
-                    )
-                    nativeValueRow(
-                        String(localized: "Errors"),
-                        "\(selectedErrorCount)",
-                        color: selectedErrorCount > 0 ? .red : .secondary
-                    )
-                    nativeValueRow(
-                        String(localized: "Rules Hit"),
-                        "\(selectedTransactions.count { $0.matchedRuleID != nil })"
-                    )
-                    nativeValueRow(String(localized: "Transferred"), selectedTransferredText)
-                }
-
-                Section(String(localized: "Inspector")) {
-                    Text(String(localized: "Select one request to inspect payload and timing details."))
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
-            }
-            .listStyle(.inset)
-
-            WorkspaceFooterBar(horizontalPadding: 10) {
-                HStack(spacing: 8) {
-                    Button {
-                        let transactions = selectedTransactions
-                        guard transactions.count == 2 else {
-                            return
-                        }
-                        coordinator.compareTransactions(transactions[0], transactions[1])
-                    } label: {
-                        Label(String(localized: "Compare"), systemImage: "arrow.left.arrow.right")
-                    }
-                    .disabled(selectedTransactions.count != 2)
-                    Spacer()
-                    Button {
-                        coordinator.presentSelectedExport(format: .har)
-                    } label: {
-                        Label(String(localized: "Export Selection"), systemImage: "square.and.arrow.up")
-                    }
-                    .disabled(selectedTransactions.isEmpty)
-                }
-                .controlSize(.small)
-            }
+    private func overviewFields(_ transaction: HTTPTransaction) -> [ContextTableField] {
+        var fields: [ContextTableField] = [
+            ContextTableField(
+                label: String(localized: "Outcome"),
+                value: outcomeText(for: transaction),
+                color: statusColor(for: transaction)
+            ),
+            ContextTableField(
+                label: String(localized: "Application"),
+                value: transaction.clientApp ?? String(localized: "Unknown"),
+                monospaced: false
+            ),
+            ContextTableField(label: String(localized: "Protocol"), value: transaction.request.httpVersion),
+            ContextTableField(label: String(localized: "Transport"), value: transportText(for: transaction)),
+            ContextTableField(label: String(localized: "Duration"), value: durationText(for: transaction)),
+            ContextTableField(label: String(localized: "Transferred"), value: transferredText(for: transaction)),
+        ]
+        if let sourcePort = transaction.sourcePort {
+            fields.append(ContextTableField(label: String(localized: "Source Port"), value: String(sourcePort)))
         }
+        return fields
     }
 
-    private var selectedTransactions: [HTTPTransaction] {
-        coordinator.resolveSelectedTransactions()
-    }
-
-    private var selectedErrorCount: Int {
-        selectedTransactions.count { ($0.response?.statusCode ?? 0) >= 400 || $0.state == .failed }
-    }
-
-    private var selectedTransferredText: String {
-        let bytes = selectedTransactions.reduce(Int64(0)) { partial, transaction in
-            partial + Int64(transaction.request.body?.count ?? 0)
-                + Int64(transaction.response?.body?.count ?? 0)
+    /// Resolves the live matched rule so "Open Rule" routes to the correct existing tool window.
+    /// Returns `nil` when the rule was deleted or has no dedicated window, so the button hides
+    /// instead of routing to a wrong surface.
+    private func matchedRuleNavigationTarget(_ transaction: HTTPTransaction) -> MatchedRuleNavigationTarget? {
+        guard let id = transaction.matchedRuleID,
+              let rule = coordinator.rules.first(where: { $0.id == id }) else
+        {
+            return nil
         }
-        return ByteCountFormatter.string(fromByteCount: bytes, countStyle: .file)
+        return MatchedRuleNavigationTarget(action: rule.action)
     }
 
     private func insights(for transaction: HTTPTransaction) -> [ContextInsight] {
@@ -403,7 +537,9 @@ struct ContextDetailsView: View {
             values.append(ContextInsight(
                 id: "host-baseline",
                 title: String(localized: "Slower than this host's recent requests"),
-                detail: String(localized: "About \(percent)% slower than the session median of \(formatDuration(baseline))."),
+                detail: String(
+                    localized: "About \(percent)% slower than the session median of \(formatDuration(baseline))."
+                ),
                 systemImage: "chart.line.uptrend.xyaxis",
                 color: .orange
             ))
@@ -463,7 +599,7 @@ struct ContextDetailsView: View {
             values.append(ContextInsight(
                 id: "rule",
                 title: String(localized: "A rule affected this request"),
-                detail: transaction.matchedRuleActionSummary ?? String(localized: "Review Rules & Tools below."),
+                detail: transaction.matchedRuleActionSummary ?? String(localized: "Review Rule Impact above."),
                 systemImage: "wand.and.stars",
                 color: .green
             ))
@@ -528,16 +664,6 @@ struct ContextDetailsView: View {
         ]
     }
 
-    private func nativeValueRow(_ label: String, _ value: String, color: Color = .secondary) -> some View {
-        LabeledContent(label) {
-            Text(value)
-                .foregroundStyle(color)
-                .multilineTextAlignment(.trailing)
-                .lineLimit(2)
-        }
-        .font(.caption)
-    }
-
     private func outcomeText(for transaction: HTTPTransaction) -> String {
         if let response = transaction.response {
             return "\(response.statusCode) \(response.statusMessage)"
@@ -599,5 +725,90 @@ struct ContextDetailsView: View {
         case 500...: return .red
         default: return .secondary
         }
+    }
+}
+
+// MARK: - ContextNotesEditor
+
+/// Compact Notes editor for the Context Dock. Routes every edit through the coordinator's note seam
+/// (`updateNoteDraft`) so whitespace is normalized, the Library's Notes collection stays in sync, and
+/// persistence is debounced instead of rewriting the transaction row on every keystroke. Its own
+/// `@State` seeds from the selection because the enclosing single-selection content carries
+/// `.id(transaction.id)`; `onDisappear` flushes any pending write when the selection changes.
+private struct ContextNotesEditor: View {
+    // MARK: Internal
+
+    let coordinator: MainContentCoordinator
+    let transaction: HTTPTransaction
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            ZStack(alignment: .topLeading) {
+                if noteText.isEmpty {
+                    Text(String(localized: "Add a note about this request…"))
+                        .font(.system(size: metrics.primaryFontSize))
+                        .foregroundStyle(.tertiary)
+                        .padding(.horizontal, 5)
+                        .padding(.vertical, 4)
+                        .allowsHitTesting(false)
+                }
+                TextEditor(text: $noteText)
+                    .font(.system(size: metrics.primaryFontSize))
+                    .scrollContentBackground(.hidden)
+                    .frame(minHeight: 52, maxHeight: 108)
+                    .padding(.horizontal, 1)
+                    .accessibilityLabel(String(localized: "Request note"))
+            }
+            .background(
+                RoundedRectangle(cornerRadius: 5)
+                    .fill(Color(nsColor: .textBackgroundColor))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 5)
+                            .strokeBorder(Color(nsColor: .separatorColor), lineWidth: 0.5)
+                    )
+            )
+
+            HStack(spacing: 0) {
+                Spacer(minLength: 0)
+                Button(action: saveNote) {
+                    Image(systemName: "square.and.arrow.down")
+                }
+                .buttonStyle(.borderless)
+                .controlSize(.small)
+                .disabled(!isDirty)
+                .help(String(localized: "Save Note"))
+                .accessibilityLabel(String(localized: "Save Note"))
+            }
+        }
+        .onAppear {
+            noteText = transaction.comment ?? ""
+            lastExplicitlySavedNote = MainContentCoordinator.normalizedNote(noteText)
+        }
+        .onChange(of: noteText) { _, newValue in
+            coordinator.updateNoteDraft(newValue, for: transaction)
+        }
+        .onDisappear {
+            coordinator.flushNotePersistence(for: transaction)
+        }
+    }
+
+    // MARK: Private
+
+    @State private var noteText = ""
+    @State private var lastExplicitlySavedNote: String?
+    @Environment(\.appUIDisplayMetrics) private var metrics
+
+    /// Tracks changes since the user's last explicit save. Inline editing still keeps the existing
+    /// debounce and selection-change safety, while this state gives the Save action a stable lifecycle
+    /// even though the coordinator updates the in-memory transaction immediately.
+    private var isDirty: Bool {
+        MainContentCoordinator.normalizedNote(noteText) != lastExplicitlySavedNote
+    }
+
+    /// Commits the current draft immediately, cancelling the debounced write so the note is
+    /// persisted right away instead of waiting on the autosave timer.
+    private func saveNote() {
+        coordinator.setNote(noteText, for: transaction)
+        lastExplicitlySavedNote = MainContentCoordinator.normalizedNote(noteText)
     }
 }

--- a/Rockxy/Views/Inspector/ContextDockView.swift
+++ b/Rockxy/Views/Inspector/ContextDockView.swift
@@ -81,7 +81,7 @@ private struct AIAssistantDockView: View {
         }
         .background(Color.clear)
         .accessibilityElement(children: .contain)
-        .accessibilityLabel(String(localized: "Rockxy AI Assistant"))
+        .accessibilityLabel(String(localized: "AI Assistant"))
         .sheet(item: reviewPackBinding) { _ in
             DebugAssistantReviewDataSheet(
                 coordinator: coordinator,
@@ -514,12 +514,12 @@ private struct AIAssistantDockView: View {
                 .foregroundStyle(.secondary)
 
             Text(primaryTransaction == nil
-                ? String(localized: "Ask about captured traffic")
-                : String(localized: "What should I check?"))
+                ? String(localized: "Investigate captured traffic")
+                : String(localized: "Start an investigation"))
                 .font(assistantFont(appMetrics.primaryFontSize, weight: .semibold))
 
             if primaryTransaction == nil {
-                Text(String(localized: "Select a request or start typing below."))
+                Text(String(localized: "Select a request to investigate, or type a question below."))
                     .font(assistantFont(appMetrics.secondaryFontSize))
                     .foregroundStyle(.secondary)
             } else {
@@ -531,9 +531,15 @@ private struct AIAssistantDockView: View {
         .frame(maxWidth: .infinity)
     }
 
+    /// Compact horizontal suggestion cards in a two-column grid — the original GPT-style recipe
+    /// launcher. Each card shows an icon + title only; the full `recipe.detail` stays in the tooltip
+    /// rather than crowding the card.
     private var suggestionGrid: some View {
         LazyVGrid(
-            columns: [GridItem(.flexible(), spacing: 6), GridItem(.flexible(), spacing: 6)],
+            columns: [
+                GridItem(.flexible(), spacing: 6),
+                GridItem(.flexible(), spacing: 6),
+            ],
             spacing: 6
         ) {
             ForEach(DebugAssistantRecipe.allCases) { recipe in
@@ -542,16 +548,14 @@ private struct AIAssistantDockView: View {
                 } label: {
                     HStack(spacing: 6) {
                         Image(systemName: recipe.systemImage)
-                            .frame(width: 14)
+                            .foregroundStyle(.secondary)
                         Text(recipe.title)
-                            .font(assistantFont(appMetrics.metadataFontSize, weight: .medium))
+                            .font(assistantFont(appMetrics.secondaryFontSize, weight: .medium))
                             .lineLimit(2)
+                            .multilineTextAlignment(.leading)
                         Spacer(minLength: 0)
                     }
-                    .padding(.horizontal, 8)
-                    .padding(.vertical, 7)
-                    .frame(maxWidth: .infinity, minHeight: 34, alignment: .leading)
-                    .contentShape(Rectangle())
+                    .frame(maxWidth: .infinity, alignment: .leading)
                 }
                 .buttonStyle(.bordered)
                 .controlSize(.small)
@@ -559,7 +563,7 @@ private struct AIAssistantDockView: View {
                 .help(recipe.detail)
             }
         }
-        .frame(maxWidth: 360)
+        .frame(maxWidth: 420)
     }
 
     @ViewBuilder private var activeAssistantTurn: some View {
@@ -890,13 +894,11 @@ private struct AIAssistantDockView: View {
     private func conversationMessage(_ message: DebugAssistantMessage) -> some View {
         switch message.role {
         case .user:
-            AssistantUserMessageBubble(text: message.text)
+            AssistantQueryRow(text: message.text)
         case .assistant:
-            VStack(alignment: .leading, spacing: 8) {
-                if let investigation = message.investigation {
-                    completedWorkEvent(investigation)
-                }
-
+            if message.investigation != nil {
+                investigationReport(message)
+            } else {
                 assistantBubble {
                     AssistantMarkdownText(
                         source: message.text.isEmpty
@@ -904,17 +906,13 @@ private struct AIAssistantDockView: View {
                             : message.text
                     )
 
-                    if let investigation = message.investigation {
-                        investigationDetails(investigation)
-                    }
-
                     if let modelResult = message.modelResult {
                         modelAttribution(modelResult)
                     }
 
                     assistantResponseActions(
                         text: message.text,
-                        investigation: message.investigation,
+                        investigation: nil,
                         canRetryModel: message.modelResult != nil
                     )
                 }
@@ -962,91 +960,31 @@ private struct AIAssistantDockView: View {
         )
     }
 
-    private func investigationDetails(_ result: InvestigationResult) -> some View {
-        VStack(alignment: .leading, spacing: 7) {
-            if !result.evidence.isEmpty {
-                DisclosureGroup {
-                    VStack(alignment: .leading, spacing: 4) {
-                        ForEach(result.evidence.prefix(3)) { evidence in
-                            Button {
-                                coordinator.revealDebugAssistantEvidence(evidence)
-                            } label: {
-                                HStack(spacing: 6) {
-                                    Circle()
-                                        .fill(evidenceColor(evidence.kind))
-                                        .frame(width: 6, height: 6)
-                                    Text(evidence.title)
-                                        .font(assistantFont(appMetrics.metadataFontSize, weight: .medium))
-                                        .foregroundStyle(.primary)
-                                        .lineLimit(1)
-                                    Spacer(minLength: 0)
-                                }
-                                .contentShape(Rectangle())
-                            }
-                            .buttonStyle(.plain)
-                            .disabled(evidence.sourceTransactionID == nil)
-                            .help(evidence.detail)
-                        }
-                    }
-                    .padding(.top, 4)
-                } label: {
-                    Label(
-                        String(localized: "\(result.evidence.count) Findings"),
-                        systemImage: "list.bullet"
-                    )
-                    .font(assistantFont(appMetrics.metadataFontSize, weight: .medium))
-                    .foregroundStyle(.secondary)
+    @ViewBuilder
+    private func investigationReport(_ message: DebugAssistantMessage) -> some View {
+        if let result = message.investigation {
+            InvestigationReportView(
+                message: message,
+                isCurrentResult: isCurrentResult(result),
+                showsContinueWithModel: isCurrentResult(result)
+                    && coordinator.activeWorkspace.debugAssistantUsesConfiguredModel
+                    && configuredModelIsAvailable,
+                isPreparingReview: coordinator.activeWorkspace.isPreparingDebugAssistantReview,
+                onReveal: coordinator.revealDebugAssistantEvidence,
+                onContinueWithModel: { coordinator.prepareDebugAssistantReview() },
+                onHandoff: { handoff, target in
+                    coordinator.performUserInitiatedDebugAssistantHandoff(handoff, result: target)
+                },
+                onPrepareReplay: { resultPendingReplay = $0 }
+            ) {
+                if let modelResult = message.modelResult {
+                    modelAttribution(modelResult)
                 }
-            }
-
-            Label(result.nextStep, systemImage: "arrow.turn.down.right")
-                .font(assistantFont(appMetrics.secondaryFontSize, weight: .medium))
-                .foregroundStyle(.primary)
-                .fixedSize(horizontal: false, vertical: true)
-
-            if isCurrentResult(result),
-               coordinator.activeWorkspace.debugAssistantUsesConfiguredModel,
-               configuredModelIsAvailable
-            {
-                HStack(spacing: 8) {
-                    if coordinator.activeWorkspace.isPreparingDebugAssistantReview {
-                        ProgressView()
-                            .controlSize(.small)
-                        Text(String(localized: "Preparing redacted preview…"))
-                            .font(assistantFont(appMetrics.secondaryFontSize))
-                            .foregroundStyle(.secondary)
-                    } else {
-                        Button {
-                            coordinator.prepareDebugAssistantReview()
-                        } label: {
-                            Label(String(localized: "Continue With Model"), systemImage: "lock.shield")
-                        }
-                        .buttonStyle(.borderless)
-                        .controlSize(.small)
-                    }
-                }
-            }
-
-            if isCurrentResult(result) {
-                assistantHandoffButtons(for: result)
-            }
-        }
-    }
-
-    private func assistantHandoffButtons(for result: InvestigationResult) -> some View {
-        HStack(spacing: 6) {
-            ForEach(AssistantTrustPolicy.recommendedHandoffs(for: result.recipe)) { handoff in
-                Button {
-                    if handoff == .prepareReplay {
-                        resultPendingReplay = result
-                    } else {
-                        coordinator.performUserInitiatedDebugAssistantHandoff(handoff, result: result)
-                    }
-                } label: {
-                    Label(handoff.title, systemImage: handoff.systemImage)
-                }
-                .buttonStyle(.bordered)
-                .controlSize(.small)
+                assistantResponseActions(
+                    text: message.text,
+                    investigation: result,
+                    canRetryModel: message.modelResult != nil
+                )
             }
         }
     }
@@ -1144,20 +1082,6 @@ private struct AIAssistantDockView: View {
         }
     }
 
-    private func completedWorkEvent(_ result: InvestigationResult) -> some View {
-        HStack(spacing: 7) {
-            Image(systemName: "checkmark.circle.fill")
-                .foregroundStyle(.green)
-            Text(String(localized: "Local analysis · \(result.scopeTransactionIDs.count) requests"))
-                .font(assistantFont(appMetrics.metadataFontSize, weight: .medium))
-                .foregroundStyle(.secondary)
-                .lineLimit(1)
-        }
-        .padding(.horizontal, 2)
-        .padding(.vertical, 2)
-        .frame(maxWidth: .infinity, alignment: .leading)
-    }
-
     private func failureTurn(_ message: String) -> some View {
         assistantBubble {
             Label(
@@ -1198,6 +1122,10 @@ private struct AIAssistantDockView: View {
         }
     }
 
+    /// Explicit `.system(size:)` roles that mirror the horizontal request/response inspector:
+    /// UI labels and prose stay proportional; callers opt into monospaced only for technical data
+    /// (request summaries, model IDs, endpoints). Deliberately does not honor the global
+    /// `useMonospacedFont` preference, so prose never renders monospaced.
     private func assistantFont(
         _ size: CGFloat,
         weight: Font.Weight = .regular,
@@ -1205,7 +1133,9 @@ private struct AIAssistantDockView: View {
     )
         -> Font
     {
-        appMetrics.swiftUIFont(size: size, weight: weight, monospaced: monospaced)
+        monospaced
+            ? .system(size: size, weight: weight, design: .monospaced)
+            : .system(size: size, weight: weight)
     }
 }
 
@@ -1239,15 +1169,6 @@ private extension AIAssistantDockView {
     func requestSummary(for transaction: HTTPTransaction) -> String {
         let status = transaction.response.map { String($0.statusCode) } ?? "—"
         return "\(transaction.request.method) \(status)  \(transaction.request.host)\(transaction.request.path)"
-    }
-
-    func evidenceColor(_ kind: InvestigationEvidenceKind) -> Color {
-        switch kind {
-        case .observed: .blue
-        case .derived: .purple
-        case .inferred: .orange
-        case .unknown: .secondary
-        }
     }
 
     func statusColor(for transaction: HTTPTransaction) -> Color {

--- a/Rockxy/Views/Inspector/ContextInspectorTable.swift
+++ b/Rockxy/Views/Inspector/ContextInspectorTable.swift
@@ -1,0 +1,264 @@
+import SwiftUI
+
+// MARK: - ContextTableField
+
+/// A single leading-label / trailing-value pair for a Context Dock diagnostics table.
+/// Values are monospaced by default because most carry technical data (status, host,
+/// byte counts, timing); pass `monospaced: false` for prose such as an application name.
+struct ContextTableField {
+    let label: String
+    let value: String
+    var monospaced = true
+    var color: Color = .primary
+}
+
+// MARK: - ContextInspectorTable
+
+/// Reusable table shell for the Context Dock Details inspector. Mirrors `HeaderKeyValueTable`'s
+/// visual language — a control-background title header, text-background rows, a 0.5pt separator
+/// stroke, 6pt corner radius, and clipped rounded container — so every diagnostics group reads
+/// like the horizontal inspector's native key/value grid rather than a flat heading plus rows.
+/// Callers compose rows and interleave `Divider()` between them.
+struct ContextInspectorTable<Content: View>: View {
+    let title: String
+    @ViewBuilder let content: () -> Content
+
+    var body: some View {
+        VStack(spacing: 0) {
+            ContextInspectorTableHeader(title: title)
+            Divider()
+            content()
+        }
+        .contextInspectorTableChrome()
+    }
+}
+
+// MARK: - ContextInspectorFieldTable
+
+/// Convenience table for the common all-Field/Value groups (Selection summary, Details).
+/// Renders a header plus a divided list of `ContextInspectorFieldRow`s.
+struct ContextInspectorFieldTable: View {
+    let title: String
+    let fields: [ContextTableField]
+
+    var body: some View {
+        ContextInspectorTable(title: title) {
+            ForEach(Array(fields.enumerated()), id: \.element.label) { index, field in
+                if index > 0 {
+                    Divider()
+                }
+                ContextInspectorFieldRow(field: field)
+            }
+        }
+    }
+}
+
+// MARK: - ContextInspectorDisclosureTable
+
+/// A table whose title header doubles as a progressive-disclosure toggle. Collapsed, it reads as a
+/// single rounded bar; expanded, the same bordered container reveals divided rows. Used by the
+/// Timing and Related Requests groups.
+struct ContextInspectorDisclosureTable<Content: View>: View {
+    // MARK: Internal
+
+    let title: String
+    @Binding var isExpanded: Bool
+
+    var summary: String?
+    @ViewBuilder let content: () -> Content
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Button {
+                withAnimation(.easeInOut(duration: 0.15)) {
+                    isExpanded.toggle()
+                }
+            } label: {
+                HStack(spacing: 6) {
+                    Text(title)
+                        .font(.system(size: metrics.fontSize, weight: .semibold))
+                        .foregroundStyle(.primary)
+                    Spacer(minLength: 6)
+                    if let summary {
+                        Text(summary)
+                            .font(.system(size: metrics.metadataFontSize, design: .monospaced))
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                    }
+                    Image(systemName: "chevron.right")
+                        .font(.system(size: metrics.metadataFontSize, weight: .semibold))
+                        .foregroundStyle(.secondary)
+                        .rotationEffect(.degrees(isExpanded ? 90 : 0))
+                }
+                .padding(.horizontal, 10)
+                .padding(.vertical, 7)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(Color(nsColor: .controlBackgroundColor))
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+
+            if isExpanded {
+                Divider()
+                content()
+            }
+        }
+        .contextInspectorTableChrome()
+    }
+
+    // MARK: Private
+
+    @Environment(\.appUIDisplayMetrics) private var metrics
+}
+
+// MARK: - ContextInspectorFieldRow
+
+/// Dense two-column table row: a proportional secondary label beside a value column, separated by a
+/// vertical divider. The value is monospaced for technical data and stays leading-aligned and
+/// selectable so long host / path / pattern text truncates predictably in a narrow dock.
+struct ContextInspectorFieldRow: View {
+    // MARK: Internal
+
+    let field: ContextTableField
+
+    var body: some View {
+        HStack(spacing: 0) {
+            Text(field.label)
+                .font(.system(size: metrics.secondaryFontSize))
+                .foregroundStyle(.secondary)
+                .frame(width: ContextInspectorTableMetrics.labelColumnWidth(metrics), alignment: .topLeading)
+                .padding(.horizontal, 10)
+                .padding(.vertical, 6)
+            Divider()
+            Text(field.value)
+                .font(field.monospaced
+                    ? .system(size: metrics.secondaryFontSize, design: .monospaced)
+                    : .system(size: metrics.secondaryFontSize))
+                .foregroundStyle(field.color)
+                .frame(maxWidth: .infinity, alignment: .topLeading)
+                .lineLimit(3)
+                .truncationMode(.middle)
+                .textSelection(.enabled)
+                .padding(.horizontal, 10)
+                .padding(.vertical, 6)
+        }
+    }
+
+    // MARK: Private
+
+    @Environment(\.appUIDisplayMetrics) private var metrics
+}
+
+// MARK: - ContextInspectorInsightRow
+
+/// A two-column insight row: a compact semantic icon + title on the field side, the detail on the
+/// value side, split by the same vertical divider so insights read as a table mapping.
+struct ContextInspectorInsightRow: View {
+    // MARK: Internal
+
+    let systemImage: String
+    let title: String
+    let detail: String
+    let color: Color
+
+    var body: some View {
+        HStack(spacing: 0) {
+            HStack(alignment: .top, spacing: 6) {
+                Image(systemName: systemImage)
+                    .font(.system(size: metrics.secondaryFontSize))
+                    .foregroundStyle(color)
+                    .frame(width: 16)
+                Text(title)
+                    .font(.system(size: metrics.secondaryFontSize, weight: .medium))
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            .frame(width: ContextInspectorTableMetrics.insightLabelColumnWidth(metrics), alignment: .topLeading)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
+            Divider()
+            Text(detail)
+                .font(.system(size: metrics.metadataFontSize))
+                .foregroundStyle(.secondary)
+                .frame(maxWidth: .infinity, alignment: .topLeading)
+                .fixedSize(horizontal: false, vertical: true)
+                .padding(.horizontal, 10)
+                .padding(.vertical, 6)
+        }
+    }
+
+    // MARK: Private
+
+    @Environment(\.appUIDisplayMetrics) private var metrics
+}
+
+// MARK: - ContextInspectorFullRow
+
+/// A full-width table row for content that spans both columns: truncation warnings, truthful empty
+/// states, action rows, selectable request rows, and the Notes editor.
+struct ContextInspectorFullRow<Content: View>: View {
+    @ViewBuilder let content: () -> Content
+
+    var body: some View {
+        content()
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
+    }
+}
+
+// MARK: - ContextInspectorTableMetrics
+
+/// Shared column sizing so field, insight, and value columns align across every table. Scales with
+/// the Appearance font size, mirroring the horizontal inspector's key column.
+enum ContextInspectorTableMetrics {
+    static func labelColumnWidth(_ metrics: AppUIDisplayMetrics) -> CGFloat {
+        min(max(90, metrics.fontSize * 5 + 8), 150)
+    }
+
+    static func insightLabelColumnWidth(_ metrics: AppUIDisplayMetrics) -> CGFloat {
+        min(max(110, metrics.fontSize * 5.5 + 8), 160)
+    }
+}
+
+// MARK: - ContextInspectorTableHeader
+
+private struct ContextInspectorTableHeader: View {
+    // MARK: Internal
+
+    let title: String
+
+    var body: some View {
+        Text(title)
+            .font(.system(size: metrics.fontSize, weight: .semibold))
+            .foregroundStyle(.primary)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 7)
+            .background(Color(nsColor: .controlBackgroundColor))
+    }
+
+    // MARK: Private
+
+    @Environment(\.appUIDisplayMetrics) private var metrics
+}
+
+// MARK: - ContextInspectorTableChrome
+
+private struct ContextInspectorTableChrome: ViewModifier {
+    func body(content: Content) -> some View {
+        content
+            .frame(maxWidth: .infinity, alignment: .topLeading)
+            .background(Color(nsColor: .textBackgroundColor))
+            .overlay {
+                RoundedRectangle(cornerRadius: 6)
+                    .stroke(Color(nsColor: .separatorColor), lineWidth: 0.5)
+            }
+            .clipShape(RoundedRectangle(cornerRadius: 6))
+    }
+}
+
+private extension View {
+    func contextInspectorTableChrome() -> some View {
+        modifier(ContextInspectorTableChrome())
+    }
+}

--- a/Rockxy/Views/Inspector/InspectorTabStrip.swift
+++ b/Rockxy/Views/Inspector/InspectorTabStrip.swift
@@ -1,29 +1,71 @@
+import AppKit
 import SwiftUI
 
-/// Single-line, horizontally scrollable tab strip used by the request/response inspector.
-/// Keeps dense native macOS tab labels readable in narrow split panes without wrapping.
-struct InspectorTabStrip<Content: View, TrailingContent: View>: View {
-    let content: Content
-    let trailingContent: TrailingContent
+// MARK: - InspectorTabDescriptor
+
+/// A single tab presented by `InspectorTabStrip`. Value-typed so the strip can measure and
+/// distribute tabs deterministically; the `action` closure carries the exact selection-state
+/// mutation the owning inspector wants to perform when the tab is chosen (directly or from the
+/// overflow menu).
+struct InspectorTabDescriptor: Identifiable {
+    // MARK: Lifecycle
 
     init(
-        @ViewBuilder content: () -> Content,
-        @ViewBuilder trailingContent: () -> TrailingContent
+        id: String,
+        title: String,
+        isActive: Bool,
+        startsNewGroup: Bool = false,
+        action: @escaping () -> Void
     ) {
-        self.content = content()
-        self.trailingContent = trailingContent()
+        self.id = id
+        self.title = title
+        self.isActive = isActive
+        self.startsNewGroup = startsNewGroup
+        self.action = action
     }
+
+    // MARK: Internal
+
+    let id: String
+    let title: String
+    let isActive: Bool
+    /// When `true`, a group separator is drawn before this tab in the direct strip and its
+    /// reserved width includes that separator during layout planning.
+    let startsNewGroup: Bool
+    let action: () -> Void
+}
+
+// MARK: - InspectorTabStripLayout
+
+/// Layout constants shared by `InspectorTabStrip`. Kept at file scope because a generic type
+/// cannot declare static stored properties.
+private enum InspectorTabStripLayout {
+    /// Combined leading + trailing padding used by `InspectorTabButton` (6 pt each side).
+    static let horizontalTabPadding: CGFloat = 12
+    /// Reserved width for a group separator (8 pt horizontal padding + ~1 pt divider).
+    static let groupSeparatorWidth: CGFloat = 9
+    static let leadingStripPadding: CGFloat = 4
+}
+
+// MARK: - InspectorTabStrip
+
+/// Single-line inspector tab strip that keeps every tab reachable in narrow split panes.
+/// Tabs that fit are rendered directly; the remainder collapse into a native overflow menu that
+/// still lists every tab (with a checkmark on the active one). Trailing controls are laid out
+/// first, so the strip plans overflow against the width that is actually left for tabs.
+struct InspectorTabStrip<TrailingContent: View>: View {
+    // MARK: Internal
+
+    let tabs: [InspectorTabDescriptor]
+    @ViewBuilder let trailingContent: TrailingContent
 
     var body: some View {
         HStack(spacing: 0) {
-            ScrollView(.horizontal) {
-                HStack(spacing: 0) {
-                    content
-                }
-                .padding(.leading, 4)
-                .frame(minWidth: 0, alignment: .leading)
+            GeometryReader { proxy in
+                tabRow(availableWidth: proxy.size.width)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
             }
-            .scrollIndicators(.hidden)
+            .frame(height: metrics.inspectorTabHeight)
             .frame(maxWidth: .infinity, alignment: .leading)
             .layoutPriority(0)
 
@@ -35,5 +77,105 @@ struct InspectorTabStrip<Content: View, TrailingContent: View>: View {
         .frame(minHeight: metrics.inspectorTabHeight)
     }
 
+    // MARK: Private
+
     @Environment(\.appUIDisplayMetrics) private var metrics
+
+    private var overflowButtonWidth: CGFloat {
+        metrics.inspectorTabHeight + 8
+    }
+
+    private var groupSeparator: some View {
+        Divider()
+            .frame(height: max(14, metrics.controlFontSize + 2))
+            .padding(.horizontal, 4)
+    }
+
+    private var overflowMenu: some View {
+        Menu {
+            ForEach(tabs) { descriptor in
+                Button(action: descriptor.action) {
+                    overflowMenuLabel(descriptor)
+                }
+            }
+        } label: {
+            Image(systemName: "ellipsis.circle")
+                .font(.system(size: metrics.controlFontSize, weight: .medium))
+                .foregroundStyle(Color(nsColor: .tertiaryLabelColor))
+                .frame(width: metrics.inspectorTabHeight, height: metrics.inspectorTabHeight)
+        }
+        .menuStyle(.borderlessButton)
+        .menuIndicator(.hidden)
+        .fixedSize()
+        .help(String(localized: "More inspector tabs"))
+        .accessibilityLabel(String(localized: "More inspector tabs"))
+    }
+
+    @ViewBuilder
+    private func tabRow(availableWidth: CGFloat) -> some View {
+        let plan = InspectorTabOverflowPlanner.plan(
+            items: layoutItems(),
+            activeID: tabs.first(where: \.isActive)?.id,
+            availableWidth: max(0, availableWidth - InspectorTabStripLayout.leadingStripPadding),
+            overflowAffordanceWidth: overflowButtonWidth
+        )
+        let visibleIDs = Set(plan.visibleIDs)
+        let visibleTabs = tabs.filter { visibleIDs.contains($0.id) }
+
+        HStack(spacing: 0) {
+            ForEach(Array(visibleTabs.enumerated()), id: \.element.id) { index, descriptor in
+                if descriptor.startsNewGroup, index > 0 {
+                    groupSeparator
+                }
+                InspectorTabButton(
+                    title: descriptor.title,
+                    isActive: descriptor.isActive,
+                    action: descriptor.action
+                )
+            }
+
+            if plan.hasOverflow {
+                overflowMenu
+            }
+        }
+        .padding(.leading, InspectorTabStripLayout.leadingStripPadding)
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func overflowMenuLabel(_ descriptor: InspectorTabDescriptor) -> some View {
+        HStack {
+            if descriptor.isActive {
+                Image(systemName: "checkmark")
+            }
+            Text(descriptor.title)
+        }
+    }
+
+    private static func measuredWidth(
+        title: String,
+        fontSize: CGFloat,
+        startsNewGroup: Bool
+    )
+        -> CGFloat
+    {
+        // Measure at bold weight (the active-tab weight) so a tab never overflows after selection.
+        let font = NSFont.systemFont(ofSize: fontSize, weight: .bold)
+        let textWidth = (title as NSString).size(withAttributes: [.font: font]).width
+        return ceil(textWidth)
+            + InspectorTabStripLayout.horizontalTabPadding
+            + (startsNewGroup ? InspectorTabStripLayout.groupSeparatorWidth : 0)
+    }
+
+    private func layoutItems() -> [InspectorTabLayoutItem] {
+        tabs.map { descriptor in
+            InspectorTabLayoutItem(
+                id: descriptor.id,
+                width: Self.measuredWidth(
+                    title: descriptor.title,
+                    fontSize: metrics.controlFontSize,
+                    startsNewGroup: descriptor.startsNewGroup
+                )
+            )
+        }
+    }
 }

--- a/Rockxy/Views/Inspector/InvestigationEvidenceViews.swift
+++ b/Rockxy/Views/Inspector/InvestigationEvidenceViews.swift
@@ -1,0 +1,406 @@
+import SwiftUI
+
+// MARK: - InvestigationEvidenceGroupView
+
+/// Dense native rendering of one evidence kind ("Observed", "Derived", "Inferred") in the
+/// Investigate dock. Grouping is computed by `InvestigationResultPresentation`; this view only
+/// lays the rows out.
+struct InvestigationEvidenceGroupView: View {
+    // MARK: Internal
+
+    let group: InvestigationEvidenceGroup
+    let onReveal: (InvestigationEvidence) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(group.kind.title)
+                .font(.system(size: metrics.metadataFontSize, weight: .semibold))
+                .foregroundStyle(.secondary)
+            ForEach(group.evidence) { evidence in
+                InvestigationEvidenceRow(evidence: evidence, onReveal: onReveal)
+            }
+        }
+    }
+
+    // MARK: Private
+
+    @Environment(\.appUIDisplayMetrics) private var metrics
+}
+
+// MARK: - InvestigationUnknownsView
+
+/// The dedicated "Unknowns" section surfaced from `.unknown` evidence — open questions the local
+/// investigation could not resolve from captured traffic alone. Always rendered so the report is
+/// honest about whether open questions remain, including a truthful empty state.
+struct InvestigationUnknownsView: View {
+    // MARK: Internal
+
+    let unknowns: [InvestigationEvidence]
+    let onReveal: (InvestigationEvidence) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Label(String(localized: "Unknowns"), systemImage: "questionmark.circle")
+                .font(.system(size: metrics.metadataFontSize, weight: .semibold))
+                .foregroundStyle(.secondary)
+            if unknowns.isEmpty {
+                Text(String(localized: "No open questions — captured traffic answered this investigation."))
+                    .font(.system(size: metrics.metadataFontSize))
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            } else {
+                ForEach(unknowns) { evidence in
+                    InvestigationEvidenceRow(evidence: evidence, onReveal: onReveal)
+                }
+            }
+        }
+    }
+
+    // MARK: Private
+
+    @Environment(\.appUIDisplayMetrics) private var metrics
+}
+
+// MARK: - InvestigationEvidenceRow
+
+/// A single finding row. When it is backed by a captured request, tapping reveals that request;
+/// the `scope` glyph keeps the reveal affordance discoverable.
+struct InvestigationEvidenceRow: View {
+    // MARK: Internal
+
+    let evidence: InvestigationEvidence
+    let onReveal: (InvestigationEvidence) -> Void
+
+    var body: some View {
+        Button {
+            onReveal(evidence)
+        } label: {
+            HStack(alignment: .top, spacing: 6) {
+                Circle()
+                    .fill(evidenceColor)
+                    .frame(width: 6, height: 6)
+                    .padding(.top, 4)
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(evidence.title)
+                        .font(.system(size: metrics.metadataFontSize, weight: .medium))
+                        .foregroundStyle(.primary)
+                        .lineLimit(2)
+                    if !evidence.detail.isEmpty {
+                        Text(evidence.detail)
+                            .font(.system(size: metrics.metadataFontSize))
+                            .foregroundStyle(.secondary)
+                            .lineLimit(2)
+                    }
+                }
+                Spacer(minLength: 0)
+                if evidence.sourceTransactionID != nil {
+                    Image(systemName: "scope")
+                        .font(.system(size: metrics.metadataFontSize))
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .disabled(evidence.sourceTransactionID == nil)
+        .help(evidence.sourceTransactionID == nil
+            ? evidence.detail
+            : String(localized: "Reveal the request behind this finding"))
+        .accessibilityLabel(String(localized: "\(evidence.kind.title) finding: \(evidence.title)"))
+    }
+
+    // MARK: Private
+
+    @Environment(\.appUIDisplayMetrics) private var metrics
+
+    private var evidenceColor: Color {
+        switch evidence.kind {
+        case .observed: .blue
+        case .derived: .purple
+        case .inferred: .orange
+        case .unknown: .secondary
+        }
+    }
+}
+
+// MARK: - InvestigationReportSection
+
+/// A labelled native inspector section for the investigation report — a restrained secondary title
+/// with an SF Symbol above its content. Keeps every section header consistent and readable at large
+/// fonts without web-style uppercase dashboard headings.
+struct InvestigationReportSection<Content: View>: View {
+    // MARK: Internal
+
+    let title: String
+    let systemImage: String
+    @ViewBuilder let content: Content
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Label(title, systemImage: systemImage)
+                .font(.system(size: metrics.metadataFontSize, weight: .semibold))
+                .foregroundStyle(.secondary)
+            content
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    // MARK: Private
+
+    @Environment(\.appUIDisplayMetrics) private var metrics
+}
+
+// MARK: - InvestigationReportHeader
+
+/// Report title row: the recipe that produced the investigation plus honest local/model
+/// attribution and the number of requests in scope.
+struct InvestigationReportHeader: View {
+    // MARK: Internal
+
+    let result: InvestigationResult
+    let hasModelResult: Bool
+
+    var body: some View {
+        HStack(spacing: 7) {
+            Image(systemName: result.recipe.systemImage)
+                .foregroundStyle(.secondary)
+            Text(result.recipe.title)
+                .font(.system(size: metrics.secondaryFontSize, weight: .semibold))
+                .lineLimit(1)
+            Spacer(minLength: 4)
+            Label(attribution, systemImage: hasModelResult ? "cpu" : "checkmark.seal")
+                .font(.system(size: metrics.metadataFontSize, weight: .medium))
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+        }
+        .accessibilityElement(children: .combine)
+    }
+
+    // MARK: Private
+
+    @Environment(\.appUIDisplayMetrics) private var metrics
+
+    private var attribution: String {
+        hasModelResult
+            ? String(localized: "Model analysis · \(result.scopeTransactionIDs.count) requests")
+            : String(localized: "Local analysis · \(result.scopeTransactionIDs.count) requests")
+    }
+}
+
+// MARK: - InvestigationFindingsDisclosure
+
+/// The "Findings" section: grouped Observed / Derived / Inferred evidence, expanded by default so
+/// the report reads as a native inspector list rather than a hidden drawer.
+struct InvestigationFindingsDisclosure: View {
+    // MARK: Internal
+
+    let findingGroups: [InvestigationEvidenceGroup]
+    let findingCount: Int
+    let onReveal: (InvestigationEvidence) -> Void
+
+    var body: some View {
+        DisclosureGroup(isExpanded: $isExpanded) {
+            VStack(alignment: .leading, spacing: 8) {
+                ForEach(findingGroups) { group in
+                    InvestigationEvidenceGroupView(group: group, onReveal: onReveal)
+                }
+            }
+            .padding(.top, 4)
+        } label: {
+            HStack(spacing: 6) {
+                Label(String(localized: "Findings"), systemImage: "list.bullet")
+                    .font(.system(size: metrics.metadataFontSize, weight: .semibold))
+                    .foregroundStyle(.secondary)
+                Text(findingCount.formatted())
+                    .font(.system(size: metrics.metadataFontSize, weight: .medium))
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .accessibilityLabel(String(localized: "Findings, \(findingCount) total"))
+    }
+
+    // MARK: Private
+
+    @Environment(\.appUIDisplayMetrics) private var metrics
+    @State private var isExpanded = true
+}
+
+// MARK: - InvestigationReportView
+
+/// The completed investigation turn, rendered as a full-width native report rather than a chat
+/// exchange. Presents Scope, Summary, optional Model Analysis, Findings, Unknowns, Next Step, and
+/// Proposed Actions. Evidence-level reveal and all handoffs are surfaced through injected closures
+/// so this stays a pure presentation surface; the caller supplies attribution + action-bar `footer`.
+struct InvestigationReportView<Footer: View>: View {
+    // MARK: Internal
+
+    let message: DebugAssistantMessage
+    let isCurrentResult: Bool
+    let showsContinueWithModel: Bool
+    let isPreparingReview: Bool
+    let onReveal: (InvestigationEvidence) -> Void
+    let onContinueWithModel: () -> Void
+    let onHandoff: (AssistantUserHandoff, InvestigationResult) -> Void
+    let onPrepareReplay: (InvestigationResult) -> Void
+    @ViewBuilder let footer: Footer
+
+    var body: some View {
+        if let result = message.investigation {
+            VStack(alignment: .leading, spacing: 12) {
+                InvestigationReportHeader(result: result, hasModelResult: message.modelResult != nil)
+
+                InvestigationReportSection(title: String(localized: "Scope"), systemImage: "scope") {
+                    reportBody(result.scopeSummary)
+                        .accessibilityLabel(String(localized: "Investigation scope: \(result.scopeSummary)"))
+                }
+
+                InvestigationReportSection(title: String(localized: "Summary"), systemImage: "text.alignleft") {
+                    reportBody(result.summary)
+                        .textSelection(.enabled)
+                }
+
+                if message.modelResult != nil, !message.text.isEmpty, message.text != result.summary {
+                    InvestigationReportSection(title: String(localized: "Model Analysis"), systemImage: "cpu") {
+                        AssistantMarkdownText(source: message.text)
+                    }
+                }
+
+                findingsSection(result)
+
+                InvestigationUnknownsView(
+                    unknowns: InvestigationResultPresentation.unknowns(for: result.evidence),
+                    onReveal: onReveal
+                )
+
+                InvestigationReportSection(
+                    title: String(localized: "Next Step"),
+                    systemImage: "arrow.turn.down.right"
+                ) {
+                    reportBody(result.nextStep, weight: .medium)
+                        .accessibilityLabel(String(localized: "Next step: \(result.nextStep)"))
+                }
+
+                proposedActionsSection(result)
+
+                footer
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .accessibilityElement(children: .contain)
+            .accessibilityLabel(String(localized: "Investigation report"))
+        }
+    }
+
+    // MARK: Private
+
+    @Environment(\.appUIDisplayMetrics) private var metrics
+
+    private var continueWithModelControl: some View {
+        HStack(spacing: 8) {
+            if isPreparingReview {
+                ProgressView()
+                    .controlSize(.small)
+                Text(String(localized: "Preparing redacted preview…"))
+                    .font(.system(size: metrics.secondaryFontSize))
+                    .foregroundStyle(.secondary)
+            } else {
+                Button(action: onContinueWithModel) {
+                    Label(String(localized: "Continue With Model"), systemImage: "lock.shield")
+                }
+                .buttonStyle(.borderless)
+                .controlSize(.small)
+            }
+        }
+    }
+
+    private func reportBody(_ text: String, weight: Font.Weight = .regular) -> some View {
+        Text(text)
+            .font(.system(size: metrics.secondaryFontSize, weight: weight))
+            .fixedSize(horizontal: false, vertical: true)
+            .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    @ViewBuilder
+    private func findingsSection(_ result: InvestigationResult) -> some View {
+        let findingGroups = InvestigationResultPresentation.findingGroups(for: result.evidence)
+        if findingGroups.isEmpty {
+            InvestigationReportSection(title: String(localized: "Findings"), systemImage: "list.bullet") {
+                Text(String(localized: "No concrete findings from the captured traffic."))
+                    .font(.system(size: metrics.metadataFontSize))
+                    .foregroundStyle(.secondary)
+            }
+        } else {
+            InvestigationFindingsDisclosure(
+                findingGroups: findingGroups,
+                findingCount: InvestigationResultPresentation.findingCount(for: result.evidence),
+                onReveal: onReveal
+            )
+        }
+    }
+
+    @ViewBuilder
+    private func proposedActionsSection(_ result: InvestigationResult) -> some View {
+        let handoffs = AssistantTrustPolicy.recommendedHandoffs(for: result.recipe)
+        InvestigationReportSection(
+            title: String(localized: "Proposed Actions"),
+            systemImage: "wrench.and.screwdriver"
+        ) {
+            VStack(alignment: .leading, spacing: 6) {
+                if showsContinueWithModel {
+                    continueWithModelControl
+                }
+                if handoffs.isEmpty {
+                    if !showsContinueWithModel {
+                        Text(String(localized: "No follow-up workflow is recommended for this investigation."))
+                            .font(.system(size: metrics.metadataFontSize))
+                            .foregroundStyle(.secondary)
+                    }
+                } else {
+                    handoffButtons(result, handoffs: handoffs)
+                }
+            }
+        }
+    }
+
+    private func handoffButtons(
+        _ result: InvestigationResult,
+        handoffs: [AssistantUserHandoff]
+    )
+        -> some View
+    {
+        ViewThatFits(in: .horizontal) {
+            HStack(spacing: 6) {
+                ForEach(handoffs) { handoff in
+                    handoffButton(handoff, result: result)
+                }
+            }
+            VStack(alignment: .leading, spacing: 6) {
+                ForEach(handoffs) { handoff in
+                    handoffButton(handoff, result: result)
+                }
+            }
+        }
+    }
+
+    private func handoffButton(
+        _ handoff: AssistantUserHandoff,
+        result: InvestigationResult
+    )
+        -> some View
+    {
+        Button {
+            if handoff == .prepareReplay {
+                onPrepareReplay(result)
+            } else {
+                onHandoff(handoff, result)
+            }
+        } label: {
+            Label(handoff.title, systemImage: handoff.systemImage)
+        }
+        .buttonStyle(.bordered)
+        .controlSize(.small)
+        .disabled(!isCurrentResult)
+        .help(isCurrentResult
+            ? handoff.title
+            : String(localized: "Reselect the original request to reopen this action"))
+    }
+}

--- a/Rockxy/Views/Inspector/InvestigationResultPresentation.swift
+++ b/Rockxy/Views/Inspector/InvestigationResultPresentation.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+// MARK: - InvestigationEvidenceGroup
+
+/// Evidence for one `InvestigationEvidenceKind`, used to render dense native "Findings" and
+/// "Unknowns" sections in the Investigate dock instead of one flat, ungrouped list.
+struct InvestigationEvidenceGroup: Identifiable, Equatable {
+    let kind: InvestigationEvidenceKind
+    let evidence: [InvestigationEvidence]
+
+    var id: String {
+        kind.rawValue
+    }
+
+    var isUnknown: Bool {
+        kind == .unknown
+    }
+}
+
+// MARK: - InvestigationResultPresentation
+
+/// Pure grouping/derivation for an `InvestigationResult`. Keeps evidence bucketing out of view
+/// bodies so the Investigate dock never re-sorts findings during layout.
+enum InvestigationResultPresentation {
+    /// Reader-friendly, stable order: observed → derived → inferred → unknown. Empty kinds are
+    /// dropped so a group only appears when it has evidence.
+    static func evidenceGroups(for evidence: [InvestigationEvidence]) -> [InvestigationEvidenceGroup] {
+        let order: [InvestigationEvidenceKind] = [.observed, .derived, .inferred, .unknown]
+        return order.compactMap { kind in
+            let matches = evidence.filter { $0.kind == kind }
+            guard !matches.isEmpty else {
+                return nil
+            }
+            return InvestigationEvidenceGroup(kind: kind, evidence: matches)
+        }
+    }
+
+    /// Concrete findings — every group except `.unknown`, which reads as open questions.
+    static func findingGroups(for evidence: [InvestigationEvidence]) -> [InvestigationEvidenceGroup] {
+        evidenceGroups(for: evidence).filter { !$0.isUnknown }
+    }
+
+    /// Open questions surfaced as a dedicated "Unknowns" section.
+    static func unknowns(for evidence: [InvestigationEvidence]) -> [InvestigationEvidence] {
+        evidence.filter { $0.kind == .unknown }
+    }
+
+    /// Number of concrete findings (everything that is not an unknown).
+    static func findingCount(for evidence: [InvestigationEvidence]) -> Int {
+        evidence.count { $0.kind != .unknown }
+    }
+}

--- a/Rockxy/Views/Inspector/MatchedRuleNavigationTarget.swift
+++ b/Rockxy/Views/Inspector/MatchedRuleNavigationTarget.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+// MARK: - MatchedRuleNavigationTarget
+
+/// Pure mapping from a matched rule's `RuleAction` to the existing tool window that edits that
+/// rule category. This is deliberately a bounded routing table — it opens the correct existing
+/// rules window rather than inventing a cross-window rule-selection framework. Categories that
+/// have no dedicated tool window resolve to `.unavailable`, so the Context dock can stay honest
+/// and hide "Open Rule" instead of routing to a wrong or non-existent surface.
+enum MatchedRuleNavigationTarget: Equatable {
+    case toolWindow(id: String, windowTitle: String)
+    case unavailable
+
+    // MARK: Lifecycle
+
+    init(action: RuleAction) {
+        switch action {
+        case .breakpoint:
+            self = .toolWindow(id: "breakpointRules", windowTitle: String(localized: "Breakpoint Rules"))
+        case .mapLocal:
+            self = .toolWindow(id: "mapLocal", windowTitle: String(localized: "Map Local"))
+        case .mapRemote:
+            self = .toolWindow(id: "mapRemote", windowTitle: String(localized: "Map Remote"))
+        case .block:
+            self = .toolWindow(id: "blockList", windowTitle: String(localized: "Block List"))
+        case .modifyHeader:
+            self = .toolWindow(id: "modifyHeaders", windowTitle: String(localized: "Modify Headers"))
+        case .networkCondition:
+            self = .toolWindow(id: "networkConditions", windowTitle: String(localized: "Network Conditions"))
+        case .throttle:
+            // Throttle rules have no standalone tool window; they live in the generic rule list.
+            self = .unavailable
+        }
+    }
+
+    // MARK: Internal
+
+    var windowID: String? {
+        switch self {
+        case let .toolWindow(id, _): id
+        case .unavailable: nil
+        }
+    }
+
+    /// Truthful help text: this opens the rule's editor window, it does not reveal the exact rule.
+    var openHelp: String? {
+        switch self {
+        case let .toolWindow(_, windowTitle):
+            String(localized: "Open the \(windowTitle) window")
+        case .unavailable:
+            nil
+        }
+    }
+}

--- a/Rockxy/Views/Inspector/RequestInspectorView.swift
+++ b/Rockxy/Views/Inspector/RequestInspectorView.swift
@@ -40,40 +40,37 @@ struct RequestInspectorView: View {
     @State private var showPreviewPopover = false
     @Environment(\.appUIDisplayMetrics) private var metrics
 
-    private var inspectorTabBar: some View {
-        InspectorTabStrip {
-            ForEach(RequestInspectorTab.allCases, id: \.self) { tab in
-                InspectorTabButton(
-                    title: tab.displayName,
-                    isActive: selectedPreviewTab == nil && selectedTab == tab
+    private var tabDescriptors: [InspectorTabDescriptor] {
+        var descriptors: [InspectorTabDescriptor] = RequestInspectorTab.allCases.map { tab in
+            InspectorTabDescriptor(
+                id: "native.\(tab.rawValue)",
+                title: tab.displayName,
+                isActive: selectedPreviewTab == nil && selectedTab == tab
+            ) {
+                selectedPreviewTab = nil
+                selectedTab = tab
+            }
+        }
+
+        for (index, tab) in previewTabStore.requestTabs.enumerated() {
+            descriptors.append(
+                InspectorTabDescriptor(
+                    id: "preview.\(tab.id)",
+                    title: tab.name,
+                    isActive: selectedPreviewTab == tab,
+                    startsNewGroup: index == 0
                 ) {
-                    selectedPreviewTab = nil
-                    selectedTab = tab
+                    selectedPreviewTab = tab
                 }
-            }
+            )
+        }
 
-            if !previewTabStore.requestTabs.isEmpty {
-                Divider()
-                    .frame(height: max(14, metrics.controlFontSize + 2))
-                    .padding(.horizontal, 4)
+        return descriptors
+    }
 
-                ForEach(previewTabStore.requestTabs) { tab in
-                    InspectorTabButton(
-                        title: tab.name,
-                        isActive: selectedPreviewTab == tab
-                    ) {
-                        selectedPreviewTab = tab
-                    }
-                }
-            }
-
-            Divider()
-                .frame(height: max(14, metrics.controlFontSize + 2))
-                .padding(.horizontal, 4)
-
+    private var inspectorTabBar: some View {
+        InspectorTabStrip(tabs: tabDescriptors) {
             previewTabMenuButton
-        } trailingContent: {
-            EmptyView()
         }
     }
 

--- a/Rockxy/Views/Inspector/RequestInspectorView.swift
+++ b/Rockxy/Views/Inspector/RequestInspectorView.swift
@@ -125,7 +125,7 @@ struct RequestInspectorView: View {
         case .synopsis:
             SynopsisInspectorView(transaction: transaction)
         case .comments:
-            CommentsTabView(transaction: transaction)
+            CommentsTabView(coordinator: coordinator, transaction: transaction)
         }
     }
 

--- a/Rockxy/Views/Inspector/ResponseInspectorView.swift
+++ b/Rockxy/Views/Inspector/ResponseInspectorView.swift
@@ -63,10 +63,6 @@ struct ResponseInspectorView: View {
     @State private var showPreviewPopover = false
     @Environment(\.appUIDisplayMetrics) private var metrics
 
-    private var hasProtocolTabs: Bool {
-        !ProtocolTabKind.availableTabs(for: transaction).isEmpty
-    }
-
     private var httpsPromptModel: HTTPSInspectionPromptModel? {
         HTTPSInspectionPromptModel.make(
             transaction: transaction,
@@ -89,10 +85,12 @@ struct ResponseInspectorView: View {
         return clientApp
     }
 
-    private var inspectorTabBar: some View {
-        InspectorTabStrip {
-            ForEach(ResponseInspectorTab.availableTabs(hasAIInspection: hasAIInspection), id: \.self) { tab in
-                InspectorTabButton(
+    private var tabDescriptors: [InspectorTabDescriptor] {
+        var descriptors: [InspectorTabDescriptor] = ResponseInspectorTab
+            .availableTabs(hasAIInspection: hasAIInspection)
+            .map { tab in
+                InspectorTabDescriptor(
+                    id: "native.\(tab.rawValue)",
                     title: tab.displayName,
                     isActive: protocolTab == nil && selectedPreviewTab == nil && selectedTab == tab
                 ) {
@@ -103,51 +101,42 @@ struct ResponseInspectorView: View {
                 }
             }
 
-            if !previewTabStore.responseTabs.isEmpty {
-                Divider()
-                    .frame(height: max(14, metrics.controlFontSize + 2))
-                    .padding(.horizontal, 4)
-
-                ForEach(previewTabStore.responseTabs) { tab in
-                    InspectorTabButton(
-                        title: tab.name,
-                        isActive: selectedPreviewTab == tab
-                    ) {
-                        selectionIntent = .preview
-                        protocolTab = nil
-                        selectedPreviewTab = tab
-                    }
+        for (index, tab) in previewTabStore.responseTabs.enumerated() {
+            descriptors.append(
+                InspectorTabDescriptor(
+                    id: "preview.\(tab.id)",
+                    title: tab.name,
+                    isActive: selectedPreviewTab == tab,
+                    startsNewGroup: index == 0
+                ) {
+                    selectionIntent = .preview
+                    protocolTab = nil
+                    selectedPreviewTab = tab
                 }
-            }
-
-            if hasProtocolTabs {
-                Divider()
-                    .frame(height: max(14, metrics.controlFontSize + 2))
-                    .padding(.horizontal, 4)
-
-                protocolTabButtons
-            }
-
-            Divider()
-                .frame(height: max(14, metrics.controlFontSize + 2))
-                .padding(.horizontal, 4)
-
-            previewTabMenuButton
-        } trailingContent: {
-            inspectorTrailingControls
+            )
         }
+
+        for (index, tab) in ProtocolTabKind.availableTabs(for: transaction).enumerated() {
+            descriptors.append(
+                InspectorTabDescriptor(
+                    id: "protocol.\(String(describing: tab))",
+                    title: tab.displayName,
+                    isActive: protocolTab == tab,
+                    startsNewGroup: index == 0
+                ) {
+                    selectionIntent = .protocolSpecific
+                    protocolTab = tab
+                    selectedPreviewTab = nil
+                }
+            )
+        }
+
+        return descriptors
     }
 
-    @ViewBuilder private var protocolTabButtons: some View {
-        ForEach(ProtocolTabKind.availableTabs(for: transaction), id: \.self) { tab in
-            InspectorTabButton(
-                title: tab.displayName,
-                isActive: protocolTab == tab
-            ) {
-                selectionIntent = .protocolSpecific
-                protocolTab = tab
-                selectedPreviewTab = nil
-            }
+    private var inspectorTabBar: some View {
+        InspectorTabStrip(tabs: tabDescriptors) {
+            inspectorTrailingControls
         }
     }
 
@@ -167,14 +156,16 @@ struct ResponseInspectorView: View {
         }
     }
 
-    @ViewBuilder private var inspectorTrailingControls: some View {
-        if protocolTab == nil,
-           selectedPreviewTab == nil,
-           selectedTab == .body
-        {
-            responseBodyOptionsMenu
-        } else {
-            EmptyView()
+    private var inspectorTrailingControls: some View {
+        HStack(spacing: 4) {
+            previewTabMenuButton
+
+            if protocolTab == nil,
+               selectedPreviewTab == nil,
+               selectedTab == .body
+            {
+                responseBodyOptionsMenu
+            }
         }
     }
 

--- a/Rockxy/Views/Main/Extensions/MainContentCoordinator+ContextMenu.swift
+++ b/Rockxy/Views/Main/Extensions/MainContentCoordinator+ContextMenu.swift
@@ -139,20 +139,19 @@ extension MainContentCoordinator {
 
     func promptComment(for transaction: HTTPTransaction) {
         let alert = NSAlert()
-        alert.messageText = String(localized: "Add Comment")
-        alert.informativeText = String(localized: "Enter a comment for this request:")
+        alert.messageText = String(localized: "Add Note")
+        alert.informativeText = String(localized: "Enter a note for this request:")
         alert.addButton(withTitle: String(localized: "OK"))
         alert.addButton(withTitle: String(localized: "Cancel"))
 
         let input = NSTextField(frame: NSRect(x: 0, y: 0, width: 300, height: 24))
         input.stringValue = transaction.comment ?? ""
-        input.placeholderString = String(localized: "Comment…")
+        input.placeholderString = String(localized: "Note…")
         alert.accessoryView = input
 
         let response = alert.runModal()
         if response == .alertFirstButtonReturn {
-            transaction.comment = input.stringValue.isEmpty ? nil : input.stringValue
-            refreshRowsAfterMutation()
+            setNote(input.stringValue, for: transaction)
         }
     }
 
@@ -311,6 +310,7 @@ extension MainContentCoordinator {
         filter.sidebarScope = switch section {
         case .pinned: .pinned
         case .saved: .saved
+        case .notes: .notes
         }
 
         let title = favoriteTransactionDisplayName(transaction)
@@ -329,6 +329,9 @@ extension MainContentCoordinator {
             transaction.isPinned = false
         case .saved:
             transaction.isSaved = false
+        case .notes:
+            noteFlushTasks.removeValue(forKey: transaction.id)?.cancel()
+            transaction.comment = nil
         }
 
         invalidateSidebarFavoriteCache()
@@ -422,13 +425,13 @@ extension MainContentCoordinator {
 
     // MARK: - Row Refresh After Mutation
 
-    /// Refreshes all workspaces after a row-visible property mutation (pin, save, comment,
-    /// highlight). Workspaces in saved/pinned scopes get a full recompute because membership
-    /// may have changed. Other workspaces just re-derive rows.
+    /// Refreshes all workspaces after a row-visible property mutation (pin, save, note,
+    /// highlight). Library scopes get a full recompute because membership may have changed.
     func refreshRowsAfterMutation() {
         for workspace in workspaceStore.workspaces {
             if workspace.filterCriteria.sidebarScope == .saved
                 || workspace.filterCriteria.sidebarScope == .pinned
+                || workspace.filterCriteria.sidebarScope == .notes
             {
                 recomputeFilteredTransactions(for: workspace)
             } else {
@@ -440,7 +443,7 @@ extension MainContentCoordinator {
 
     // MARK: - Persistence
 
-    private func persistTransaction(_ transaction: HTTPTransaction) {
+    func persistTransaction(_ transaction: HTTPTransaction) {
         do {
             let store = try resolveSessionStore()
             Task {
@@ -455,12 +458,12 @@ extension MainContentCoordinator {
         }
     }
 
-    private func updatePersistedFavoriteCache(after transaction: HTTPTransaction) {
+    func updatePersistedFavoriteCache(after transaction: HTTPTransaction) {
         guard let index = persistedFavorites.firstIndex(where: { $0.id == transaction.id }) else {
             return
         }
 
-        if transaction.isPinned || transaction.isSaved {
+        if transaction.isPinned || transaction.isSaved || transaction.hasNote {
             persistedFavorites[index] = transaction
         } else {
             persistedFavorites.remove(at: index)

--- a/Rockxy/Views/Main/Extensions/MainContentCoordinator+Filtering.swift
+++ b/Rockxy/Views/Main/Extensions/MainContentCoordinator+Filtering.swift
@@ -98,6 +98,32 @@ extension MainContentCoordinator {
         recomputeFilteredTransactions()
     }
 
+    /// True when any workspace-level filter narrows the visible traffic: search/method/status/etc.
+    /// via `FilterCriteria`, an active advanced rule, a Traffic Signal, a Focus Set, or muted sources.
+    /// A merely-visible but empty advanced editor is intentionally not treated as active.
+    var hasActiveWorkspaceFilters: Bool {
+        !filterCriteria.isEmpty
+            || !FilterRuleEvaluator.activeRules(in: filterRules, isFilterBarVisible: isFilterBarVisible).isEmpty
+            || activeWorkspace.activeTrafficSignal != nil
+            || activeWorkspace.activeFocusSet != nil
+            || !activeWorkspace.mutedTrafficSources.isEmpty
+    }
+
+    /// Full reset of every workspace filter, scope, and focus/noise dimension back to "All Traffic",
+    /// then recompute. Single source of truth for the filter-summary "Clear All" chip and the
+    /// request-list empty-state recovery actions so they cannot drift apart.
+    func clearAllWorkspaceFilters() {
+        filterCriteria = .empty
+        filterCriteria.sidebarScope = .allTraffic
+        sidebarSelection = nil
+        isFilterBarVisible = false
+        filterRules = [FilterRule()]
+        activeWorkspace.activeTrafficSignal = nil
+        activeWorkspace.activeFocusSetID = nil
+        activeWorkspace.mutedTrafficSources.removeAll()
+        recomputeFilteredTransactions()
+    }
+
     var availableTransactionCountForCurrentScope: Int {
         let baseList: [HTTPTransaction] = switch filterCriteria.sidebarScope {
         case .saved:

--- a/Rockxy/Views/Main/Extensions/MainContentCoordinator+Filtering.swift
+++ b/Rockxy/Views/Main/Extensions/MainContentCoordinator+Filtering.swift
@@ -104,6 +104,8 @@ extension MainContentCoordinator {
             allSavedTransactions
         case .pinned:
             allPinnedTransactions
+        case .notes:
+            allNotesTransactions
         case .allTraffic:
             transactions
         }
@@ -131,6 +133,8 @@ extension MainContentCoordinator {
             allSavedTransactions
         case .pinned:
             allPinnedTransactions
+        case .notes:
+            allNotesTransactions
         case .allTraffic:
             transactions
         }
@@ -298,6 +302,8 @@ extension MainContentCoordinator {
             allSavedTransactions
         case .pinned:
             allPinnedTransactions
+        case .notes:
+            allNotesTransactions
         case .allTraffic:
             transactions
         }

--- a/Rockxy/Views/Main/Extensions/MainContentCoordinator+Layout.swift
+++ b/Rockxy/Views/Main/Extensions/MainContentCoordinator+Layout.swift
@@ -14,21 +14,56 @@ extension MainContentCoordinator {
 
     /// Applies Context Dock visibility from either toolbar commands or the native split item.
     func setContextDockVisible(_ isVisible: Bool) {
-        guard isContextDockVisible != isVisible else { return }
+        guard isContextDockVisible != isVisible else {
+            return
+        }
         withAnimation(.smooth(duration: 0.18)) {
             isContextDockVisible = isVisible
             workspaceStore.rememberContextDockVisibility(isVisible)
         }
     }
 
+    /// Content the bottom payload inspector can present for the current selection.
+    var bottomInspectorContent: BottomInspectorContent {
+        BottomInspectorPresentation.content(
+            selectedCount: selectedTransactionIDs.count,
+            hasSingleSelection: selectedTransaction != nil
+        )
+    }
+
+    /// Whether the current selection has something the bottom payload inspector can present.
+    /// Drives control enablement and, crucially, distinguishes a collapse caused purely by
+    /// losing the selection (must not persist a hidden preference) from a manual/native
+    /// collapse the user actually intends to keep.
+    var hasPayloadInspectorSelection: Bool {
+        bottomInspectorContent != .none
+    }
+
+    /// Effective (derived) bottom-inspector visibility. Collapses when there is nothing to
+    /// inspect so the request table reclaims the space, without touching the stored preference.
+    var isBottomInspectorEffectivelyPresented: Bool {
+        BottomInspectorPresentation.isPresented(layout: inspectorLayout, content: bottomInspectorContent)
+    }
+
+    /// Whether the bottom-inspector show/hide controls should be enabled. With nothing to
+    /// inspect, toggling only flips a hidden preference with no visible result.
+    var canToggleBottomInspector: Bool {
+        BottomInspectorPresentation.allowsToggle(content: bottomInspectorContent)
+    }
+
     func toggleInspectorBottom() {
+        guard canToggleBottomInspector else {
+            return
+        }
         setBottomInspectorVisible(inspectorLayout != .bottom)
     }
 
     /// Applies bottom inspector visibility from toolbar commands or the native split item.
     func setBottomInspectorVisible(_ isVisible: Bool) {
         let layout: InspectorLayout = isVisible ? .bottom : .hidden
-        guard inspectorLayout != layout || activeWorkspace.allowsAutomaticInspectorReveal else { return }
+        guard inspectorLayout != layout || activeWorkspace.allowsAutomaticInspectorReveal else {
+            return
+        }
         withAnimation(.smooth(duration: 0.18)) {
             inspectorLayout = layout
             activeWorkspace.allowsAutomaticInspectorReveal = false

--- a/Rockxy/Views/Main/Extensions/MainContentCoordinator+Notes.swift
+++ b/Rockxy/Views/Main/Extensions/MainContentCoordinator+Notes.swift
@@ -1,0 +1,119 @@
+import Foundation
+
+// Extends `MainContentCoordinator` with the request-note mutation and persistence seam.
+
+// MARK: - MainContentCoordinator + Notes
+
+/// Coordinator extension owning every write to a transaction's user note (`HTTPTransaction.comment`).
+/// Views never mutate `comment` directly — they route through `setNote` (immediate commit, used by the
+/// menu / modal entry points) or `updateNoteDraft` (inline editors, debounced persistence). Both
+/// normalize whitespace-only input to `nil`, keep the Library's Notes collection in sync, and persist
+/// through `SessionStore` so note-only transactions survive restart.
+extension MainContentCoordinator {
+    // MARK: - Normalization
+
+    /// Trims a raw note string and collapses whitespace-only input to `nil`.
+    /// Pure and side-effect free so the normalization contract is directly testable.
+    static func normalizedNote(_ raw: String?) -> String? {
+        guard let raw else {
+            return nil
+        }
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    // MARK: - Mutation Entry Points
+
+    /// Commits a note edit immediately. Used by the main-menu and right-click "Add Note…" modal,
+    /// where the user has finished editing and there is a single discrete commit.
+    func setNote(_ rawText: String?, for transaction: HTTPTransaction) {
+        let changed = applyNoteInMemory(rawText, to: transaction)
+        let pendingTask = noteFlushTasks.removeValue(forKey: transaction.id)
+        pendingTask?.cancel()
+        guard changed || pendingTask != nil else {
+            return
+        }
+        persistTransaction(transaction)
+    }
+
+    /// Updates a note from an inline editor. Applies to the in-memory model immediately so the Notes
+    /// scope and editor stay live, but debounces the SQLite write so a large transaction row is not
+    /// rewritten on every keystroke.
+    func updateNoteDraft(_ rawText: String?, for transaction: HTTPTransaction) {
+        guard applyNoteInMemory(rawText, to: transaction) else {
+            return
+        }
+        scheduleNotePersistence(for: transaction)
+    }
+
+    /// Cancels any pending debounced write and persists the current note value now. Inline editors
+    /// call this on disappear so an in-flight edit is never lost when selection changes or the app quits.
+    func flushNotePersistence(for transaction: HTTPTransaction) {
+        guard let pendingTask = noteFlushTasks.removeValue(forKey: transaction.id) else {
+            return
+        }
+        pendingTask.cancel()
+        persistTransaction(transaction)
+    }
+
+    // MARK: - Private
+
+    /// Applies a normalized note to the model. Returns `true` when the stored value actually changed.
+    /// Membership in the Notes collection flips only when the note transitions empty↔non-empty, so the
+    /// sidebar cache is invalidated and rows recomputed only then — keeping keystroke edits cheap while
+    /// still dropping a transaction from the Notes scope the instant its last note is removed.
+    @discardableResult
+    private func applyNoteInMemory(_ rawText: String?, to transaction: HTTPTransaction) -> Bool {
+        let normalized = Self.normalizedNote(rawText)
+        guard transaction.comment != normalized else {
+            return false
+        }
+        let membershipChanged = transaction.hasNote != (normalized != nil)
+        transaction.comment = normalized
+        if membershipChanged {
+            invalidateSidebarFavoriteCache()
+            updatePersistedFavoriteCache(after: transaction)
+            if !transaction.hasNote,
+               sidebarSelection == .noteTransaction(id: transaction.id)
+            {
+                sidebarSelection = .allNotes
+            }
+            refreshRowsAfterMutation()
+        } else {
+            refreshWorkspacesFilteringNotes()
+        }
+        return true
+    }
+
+    /// Note text can participate in both the simple search field and compound filters. When an edit
+    /// keeps the request inside Notes, only those workspaces need a full filter recomputation.
+    private func refreshWorkspacesFilteringNotes() {
+        for workspace in workspaceStore.workspaces {
+            let criteria = workspace.filterCriteria
+            let usesSimpleNoteSearch = criteria.isSearchEnabled
+                && criteria.searchField == .comment
+                && !criteria.searchText.isEmpty
+            let usesCompoundNoteFilter = FilterRuleEvaluator.activeRules(
+                in: workspace.filterRules,
+                isFilterBarVisible: workspace.isFilterBarVisible
+            ).contains { $0.field == .comment }
+
+            if usesSimpleNoteSearch || usesCompoundNoteFilter {
+                recomputeFilteredTransactions(for: workspace)
+            }
+        }
+    }
+
+    private func scheduleNotePersistence(for transaction: HTTPTransaction) {
+        let id = transaction.id
+        noteFlushTasks[id]?.cancel()
+        noteFlushTasks[id] = Task { [weak self] in
+            try? await Task.sleep(for: .milliseconds(600))
+            guard !Task.isCancelled, let self else {
+                return
+            }
+            self.noteFlushTasks[id] = nil
+            self.persistTransaction(transaction)
+        }
+    }
+}

--- a/Rockxy/Views/Main/Extensions/MainContentCoordinator+Selection.swift
+++ b/Rockxy/Views/Main/Extensions/MainContentCoordinator+Selection.swift
@@ -92,6 +92,22 @@ extension MainContentCoordinator {
             filterCriteria.exactTransactionID = nil
             recomputeFilteredTransactions()
             selectTransaction(transaction(for: id))
+        case .allNotes:
+            filterCriteria.sidebarDomain = nil
+            filterCriteria.sidebarPathPrefix = nil
+            filterCriteria.sidebarApp = nil
+            filterCriteria.sidebarScope = .notes
+            filterCriteria.exactTransactionID = nil
+            selectTransaction(nil)
+            recomputeFilteredTransactions()
+        case let .noteTransaction(id):
+            filterCriteria.sidebarDomain = nil
+            filterCriteria.sidebarPathPrefix = nil
+            filterCriteria.sidebarApp = nil
+            filterCriteria.sidebarScope = .notes
+            filterCriteria.exactTransactionID = nil
+            recomputeFilteredTransactions()
+            selectTransaction(transaction(for: id))
         default:
             filterCriteria.sidebarDomain = nil
             filterCriteria.sidebarPathPrefix = nil

--- a/Rockxy/Views/Main/Extensions/MainContentCoordinator+Workspaces.swift
+++ b/Rockxy/Views/Main/Extensions/MainContentCoordinator+Workspaces.swift
@@ -111,10 +111,13 @@ extension MainContentCoordinator {
             allPinnedTransactions.contains { $0.id == id }
         case let .savedTransaction(id):
             allSavedTransactions.contains { $0.id == id }
+        case let .noteTransaction(id):
+            allNotesTransactions.contains { $0.id == id }
         case .allApps,
              .allDomains,
              .allPinned,
-             .allSaved:
+             .allSaved,
+             .allNotes:
             true
         case .filter,
              .ruleGroup,

--- a/Rockxy/Views/Main/MainContentCommandActions.swift
+++ b/Rockxy/Views/Main/MainContentCommandActions.swift
@@ -25,7 +25,11 @@ struct MainContentCommandActions {
     }
 
     var isBottomInspectorVisible: Bool {
-        coordinator.inspectorLayout == .bottom
+        coordinator.isBottomInspectorEffectivelyPresented
+    }
+
+    var canToggleBottomInspector: Bool {
+        coordinator.canToggleBottomInspector
     }
 
     var isContextDockVisible: Bool {

--- a/Rockxy/Views/Main/MainContentCoordinator.swift
+++ b/Rockxy/Views/Main/MainContentCoordinator.swift
@@ -126,6 +126,7 @@ final class MainContentCoordinator {
         let key: SidebarFavoritesCacheKey
         let pinned: [HTTPTransaction]
         let saved: [HTTPTransaction]
+        let notes: [HTTPTransaction]
     }
 
     struct DebugAssistantTaskHandle {
@@ -249,6 +250,11 @@ final class MainContentCoordinator {
     @ObservationIgnored var observedDomainCountsByApp: [String: [String: Int]] = [:]
 
     nonisolated(unsafe) var sslProxyingObserver: NSObjectProtocol?
+
+    /// Pending debounced note-persistence tasks, keyed by transaction id. Inline note
+    /// editors update the model immediately but coalesce SQLite writes through these so a
+    /// large transaction row is not rewritten on every keystroke. See `+Notes`.
+    @ObservationIgnored var noteFlushTasks: [UUID: Task<Void, Never>] = [:]
 
     var systemProxyWarning: SystemProxyWarning? {
         guard let warning = readiness.activeWarning else {
@@ -405,6 +411,10 @@ final class MainContentCoordinator {
         sidebarFavoriteTransactions().saved
     }
 
+    var allNotesTransactions: [HTTPTransaction] {
+        sidebarFavoriteTransactions().notes
+    }
+
     var totalDomainCount: Int {
         activeWorkspace.totalDomainCount
     }
@@ -557,10 +567,14 @@ final class MainContentCoordinator {
         let liveSaved = transactions.filter(\.isSaved)
         let persistedSaved = persistedFavorites.filter(\.isSaved)
         let liveSavedIds = Set(liveSaved.map(\.id))
+        let liveNotes = transactions.filter(\.hasNote)
+        let persistedNotes = persistedFavorites.filter(\.hasNote)
+        let liveNoteIds = Set(liveNotes.map(\.id))
         let cache = SidebarFavoritesCache(
             key: key,
             pinned: livePinned + persistedPinned.filter { !livePinnedIds.contains($0.id) },
-            saved: liveSaved + persistedSaved.filter { !liveSavedIds.contains($0.id) }
+            saved: liveSaved + persistedSaved.filter { !liveSavedIds.contains($0.id) },
+            notes: liveNotes + persistedNotes.filter { !liveNoteIds.contains($0.id) }
         )
         sidebarFavoritesCache = cache
         return cache

--- a/Rockxy/Views/RequestList/CenterContentView.swift
+++ b/Rockxy/Views/RequestList/CenterContentView.swift
@@ -172,6 +172,22 @@ struct CenterContentView: View {
             + (coordinator.activeWorkspace.mutedTrafficSources.isEmpty ? 0 : 1)
     }
 
+    private var bottomInspectorVisibility: Binding<Bool> {
+        Binding(
+            get: { coordinator.isBottomInspectorEffectivelyPresented },
+            set: { isPresented in
+                // A false transition driven purely by losing the selection (the effective
+                // getter collapsing) must not persist a hidden preference — only a manual or
+                // native collapse while something is still selected should. Expansions always
+                // pass through.
+                if !isPresented, !coordinator.hasPayloadInspectorSelection {
+                    return
+                }
+                coordinator.setBottomInspectorVisible(isPresented)
+            }
+        )
+    }
+
     private var inspectorWorkspace: some View {
         NativeBottomInspectorSplitView(
             isInspectorPresented: bottomInspectorVisibility,
@@ -191,13 +207,6 @@ struct CenterContentView: View {
             .appUIDisplayMetrics(displayMetrics)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-    }
-
-    private var bottomInspectorVisibility: Binding<Bool> {
-        Binding(
-            get: { coordinator.inspectorLayout == .bottom },
-            set: { coordinator.setBottomInspectorVisible($0) }
-        )
     }
 
     private var tableContent: some View {

--- a/Rockxy/Views/RequestList/CenterContentView.swift
+++ b/Rockxy/Views/RequestList/CenterContentView.swift
@@ -135,8 +135,6 @@ struct CenterContentView: View {
 
     // MARK: Private
 
-    private static let minimumBottomTableHeight: CGFloat = 200
-    private static let minimumBottomInspectorHeight: CGFloat = 320
     private static let bottomInspectorSplitAutosaveName = RockxyIdentity.current.defaultsKey(
         "workspaceBottomInspectorSplit.v1"
     )
@@ -188,12 +186,16 @@ struct CenterContentView: View {
         )
     }
 
+    private var bottomInspectorLayoutMetrics: BottomInspectorLayoutMetrics {
+        BottomInspectorLayoutMetrics(appMetrics: displayMetrics)
+    }
+
     private var inspectorWorkspace: some View {
         NativeBottomInspectorSplitView(
             isInspectorPresented: bottomInspectorVisibility,
             autosaveName: Self.bottomInspectorSplitAutosaveName,
-            primaryMinimumHeight: Self.minimumBottomTableHeight,
-            inspectorMinimumHeight: Self.minimumBottomInspectorHeight
+            primaryMinimumHeight: bottomInspectorLayoutMetrics.requestListMinimumHeight,
+            inspectorMinimumHeight: bottomInspectorLayoutMetrics.inspectorMinimumHeight
         ) {
             tableContent
                 .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/Rockxy/Views/RequestList/CenterContentView.swift
+++ b/Rockxy/Views/RequestList/CenterContentView.swift
@@ -96,6 +96,10 @@ struct CenterContentView: View {
                     "\($0.request.method) \($0.request.path)"
                 },
                 sessionProvenance: coordinator.sessionProvenance,
+                activeRules: coordinator.rules,
+                mapLocalToolEnabled: mapLocalToolEnabled,
+                mapRemoteToolEnabled: mapRemoteToolEnabled,
+                breakpointToolEnabled: breakpointToolEnabled,
                 onClear: {
                     Task { @MainActor in
                         await coordinator.clearSession()
@@ -138,6 +142,9 @@ struct CenterContentView: View {
     )
 
     @AppStorage(NoCacheHeaderMutator.userDefaultsKey) private var isNoCachingEnabled = false
+    @AppStorage("mapLocalToolEnabled") private var mapLocalToolEnabled = true
+    @AppStorage("mapRemoteToolEnabled") private var mapRemoteToolEnabled = true
+    @AppStorage("breakpointToolEnabled") private var breakpointToolEnabled = true
     @Environment(\.appUIDisplayMetrics) private var displayMetrics
 
     @State private var selectedIDs: Set<UUID> = []

--- a/Rockxy/Views/RequestList/CenterContentView.swift
+++ b/Rockxy/Views/RequestList/CenterContentView.swift
@@ -239,5 +239,13 @@ struct CenterContentView: View {
             mainCoordinator: coordinator,
             headerColumns: coordinator.headerColumnStore.columns
         )
+        .overlay {
+            // Overlay (not replacement) so the table stays mounted: live append, native column
+            // widths, selection, and scroll position survive an empty-then-populated transition.
+            RequestListEmptyStateView(
+                coordinator: coordinator,
+                hasVisibleRows: !coordinator.filteredRows.isEmpty
+            )
+        }
     }
 }

--- a/Rockxy/Views/RequestList/NativeBottomInspectorSplitView.swift
+++ b/Rockxy/Views/RequestList/NativeBottomInspectorSplitView.swift
@@ -105,6 +105,10 @@ struct NativeBottomInspectorSplitView<Primary: View, Inspector: View>: NSViewCon
         // Replacing either root during an outer SwiftUI/AppKit constraint pass can recurse
         // through SplitViewChildController and crash in swift_beginAccess.
         updateVisibilityCallback(on: controller)
+        controller.updateMinimumHeights(
+            primary: primaryMinimumHeight,
+            inspector: inspectorMinimumHeight
+        )
         if context.coordinator.shouldApplyPresentation(isInspectorPresented) {
             controller.setInspectorPresented(isInspectorPresented, animated: true)
         }
@@ -153,6 +157,10 @@ struct NativeBottomDeferredContent<Content: View>: View {
 // MARK: - NativeBottomInspectorSplitSizing
 
 enum NativeBottomInspectorSplitSizing {
+    /// Fraction of the available height seated above the divider (request list) on a fresh
+    /// layout, leaving the remainder to the inspector — ≈62% / 38%.
+    static let defaultRequestListRatio: CGFloat = 0.62
+
     static func resolve(_ proposal: ProposedViewSize, naturalHeight: CGFloat) -> CGSize? {
         let resolved = proposal.replacingUnspecifiedDimensions(
             by: CGSize(width: 800, height: naturalHeight)
@@ -166,11 +174,88 @@ enum NativeBottomInspectorSplitSizing {
     /// The split view can safely consume its pending initial state once both dimensions are
     /// finite and strictly positive. Collapsing or expanding into zero/insufficient bounds is
     /// what produced startup `Invalid view geometry` faults.
+    ///
+    /// Reads the raw stored size rather than `CGRect.width`/`.height`, which standardize a
+    /// negative size and report it as positive — a raw-negative provisional frame must be
+    /// rejected, not silently accepted.
     static func isLayoutReady(_ bounds: CGRect) -> Bool {
-        bounds.width.isFinite
-            && bounds.height.isFinite
-            && bounds.width > 0
-            && bounds.height > 0
+        let width = bounds.size.width
+        let height = bounds.size.height
+        return width.isFinite
+            && height.isFinite
+            && width > 0
+            && height > 0
+    }
+
+    /// Whether `totalHeight` can seat the requested panes at their declared minimum thickness,
+    /// including the divider when the inspector is presented.
+    ///
+    /// A merely positive, finite height is not sufficient readiness: an early provisional AppKit
+    /// layout pass can report a positive-but-too-short height. Latching the initial layout there
+    /// seats the panes at their minima and blocks the later, correctly-sized pass from applying
+    /// the ideal ratio.
+    static func canSeatRequestedMinima(
+        totalHeight: CGFloat,
+        dividerThickness: CGFloat,
+        inspectorPresented: Bool,
+        primaryMinimumHeight: CGFloat,
+        inspectorMinimumHeight: CGFloat
+    )
+        -> Bool
+    {
+        guard totalHeight.isFinite,
+              dividerThickness.isFinite,
+              primaryMinimumHeight.isFinite,
+              inspectorMinimumHeight.isFinite,
+              totalHeight > 0,
+              dividerThickness >= 0,
+              primaryMinimumHeight >= 0,
+              inspectorMinimumHeight >= 0 else
+        {
+            return false
+        }
+
+        let inspectorHeight = inspectorPresented ? inspectorMinimumHeight : 0
+        let divider = inspectorPresented ? dividerThickness : 0
+        return totalHeight >= primaryMinimumHeight + inspectorHeight + divider
+    }
+
+    /// Ideal height for the top (request list) pane on a fresh layout, placing `requestListRatio`
+    /// of the available height above the divider while honoring both minima. Returns `nil` when
+    /// the split is too short to seat both panes, telling the caller to defer to AppKit
+    /// constraints instead of forcing a position that would drive a pane negative.
+    static func idealPrimaryHeight(
+        totalHeight: CGFloat,
+        dividerThickness: CGFloat,
+        requestListRatio: CGFloat,
+        primaryMinimumHeight: CGFloat,
+        inspectorMinimumHeight: CGFloat
+    )
+        -> CGFloat?
+    {
+        guard totalHeight.isFinite,
+              dividerThickness.isFinite,
+              requestListRatio.isFinite,
+              primaryMinimumHeight.isFinite,
+              inspectorMinimumHeight.isFinite,
+              totalHeight > 0,
+              dividerThickness >= 0,
+              (0 ... 1).contains(requestListRatio),
+              primaryMinimumHeight >= 0,
+              inspectorMinimumHeight >= 0 else
+        {
+            return nil
+        }
+
+        let available = totalHeight - dividerThickness
+        let lowerBound = primaryMinimumHeight
+        let upperBound = available - inspectorMinimumHeight
+        guard upperBound >= lowerBound else {
+            return nil
+        }
+
+        let target = available * requestListRatio
+        return min(max(target, lowerBound), upperBound)
     }
 }
 
@@ -181,6 +266,8 @@ final class NativeBottomInspectorSplitViewController: NSSplitViewController {
     // MARK: Internal
 
     var onInspectorVisibilityChanged: ((Bool) -> Void)?
+    private(set) var hasAutosavedFrames = false
+    private(set) var defaultDividerApplicationCount = 0
 
     var isInspectorPresented: Bool {
         inspectorItem.map { !$0.isCollapsed } ?? false
@@ -188,20 +275,30 @@ final class NativeBottomInspectorSplitViewController: NSSplitViewController {
 
     override func viewDidLayout() {
         super.viewDidLayout()
-        guard pendingInitialVisibility != nil else {
-            return
-        }
-        guard NativeBottomInspectorSplitSizing.isLayoutReady(splitView.bounds) else {
+        let bounds = splitView.bounds
+        guard NativeBottomInspectorSplitSizing.isLayoutReady(bounds) else {
             // Bounds are still zero/insufficient. Retain the requested state and wait for a
             // valid layout pass rather than collapsing/expanding into negative geometry.
             return
         }
-        guard let pendingInitialVisibility else {
-            return
+
+        if let pendingInitialVisibility {
+            guard NativeBottomInspectorSplitSizing.canSeatRequestedMinima(
+                totalHeight: bounds.height,
+                dividerThickness: splitView.dividerThickness,
+                inspectorPresented: pendingInitialVisibility,
+                primaryMinimumHeight: primaryMinimumHeight,
+                inspectorMinimumHeight: inspectorMinimumHeight
+            ) else {
+                return
+            }
+
+            self.pendingInitialVisibility = nil
+            setInspectorPresented(pendingInitialVisibility, animated: false)
+            isApplyingInitialState = false
         }
-        self.pendingInitialVisibility = nil
-        setInspectorPresented(pendingInitialVisibility, animated: false)
-        isApplyingInitialState = false
+
+        applyDefaultDividerIfNeeded(totalHeight: bounds.height)
     }
 
     func configure(
@@ -215,6 +312,11 @@ final class NativeBottomInspectorSplitViewController: NSSplitViewController {
         splitView.isVertical = false
         splitView.dividerStyle = .thin
 
+        let autosave = NSSplitView.AutosaveName(autosaveName)
+        hasAutosavedFrames = UserDefaults.standard.object(
+            forKey: "NSSplitView Subview Frames \(autosave)"
+        ) != nil
+
         let primaryItem = NSSplitViewItem(viewController: primaryController)
         primaryItem.minimumThickness = primaryMinimumHeight
         primaryItem.canCollapse = false
@@ -227,12 +329,22 @@ final class NativeBottomInspectorSplitViewController: NSSplitViewController {
         inspectorItem.isSpringLoaded = true
         inspectorItem.holdingPriority = .defaultHigh
 
+        if !hasAutosavedFrames {
+            primaryItem.preferredThicknessFraction = NativeBottomInspectorSplitSizing
+                .defaultRequestListRatio
+            inspectorItem.preferredThicknessFraction = 1
+                - NativeBottomInspectorSplitSizing.defaultRequestListRatio
+        }
+
         addSplitViewItem(primaryItem)
         addSplitViewItem(inspectorItem)
 
         // AppKit restores divider position only after both items belong to the split controller.
-        splitView.autosaveName = NSSplitView.AutosaveName(autosaveName)
+        splitView.autosaveName = autosave
+        self.primaryItem = primaryItem
         self.inspectorItem = inspectorItem
+        self.primaryMinimumHeight = primaryMinimumHeight
+        self.inspectorMinimumHeight = inspectorMinimumHeight
         requestedInspectorVisibility = isInspectorPresented
         pendingInitialVisibility = isInspectorPresented
         observeCollapseState(of: inspectorItem)
@@ -256,13 +368,51 @@ final class NativeBottomInspectorSplitViewController: NSSplitViewController {
         }
     }
 
+    func updateMinimumHeights(primary: CGFloat, inspector: CGFloat) {
+        primaryMinimumHeight = primary
+        inspectorMinimumHeight = inspector
+        primaryItem?.minimumThickness = primary
+        inspectorItem?.minimumThickness = inspector
+    }
+
     // MARK: Private
 
+    private weak var primaryItem: NSSplitViewItem?
     private weak var inspectorItem: NSSplitViewItem?
     private var collapseObservation: NSKeyValueObservation?
+    private var primaryMinimumHeight: CGFloat = 0
+    private var inspectorMinimumHeight: CGFloat = 0
     private var requestedInspectorVisibility = false
     private var pendingInitialVisibility: Bool?
+    private var didApplyDefaultDivider = false
     private var isApplyingInitialState = true
+
+    private func applyDefaultDividerIfNeeded(totalHeight: CGFloat) {
+        guard !hasAutosavedFrames,
+              !didApplyDefaultDivider,
+              isInspectorPresented,
+              NativeBottomInspectorSplitSizing.canSeatRequestedMinima(
+                  totalHeight: totalHeight,
+                  dividerThickness: splitView.dividerThickness,
+                  inspectorPresented: true,
+                  primaryMinimumHeight: primaryMinimumHeight,
+                  inspectorMinimumHeight: inspectorMinimumHeight
+              ),
+              let primaryHeight = NativeBottomInspectorSplitSizing.idealPrimaryHeight(
+                  totalHeight: totalHeight,
+                  dividerThickness: splitView.dividerThickness,
+                  requestListRatio: NativeBottomInspectorSplitSizing.defaultRequestListRatio,
+                  primaryMinimumHeight: primaryMinimumHeight,
+                  inspectorMinimumHeight: inspectorMinimumHeight
+              ) else
+        {
+            return
+        }
+
+        splitView.setPosition(primaryHeight, ofDividerAt: 0)
+        didApplyDefaultDivider = true
+        defaultDividerApplicationCount += 1
+    }
 
     private func observeCollapseState(of item: NSSplitViewItem) {
         collapseObservation = item.observe(\.isCollapsed, options: [.new]) { [weak self] _, _ in

--- a/Rockxy/Views/RequestList/RequestListEmptyStateView.swift
+++ b/Rockxy/Views/RequestList/RequestListEmptyStateView.swift
@@ -1,0 +1,62 @@
+import SwiftUI
+
+// Renders the truthful, recoverable empty state for the main request list.
+
+// MARK: - RequestListEmptyStateView
+
+/// Native `ContentUnavailableView` overlay describing why the request list has no visible rows,
+/// with the nearest safe recovery action. Renders nothing when rows are visible, so it can sit as
+/// an overlay above the still-mounted `RequestTableView` without disturbing its state.
+///
+/// All state derives from observable coordinator properties, so the overlay updates live as the
+/// proxy starts/stops/pauses, traffic arrives, or the workspace, scope, or filters change.
+struct RequestListEmptyStateView: View {
+    // MARK: Internal
+
+    let coordinator: MainContentCoordinator
+
+    /// Whether the current view has any visible rows. Passed in so both the NSTableView-backed
+    /// list (`filteredRows`) and the SwiftUI fallback (`filteredTransactions`) resolve identically.
+    let hasVisibleRows: Bool
+
+    var body: some View {
+        if let state = resolvedState {
+            let copy = RequestListEmptyStateCopy(state)
+            ContentUnavailableView {
+                Label(copy.title, systemImage: copy.systemImage)
+            } description: {
+                Text(copy.description)
+            } actions: {
+                if let action = copy.action, let actionTitle = copy.actionTitle {
+                    Button(actionTitle) { perform(action) }
+                        .accessibilityLabel(Text(actionTitle))
+                        .help(copy.actionHelp ?? actionTitle)
+                }
+            }
+        }
+    }
+
+    // MARK: Private
+
+    private var resolvedState: RequestListEmptyState? {
+        RequestListEmptyState.resolve(
+            hasVisibleRows: hasVisibleRows,
+            availableCount: coordinator.availableTransactionCountForCurrentScope,
+            hasActiveFilters: coordinator.hasActiveWorkspaceFilters,
+            scope: coordinator.filterCriteria.sidebarScope,
+            proxyState: coordinator.proxyDisplayState
+        )
+    }
+
+    private func perform(_ action: RequestListEmptyStateAction) {
+        switch action {
+        case .clearFilters,
+             .showAllTraffic:
+            coordinator.clearAllWorkspaceFilters()
+        case .startProxy:
+            coordinator.startProxy()
+        case .resumeRecording:
+            coordinator.toggleRecording()
+        }
+    }
+}

--- a/Rockxy/Views/RequestList/RequestListView.swift
+++ b/Rockxy/Views/RequestList/RequestListView.swift
@@ -54,11 +54,7 @@ struct RequestListView: View {
 
     @ViewBuilder private var trafficListView: some View {
         if coordinator.filteredTransactions.isEmpty {
-            ContentUnavailableView(
-                "No Traffic",
-                systemImage: "network.slash",
-                description: Text("Start the proxy to capture network traffic")
-            )
+            RequestListEmptyStateView(coordinator: coordinator, hasVisibleRows: false)
         } else {
             List(coordinator.filteredTransactions, selection: Binding(
                 get: { coordinator.selectedTransaction?.id },

--- a/Rockxy/Views/RequestList/RequestTableView.swift
+++ b/Rockxy/Views/RequestList/RequestTableView.swift
@@ -2160,6 +2160,7 @@ extension RequestTableView {
                 }
                 nameLabel?.stringValue = appName
                 nameLabel?.font = parent.effectiveDisplayMetrics.appKitFont()
+                nameLabel?.toolTip = appName.isEmpty ? nil : appName
                 if let icon = appIcon(for: appName) {
                     imageView?.image = icon
                     imageView?.isHidden = false
@@ -2212,6 +2213,7 @@ extension RequestTableView {
 
             // Populate content
             nameLabel.stringValue = appName
+            nameLabel.toolTip = appName.isEmpty ? nil : appName
             if let icon = appIcon(for: appName) {
                 imageView.image = icon
                 imageView.isHidden = false
@@ -2328,6 +2330,7 @@ extension RequestTableView {
 
             case "url":
                 cell.stringValue = rowData.host + rowData.path
+                cell.toolTip = cell.stringValue
                 cell.font = metrics.appKitFont(monospaced: true)
                 cell.textColor = .labelColor
 
@@ -2426,7 +2429,9 @@ extension RequestTableView {
 
             default:
                 if column.hasPrefix("reqHeader.") || column.hasPrefix("resHeader.") {
-                    cell.stringValue = RequestListRow.resolveHeaderValue(for: column, row: rowData)
+                    let headerValue = RequestListRow.resolveHeaderValue(for: column, row: rowData)
+                    cell.stringValue = headerValue
+                    cell.toolTip = headerValue.isEmpty ? nil : headerValue
                     cell.font = metrics.appKitFont(monospaced: true)
                     cell.textColor = .secondaryLabelColor
                 } else {

--- a/Rockxy/Views/RequestList/RequestTableView.swift
+++ b/Rockxy/Views/RequestList/RequestTableView.swift
@@ -1548,7 +1548,7 @@ extension RequestTableView {
 
         private func buildAnnotationGroup(_ menu: NSMenu, transaction: HTTPTransaction) {
             menu.addItem(menuItem(
-                String(localized: "Add Comment…"), action: #selector(handleAddComment(_:)),
+                String(localized: "Add Note…"), action: #selector(handleAddComment(_:)),
                 key: "l", symbol: "pencil.line", transaction: transaction
             ))
 

--- a/Rockxy/Views/RequestList/StatusBarView.swift
+++ b/Rockxy/Views/RequestList/StatusBarView.swift
@@ -108,6 +108,144 @@ struct FooterActionDescriptor: Identifiable, Equatable {
     }
 }
 
+// MARK: - FooterMutationIndicator
+
+/// A live active-mutation indicator for the footer: shows a rule tool category
+/// (Map Local, Map Remote, Breakpoints) together with its enabled-rule count.
+/// Purely derived from `[ProxyRule]` plus the tool-level master switches so the
+/// footer can expose active mutation state without displacing traffic.
+struct FooterMutationIndicator: Identifiable, Equatable {
+    // MARK: Lifecycle
+
+    init(category: Category, count: Int) {
+        id = category
+        self.count = count
+    }
+
+    // MARK: Internal
+
+    enum Category: String, CaseIterable {
+        case mapLocal
+        case mapRemote
+        case breakpoint
+
+        // MARK: Internal
+
+        /// The `RuleAction.toolCategory` value that maps to this indicator.
+        var toolCategory: String {
+            switch self {
+            case .mapLocal: "mapLocal"
+            case .mapRemote: "mapRemote"
+            case .breakpoint: "breakpoint"
+            }
+        }
+
+        /// The tool-window ID opened when the indicator is activated.
+        var windowID: String {
+            switch self {
+            case .mapLocal: "mapLocal"
+            case .mapRemote: "mapRemote"
+            case .breakpoint: "breakpointRules"
+            }
+        }
+
+        var title: String {
+            switch self {
+            case .mapLocal: String(localized: "Map Local")
+            case .mapRemote: String(localized: "Map Remote")
+            case .breakpoint: String(localized: "Breakpoints")
+            }
+        }
+
+        var systemImage: String {
+            switch self {
+            case .mapLocal: "folder.badge.gearshape"
+            case .mapRemote: "arrow.triangle.branch"
+            case .breakpoint: "pause.circle"
+            }
+        }
+    }
+
+    let id: Category
+    let count: Int
+
+    var title: String {
+        id.title
+    }
+
+    var systemImage: String {
+        id.systemImage
+    }
+
+    var windowID: String {
+        id.windowID
+    }
+
+    var help: String {
+        switch id {
+        case .mapLocal:
+            if count == 1 {
+                return String(localized: "1 active Map Local rule. Open Map Local.")
+            }
+            return String(localized: "\(count) active Map Local rules. Open Map Local.")
+        case .mapRemote:
+            if count == 1 {
+                return String(localized: "1 active Map Remote rule. Open Map Remote.")
+            }
+            return String(localized: "\(count) active Map Remote rules. Open Map Remote.")
+        case .breakpoint:
+            if count == 1 {
+                return String(localized: "1 active Breakpoint rule. Open Breakpoint Rules.")
+            }
+            return String(localized: "\(count) active Breakpoint rules. Open Breakpoint Rules.")
+        }
+    }
+
+    var accessibilityLabel: String {
+        String(localized: "\(id.title), \(count) active rules")
+    }
+}
+
+// MARK: - FooterMutationIndicatorBuilder
+
+/// Pure builder that derives the ordered footer mutation indicators from the
+/// current rule set and the three tool-level master switches. A category is
+/// surfaced only when its master switch is enabled AND it has at least one
+/// enabled rule. Order is always Map Local, Map Remote, then Breakpoint.
+enum FooterMutationIndicatorBuilder {
+    static func indicators(
+        rules: [ProxyRule],
+        mapLocalToolEnabled: Bool,
+        mapRemoteToolEnabled: Bool,
+        breakpointToolEnabled: Bool
+    )
+        -> [FooterMutationIndicator]
+    {
+        var counts: [String: Int] = [:]
+        for rule in rules where rule.isEnabled {
+            counts[rule.action.toolCategory, default: 0] += 1
+        }
+
+        let toolSwitches: [FooterMutationIndicator.Category: Bool] = [
+            .mapLocal: mapLocalToolEnabled,
+            .mapRemote: mapRemoteToolEnabled,
+            .breakpoint: breakpointToolEnabled,
+        ]
+
+        let order: [FooterMutationIndicator.Category] = [.mapLocal, .mapRemote, .breakpoint]
+        return order.compactMap { category in
+            guard toolSwitches[category] == true else {
+                return nil
+            }
+            let count = counts[category.toolCategory, default: 0]
+            guard count > 0 else {
+                return nil
+            }
+            return FooterMutationIndicator(category: category, count: count)
+        }
+    }
+}
+
 // MARK: - FooterToolingButton
 
 private struct FooterToolingButton: View {
@@ -132,6 +270,65 @@ private struct FooterToolingButton: View {
     // MARK: Private
 
     @State private var isHovered = false
+}
+
+// MARK: - FooterMutationIndicatorButton
+
+/// Compact active-mutation chip rendered in the footer. Shows the tool category
+/// plus its live enabled-rule count, and opens the matching tool window when
+/// activated. The parent group chooses the titled or compact form based on the
+/// horizontal space available in the existing fixed-height footer.
+private struct FooterMutationIndicatorButton: View {
+    // MARK: Internal
+
+    let indicator: FooterMutationIndicator
+    let showsTitle: Bool
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            chip
+        }
+        .buttonStyle(.plain)
+        .help(indicator.help)
+        .accessibilityLabel(indicator.accessibilityLabel)
+        .onHover { isHovered = $0 }
+    }
+
+    // MARK: Private
+
+    @State private var isHovered = false
+    @Environment(\.appUIDisplayMetrics) private var metrics
+
+    private var indicatorColor: Color {
+        switch indicator.id {
+        case .mapLocal, .mapRemote:
+            Color(nsColor: .systemOrange)
+        case .breakpoint:
+            Color(nsColor: .systemPurple)
+        }
+    }
+
+    private var chip: some View {
+        HStack(spacing: 4) {
+            Image(systemName: indicator.systemImage)
+            if showsTitle {
+                Text(indicator.title)
+            }
+            Text("\(indicator.count)")
+                .monospacedDigit()
+        }
+        .font(.system(size: metrics.badgeFontSize, weight: .semibold))
+        .foregroundStyle(indicatorColor)
+        .lineLimit(1)
+        .padding(.horizontal, 7)
+        .padding(.vertical, 2)
+        .background(indicatorColor.opacity(isHovered ? 0.24 : 0.14), in: Capsule())
+        .overlay {
+            Capsule()
+                .stroke(indicatorColor.opacity(isHovered ? 0.55 : 0.32), lineWidth: 0.5)
+        }
+    }
 }
 
 // MARK: - FooterProxyOverrideButton
@@ -267,7 +464,7 @@ private struct FooterPrimaryButton: View {
     }
 }
 
-// MARK: - StatusBarView
+// MARK: - StatusBarRequestSummary
 
 enum StatusBarRequestSummary {
     static func text(
@@ -291,6 +488,8 @@ enum StatusBarRequestSummary {
         return String(localized: "\(visibleCount) requests")
     }
 }
+
+// MARK: - StatusBarView
 
 /// Bottom status bar showing request counts, bandwidth stats (upload/download speed),
 /// and quick-action buttons for clearing, toggling filters, and auto-select mode.
@@ -316,6 +515,10 @@ struct StatusBarView: View {
     var proxyStartedAt: Date?
     var selectedRequestInfo: String?
     var sessionProvenance: SessionProvenance?
+    var activeRules: [ProxyRule] = []
+    var mapLocalToolEnabled: Bool = true
+    var mapRemoteToolEnabled: Bool = true
+    var breakpointToolEnabled: Bool = true
 
     var onClear: () -> Void = {}
     var onFilter: () -> Void = {}
@@ -327,6 +530,7 @@ struct StatusBarView: View {
         WorkspaceFooterBar(horizontalPadding: 12) {
             HStack(spacing: 0) {
                 quickTools
+                mutationIndicators
                 Spacer(minLength: 24)
                 centerStatus
                 Spacer(minLength: 24)
@@ -348,6 +552,72 @@ struct StatusBarView: View {
 
     private var formattedDataSize: String {
         ByteCountFormatter.string(fromByteCount: totalDataSize, countStyle: .file)
+    }
+
+    private var mutationIndicatorList: [FooterMutationIndicator] {
+        FooterMutationIndicatorBuilder.indicators(
+            rules: activeRules,
+            mapLocalToolEnabled: mapLocalToolEnabled,
+            mapRemoteToolEnabled: mapRemoteToolEnabled,
+            breakpointToolEnabled: breakpointToolEnabled
+        )
+    }
+
+    @ViewBuilder private var mutationIndicators: some View {
+        let indicators = mutationIndicatorList
+        if !indicators.isEmpty {
+            HStack(spacing: 6) {
+                Divider()
+                    .frame(height: 12)
+                ViewThatFits(in: .horizontal) {
+                    mutationIndicatorRow(indicators, showsTitles: true)
+                    mutationIndicatorRow(indicators, showsTitles: false)
+                    mutationIndicatorMenu(indicators)
+                }
+            }
+            .padding(.leading, 8)
+            .layoutPriority(1)
+        }
+    }
+
+    private func mutationIndicatorRow(
+        _ indicators: [FooterMutationIndicator],
+        showsTitles: Bool
+    ) -> some View {
+        HStack(spacing: 6) {
+            ForEach(indicators) { indicator in
+                FooterMutationIndicatorButton(indicator: indicator, showsTitle: showsTitles) {
+                    onOpenToolWindow(indicator.windowID)
+                }
+            }
+        }
+    }
+
+    private func mutationIndicatorMenu(_ indicators: [FooterMutationIndicator]) -> some View {
+        Menu {
+            ForEach(indicators) { indicator in
+                Button {
+                    onOpenToolWindow(indicator.windowID)
+                } label: {
+                    Label("\(indicator.title)  \(indicator.count)", systemImage: indicator.systemImage)
+                }
+            }
+        } label: {
+            Label(
+                "\(indicators.reduce(0) { $0 + $1.count })",
+                systemImage: "bolt.horizontal.circle"
+            )
+            .font(.system(size: metrics.badgeFontSize, weight: .semibold))
+            .foregroundStyle(Color(nsColor: .systemOrange))
+            .padding(.horizontal, 7)
+            .padding(.vertical, 2)
+            .background(Color(nsColor: .systemOrange).opacity(0.14), in: Capsule())
+        }
+        .menuStyle(.borderlessButton)
+        .menuIndicator(.hidden)
+        .fixedSize()
+        .help(String(localized: "Active mutation rules"))
+        .accessibilityLabel(String(localized: "Active mutation rules"))
     }
 
     private var centerStatus: some View {

--- a/Rockxy/Views/Sidebar/SidebarView.swift
+++ b/Rockxy/Views/Sidebar/SidebarView.swift
@@ -200,6 +200,7 @@ struct SidebarView: View {
     @State private var isDomainsExpanded = false
     @State private var isPinnedExpanded = false
     @State private var isSavedExpanded = false
+    @State private var isNotesExpanded = false
     @State private var expandedAppNames: Set<String> = []
     @State private var expandedDomainNodeIDs: Set<String> = []
     @Environment(\.appUIDisplayMetrics) private var metrics
@@ -236,6 +237,10 @@ struct SidebarView: View {
 
     private var savedTransactions: [HTTPTransaction] {
         SidebarSearchFilter.transactions(coordinator.allSavedTransactions, query: sidebarFilterText)
+    }
+
+    private var notesTransactions: [HTTPTransaction] {
+        SidebarSearchFilter.transactions(coordinator.allNotesTransactions, query: sidebarFilterText)
     }
 
     private var filteredFavorites: [SidebarItem] {
@@ -481,6 +486,44 @@ struct SidebarView: View {
                     .frame(minHeight: metrics.sidebarRowHeight)
                     .contentShape(Rectangle())
                     .onTapGesture { coordinator.selectSidebarItem(.allSaved) }
+            }
+
+            DisclosureGroup(isExpanded: searchAwareExpansionBinding(for: $isNotesExpanded)) {
+                let notes = notesTransactions
+                if notes.isEmpty {
+                    Text(
+                        SidebarSearchFilter.hasQuery(sidebarFilterText)
+                            ? String(localized: "No matching notes")
+                            : String(localized: "No notes")
+                    )
+                        .foregroundStyle(.secondary)
+                        .font(.system(size: metrics.sidebarSecondaryFontSize))
+                        .frame(minHeight: metrics.sidebarRowHeight, alignment: .center)
+                } else {
+                    ForEach(notes) { transaction in
+                        Label {
+                            Text(transaction.request.host + transaction.request.path)
+                                .font(sidebarNavigationFont)
+                                .lineLimit(1)
+                        } icon: {
+                            Image(systemName: "note.text")
+                                .font(sidebarIconFont)
+                        }
+                        .font(sidebarNavigationFont)
+                        .tag(SidebarItem.noteTransaction(id: transaction.id))
+                        .frame(minHeight: metrics.sidebarRowHeight)
+                        .contextMenu {
+                            favoriteTransactionContextMenu(transaction, section: .notes)
+                        }
+                    }
+                }
+            } label: {
+                Label(String(localized: "Notes"), systemImage: "note.text")
+                    .badge(notesTransactions.count)
+                    .tag(SidebarItem.allNotes)
+                    .frame(minHeight: metrics.sidebarRowHeight)
+                    .contentShape(Rectangle())
+                    .onTapGesture { coordinator.selectSidebarItem(.allNotes) }
             }
 
             ForEach(filteredFavorites, id: \.self) { item in

--- a/Rockxy/Views/Toolbar/ActiveFilterSummaryBar.swift
+++ b/Rockxy/Views/Toolbar/ActiveFilterSummaryBar.swift
@@ -79,6 +79,15 @@ struct ActiveFilterSummaryBar: View {
                         }
                     }
 
+                    if coordinator.filterCriteria.sidebarScope == .notes {
+                        FilterChip(label: String(localized: "Notes")) {
+                            coordinator.filterCriteria.sidebarScope = .allTraffic
+                            coordinator.filterCriteria.exactTransactionID = nil
+                            coordinator.sidebarSelection = nil
+                            coordinator.recomputeFilteredTransactions()
+                        }
+                    }
+
                     if coordinator.filterCriteria.isSearchEnabled,
                        !coordinator.filterCriteria.searchText.isEmpty
                     {
@@ -145,6 +154,7 @@ struct ActiveFilterSummaryBar: View {
             || coordinator.filterCriteria.sidebarApp != nil
             || coordinator.filterCriteria.sidebarScope == .saved
             || coordinator.filterCriteria.sidebarScope == .pinned
+            || coordinator.filterCriteria.sidebarScope == .notes
             || (coordinator.filterCriteria.isSearchEnabled && !coordinator.filterCriteria.searchText.isEmpty)
             || !coordinator.filterCriteria.activeProtocolFilters.isEmpty
             || (coordinator.isFilterBarVisible

--- a/Rockxy/Views/Toolbar/ActiveFilterSummaryBar.swift
+++ b/Rockxy/Views/Toolbar/ActiveFilterSummaryBar.swift
@@ -102,12 +102,14 @@ struct ActiveFilterSummaryBar: View {
                         )
                     }
 
-                    if !coordinator.filterCriteria.activeProtocolFilters.isEmpty {
-                        let count = coordinator.filterCriteria.activeProtocolFilters.count
+                    ForEach(
+                        ProtocolFilterSelection.summaryFilters(in: coordinator.filterCriteria.activeProtocolFilters),
+                        id: \.self
+                    ) { filter in
                         FilterChip(
-                            label: String(localized: "\(count) protocol filters"),
+                            label: filter.displayName,
                             onRemove: {
-                                coordinator.filterCriteria.activeProtocolFilters.removeAll()
+                                coordinator.filterCriteria.activeProtocolFilters.remove(filter)
                                 coordinator.recomputeFilteredTransactions()
                             }
                         )

--- a/Rockxy/Views/Toolbar/ActiveFilterSummaryBar.swift
+++ b/Rockxy/Views/Toolbar/ActiveFilterSummaryBar.swift
@@ -129,7 +129,7 @@ struct ActiveFilterSummaryBar: View {
                     }
 
                     Button(String(localized: "Clear All")) {
-                        clearAllFilters()
+                        coordinator.clearAllWorkspaceFilters()
                     }
                     .font(.system(size: metrics.secondaryFontSize, weight: .medium))
                     .foregroundStyle(Color.accentColor)
@@ -161,18 +161,6 @@ struct ActiveFilterSummaryBar: View {
             || !coordinator.filterCriteria.activeProtocolFilters.isEmpty
             || (coordinator.isFilterBarVisible
                 && coordinator.filterRules.contains(where: { $0.isEnabled && !$0.value.isEmpty }))
-    }
-
-    private func clearAllFilters() {
-        coordinator.filterCriteria = .empty
-        coordinator.filterCriteria.sidebarScope = .allTraffic
-        coordinator.sidebarSelection = nil
-        coordinator.isFilterBarVisible = false
-        coordinator.filterRules = [FilterRule()]
-        coordinator.activeWorkspace.activeTrafficSignal = nil
-        coordinator.activeWorkspace.activeFocusSetID = nil
-        coordinator.activeWorkspace.mutedTrafficSources.removeAll()
-        coordinator.recomputeFilteredTransactions()
     }
 }
 

--- a/Rockxy/Views/Toolbar/ProtocolFilterBar.swift
+++ b/Rockxy/Views/Toolbar/ProtocolFilterBar.swift
@@ -4,50 +4,30 @@ import SwiftUI
 
 // MARK: - ProtocolFilterBar
 
-/// Horizontal row of filter pills for narrowing traffic by content type (JSON, HTML, Image, etc.)
-/// and HTTP status category (2xx, 3xx, 4xx, 5xx). Content filters and status filters are applied
-/// independently — a request must match at least one active filter in each group.
+/// Dense, native filtering surface for narrowing traffic. An adaptive single line shows the most
+/// useful `FilterPillButton`s directly — `All`, transport, the AI / Web3 / content lenses, and the
+/// common status ranges — with a native `ellipsis.circle` overflow menu holding the rest, grouped
+/// under Transport / Protocol / Content / Status. `ViewThatFits` picks the widest deterministic
+/// tier that fits, so the row never scrolls or clips and visible pills never reorder on selection.
+/// Traffic-type and status filters combine with AND across groups; selections within a group
+/// combine with OR (see `MainContentCoordinator+Filtering`).
 struct ProtocolFilterBar: View {
     // MARK: Internal
 
     @Binding var activeFilters: Set<ProtocolFilter>
 
     var body: some View {
-        ScrollView(.horizontal, showsIndicators: false) {
-            HStack(spacing: 2) {
-                ForEach(ProtocolFilter.contentFilters, id: \.self) { filter in
-                    FilterPillButton(
-                        title: filter.displayName,
-                        isActive: isActive(filter),
-                        action: { toggle(filter) }
-                    )
-                }
-
-                Divider()
-                    .frame(height: 16)
-                    .padding(.horizontal, 4)
-
-                ForEach(ProtocolFilter.statusFilters, id: \.self) { filter in
-                    FilterPillButton(
-                        title: filter.displayName,
-                        isActive: isActive(filter),
-                        action: { toggle(filter) }
-                    )
-                }
-
-                Spacer()
-
-                if !activeFilters.isEmpty {
-                    Button(String(localized: "Reset Filters")) {
-                        activeFilters.removeAll()
-                    }
-                    .buttonStyle(.borderless)
-                    .font(.system(size: metrics.secondaryFontSize))
-                    .foregroundStyle(.secondary)
-                }
-            }
-            .padding(.horizontal, 8)
+        // Widest tier first; `ViewThatFits` keeps the first that fits. Tier 5 (`.all` + overflow +
+        // icon Clear All) is the always-fitting fallback. Kept in sync with `inlinePillTiers`.
+        ViewThatFits(in: .horizontal) {
+            tierRow(0)
+            tierRow(1)
+            tierRow(2)
+            tierRow(3)
+            tierRow(4)
+            tierRow(5)
         }
+        .padding(.horizontal, Theme.Layout.contentPadding)
         .padding(.vertical, max(4, (metrics.fontSize - 10) / 3))
         .background(Color(nsColor: .windowBackgroundColor))
         .overlay(alignment: .bottom) { Divider() }
@@ -58,26 +38,135 @@ struct ProtocolFilterBar: View {
 
     @Environment(\.appUIDisplayMetrics) private var metrics
 
-    private func isActive(_ filter: ProtocolFilter) -> Bool {
-        if filter == .all {
-            let contentActive = activeFilters.filter { !$0.isStatusFilter }
-            return contentActive.isEmpty
-        }
-        return activeFilters.contains(filter)
+    private var hasActiveFilters: Bool {
+        !activeFilters.isEmpty
     }
 
-    private func toggle(_ filter: ProtocolFilter) {
-        if filter == .all {
-            let statusFilters = activeFilters.filter(\.isStatusFilter)
-            activeFilters = statusFilters
-            return
-        }
+    private var anyStatusBinding: Binding<Bool> {
+        Binding(
+            get: { ProtocolFilterSelection.activeStatusFilters(in: activeFilters).isEmpty },
+            set: { _ in activeFilters = ProtocolFilterSelection.clearingStatusFilters(in: activeFilters) }
+        )
+    }
 
-        if activeFilters.contains(filter) {
-            activeFilters.remove(filter)
-        } else {
-            activeFilters.insert(filter)
-            activeFilters.remove(.all)
+    private func tierRow(_ tier: Int) -> some View {
+        let visible = ProtocolFilterSelection.inlinePills(forTier: tier)
+        let isNarrowest = tier == ProtocolFilterSelection.inlinePillTiers.count - 1
+        return HStack(spacing: Theme.Layout.controlSpacing) {
+            pillRow(visible: visible)
+            overflowMenu(visiblePills: visible)
+            Spacer(minLength: 0)
+            if hasActiveFilters {
+                clearAllButton(iconOnly: isNarrowest)
+            }
         }
+    }
+
+    private func pillRow(visible: [ProtocolFilter]) -> some View {
+        let typePills = visible.filter { !$0.isStatusFilter }
+        let statusPills = visible.filter(\.isStatusFilter)
+        return HStack(spacing: Theme.Layout.controlSpacing) {
+            ForEach(typePills, id: \.self) { pill(for: $0) }
+            if !statusPills.isEmpty {
+                Divider()
+                    .frame(height: 16)
+                    .padding(.horizontal, 4)
+                ForEach(statusPills, id: \.self) { pill(for: $0) }
+            }
+        }
+    }
+
+    private func pill(for filter: ProtocolFilter) -> some View {
+        FilterPillButton(
+            title: filter.displayName,
+            isActive: ProtocolFilterSelection.isSelected(filter, in: activeFilters),
+            action: { activeFilters = ProtocolFilterSelection.toggling(filter, in: activeFilters) }
+        )
+    }
+
+    private func overflowMenu(visiblePills: [ProtocolFilter]) -> some View {
+        let hasHidden = ProtocolFilterSelection.hasHiddenActiveFilter(
+            activeFilters: activeFilters,
+            visiblePills: visiblePills
+        )
+        return Menu {
+            overflowSection(String(localized: "Transport"), ProtocolFilterSelection.transportFilters, visiblePills)
+            overflowSection(String(localized: "Protocol"), ProtocolFilterSelection.protocolFilters, visiblePills)
+            overflowSection(String(localized: "Content"), ProtocolFilterSelection.contentTypeFilters, visiblePills)
+            overflowStatusSection(visiblePills)
+        } label: {
+            Image(systemName: hasHidden ? "ellipsis.circle.fill" : "ellipsis.circle")
+                .font(.system(size: metrics.secondaryFontSize))
+        }
+        .menuStyle(.borderlessButton)
+        .menuIndicator(.hidden)
+        .fixedSize()
+        .foregroundStyle(hasHidden ? Color.accentColor : Color.secondary)
+        .help(String(localized: "More filters"))
+        .accessibilityLabel(String(localized: "More filters"))
+        .accessibilityValue(
+            hasHidden
+                ? String(localized: "Hidden filters active")
+                : String(localized: "No hidden filters active")
+        )
+    }
+
+    @ViewBuilder
+    private func overflowSection(
+        _ title: String,
+        _ group: [ProtocolFilter],
+        _ visiblePills: [ProtocolFilter]
+    )
+        -> some View
+    {
+        let hidden = ProtocolFilterSelection.overflowFilters(in: group, visiblePills: visiblePills)
+        if !hidden.isEmpty {
+            Section(title) {
+                ForEach(hidden, id: \.self) { filter in
+                    Toggle(ProtocolFilterSelection.menuLabel(for: filter), isOn: binding(for: filter))
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func overflowStatusSection(_ visiblePills: [ProtocolFilter]) -> some View {
+        let hidden = ProtocolFilterSelection.overflowFilters(
+            in: ProtocolFilterSelection.statusFilters,
+            visiblePills: visiblePills
+        )
+        if !hidden.isEmpty {
+            Section(String(localized: "Status")) {
+                Toggle(String(localized: "Any Status"), isOn: anyStatusBinding)
+                Divider()
+                ForEach(hidden, id: \.self) { filter in
+                    Toggle(ProtocolFilterSelection.menuLabel(for: filter), isOn: binding(for: filter))
+                }
+            }
+        }
+    }
+
+    private func clearAllButton(iconOnly: Bool) -> some View {
+        Button {
+            activeFilters = ProtocolFilterSelection.clearingAllFilters(in: activeFilters)
+        } label: {
+            if iconOnly {
+                Image(systemName: "xmark.circle")
+            } else {
+                Text(String(localized: "Clear All"))
+            }
+        }
+        .buttonStyle(.borderless)
+        .font(.system(size: metrics.secondaryFontSize, weight: .medium))
+        .foregroundStyle(Color.accentColor)
+        .help(String(localized: "Clear all traffic-type and status filters"))
+        .accessibilityLabel(String(localized: "Clear all protocol filters"))
+    }
+
+    private func binding(for filter: ProtocolFilter) -> Binding<Bool> {
+        Binding(
+            get: { ProtocolFilterSelection.isSelected(filter, in: activeFilters) },
+            set: { _ in activeFilters = ProtocolFilterSelection.toggling(filter, in: activeFilters) }
+        )
     }
 }

--- a/Rockxy/Views/Toolbar/ProxyToolbarContent.swift
+++ b/Rockxy/Views/Toolbar/ProxyToolbarContent.swift
@@ -7,8 +7,7 @@ import SwiftUI
 /// Main window toolbar providing start/stop, Developer Setup access, and inspector
 /// layout toggle buttons, plus the central proxy status indicator.
 struct ProxyToolbarContent: ToolbarContent {
-    @Environment(\.openWindow) private var openWindow
-    @ObservedObject private var updater = AppUpdater.shared
+    // MARK: Internal
 
     @Bindable var coordinator: MainContentCoordinator
 
@@ -48,7 +47,12 @@ struct ProxyToolbarContent: ToolbarContent {
                     systemImage: "rectangle.split.1x2"
                 )
             }
-            .help(String(localized: "Show or hide the bottom inspector panel"))
+            .help(
+                coordinator.canToggleBottomInspector
+                    ? String(localized: "Show or hide the bottom inspector panel")
+                    : String(localized: "Select a request to use the bottom inspector")
+            )
+            .disabled(!coordinator.canToggleBottomInspector)
 
             Button {
                 coordinator.toggleInspectorRight()
@@ -77,13 +81,18 @@ struct ProxyToolbarContent: ToolbarContent {
             )
         }
     }
+
+    // MARK: Private
+
+    @Environment(\.openWindow) private var openWindow
+    @ObservedObject private var updater = AppUpdater.shared
 }
 
 // MARK: - ProxyToolbarStatusView
 
 /// Reusable status content for the AppKit-owned main toolbar.
 struct ProxyToolbarStatusView: View {
-    @ObservedObject private var updater = AppUpdater.shared
+    // MARK: Internal
 
     @Bindable var coordinator: MainContentCoordinator
 
@@ -101,4 +110,8 @@ struct ProxyToolbarStatusView: View {
             showPopover: $coordinator.showProxyStatusPopover
         )
     }
+
+    // MARK: Private
+
+    @ObservedObject private var updater = AppUpdater.shared
 }

--- a/Rockxy/Views/Toolbar/SearchFilterBar.swift
+++ b/Rockxy/Views/Toolbar/SearchFilterBar.swift
@@ -6,15 +6,42 @@ import SwiftUI
 
 /// Single-field search bar with a field selector (URL, host, path, method) and enable/disable toggle.
 struct SearchFilterBar: View {
+    // MARK: Internal
+
     @Binding var searchText: String
     @Binding var filterField: FilterField
     @Binding var isEnabled: Bool
+
     let isAdvancedFilterVisible: Bool
     let advancedFilterCount: Int
     let onAddFilter: () -> Void
     let onToggleAdvancedFilters: () -> Void
 
     var body: some View {
+        // Widest tier first; `ViewThatFits` keeps the first that fits. The search field carries a
+        // useful minimum width so it stays the flexible dominant area and never collapses; when the
+        // wide row no longer fits, the compact fallback narrows the picker and drops the visible
+        // `Add Filter` title while keeping every control and its order intact.
+        ViewThatFits(in: .horizontal) {
+            filterRow(pickerWidth: 130, showsAddFilterTitle: true)
+            filterRow(pickerWidth: 100, showsAddFilterTitle: false)
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, max(4, (metrics.fontSize - 10) / 3))
+        .background(Color(nsColor: .windowBackgroundColor))
+        .overlay(alignment: .bottom) { Divider() }
+        .onReceive(NotificationCenter.default.publisher(for: .focusMainSearchField)) { _ in
+            isEnabled = true
+            isSearchFocused = true
+        }
+    }
+
+    // MARK: Private
+
+    @FocusState private var isSearchFocused: Bool
+    @Environment(\.appUIDisplayMetrics) private var metrics
+
+    private func filterRow(pickerWidth: CGFloat, showsAddFilterTitle: Bool) -> some View {
         HStack(spacing: 8) {
             Toggle("", isOn: $isEnabled)
                 .toggleStyle(.checkbox)
@@ -25,12 +52,13 @@ struct SearchFilterBar: View {
                     Text(field.displayName).tag(field)
                 }
             }
-            .frame(width: 130)
+            .frame(width: pickerWidth)
 
             TextField(String(localized: "Search..."), text: $searchText)
                 .textFieldStyle(.roundedBorder)
                 .font(metrics.swiftUIFont())
                 .focused($isSearchFocused)
+                .frame(minWidth: 220, maxWidth: .infinity)
 
             if !searchText.isEmpty {
                 Button {
@@ -40,17 +68,23 @@ struct SearchFilterBar: View {
                         .foregroundStyle(.secondary)
                 }
                 .buttonStyle(.borderless)
+                .accessibilityLabel(String(localized: "Clear search"))
             }
 
             Divider()
                 .frame(height: 18)
 
             Button(action: onAddFilter) {
-                Label(String(localized: "Add Filter"), systemImage: "plus")
+                if showsAddFilterTitle {
+                    Label(String(localized: "Add Filter"), systemImage: "plus")
+                } else {
+                    Image(systemName: "plus")
+                }
             }
             .buttonStyle(.bordered)
             .controlSize(.small)
             .help(String(localized: "Add a compound filter rule"))
+            .accessibilityLabel(String(localized: "Add Filter"))
 
             Button(action: onToggleAdvancedFilters) {
                 HStack(spacing: 4) {
@@ -69,16 +103,5 @@ struct SearchFilterBar: View {
                 ? String(localized: "Hide compound filters")
                 : String(localized: "Show compound filters"))
         }
-        .padding(.horizontal, 8)
-        .padding(.vertical, max(4, (metrics.fontSize - 10) / 3))
-        .background(Color(nsColor: .windowBackgroundColor))
-        .overlay(alignment: .bottom) { Divider() }
-        .onReceive(NotificationCenter.default.publisher(for: .focusMainSearchField)) { _ in
-            isEnabled = true
-            isSearchFocused = true
-        }
     }
-
-    @FocusState private var isSearchFocused: Bool
-    @Environment(\.appUIDisplayMetrics) private var metrics
 }

--- a/RockxyTests/Core/Storage/SessionStoreNotesLoadTests.swift
+++ b/RockxyTests/Core/Storage/SessionStoreNotesLoadTests.swift
@@ -1,0 +1,62 @@
+import Foundation
+@testable import Rockxy
+import Testing
+
+// Regression tests for note-only transaction persistence in `SessionStore`.
+// A transaction that is neither pinned nor saved must still survive a restart when it carries a note.
+
+struct SessionStoreNotesLoadTests {
+    // MARK: Internal
+
+    @Test("Note-only transaction is reloaded by the Library startup query")
+    func noteOnlyTransactionSurvivesReload() async throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let store = try SessionStore(directory: dir)
+        let noteOnly = TestFixtures.makeTransaction(url: "https://api.example.com/note-only")
+        noteOnly.comment = "Investigate later"
+        try await store.saveTransaction(noteOnly)
+
+        let reloaded = try SessionStore(directory: dir)
+        let loaded = try await reloaded.loadPinnedAndSavedTransactions()
+
+        let match = try #require(loaded.first { $0.id == noteOnly.id })
+        #expect(match.isPinned == false)
+        #expect(match.isSaved == false)
+        #expect(match.comment == "Investigate later")
+    }
+
+    @Test("Startup query still excludes plain transactions and keeps pinned/saved")
+    func startupQueryScopesCorrectly() async throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let store = try SessionStore(directory: dir)
+        let plain = TestFixtures.makeTransaction(url: "https://api.example.com/plain")
+        let pinned = TestFixtures.makeTransaction(url: "https://api.example.com/pinned")
+        pinned.isPinned = true
+        let saved = TestFixtures.makeTransaction(url: "https://api.example.com/saved")
+        saved.isSaved = true
+        let noted = TestFixtures.makeTransaction(url: "https://api.example.com/noted")
+        noted.comment = "note"
+        for transaction in [plain, pinned, saved, noted] {
+            try await store.saveTransaction(transaction)
+        }
+
+        let loaded = try await store.loadPinnedAndSavedTransactions()
+        let ids = Set(loaded.map(\.id))
+
+        #expect(ids == [pinned.id, saved.id, noted.id])
+        #expect(!ids.contains(plain.id))
+    }
+
+    // MARK: Private
+
+    private func makeTempDir() throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("RockxyTest-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+}

--- a/RockxyTests/Models/UI/ContextDockEmptyStateTests.swift
+++ b/RockxyTests/Models/UI/ContextDockEmptyStateTests.swift
@@ -1,0 +1,70 @@
+@testable import Rockxy
+import Testing
+
+struct ContextDockEmptyStateTests {
+    @Test("Captured traffic with visible results prompts to select a request while capturing")
+    func selectRequestWhileCapturing() {
+        let state = ContextDockEmptyState.resolve(
+            hasCapturedTraffic: true,
+            hasVisibleResults: true,
+            isCapturing: true
+        )
+
+        #expect(state == .selectRequest)
+    }
+
+    @Test("Captured traffic with visible results prompts to select a request while stopped")
+    func selectRequestWhileStopped() {
+        let state = ContextDockEmptyState.resolve(
+            hasCapturedTraffic: true,
+            hasVisibleResults: true,
+            isCapturing: false
+        )
+
+        #expect(state == .selectRequest)
+    }
+
+    @Test("Visible workspace results are sufficient even when the global capture list is empty")
+    func visibleWorkspaceResultsTakePriority() {
+        let state = ContextDockEmptyState.resolve(
+            hasCapturedTraffic: false,
+            hasVisibleResults: true,
+            isCapturing: false
+        )
+
+        #expect(state == .selectRequest)
+    }
+
+    @Test("No captured traffic while capturing explains that requests will appear")
+    func waitingForTrafficWhileCapturing() {
+        let state = ContextDockEmptyState.resolve(
+            hasCapturedTraffic: false,
+            hasVisibleResults: false,
+            isCapturing: true
+        )
+
+        #expect(state == .waitingForTraffic)
+    }
+
+    @Test("No captured traffic while stopped prompts to start capture")
+    func captureStoppedWithoutTraffic() {
+        let state = ContextDockEmptyState.resolve(
+            hasCapturedTraffic: false,
+            hasVisibleResults: false,
+            isCapturing: false
+        )
+
+        #expect(state == .captureStopped)
+    }
+
+    @Test("Captured traffic hidden by filters explains that nothing matches the scope")
+    func filteredNoResults() {
+        let state = ContextDockEmptyState.resolve(
+            hasCapturedTraffic: true,
+            hasVisibleResults: false,
+            isCapturing: true
+        )
+
+        #expect(state == .filteredNoResults)
+    }
+}

--- a/RockxyTests/Models/UI/ProtocolFilterSelectionTests.swift
+++ b/RockxyTests/Models/UI/ProtocolFilterSelectionTests.swift
@@ -1,0 +1,207 @@
+import Foundation
+@testable import Rockxy
+import Testing
+
+// Regression tests for `ProtocolFilterSelection` — the pure menu selection/presentation helper.
+
+// MARK: - ProtocolFilterSelectionTests
+
+struct ProtocolFilterSelectionTests {
+    // MARK: - Menu Group Partition & Order
+
+    @Test("Menu groups partition every non-status filter exactly once")
+    func groupsPartitionNonStatusFilters() {
+        let grouped = ProtocolFilterSelection.transportFilters
+            + ProtocolFilterSelection.protocolFilters
+            + ProtocolFilterSelection.contentTypeFilters
+
+        let expected = ProtocolFilter.allCases.filter { !$0.isStatusFilter }
+
+        #expect(Set(grouped) == Set(expected))
+        #expect(grouped.count == expected.count)
+        #expect(Set(grouped).count == grouped.count)
+    }
+
+    @Test("Status group is exactly the five status ranges in ascending order")
+    func statusGroupOrder() {
+        #expect(ProtocolFilterSelection.statusFilters == [.status1xx, .status2xx, .status3xx, .status4xx, .status5xx])
+    }
+
+    @Test("Transport / protocol / content groups keep their required order")
+    func groupOrdering() {
+        #expect(ProtocolFilterSelection.transportFilters == [.all, .http, .https, .websocket])
+        #expect(ProtocolFilterSelection.protocolFilters == [.ai, .aiSession, .web3RPC, .rpcError, .graphql, .grpc])
+        #expect(ProtocolFilterSelection.contentTypeFilters == [
+            .json, .xml, .js, .css, .document, .media, .form, .font, .other,
+        ])
+    }
+
+    // MARK: - Inline Tiers
+
+    @Test("Tier counts descend to a single fallback pill")
+    func tierCountsShape() {
+        let counts = ProtocolFilterSelection.inlinePillTiers.map(\.count)
+        #expect(counts.last == 1)
+        #expect(counts == counts.sorted(by: >))
+        #expect(counts.allSatisfy { $0 >= 1 })
+    }
+
+    @Test("Each tier has stable unique pills, leads with .all, and practical tiers show status")
+    func tierContents() {
+        for tier in ProtocolFilterSelection.inlinePillTiers.indices {
+            let visible = ProtocolFilterSelection.inlinePills(forTier: tier)
+            #expect(visible.first == .all)
+            #expect(Set(visible).count == visible.count)
+            #expect(visible.allSatisfy { ProtocolFilter.allCases.contains($0) })
+            if tier < ProtocolFilterSelection.inlinePillTiers.count - 1 {
+                #expect(visible.contains { $0.isStatusFilter })
+                #expect(visible.contains { $0 != .all && !$0.isStatusFilter })
+            }
+        }
+        #expect(ProtocolFilterSelection.inlinePills(forTier: ProtocolFilterSelection.inlinePillTiers.count - 1)
+            == [.all])
+    }
+
+    @Test("Tier index is clamped to the valid range")
+    func tierClamping() {
+        let last = ProtocolFilterSelection.inlinePillTiers.count - 1
+        #expect(ProtocolFilterSelection.inlinePills(forTier: -5) == ProtocolFilterSelection.inlinePills(forTier: 0))
+        #expect(ProtocolFilterSelection.inlinePills(forTier: 99) == ProtocolFilterSelection.inlinePills(forTier: last))
+    }
+
+    // MARK: - Overflow Partitioning
+
+    @Test("Visible pills and overflow partition every non-.all filter with no overlap")
+    func overflowPartition() {
+        let sections = [
+            ProtocolFilterSelection.transportFilters,
+            ProtocolFilterSelection.protocolFilters,
+            ProtocolFilterSelection.contentTypeFilters,
+            ProtocolFilterSelection.statusFilters,
+        ]
+        let allSelectable = Set(ProtocolFilter.allCases.filter { $0 != .all })
+
+        for tier in ProtocolFilterSelection.inlinePillTiers.indices {
+            let visible = ProtocolFilterSelection.inlinePills(forTier: tier)
+            let visibleReal = Set(visible.filter { $0 != .all })
+            let overflow = sections.flatMap {
+                ProtocolFilterSelection.overflowFilters(in: $0, visiblePills: visible)
+            }
+
+            #expect(!overflow.contains(.all))
+            #expect(Set(overflow).count == overflow.count)
+            #expect(visibleReal.isDisjoint(with: Set(overflow)))
+            #expect(visibleReal.union(overflow) == allSelectable)
+        }
+    }
+
+    @Test("Overflow of a section keeps stable order and drops visible members")
+    func overflowSectionOrder() {
+        let visible: [ProtocolFilter] = [.all, .http, .https]
+        let transport = ProtocolFilterSelection.overflowFilters(
+            in: ProtocolFilterSelection.transportFilters,
+            visiblePills: visible
+        )
+        #expect(transport == [.websocket])
+
+        let protocols = ProtocolFilterSelection.overflowFilters(
+            in: ProtocolFilterSelection.protocolFilters,
+            visiblePills: visible
+        )
+        #expect(protocols == ProtocolFilterSelection.protocolFilters)
+    }
+
+    // MARK: - Hidden Active Signal
+
+    @Test("Hidden active signal fires only when an active filter is off-screen")
+    func hiddenActiveSignal() {
+        let visible: [ProtocolFilter] = [.all, .http, .https, .websocket]
+        #expect(!ProtocolFilterSelection.hasHiddenActiveFilter(activeFilters: [], visiblePills: visible))
+        #expect(!ProtocolFilterSelection.hasHiddenActiveFilter(activeFilters: [.https], visiblePills: visible))
+        #expect(ProtocolFilterSelection.hasHiddenActiveFilter(activeFilters: [.json], visiblePills: visible))
+        #expect(ProtocolFilterSelection.hasHiddenActiveFilter(
+            activeFilters: [.https, .status4xx],
+            visiblePills: visible
+        ))
+    }
+
+    // MARK: - Selection State
+
+    @Test("All Traffic is selected only when no traffic-type filter is active")
+    func allTrafficSelectionState() {
+        #expect(ProtocolFilterSelection.isSelected(.all, in: []))
+        #expect(ProtocolFilterSelection.isSelected(.all, in: [.status2xx]))
+        #expect(!ProtocolFilterSelection.isSelected(.all, in: [.json]))
+        #expect(ProtocolFilterSelection.isSelected(.json, in: [.json]))
+    }
+
+    // MARK: - Toggling
+
+    @Test("Toggling a type inserts then removes it and never stores .all")
+    func toggleTypeMembership() {
+        let inserted = ProtocolFilterSelection.toggling(.json, in: [])
+        #expect(inserted == [.json])
+        #expect(!inserted.contains(.all))
+
+        let removed = ProtocolFilterSelection.toggling(.json, in: inserted)
+        #expect(removed.isEmpty)
+    }
+
+    @Test("Toggling a status preserves active traffic types")
+    func toggleStatusMembership() {
+        let inserted = ProtocolFilterSelection.toggling(.status5xx, in: [.https, .json])
+        #expect(inserted == [.https, .json, .status5xx])
+
+        let removed = ProtocolFilterSelection.toggling(.status5xx, in: inserted)
+        #expect(removed == [.https, .json])
+    }
+
+    @Test("Selecting All Traffic clears types but preserves status filters")
+    func allTrafficPreservesStatuses() {
+        let start: Set<ProtocolFilter> = [.json, .https, .status2xx, .status4xx]
+        let result = ProtocolFilterSelection.toggling(.all, in: start)
+        #expect(result == [.status2xx, .status4xx])
+        #expect(!result.contains(.all))
+    }
+
+    @Test("Any Status clears status filters but preserves traffic-type filters")
+    func anyStatusPreservesTypes() {
+        let start: Set<ProtocolFilter> = [.json, .https, .status2xx, .status4xx]
+        let result = ProtocolFilterSelection.clearingStatusFilters(in: start)
+        #expect(result == [.json, .https])
+        #expect(!result.contains(.all))
+    }
+
+    @Test("Clear All removes both traffic-type and status filters")
+    func clearAllRemovesEveryFilter() {
+        let start: Set<ProtocolFilter> = [.all, .https, .json, .status2xx, .status4xx]
+        #expect(ProtocolFilterSelection.clearingAllFilters(in: start).isEmpty)
+    }
+
+    // MARK: - Active Group Extraction
+
+    @Test("Active type and status filters exclude the opposite group and .all")
+    func activeGroupExtraction() {
+        let start: Set<ProtocolFilter> = [.all, .https, .json, .status5xx]
+        #expect(ProtocolFilterSelection.activeTypeFilters(in: start) == [.https, .json])
+        #expect(ProtocolFilterSelection.activeStatusFilters(in: start) == [.status5xx])
+    }
+
+    // MARK: - Summary Ordering
+
+    @Test("Summary chips follow allCases order and exclude .all")
+    func summaryOrdering() {
+        let start: Set<ProtocolFilter> = [.status4xx, .json, .https, .all, .ai]
+        #expect(ProtocolFilterSelection.summaryFilters(in: start) == [.https, .ai, .json, .status4xx])
+        #expect(!ProtocolFilterSelection.summaryFilters(in: start).contains(.all))
+    }
+
+    // MARK: - Menu Labels
+
+    @Test("Menu label renders All Traffic for .all and display names otherwise")
+    func menuLabels() {
+        #expect(ProtocolFilterSelection.menuLabel(for: .all) == "All Traffic")
+        #expect(ProtocolFilterSelection.menuLabel(for: .https) == "HTTPS")
+        #expect(ProtocolFilterSelection.menuLabel(for: .status3xx) == "3xx")
+    }
+}

--- a/RockxyTests/Models/UI/RequestListEmptyStateTests.swift
+++ b/RockxyTests/Models/UI/RequestListEmptyStateTests.swift
@@ -1,0 +1,193 @@
+@testable import Rockxy
+import Testing
+
+// Unit tests for the pure request-list empty-state presentation model.
+
+// MARK: - RequestListEmptyStateTests
+
+struct RequestListEmptyStateTests {
+    // MARK: - Nil When Visible
+
+    @Test("Visible rows resolve to nil regardless of every other input")
+    func visibleRowsResolveToNil() {
+        for scope in [SidebarScope.allTraffic, .saved, .pinned, .notes] {
+            for proxyState in [ProxyDisplayState.starting, .running, .paused, .stopped] {
+                let state = RequestListEmptyState.resolve(
+                    hasVisibleRows: true,
+                    availableCount: 0,
+                    hasActiveFilters: true,
+                    scope: scope,
+                    proxyState: proxyState
+                )
+                #expect(state == nil)
+            }
+        }
+    }
+
+    // MARK: - Filtered Empty
+
+    @Test("Candidates plus active filters with no visible rows resolves to filtered")
+    func filteredEmptyResolves() {
+        let state = RequestListEmptyState.resolve(
+            hasVisibleRows: false,
+            availableCount: 12,
+            hasActiveFilters: true,
+            scope: .allTraffic,
+            proxyState: .running
+        )
+
+        #expect(state == .filtered(availableCount: 12))
+    }
+
+    @Test("Filtered state offers the Clear Filters action")
+    func filteredActionIsClearFilters() {
+        let copy = RequestListEmptyStateCopy(.filtered(availableCount: 3))
+        #expect(copy.action == .clearFilters)
+        #expect(copy.actionTitle != nil)
+    }
+
+    @Test("Filtered copy pluralizes the available count")
+    func filteredCopyPluralizes() {
+        let single = RequestListEmptyStateCopy(.filtered(availableCount: 1))
+        #expect(single.description.contains("1 request is available"))
+
+        let plural = RequestListEmptyStateCopy(.filtered(availableCount: 7))
+        #expect(plural.description.contains("7 requests are available"))
+    }
+
+    @Test("No candidates never reports no-matches even with active filters")
+    func noCandidatesNeverFiltered() {
+        let state = RequestListEmptyState.resolve(
+            hasVisibleRows: false,
+            availableCount: 0,
+            hasActiveFilters: true,
+            scope: .allTraffic,
+            proxyState: .running
+        )
+
+        #expect(state == .waitingForTraffic)
+    }
+
+    @Test("Candidates present but no active filters falls through to proxy state")
+    func candidatesWithoutFiltersFallThrough() {
+        let state = RequestListEmptyState.resolve(
+            hasVisibleRows: false,
+            availableCount: 5,
+            hasActiveFilters: false,
+            scope: .allTraffic,
+            proxyState: .stopped
+        )
+
+        #expect(state == .proxyStopped)
+    }
+
+    // MARK: - Empty Library Collection
+
+    @Test("Empty Saved / Pinned / Notes collections resolve to emptyCollection")
+    func emptyCollectionResolves() {
+        for scope in [SidebarScope.saved, .pinned, .notes] {
+            let state = RequestListEmptyState.resolve(
+                hasVisibleRows: false,
+                availableCount: 0,
+                hasActiveFilters: true,
+                scope: scope,
+                proxyState: .running
+            )
+            #expect(state == .emptyCollection(scope))
+        }
+    }
+
+    @Test("Empty collection takes precedence over every proxy state")
+    func emptyCollectionBeatsProxyState() {
+        for proxyState in [ProxyDisplayState.starting, .running, .paused, .stopped] {
+            let state = RequestListEmptyState.resolve(
+                hasVisibleRows: false,
+                availableCount: 0,
+                hasActiveFilters: false,
+                scope: .saved,
+                proxyState: proxyState
+            )
+            #expect(state == .emptyCollection(.saved))
+        }
+    }
+
+    @Test("Library collection with hidden candidates reports filtered, not empty")
+    func collectionWithCandidatesIsFiltered() {
+        let state = RequestListEmptyState.resolve(
+            hasVisibleRows: false,
+            availableCount: 4,
+            hasActiveFilters: true,
+            scope: .pinned,
+            proxyState: .running
+        )
+
+        #expect(state == .filtered(availableCount: 4))
+    }
+
+    @Test("Empty collection offers the Show All Traffic action with collection-specific copy")
+    func emptyCollectionActionAndCopy() {
+        let saved = RequestListEmptyStateCopy(.emptyCollection(.saved))
+        #expect(saved.action == .showAllTraffic)
+        #expect(saved.title == "No Saved Requests")
+
+        let pinned = RequestListEmptyStateCopy(.emptyCollection(.pinned))
+        #expect(pinned.title == "No Pinned Requests")
+
+        let notes = RequestListEmptyStateCopy(.emptyCollection(.notes))
+        #expect(notes.title == "No Requests with Notes")
+    }
+
+    // MARK: - Proxy States
+
+    @Test("Proxy starting resolves with no action")
+    func proxyStartingHasNoAction() {
+        let state = RequestListEmptyState.resolve(
+            hasVisibleRows: false,
+            availableCount: 0,
+            hasActiveFilters: false,
+            scope: .allTraffic,
+            proxyState: .starting
+        )
+        #expect(state == .proxyStarting)
+        #expect(RequestListEmptyStateCopy(.proxyStarting).action == nil)
+    }
+
+    @Test("Proxy stopped resolves to Start Proxy action")
+    func proxyStoppedAction() {
+        let state = RequestListEmptyState.resolve(
+            hasVisibleRows: false,
+            availableCount: 0,
+            hasActiveFilters: false,
+            scope: .allTraffic,
+            proxyState: .stopped
+        )
+        #expect(state == .proxyStopped)
+        #expect(RequestListEmptyStateCopy(.proxyStopped).action == .startProxy)
+    }
+
+    @Test("Recording paused resolves to Resume Recording action")
+    func recordingPausedAction() {
+        let state = RequestListEmptyState.resolve(
+            hasVisibleRows: false,
+            availableCount: 0,
+            hasActiveFilters: false,
+            scope: .allTraffic,
+            proxyState: .paused
+        )
+        #expect(state == .recordingPaused)
+        #expect(RequestListEmptyStateCopy(.recordingPaused).action == .resumeRecording)
+    }
+
+    @Test("Running proxy with no traffic waits without an action")
+    func runningWaitsForTraffic() {
+        let state = RequestListEmptyState.resolve(
+            hasVisibleRows: false,
+            availableCount: 0,
+            hasActiveFilters: false,
+            scope: .allTraffic,
+            proxyState: .running
+        )
+        #expect(state == .waitingForTraffic)
+        #expect(RequestListEmptyStateCopy(.waitingForTraffic).action == nil)
+    }
+}

--- a/RockxyTests/Views/Inspector/ContextDockPresentationTests.swift
+++ b/RockxyTests/Views/Inspector/ContextDockPresentationTests.swift
@@ -1,0 +1,271 @@
+import Foundation
+@testable import Rockxy
+import Testing
+
+// MARK: - MatchedRuleNavigationTargetTests
+
+struct MatchedRuleNavigationTargetTests {
+    @Test("Each windowed rule category routes to its existing tool window")
+    func windowedCategoriesRouteToToolWindows() {
+        let cases: [(RuleAction, String)] = [
+            (.breakpoint(), "breakpointRules"),
+            (.mapLocal(filePath: "/tmp/mock.json"), "mapLocal"),
+            (.mapRemote(configuration: MapRemoteConfiguration()), "mapRemote"),
+            (.block(statusCode: 403), "blockList"),
+            (.modifyHeader(operations: []), "modifyHeaders"),
+            (.networkCondition(preset: .wifi, delayMs: 0), "networkConditions"),
+        ]
+
+        for (action, expectedID) in cases {
+            let target = MatchedRuleNavigationTarget(action: action)
+            #expect(target.windowID == expectedID, "\(action.toolCategory) should open \(expectedID)")
+            #expect(target.openHelp != nil)
+        }
+    }
+
+    @Test("Throttle has no dedicated window and stays honestly unavailable")
+    func throttleIsUnavailable() {
+        let target = MatchedRuleNavigationTarget(action: .throttle(delayMs: 1_000))
+        #expect(target == .unavailable)
+        #expect(target.windowID == nil)
+        #expect(target.openHelp == nil)
+    }
+}
+
+// MARK: - InvestigationResultPresentationTests
+
+struct InvestigationResultPresentationTests {
+    // MARK: Internal
+
+    @Test("Evidence groups keep observed → derived → inferred → unknown order and drop empties")
+    func evidenceGroupsAreOrderedAndCompact() {
+        let evidence = [
+            makeEvidence(id: "a", kind: .inferred),
+            makeEvidence(id: "b", kind: .observed),
+            makeEvidence(id: "c", kind: .unknown),
+            makeEvidence(id: "d", kind: .observed),
+        ]
+
+        let groups = InvestigationResultPresentation.evidenceGroups(for: evidence)
+        #expect(groups.map(\.kind) == [.observed, .inferred, .unknown])
+        #expect(groups.first?.evidence.map(\.id) == ["b", "d"])
+    }
+
+    @Test("Findings exclude unknowns and the unknowns section captures open questions")
+    func findingsAndUnknownsSplitByKind() {
+        let evidence = [
+            makeEvidence(id: "obs", kind: .observed),
+            makeEvidence(id: "der", kind: .derived),
+            makeEvidence(id: "unk1", kind: .unknown),
+            makeEvidence(id: "unk2", kind: .unknown),
+        ]
+
+        let findingGroups = InvestigationResultPresentation.findingGroups(for: evidence)
+        #expect(findingGroups.allSatisfy { !$0.isUnknown })
+        #expect(findingGroups.map(\.kind) == [.observed, .derived])
+        #expect(InvestigationResultPresentation.findingCount(for: evidence) == 2)
+
+        let unknowns = InvestigationResultPresentation.unknowns(for: evidence)
+        #expect(unknowns.map(\.id) == ["unk1", "unk2"])
+    }
+
+    @Test("Empty evidence yields no groups, findings, or unknowns")
+    func emptyEvidenceIsEmpty() {
+        #expect(InvestigationResultPresentation.evidenceGroups(for: []).isEmpty)
+        #expect(InvestigationResultPresentation.findingGroups(for: []).isEmpty)
+        #expect(InvestigationResultPresentation.unknowns(for: []).isEmpty)
+        #expect(InvestigationResultPresentation.findingCount(for: []) == 0)
+    }
+
+    // MARK: Private
+
+    private func makeEvidence(id: String, kind: InvestigationEvidenceKind) -> InvestigationEvidence {
+        InvestigationEvidence(
+            id: id,
+            kind: kind,
+            title: "Finding \(id)",
+            detail: "Detail \(id)",
+            sourceTransactionID: nil
+        )
+    }
+}
+
+// MARK: - ContextDockInvestigationReportTests
+
+/// Source contract for the recipe-first, evidence-grounded Investigate surface (GitHub #214/#217):
+/// completed turns render as a labelled full-width investigation report, user prompts are compact
+/// query rows, and the deprecated trailing chat bubble is gone.
+struct ContextDockInvestigationReportTests {
+    // MARK: Internal
+
+    @Test("Investigate renders a native investigation report, not a chat transcript bubble")
+    func investigateRendersLabeledReport() throws {
+        let dock = try readProjectFile("Rockxy/Views/Inspector/ContextDockView.swift")
+        let report = try readProjectFile("Rockxy/Views/Inspector/InvestigationEvidenceViews.swift")
+
+        // User prompts are compact full-width query rows; the trailing chat bubble is removed.
+        #expect(!dock.contains("AssistantUserMessageBubble"))
+        #expect(dock.contains("AssistantQueryRow(text: message.text)"))
+
+        // Completed investigation turns route through the full-width report surface.
+        #expect(dock.contains("InvestigationReportView("))
+
+        // Every contracted section is visibly labelled; Summary uses InvestigationResult.summary.
+        #expect(report.contains("String(localized: \"Scope\")"))
+        #expect(report.contains("String(localized: \"Summary\")"))
+        #expect(report.contains("reportBody(result.summary)"))
+        #expect(report.contains("String(localized: \"Findings\")"))
+        #expect(report.contains("String(localized: \"Unknowns\")"))
+        #expect(report.contains("String(localized: \"Next Step\")"))
+        #expect(report.contains("String(localized: \"Proposed Actions\")"))
+
+        // Findings stay grouped (observed/derived/inferred) behind a native disclosure.
+        #expect(report.contains("DisclosureGroup"))
+        #expect(report.contains("InvestigationFindingsDisclosure"))
+
+        // Review Data / Continue With Model and the existing handoffs remain wired.
+        #expect(report.contains("Continue With Model"))
+        #expect(report.contains("onHandoff"))
+        #expect(report.contains("onPrepareReplay"))
+    }
+
+    @Test("Unknowns section is always present with a truthful empty state")
+    func unknownsHasTruthfulEmptyState() throws {
+        let report = try readProjectFile("Rockxy/Views/Inspector/InvestigationEvidenceViews.swift")
+        #expect(report.contains("struct InvestigationUnknownsView"))
+        #expect(report.contains("if unknowns.isEmpty"))
+        #expect(report.contains("No open questions"))
+    }
+
+    @Test("Evidence without a source request cannot pretend to navigate")
+    func evidenceWithoutSourceIsNotRevealable() throws {
+        let report = try readProjectFile("Rockxy/Views/Inspector/InvestigationEvidenceViews.swift")
+        #expect(report.contains(".disabled(evidence.sourceTransactionID == nil)"))
+    }
+
+    @Test("Empty-state entry point uses compact horizontal suggestion cards in a two-column grid")
+    func emptyStateUsesSuggestionGrid() throws {
+        let dock = try readProjectFile("Rockxy/Views/Inspector/ContextDockView.swift")
+        // Suggestions are a compact two-column grid of bordered cards, not a single-column list.
+        #expect(dock.contains("suggestionGrid"))
+        #expect(dock.contains("LazyVGrid"))
+        #expect(!dock.contains("recipeList"))
+        // Exactly two flexible columns.
+        #expect(dock.components(separatedBy: "GridItem(.flexible()").count - 1 == 2)
+        // Compact bordered cards, small control size.
+        #expect(dock.contains(".buttonStyle(.bordered)"))
+        #expect(dock.contains(".controlSize(.small)"))
+        // Titles stay recipe-driven, the full detail stays in help, and titles may wrap to 2 lines.
+        #expect(dock.contains("DebugAssistantRecipe.allCases"))
+        #expect(dock.contains(".help(recipe.detail)"))
+        #expect(dock.contains(".lineLimit(2)"))
+        #expect(dock.contains("Investigate captured traffic"))
+        #expect(dock.contains("Start an investigation"))
+        #expect(!dock.contains("What should I check?"))
+        #expect(!dock.contains("Ask about captured traffic"))
+    }
+
+    @Test("Mode switcher shows Details / AI Assistant, not Context / Investigate")
+    func modeSwitcherUsesRestoredLabels() throws {
+        let dock = try readProjectFile("Rockxy/Views/Inspector/ContextDockView.swift")
+        #expect(dock.contains("Text(String(localized: \"Details\")).tag(ContextDockTab.details)"))
+        #expect(dock.contains("Text(String(localized: \"AI Assistant\")).tag(ContextDockTab.aiAssistant)"))
+        #expect(!dock.contains("Text(String(localized: \"Context\")).tag"))
+        #expect(!dock.contains("Text(String(localized: \"Investigate\")).tag"))
+        #expect(dock.contains("Picker(String(localized: \"Inspector\")"))
+        #expect(dock.contains(".accessibilityLabel(String(localized: \"Inspector\"))"))
+        // Stable internal enum cases are unchanged.
+        #expect(dock.contains("ContextDockTab.details"))
+        #expect(dock.contains("ContextDockTab.aiAssistant"))
+    }
+
+    @Test("Context Details renders every group as a native inspector table matching the horizontal inspector")
+    func contextDetailsUsesInspectorTables() throws {
+        let details = try readProjectFile("Rockxy/Views/Inspector/ContextDetailsView.swift")
+        let table = try readProjectFile("Rockxy/Views/Inspector/ContextInspectorTable.swift")
+
+        // Explicit Appearance-derived typography — no semantic font styles.
+        #expect(details.contains("@Environment(\\.appUIDisplayMetrics)"))
+        #expect(details.contains(".system(size: metrics."))
+        #expect(!details.contains(".font(.headline"))
+        #expect(!details.contains(".font(.subheadline"))
+        #expect(!details.contains(".font(.caption"))
+        #expect(!details.contains(".font(.callout"))
+
+        // The reusable shell mirrors HeaderKeyValueTable's visual language.
+        #expect(table.contains("struct ContextInspectorTable"))
+        #expect(table.contains("VStack(spacing: 0)"))
+        #expect(table.contains("Color(nsColor: .controlBackgroundColor)"))
+        #expect(table.contains("Color(nsColor: .textBackgroundColor)"))
+        #expect(table.contains("RoundedRectangle(cornerRadius: 6)"))
+        #expect(table.contains("lineWidth: 0.5"))
+        #expect(table.contains(".clipShape(RoundedRectangle(cornerRadius: 6))"))
+        // A vertical divider splits the field column from the value column.
+        #expect(table.contains("struct ContextInspectorFieldRow"))
+        #expect(table.contains("struct ContextInspectorInsightRow"))
+        #expect(table.contains("struct ContextInspectorFullRow"))
+        #expect(table.contains("struct ContextInspectorDisclosureTable"))
+
+        // Flat ScrollView of stacked tables replaces List/Section, tinted rows, and loose dividers.
+        #expect(details.contains("ScrollView {"))
+        #expect(!details.contains("List {"))
+        #expect(!details.contains("Section(String(localized:"))
+        #expect(!details.contains(".listStyle"))
+        #expect(!details.contains(".listRowBackground"))
+        #expect(!details.contains("private func sectionHeader("))
+        #expect(!details.contains("private func detailRow("))
+
+        // Every named diagnostics group maps to a table.
+        #expect(details.contains(#"ContextInspectorFieldTable("#))
+        #expect(details.contains(#"title: String(localized: "Selection")"#))
+        #expect(details.contains(#"title: String(localized: "Details")"#))
+        #expect(details.contains(#"ContextInspectorTable(title: String(localized: "Rule Impact"))"#))
+        #expect(details.contains(#"ContextInspectorTable(title: String(localized: "Payload"))"#))
+        #expect(details.contains(#"ContextInspectorTable(title: String(localized: "Insights"))"#))
+        #expect(details.contains(#"ContextInspectorTable(title: String(localized: "Notes"))"#))
+        #expect(details.contains(#"title: String(localized: "Timing")"#))
+        #expect(details.contains(#"title: String(localized: "Related Requests")"#))
+
+        // Rule Impact keeps truthful rows plus an in-table Open Rule action row.
+        #expect(details.contains(#"label: String(localized: "Rule")"#))
+        #expect(details.contains(#"label: String(localized: "Action")"#))
+        #expect(details.contains(#"label: String(localized: "Pattern")"#))
+        #expect(details.contains("openRuleActionRow(windowID:"))
+
+        // Timing and Related keep progressive disclosure via the table disclosure shell.
+        #expect(details.contains("ContextInspectorDisclosureTable("))
+        #expect(details.contains("isExpanded: $isTimingExpanded"))
+        #expect(details.contains("isExpanded: $isRelatedExpanded"))
+
+        // Technical data stays monospaced.
+        #expect(details.contains("design: .monospaced"))
+
+        // Behavior preserved: honest Open Rule routing, native Compare handoff, Notes identity.
+        #expect(details.contains("matchedRuleNavigationTarget(transaction)"))
+        #expect(details.contains("coordinator.compareTransactions(transactions[0], transactions[1])"))
+        #expect(details.contains("ContextNotesEditor(coordinator: coordinator, transaction: transaction)"))
+    }
+
+    // MARK: Private
+
+    private enum ResolveError: Error {
+        case rootNotFound
+    }
+
+    private func readProjectFile(_ relativePath: String) throws -> String {
+        let root = try resolveProjectRoot()
+        return try String(contentsOf: root.appendingPathComponent(relativePath), encoding: .utf8)
+    }
+
+    private func resolveProjectRoot() throws -> URL {
+        var url = URL(fileURLWithPath: #filePath)
+        while url.lastPathComponent != "RockxyTests", url.path != "/" {
+            url.deleteLastPathComponent()
+        }
+        guard url.lastPathComponent == "RockxyTests" else {
+            throw ResolveError.rootNotFound
+        }
+        url.deleteLastPathComponent()
+        return url
+    }
+}

--- a/RockxyTests/Views/Inspector/InspectorTabOverflowPlannerTests.swift
+++ b/RockxyTests/Views/Inspector/InspectorTabOverflowPlannerTests.swift
@@ -1,0 +1,128 @@
+import CoreGraphics
+@testable import Rockxy
+import Testing
+
+/// Tests for the pure tab-distribution logic that keeps inspector tabs reachable in narrow panes.
+/// Widths are synthetic point values so the assertions stay independent of font metrics.
+struct InspectorTabOverflowPlannerTests {
+    // MARK: Internal
+
+    // MARK: - Tests
+
+    @Test("All tabs fit: every tab is visible and no overflow menu is needed")
+    func allFit() {
+        let plan = InspectorTabOverflowPlanner.plan(
+            items: items([("a", 40), ("b", 40), ("c", 40)]),
+            activeID: "a",
+            availableWidth: 200,
+            overflowAffordanceWidth: 30
+        )
+
+        #expect(plan.visibleIDs == ["a", "b", "c"])
+        #expect(plan.overflowIDs.isEmpty)
+        #expect(!plan.hasOverflow)
+    }
+
+    @Test("Overflow: leading tabs stay visible and the tail collapses into the menu")
+    func overflowPushesTail() {
+        let plan = InspectorTabOverflowPlanner.plan(
+            items: items([("a", 40), ("b", 40), ("c", 40), ("d", 40)]),
+            activeID: "a",
+            availableWidth: 120,
+            overflowAffordanceWidth: 30
+        )
+
+        #expect(plan.hasOverflow)
+        #expect(plan.visibleIDs == ["a", "b"])
+        #expect(plan.overflowIDs == ["c", "d"])
+    }
+
+    @Test("Active tab is forced visible even when it sits at the end of the list")
+    func activeForcedVisible() {
+        let plan = InspectorTabOverflowPlanner.plan(
+            items: items([("a", 40), ("b", 40), ("c", 40), ("d", 40)]),
+            activeID: "d",
+            availableWidth: 110,
+            overflowAffordanceWidth: 30
+        )
+
+        #expect(plan.visibleIDs.contains("d"))
+        #expect(plan.visibleIDs == ["a", "d"])
+        #expect(plan.overflowIDs == ["b", "c"])
+    }
+
+    @Test("Stable order: visible and overflow lists preserve source order without dropping tabs")
+    func stableOrder() {
+        let source = ["one", "two", "three", "four", "five"]
+        let plan = InspectorTabOverflowPlanner.plan(
+            items: items(source.map { ($0, 50) }),
+            activeID: "three",
+            availableWidth: 160,
+            overflowAffordanceWidth: 40
+        )
+
+        let combined = plan.visibleIDs + plan.overflowIDs
+        #expect(Set(combined) == Set(source))
+        #expect(combined.count == source.count)
+        #expect(plan.visibleIDs == source.filter { plan.visibleIDs.contains($0) })
+        #expect(plan.overflowIDs == source.filter { plan.overflowIDs.contains($0) })
+        #expect(plan.visibleIDs.contains("three"))
+    }
+
+    @Test("Extremely narrow width still keeps only the active tab visible")
+    func extremelyNarrow() {
+        let plan = InspectorTabOverflowPlanner.plan(
+            items: items([("a", 60), ("b", 60), ("c", 60)]),
+            activeID: "b",
+            availableWidth: 1,
+            overflowAffordanceWidth: 30
+        )
+
+        #expect(plan.visibleIDs == ["b"])
+        #expect(plan.overflowIDs == ["a", "c"])
+        #expect(plan.hasOverflow)
+    }
+
+    @Test("Mixed-category identifiers distribute by width, not by id prefix")
+    func mixedCategoryIDs() {
+        let plan = InspectorTabOverflowPlanner.plan(
+            items: items([
+                ("native.headers", 70),
+                ("native.body", 60),
+                ("preview.9F1C", 80),
+                ("protocol.ai", 50),
+                ("protocol.web3", 55),
+            ]),
+            activeID: "protocol.ai",
+            availableWidth: 200,
+            overflowAffordanceWidth: 36
+        )
+
+        #expect(plan.hasOverflow)
+        #expect(plan.visibleIDs.contains("protocol.ai"))
+        #expect(plan.visibleIDs == ["native.headers", "protocol.ai"])
+        #expect(plan.overflowIDs == ["native.body", "preview.9F1C", "protocol.web3"])
+    }
+
+    @Test("Empty input yields an empty plan with no overflow")
+    func emptyInput() {
+        let plan = InspectorTabOverflowPlanner.plan(
+            items: [],
+            activeID: nil,
+            availableWidth: 100,
+            overflowAffordanceWidth: 30
+        )
+
+        #expect(plan.visibleIDs.isEmpty)
+        #expect(plan.overflowIDs.isEmpty)
+        #expect(!plan.hasOverflow)
+    }
+
+    // MARK: Private
+
+    // MARK: - Helpers
+
+    private func items(_ pairs: [(String, CGFloat)]) -> [InspectorTabLayoutItem] {
+        pairs.map { InspectorTabLayoutItem(id: $0.0, width: $0.1) }
+    }
+}

--- a/RockxyTests/Views/Main/FilteringTests.swift
+++ b/RockxyTests/Views/Main/FilteringTests.swift
@@ -761,6 +761,51 @@ struct FilteringTests {
         #expect(coordinator.filteredTransactions[0].id == match.id)
     }
 
+    // MARK: - Centralized Filter Reset
+
+    @Test("clearAllWorkspaceFilters clears every filter, focus, and scope field and restores traffic")
+    func clearAllWorkspaceFiltersResetsEverything() {
+        let coordinator = MainContentCoordinator()
+        let saved = TestFixtures.makeTransaction(url: "https://api.example.com/users/1")
+        saved.isSaved = true
+        let other = TestFixtures.makeTransaction(url: "https://other.com/test")
+        coordinator.transactions = [saved, other]
+
+        coordinator.filterCriteria.searchText = "users"
+        coordinator.filterCriteria.methods = ["GET"]
+        coordinator.filterCriteria.activeProtocolFilters = [.https]
+        coordinator.filterCriteria.sidebarDomain = "example.com"
+        coordinator.filterCriteria.sidebarScope = .saved
+        coordinator.filterCriteria.exactTransactionID = saved.id
+        coordinator.sidebarSelection = .allSaved
+        coordinator.isFilterBarVisible = true
+        coordinator.filterRules = [
+            FilterRule(isEnabled: true, field: .url, filterOperator: .contains, value: "users"),
+        ]
+        coordinator.activeWorkspace.activeTrafficSignal = .errors
+        let focusSet = FocusSet(name: "API", domain: "example.com")
+        coordinator.activeWorkspace.focusSets = [focusSet]
+        coordinator.activeWorkspace.activeFocusSetID = focusSet.id
+        coordinator.activeWorkspace.mutedTrafficSources = [.host("ads.example.com")]
+        coordinator.recomputeFilteredTransactions()
+        #expect(coordinator.hasActiveWorkspaceFilters)
+
+        coordinator.clearAllWorkspaceFilters()
+
+        #expect(coordinator.filterCriteria.sidebarScope == .allTraffic)
+        #expect(coordinator.filterCriteria.isEmpty)
+        #expect(coordinator.sidebarSelection == nil)
+        #expect(!coordinator.isFilterBarVisible)
+        #expect(coordinator.filterRules.count == 1)
+        #expect(coordinator.filterRules[0].value.isEmpty)
+        #expect(coordinator.activeWorkspace.activeTrafficSignal == nil)
+        #expect(coordinator.activeWorkspace.activeFocusSetID == nil)
+        #expect(coordinator.activeWorkspace.activeFocusSet == nil)
+        #expect(coordinator.activeWorkspace.mutedTrafficSources.isEmpty)
+        #expect(!coordinator.hasActiveWorkspaceFilters)
+        #expect(coordinator.filteredTransactions.count == 2)
+    }
+
     // MARK: Private
 
     // MARK: - Setup

--- a/RockxyTests/Views/Main/FooterActionDescriptorTests.swift
+++ b/RockxyTests/Views/Main/FooterActionDescriptorTests.swift
@@ -98,6 +98,159 @@ struct FooterActionDescriptorTests {
     }
 }
 
+// MARK: - FooterMutationIndicatorBuilderTests
+
+struct FooterMutationIndicatorBuilderTests {
+    // MARK: Internal
+
+    @Test("Indicators are ordered Map Local, Map Remote, then Breakpoint")
+    func indicatorOrder() {
+        let rules = [
+            makeRule(.breakpoint()),
+            makeRule(.mapRemote(configuration: .init())),
+            makeRule(.mapLocal(filePath: "/tmp/a.json")),
+        ]
+
+        let indicators = FooterMutationIndicatorBuilder.indicators(
+            rules: rules,
+            mapLocalToolEnabled: true,
+            mapRemoteToolEnabled: true,
+            breakpointToolEnabled: true
+        )
+
+        #expect(indicators.map(\.id) == [.mapLocal, .mapRemote, .breakpoint])
+    }
+
+    @Test("Indicator count reflects only enabled rules per category")
+    func enabledRuleCounts() {
+        let rules = [
+            makeRule(.mapLocal(filePath: "/tmp/a.json")),
+            makeRule(.mapLocal(filePath: "/tmp/b.json")),
+            makeRule(.mapLocal(filePath: "/tmp/c.json"), isEnabled: false),
+            makeRule(.mapRemote(configuration: .init())),
+            makeRule(.breakpoint(), isEnabled: false),
+            makeRule(.block(statusCode: 403)),
+            makeRule(.throttle(delayMs: 50)),
+        ]
+
+        let indicators = FooterMutationIndicatorBuilder.indicators(
+            rules: rules,
+            mapLocalToolEnabled: true,
+            mapRemoteToolEnabled: true,
+            breakpointToolEnabled: true
+        )
+
+        #expect(indicators.map(\.id) == [.mapLocal, .mapRemote])
+        #expect(indicators.first { $0.id == .mapLocal }?.count == 2)
+        #expect(indicators.first { $0.id == .mapRemote }?.count == 1)
+    }
+
+    @Test("A category is omitted when its tool-level switch is off")
+    func toolSwitchGating() {
+        let rules = [
+            makeRule(.mapLocal(filePath: "/tmp/a.json")),
+            makeRule(.mapRemote(configuration: .init())),
+            makeRule(.breakpoint()),
+        ]
+
+        let withoutMapLocal = FooterMutationIndicatorBuilder.indicators(
+            rules: rules,
+            mapLocalToolEnabled: false,
+            mapRemoteToolEnabled: true,
+            breakpointToolEnabled: true
+        )
+        #expect(withoutMapLocal.map(\.id) == [.mapRemote, .breakpoint])
+
+        let withoutBreakpoint = FooterMutationIndicatorBuilder.indicators(
+            rules: rules,
+            mapLocalToolEnabled: true,
+            mapRemoteToolEnabled: true,
+            breakpointToolEnabled: false
+        )
+        #expect(withoutBreakpoint.map(\.id) == [.mapLocal, .mapRemote])
+
+        let allOff = FooterMutationIndicatorBuilder.indicators(
+            rules: rules,
+            mapLocalToolEnabled: false,
+            mapRemoteToolEnabled: false,
+            breakpointToolEnabled: false
+        )
+        #expect(allOff.isEmpty)
+    }
+
+    @Test("No indicators are produced when no enabled rules exist")
+    func zeroStateOmission() {
+        let emptyRules = FooterMutationIndicatorBuilder.indicators(
+            rules: [],
+            mapLocalToolEnabled: true,
+            mapRemoteToolEnabled: true,
+            breakpointToolEnabled: true
+        )
+        #expect(emptyRules.isEmpty)
+
+        let onlyDisabled = FooterMutationIndicatorBuilder.indicators(
+            rules: [
+                makeRule(.mapLocal(filePath: "/tmp/a.json"), isEnabled: false),
+                makeRule(.breakpoint(), isEnabled: false),
+            ],
+            mapLocalToolEnabled: true,
+            mapRemoteToolEnabled: true,
+            breakpointToolEnabled: true
+        )
+        #expect(onlyDisabled.isEmpty)
+    }
+
+    @Test("Indicators map to their existing tool-window IDs")
+    func targetWindowIDs() {
+        let rules = [
+            makeRule(.mapLocal(filePath: "/tmp/a.json")),
+            makeRule(.mapRemote(configuration: .init())),
+            makeRule(.breakpoint()),
+        ]
+
+        let indicators = FooterMutationIndicatorBuilder.indicators(
+            rules: rules,
+            mapLocalToolEnabled: true,
+            mapRemoteToolEnabled: true,
+            breakpointToolEnabled: true
+        )
+
+        #expect(indicators.first { $0.id == .mapLocal }?.windowID == "mapLocal")
+        #expect(indicators.first { $0.id == .mapRemote }?.windowID == "mapRemote")
+        #expect(indicators.first { $0.id == .breakpoint }?.windowID == "breakpointRules")
+    }
+
+    @Test("Indicators carry SF Symbols and accessible count copy")
+    func indicatorMetadata() throws {
+        let indicators = FooterMutationIndicatorBuilder.indicators(
+            rules: [
+                makeRule(.mapLocal(filePath: "/tmp/a.json")),
+                makeRule(.mapLocal(filePath: "/tmp/b.json")),
+            ],
+            mapLocalToolEnabled: true,
+            mapRemoteToolEnabled: true,
+            breakpointToolEnabled: true
+        )
+
+        let mapLocal = try #require(indicators.first { $0.id == .mapLocal })
+        #expect(mapLocal.systemImage == "folder.badge.gearshape")
+        #expect(mapLocal.title == "Map Local")
+        #expect(mapLocal.accessibilityLabel.contains("2"))
+        #expect(indicators.allSatisfy { !$0.systemImage.isEmpty })
+    }
+
+    // MARK: Private
+
+    private func makeRule(_ action: RuleAction, isEnabled: Bool = true) -> ProxyRule {
+        ProxyRule(
+            name: "test",
+            isEnabled: isEnabled,
+            matchCondition: RuleMatchCondition(urlPattern: ".*"),
+            action: action
+        )
+    }
+}
+
 struct ProxyOverrideCommandActionsTests {
     @Test("system proxy override command is enabled only while proxy is running")
     @MainActor

--- a/RockxyTests/Views/Main/InspectorLayoutBehaviorTests.swift
+++ b/RockxyTests/Views/Main/InspectorLayoutBehaviorTests.swift
@@ -59,7 +59,10 @@ struct InspectorLayoutBehaviorTests {
         defer { environment.defaults.removePersistentDomain(forName: environment.suiteName) }
         let coordinator = MainContentCoordinator(workspaceLayoutPreferences: environment.preferences)
 
-        coordinator.toggleInspectorBottom()
+        coordinator.selectTransaction(TestFixtures.makeTransaction())
+        // Establish an explicit visible preference through the same persistence seam the
+        // native split item drives while the inspector has content.
+        coordinator.setBottomInspectorVisible(true)
         coordinator.toggleInspectorRight()
         let newWorkspace = coordinator.workspaceStore.createWorkspace()
 
@@ -118,6 +121,93 @@ struct InspectorLayoutBehaviorTests {
         #expect(MainContentCoordinator(
             workspaceLayoutPreferences: environment.preferences
         ).inspectorLayout == .hidden)
+    }
+
+    @Test("Deselecting collapses the bottom inspector without losing the layout preference")
+    func deselectCollapsesWithoutPreferenceLoss() throws {
+        let environment = try makeEnvironment()
+        defer { environment.defaults.removePersistentDomain(forName: environment.suiteName) }
+        let coordinator = MainContentCoordinator(workspaceLayoutPreferences: environment.preferences)
+        let transaction = TestFixtures.makeTransaction()
+        coordinator.selectTransaction(transaction)
+
+        #expect(coordinator.isBottomInspectorEffectivelyPresented)
+        #expect(coordinator.hasPayloadInspectorSelection)
+
+        coordinator.selectTransaction(nil)
+
+        #expect(!coordinator.isBottomInspectorEffectivelyPresented)
+        #expect(!coordinator.hasPayloadInspectorSelection)
+        #expect(coordinator.inspectorLayout == .bottom)
+    }
+
+    @Test("Reselecting restores the effective bottom inspector after a deselect")
+    func reselectRestoresEffectivePresentation() throws {
+        let environment = try makeEnvironment()
+        defer { environment.defaults.removePersistentDomain(forName: environment.suiteName) }
+        let coordinator = MainContentCoordinator(workspaceLayoutPreferences: environment.preferences)
+        coordinator.selectTransaction(TestFixtures.makeTransaction())
+        coordinator.selectTransaction(nil)
+
+        #expect(!coordinator.isBottomInspectorEffectivelyPresented)
+
+        coordinator.selectTransaction(TestFixtures.makeTransaction())
+
+        #expect(coordinator.isBottomInspectorEffectivelyPresented)
+        #expect(coordinator.inspectorLayout == .bottom)
+    }
+
+    @Test("An explicit hide wins over the effective presentation across deselect and reselect")
+    func explicitHideWinsOverEffectivePresentation() throws {
+        let environment = try makeEnvironment()
+        defer { environment.defaults.removePersistentDomain(forName: environment.suiteName) }
+        let coordinator = MainContentCoordinator(workspaceLayoutPreferences: environment.preferences)
+        let transaction = TestFixtures.makeTransaction()
+        coordinator.selectTransaction(transaction)
+
+        coordinator.toggleInspectorBottom()
+
+        #expect(coordinator.inspectorLayout == .hidden)
+        #expect(!coordinator.isBottomInspectorEffectivelyPresented)
+
+        coordinator.selectTransaction(nil)
+        coordinator.selectTransaction(transaction)
+
+        #expect(coordinator.inspectorLayout == .hidden)
+        #expect(!coordinator.isBottomInspectorEffectivelyPresented)
+    }
+
+    @Test("A multi-selection is eligible for and presents the bottom inspector")
+    func multiSelectionIsEligible() throws {
+        let environment = try makeEnvironment()
+        defer { environment.defaults.removePersistentDomain(forName: environment.suiteName) }
+        let coordinator = MainContentCoordinator(workspaceLayoutPreferences: environment.preferences)
+        let first = TestFixtures.makeTransaction()
+        let second = TestFixtures.makeTransaction()
+        coordinator.selectTransaction(first)
+
+        coordinator.selectedTransactionIDs = [first.id, second.id]
+
+        #expect(coordinator.bottomInspectorContent == .summary)
+        #expect(coordinator.hasPayloadInspectorSelection)
+        #expect(coordinator.canToggleBottomInspector)
+        #expect(coordinator.isBottomInspectorEffectivelyPresented)
+    }
+
+    @Test("With no selection the bottom inspector toggle is disabled and a no-op")
+    func toggleDisabledWithoutSelection() throws {
+        let environment = try makeEnvironment()
+        defer { environment.defaults.removePersistentDomain(forName: environment.suiteName) }
+        let coordinator = MainContentCoordinator(workspaceLayoutPreferences: environment.preferences)
+
+        #expect(!coordinator.hasPayloadInspectorSelection)
+        #expect(!coordinator.canToggleBottomInspector)
+        #expect(coordinator.inspectorLayout == .hidden)
+
+        coordinator.toggleInspectorBottom()
+
+        #expect(coordinator.inspectorLayout == .hidden)
+        #expect(!coordinator.isBottomInspectorEffectivelyPresented)
     }
 
     // MARK: Private

--- a/RockxyTests/Views/Main/NativeBottomInspectorSplitViewTests.swift
+++ b/RockxyTests/Views/Main/NativeBottomInspectorSplitViewTests.swift
@@ -4,8 +4,24 @@ import SwiftUI
 import Testing
 
 @MainActor
+@Suite(.serialized)
 struct NativeBottomInspectorSplitViewTests {
     // MARK: Internal
+
+    @Test("Bottom inspector minimum heights scale with the app font")
+    func fontAwareLayoutMetrics() {
+        let defaultMetrics = BottomInspectorLayoutMetrics()
+        var largeSettings = AppUISettings.default
+        largeSettings.fontSize = 28
+        let largeMetrics = BottomInspectorLayoutMetrics(
+            appMetrics: AppUIDisplayMetrics(settings: largeSettings)
+        )
+
+        #expect(defaultMetrics.requestListMinimumHeight == 200)
+        #expect(defaultMetrics.inspectorMinimumHeight == 232)
+        #expect(largeMetrics.requestListMinimumHeight > defaultMetrics.requestListMinimumHeight)
+        #expect(largeMetrics.inspectorMinimumHeight > defaultMetrics.inspectorMinimumHeight)
+    }
 
     @Test("Bottom inspector sizing preserves the proposed workspace size")
     func proposedSizeIsPreserved() throws {
@@ -27,7 +43,89 @@ struct NativeBottomInspectorSplitViewTests {
         #expect(!controller.splitViewItems[0].canCollapse)
         #expect(controller.splitViewItems[1].canCollapse)
         #expect(controller.splitViewItems[0].minimumThickness == 200)
-        #expect(controller.splitViewItems[1].minimumThickness == 320)
+        #expect(controller.splitViewItems[1].minimumThickness == 232)
+    }
+
+    @Test("Fresh bottom split configures a sixty-two percent request list")
+    func freshLayoutUsesBalancedDefaultRatio() {
+        let autosaveName = uniqueAutosaveName()
+        removeSplitViewAutosaveDefaults(autosaveName)
+        let controller = makeConfiguredController(
+            isInspectorPresented: true,
+            autosaveName: autosaveName
+        )
+
+        layout(controller, at: CGRect(x: 0, y: 0, width: 1_200, height: 700))
+
+        let divider = controller.splitView.dividerThickness
+        let expectedPrimaryHeight = (700 - divider)
+            * NativeBottomInspectorSplitSizing.defaultRequestListRatio
+        let primaryHeight = NativeBottomInspectorSplitSizing.idealPrimaryHeight(
+            totalHeight: 700,
+            dividerThickness: divider,
+            requestListRatio: NativeBottomInspectorSplitSizing.defaultRequestListRatio,
+            primaryMinimumHeight: 200,
+            inspectorMinimumHeight: 232
+        )
+
+        #expect(primaryHeight == expectedPrimaryHeight)
+        #expect(abs(controller.splitViewItems[0].preferredThicknessFraction - 0.62) < 0.0001)
+        #expect(abs(controller.splitViewItems[1].preferredThicknessFraction - 0.38) < 0.0001)
+        #expect(controller.defaultDividerApplicationCount == 1)
+        removeSplitViewAutosaveDefaults(autosaveName)
+    }
+
+    @Test("Autosaved split frames take precedence over the default ratio")
+    func autosavedFramesSkipDefaultRatio() {
+        let autosaveName = uniqueAutosaveName()
+        setSplitViewAutosaveFrames(autosaveName)
+        let controller = makeConfiguredController(
+            isInspectorPresented: true,
+            autosaveName: autosaveName
+        )
+
+        layout(controller, at: CGRect(x: 0, y: 0, width: 1_200, height: 700))
+
+        #expect(controller.hasAutosavedFrames)
+        #expect(controller.defaultDividerApplicationCount == 0)
+        expectNonNegativeArrangedGeometry(controller)
+        removeSplitViewAutosaveDefaults(autosaveName)
+    }
+
+    @Test("Window resizing never reapplies the default divider ratio")
+    func resizeDoesNotReapplyDefaultRatio() {
+        let autosaveName = uniqueAutosaveName()
+        removeSplitViewAutosaveDefaults(autosaveName)
+        let controller = makeConfiguredController(
+            isInspectorPresented: true,
+            autosaveName: autosaveName
+        )
+
+        layout(controller, at: CGRect(x: 0, y: 0, width: 1_200, height: 700))
+        controller.splitView.setPosition(300, ofDividerAt: 0)
+        layout(controller, at: CGRect(x: 0, y: 0, width: 1_200, height: 800))
+
+        #expect(controller.defaultDividerApplicationCount == 1)
+        expectNonNegativeArrangedGeometry(controller)
+        removeSplitViewAutosaveDefaults(autosaveName)
+    }
+
+    @Test("Font-driven minimum updates preserve the applied divider")
+    func minimumUpdatesPreserveDivider() {
+        let autosaveName = uniqueAutosaveName()
+        removeSplitViewAutosaveDefaults(autosaveName)
+        let controller = makeConfiguredController(
+            isInspectorPresented: true,
+            autosaveName: autosaveName
+        )
+        layout(controller, at: CGRect(x: 0, y: 0, width: 1_200, height: 800))
+
+        controller.updateMinimumHeights(primary: 312, inspector: 397)
+
+        #expect(controller.splitViewItems[0].minimumThickness == 312)
+        #expect(controller.splitViewItems[1].minimumThickness == 397)
+        #expect(controller.defaultDividerApplicationCount == 1)
+        removeSplitViewAutosaveDefaults(autosaveName)
     }
 
     @Test("Bottom split collapses without recreating either pane")
@@ -70,8 +168,36 @@ struct NativeBottomInspectorSplitViewTests {
         #expect(!NativeBottomInspectorSplitSizing.isLayoutReady(
             CGRect(x: 0, y: 0, width: 1_200, height: CGFloat.infinity)
         ))
+        #expect(!NativeBottomInspectorSplitSizing.isLayoutReady(
+            CGRect(x: 0, y: 0, width: 1_200, height: -700)
+        ))
         #expect(NativeBottomInspectorSplitSizing.isLayoutReady(
             CGRect(x: 0, y: 0, width: 1_200, height: 700)
+        ))
+    }
+
+    @Test("Bottom split readiness includes both pane minima and the divider")
+    func minimumReadinessIncludesDivider() {
+        #expect(!NativeBottomInspectorSplitSizing.canSeatRequestedMinima(
+            totalHeight: 432,
+            dividerThickness: 1,
+            inspectorPresented: true,
+            primaryMinimumHeight: 200,
+            inspectorMinimumHeight: 232
+        ))
+        #expect(NativeBottomInspectorSplitSizing.canSeatRequestedMinima(
+            totalHeight: 433,
+            dividerThickness: 1,
+            inspectorPresented: true,
+            primaryMinimumHeight: 200,
+            inspectorMinimumHeight: 232
+        ))
+        #expect(NativeBottomInspectorSplitSizing.canSeatRequestedMinima(
+            totalHeight: 200,
+            dividerThickness: 1,
+            inspectorPresented: false,
+            primaryMinimumHeight: 200,
+            inspectorMinimumHeight: 232
         ))
     }
 
@@ -153,7 +279,7 @@ struct NativeBottomInspectorSplitViewTests {
             isInspectorPresented: isInspectorPresented,
             autosaveName: autosaveName,
             primaryMinimumHeight: 200,
-            inspectorMinimumHeight: 320
+            inspectorMinimumHeight: 232
         )
         return controller
     }
@@ -176,5 +302,15 @@ struct NativeBottomInspectorSplitViewTests {
 
     private func removeSplitViewAutosaveDefaults(_ autosaveName: String) {
         UserDefaults.standard.removeObject(forKey: "NSSplitView Subview Frames \(autosaveName)")
+    }
+
+    private func setSplitViewAutosaveFrames(_ autosaveName: String) {
+        UserDefaults.standard.set(
+            [
+                "0.000000, 0.000000, 1200.000000, 300.000000, NO, NO",
+                "0.000000, 301.000000, 1200.000000, 399.000000, NO, NO",
+            ],
+            forKey: "NSSplitView Subview Frames \(autosaveName)"
+        )
     }
 }

--- a/RockxyTests/Views/Main/NotesCollectionTests.swift
+++ b/RockxyTests/Views/Main/NotesCollectionTests.swift
@@ -1,0 +1,303 @@
+import Foundation
+@testable import Rockxy
+import Testing
+
+// Regression tests for the Library > Notes collection: navigation scope, filtering,
+// persisted-only rows, the coordinator note mutation/normalization seam, and UI contracts.
+
+// MARK: - NotesCollectionTests
+
+@MainActor
+struct NotesCollectionTests {
+    // MARK: - Aggregate & Single Selection
+
+    @Test("allNotes scope shows only note-bearing transactions")
+    func allNotesShowsNotedOnly() {
+        let coordinator = MainContentCoordinator()
+        let plain = TestFixtures.makeTransaction()
+        let noted = TestFixtures.makeTransaction()
+        noted.comment = "Investigate this 500"
+        let pinnedOnly = TestFixtures.makeTransaction()
+        pinnedOnly.isPinned = true
+        coordinator.transactions = [plain, noted, pinnedOnly]
+
+        coordinator.selectSidebarItem(.allNotes)
+
+        #expect(coordinator.filterCriteria.sidebarScope == .notes)
+        #expect(coordinator.filteredTransactions.map(\.id) == [noted.id])
+    }
+
+    @Test("Whitespace-only comment is not treated as a note")
+    func whitespaceCommentIsNotNote() {
+        let coordinator = MainContentCoordinator()
+        let blankNote = TestFixtures.makeTransaction()
+        blankNote.comment = "   \n\t"
+        coordinator.transactions = [blankNote]
+
+        coordinator.selectSidebarItem(.allNotes)
+
+        #expect(coordinator.filteredTransactions.isEmpty)
+        #expect(coordinator.allNotesTransactions.isEmpty)
+    }
+
+    @Test("Selecting a note transaction scopes to notes and selects it")
+    func noteTransactionSelectionSelectsExact() {
+        let coordinator = MainContentCoordinator()
+        let notedA = TestFixtures.makeTransaction(url: "https://api.example.com/a")
+        notedA.comment = "note A"
+        let notedB = TestFixtures.makeTransaction(url: "https://api.example.com/b")
+        notedB.comment = "note B"
+        coordinator.transactions = [notedA, notedB]
+
+        coordinator.selectSidebarItem(.noteTransaction(id: notedB.id))
+
+        #expect(coordinator.filterCriteria.sidebarScope == .notes)
+        #expect(coordinator.selectedTransaction?.id == notedB.id)
+        #expect(Set(coordinator.filteredTransactions.map(\.id)) == [notedA.id, notedB.id])
+    }
+
+    @Test("Switching away from notes resets scope to allTraffic")
+    func switchingAwayResetsScope() {
+        let coordinator = MainContentCoordinator()
+        let noted = TestFixtures.makeTransaction()
+        noted.comment = "note"
+        let plain = TestFixtures.makeTransaction()
+        coordinator.transactions = [noted, plain]
+
+        coordinator.selectSidebarItem(.allNotes)
+        #expect(coordinator.filterCriteria.sidebarScope == .notes)
+
+        coordinator.selectSidebarItem(.allApps)
+        #expect(coordinator.filterCriteria.sidebarScope == .allTraffic)
+        #expect(coordinator.filteredTransactions.count == 2)
+    }
+
+    // MARK: - Search & Persisted-Only Filtering
+
+    @Test("Notes scope respects search text")
+    func notesScopeRespectsSearch() {
+        let coordinator = MainContentCoordinator()
+        let match = TestFixtures.makeTransaction(url: "https://api.example.com/users/1")
+        match.comment = "note"
+        let noMatch = TestFixtures.makeTransaction(url: "https://api.example.com/posts/1")
+        noMatch.comment = "note"
+        coordinator.transactions = [match, noMatch]
+
+        coordinator.selectSidebarItem(.allNotes)
+        coordinator.filterCriteria.searchText = "users"
+        coordinator.recomputeFilteredTransactions()
+
+        #expect(coordinator.filteredTransactions.map(\.id) == [match.id])
+    }
+
+    @Test("Notes collection includes persisted-only rows deduplicated with live rows")
+    func notesIncludesPersistedOnlyRows() {
+        let coordinator = MainContentCoordinator()
+        let live = TestFixtures.makeTransaction(url: "https://api.example.com/live")
+        live.comment = "live note"
+        let persisted = TestFixtures.makeTransaction(url: "https://api.example.com/persisted")
+        persisted.comment = "persisted note"
+        coordinator.transactions = [live]
+        coordinator.persistedFavorites = [persisted]
+
+        let notes = coordinator.allNotesTransactions
+        #expect(Set(notes.map(\.id)) == [live.id, persisted.id])
+
+        coordinator.selectSidebarItem(.allNotes)
+        #expect(Set(coordinator.filteredTransactions.map(\.id)) == [live.id, persisted.id])
+    }
+
+    @Test("A live row that is also persisted appears once in the notes collection")
+    func notesDeduplicatesLiveAndPersisted() {
+        let coordinator = MainContentCoordinator()
+        let shared = TestFixtures.makeTransaction(url: "https://api.example.com/shared")
+        shared.comment = "shared note"
+        coordinator.transactions = [shared]
+        coordinator.persistedFavorites = [shared]
+
+        #expect(coordinator.allNotesTransactions.map(\.id) == [shared.id])
+    }
+
+    // MARK: - Mutation, Normalization & Removal Seam
+
+    @Test("normalizedNote trims and collapses whitespace-only input to nil")
+    func normalizedNoteContract() {
+        #expect(MainContentCoordinator.normalizedNote(nil) == nil)
+        #expect(MainContentCoordinator.normalizedNote("") == nil)
+        #expect(MainContentCoordinator.normalizedNote("   \n\t ") == nil)
+        #expect(MainContentCoordinator.normalizedNote("  keep me  ") == "keep me")
+    }
+
+    @Test("setNote adds a transaction to the notes collection")
+    func setNoteAddsToNotes() {
+        let coordinator = MainContentCoordinator()
+        let transaction = TestFixtures.makeTransaction()
+        coordinator.transactions = [transaction]
+
+        coordinator.setNote("  needs review  ", for: transaction)
+
+        #expect(transaction.comment == "needs review")
+        #expect(coordinator.allNotesTransactions.map(\.id) == [transaction.id])
+    }
+
+    @Test("setNote with whitespace-only input stores nil and stays out of notes")
+    func setNoteWhitespaceNormalizesToNil() {
+        let coordinator = MainContentCoordinator()
+        let transaction = TestFixtures.makeTransaction()
+        coordinator.transactions = [transaction]
+
+        coordinator.setNote("   ", for: transaction)
+
+        #expect(transaction.comment == nil)
+        #expect(coordinator.allNotesTransactions.isEmpty)
+    }
+
+    @Test("Removing the last note drops the row from notes scope")
+    func removingLastNoteDropsFromScope() {
+        let coordinator = MainContentCoordinator()
+        let transaction = TestFixtures.makeTransaction()
+        coordinator.transactions = [transaction]
+
+        coordinator.setNote("temporary", for: transaction)
+        coordinator.selectSidebarItem(.allNotes)
+        #expect(coordinator.filteredTransactions.map(\.id) == [transaction.id])
+
+        coordinator.updateNoteDraft("", for: transaction)
+
+        #expect(transaction.hasNote == false)
+        #expect(coordinator.allNotesTransactions.isEmpty)
+        #expect(coordinator.filteredTransactions.isEmpty)
+    }
+
+    @Test("Removing a note from the selected child returns selection to all Notes")
+    func removingSelectedChildFallsBackToAllNotes() {
+        let coordinator = MainContentCoordinator()
+        let transaction = TestFixtures.makeTransaction()
+        transaction.comment = "temporary"
+        coordinator.transactions = [transaction]
+        coordinator.selectSidebarItem(.noteTransaction(id: transaction.id))
+
+        coordinator.updateNoteDraft(nil, for: transaction)
+
+        #expect(coordinator.sidebarSelection == .allNotes)
+        #expect(coordinator.selectedTransaction == nil)
+        #expect(coordinator.filteredTransactions.isEmpty)
+    }
+
+    @Test("Editing note text recomputes an active Note search")
+    func editingNoteRecomputesNoteSearch() {
+        let coordinator = MainContentCoordinator()
+        let transaction = TestFixtures.makeTransaction()
+        transaction.comment = "alpha"
+        coordinator.transactions = [transaction]
+        coordinator.filterCriteria.searchField = .comment
+        coordinator.filterCriteria.searchText = "alpha"
+        coordinator.recomputeFilteredTransactions()
+        #expect(coordinator.filteredTransactions.map(\.id) == [transaction.id])
+
+        coordinator.updateNoteDraft("beta", for: transaction)
+
+        #expect(coordinator.filteredTransactions.isEmpty)
+    }
+
+    @Test("Removing a note retains the row when it is also pinned")
+    func removingNoteRetainsPinnedRow() {
+        let coordinator = MainContentCoordinator()
+        let transaction = TestFixtures.makeTransaction()
+        transaction.isPinned = true
+        coordinator.persistedFavorites = [transaction]
+        coordinator.setNote("a note", for: transaction)
+
+        coordinator.setNote(nil, for: transaction)
+
+        #expect(transaction.comment == nil)
+        #expect(coordinator.allNotesTransactions.isEmpty)
+        #expect(coordinator.allPinnedTransactions.map(\.id) == [transaction.id])
+        #expect(coordinator.persistedFavorites.map(\.id) == [transaction.id])
+    }
+
+    @Test("Remove-note context action clears the note but keeps a saved row")
+    func removeFavoriteNoteKeepsSaved() {
+        let coordinator = MainContentCoordinator()
+        let transaction = TestFixtures.makeTransaction()
+        transaction.isSaved = true
+        transaction.comment = "note text"
+        coordinator.transactions = [transaction]
+
+        coordinator.removeFavoriteTransaction(transaction, from: .notes)
+
+        #expect(transaction.comment == nil)
+        #expect(transaction.isSaved == true)
+        #expect(coordinator.allNotesTransactions.isEmpty)
+        #expect(coordinator.allSavedTransactions.map(\.id) == [transaction.id])
+    }
+
+    @Test("Open note in new tab scopes the workspace to the exact request")
+    func openNoteInNewTabScopesExact() {
+        let coordinator = MainContentCoordinator()
+        let transaction = TestFixtures.makeTransaction(url: "https://api.example.com/persisted-note")
+        transaction.comment = "persisted note"
+        coordinator.persistedFavorites = [transaction]
+
+        coordinator.openFavoriteTransactionInNewTab(transaction, from: .notes)
+
+        let workspace = coordinator.workspaceStore.workspaces[1]
+        #expect(workspace.filterCriteria.sidebarScope == .notes)
+        #expect(workspace.filterCriteria.exactTransactionID == transaction.id)
+        #expect(workspace.filteredTransactions.map(\.id) == [transaction.id])
+    }
+
+    // MARK: - Active Filter Lifecycle
+
+    @Test("Notes scope counts as an active filter")
+    func notesScopeCountsAsActiveFilter() {
+        var criteria = FilterCriteria.empty
+        #expect(criteria.isEmpty)
+        #expect(criteria.activeFilterCount == 0)
+
+        criteria.sidebarScope = .notes
+
+        #expect(!criteria.isEmpty)
+        #expect(criteria.activeFilterCount == 1)
+    }
+
+    @Test("Clearing the Notes scope restores All Traffic and selection, mirroring Saved/Pinned")
+    func clearingNotesScopeRestoresAllTraffic() {
+        let coordinator = MainContentCoordinator()
+        let noted = TestFixtures.makeTransaction()
+        noted.comment = "keep"
+        let plain = TestFixtures.makeTransaction()
+        coordinator.transactions = [noted, plain]
+
+        coordinator.selectSidebarItem(.allNotes)
+        #expect(coordinator.filterCriteria.sidebarScope == .notes)
+        #expect(coordinator.sidebarSelection == .allNotes)
+
+        // Mirror the ActiveFilterSummaryBar Notes chip removal action.
+        coordinator.filterCriteria.sidebarScope = .allTraffic
+        coordinator.filterCriteria.exactTransactionID = nil
+        coordinator.sidebarSelection = nil
+        coordinator.recomputeFilteredTransactions()
+
+        #expect(coordinator.filterCriteria.sidebarScope == .allTraffic)
+        #expect(coordinator.filterCriteria.exactTransactionID == nil)
+        #expect(coordinator.sidebarSelection == nil)
+        #expect(coordinator.filteredTransactions.count == 2)
+    }
+
+    // MARK: - UI / Source Contracts
+
+    @Test("Notes section maps to the correct sidebar items")
+    func notesSectionSidebarContract() {
+        let id = UUID()
+        #expect(FavoriteTransactionSection.notes.displayName == "Notes")
+        #expect(FavoriteTransactionSection.notes.sidebarItem(for: id) == .noteTransaction(id: id))
+        #expect(FavoriteTransactionSection.notes.fallbackSidebarItem == .allNotes)
+    }
+
+    @Test("Annotation workflow labels read as Note/Notes")
+    func annotationLabelsUseNoteNaming() {
+        #expect(RequestInspectorTab.comments.displayName == "Notes")
+        #expect(FilterField.comment.displayName == "Note")
+    }
+}

--- a/RockxyTests/Views/RequestList/RequestTableSelectionScrollTests.swift
+++ b/RockxyTests/Views/RequestList/RequestTableSelectionScrollTests.swift
@@ -636,11 +636,13 @@ struct RequestTableSelectionScrollTests {
         )
         let coordinator = RequestTableView.Coordinator(parent: parent)
         coordinator.rows = rows
-        let tableView = makeTableView(rowCount: rows.count, coordinator: coordinator, columns: ["method"])
+        let tableView = makeTableView(rowCount: rows.count, coordinator: coordinator, columns: ["method", "url"])
 
         let measuredWidth = coordinator.tableView(tableView, sizeToFitWidthOfColumn: 0)
         let cellView = coordinator.tableView(tableView, viewFor: tableView.tableColumns[0], row: 0)
         let textField = cellView?.subviews.first as? NSTextField
+        let urlCellView = coordinator.tableView(tableView, viewFor: tableView.tableColumns[1], row: 0)
+        let urlTextField = urlCellView?.subviews.first as? NSTextField
 
         #expect(measuredWidth <= 82)
         #expect(textField?.stringValue == "CONNECT")
@@ -648,6 +650,10 @@ struct RequestTableSelectionScrollTests {
         #expect(textField?.cell?.wraps == false)
         #expect((textField?.cell as? NSTextFieldCell)?.usesSingleLineMode == true)
         #expect((textField?.cell as? NSTextFieldCell)?.truncatesLastVisibleLine == true)
+        #expect(textField?.allowsExpansionToolTips == false)
+        #expect(urlTextField?.allowsExpansionToolTips == false)
+        #expect(urlTextField?.toolTip?.isEmpty == false)
+        #expect(urlTextField?.toolTip == urlTextField?.stringValue)
     }
 
     @Test("Request table SSL icon constraints shrink after large-to-small metric changes")
@@ -753,6 +759,8 @@ struct RequestTableSelectionScrollTests {
         #expect(fallbackView.frame.size.width == expected)
         #expect(fallbackView.frame.size.height == expected)
         #expect(leadingConstraintConstant(for: nameLabel, in: smallView) == expected + 4)
+        #expect(nameLabel.allowsExpansionToolTips == false)
+        #expect(nameLabel.toolTip == "Example Client")
     }
 
     @Test("Request table status, SSL, and client icons remain consistent after repeated metric changes")

--- a/RockxyTests/Views/ToolWindowReadabilityTests.swift
+++ b/RockxyTests/Views/ToolWindowReadabilityTests.swift
@@ -153,7 +153,12 @@ struct ToolWindowReadabilityTests {
         let switcherStyleSource = try readProjectFile("Rockxy/Views/Common/UtilitySegmentedHeader.swift")
 
         #expect(source.contains("@Environment(\\.appUIDisplayMetrics)"))
-        #expect(source.contains("appMetrics.swiftUIFont(size:"))
+        // UI/prose uses explicit proportional .system(size:) roles derived from Appearance metrics,
+        // no longer routed through swiftUIFont (which could force all prose monospaced). Technical
+        // data (request summaries, model IDs) stays explicitly monospaced. Restored switcher labels
+        // (Details / AI Assistant) are asserted in ContextDockPresentationTests.
+        #expect(!source.contains("swiftUIFont"))
+        #expect(source.contains("assistantFont(appMetrics."))
         #expect(source.contains("monospaced: true"))
         #expect(!source.contains(".font(.caption"))
         #expect(!source.contains(".font(.callout"))
@@ -161,8 +166,6 @@ struct ToolWindowReadabilityTests {
         #expect(!source.contains(".disabled(isBusy || primaryTransaction == nil)"))
         #expect(!source.contains(".disabled(conversationIsEmpty && !isBusy)"))
         #expect(source.contains("Ask Rockxy AI Assistant…"))
-        #expect(source.contains("Text(String(localized: \"Details\"))"))
-        #expect(source.contains("Text(String(localized: \"AI Assistant\"))"))
         #expect(source.contains("ContextDetailsView(coordinator: coordinator)"))
         #expect(source.contains("AIAssistantDockView("))
         #expect(source.contains(".workspaceModeSwitcherStyle()"))
@@ -177,7 +180,7 @@ struct ToolWindowReadabilityTests {
         let components = try readProjectFile("Rockxy/Views/Inspector/AssistantConversationComponents.swift")
 
         #expect(source.contains("ContentUnavailableView"))
-        #expect(source.contains("DisclosureGroup"))
+        #expect(source.contains("InvestigationReportView("))
         #expect(source.contains("Image(systemName: \"arrow.up\")"))
         #expect(source.contains("accessibilityLabel(String(localized: \"Conversation History\"))"))
         #expect(source.contains("accessibilityLabel(String(localized: \"New Conversation\"))"))
@@ -189,7 +192,8 @@ struct ToolWindowReadabilityTests {
         #expect(components.contains("compactAction("))
         #expect(components.contains(".accessibilityLabel(title)"))
         #expect(components.contains(".help(title)"))
-        #expect(components.contains("Color(nsColor: .controlBackgroundColor), in: RoundedRectangle(cornerRadius: 9)"))
+        #expect(!components.contains("Color(nsColor: .controlBackgroundColor), in: RoundedRectangle(cornerRadius: 9)"))
+        #expect(components.contains("AssistantQueryRow"))
         #expect(components.contains("AssistantMarkdownText"))
         #expect(components.contains("inlineOnlyPreservingWhitespace"))
         #expect(source.contains("AssistantMarkdownText("))


### PR DESCRIPTION
## Summary

Promote the latest native traffic inspection workflow improvements from `develop` to `main`.

- Refine the Context Dock into dense native Details and AI Assistant workflows with selection-aware states, evidence-linked investigation results, matched-rule navigation, and persistent request notes.
- Make request and response inspection responsive through adaptive dock presentation, balanced bottom-inspector sizing, and native tab overflow.
- Keep filtering usable at narrow widths with adaptive protocol controls, responsive search, removable active-filter summaries, and recoverable empty states.
- Surface active mutation tools in the workspace footer and keep long request URLs, header values, and client names inspectable with standard macOS help tooltips.

## Why

The primary traffic workflow must remain readable and predictable as request density, inspector content, active filters, and window constraints increase. This promotion keeps the request list central while making detail, investigation, notes, and rule state easier to discover without introducing web-style layout or horizontal overflow.

## Impact

- Notes behave as a first-class Library collection with consistent save, filter, and clear-scope behavior.
- Context Dock content follows the current request selection and yields space at narrow workspace widths.
- Inspector and protocol tabs retain visible options while moving remaining actions into native overflow menus.
- Empty filtered or scoped request lists provide explicit recovery actions.
- Active rule tools remain visible from the footer without obscuring traffic.
- Long request metadata remains accessible through standard delayed tooltips without disruptive expansion overlays.

No session format, proxy protocol, or entitlement boundary changes are included.

## Related issues

Refs #10
Refs #14
Refs #16
Refs #39
Refs #214
Refs #217

## Validation

- `swiftlint lint --strict` across all 58 Swift files in the promotion diff — passed with 0 violations.
- Focused macOS test sweep covering notes persistence and filtering, Context Dock presentation, inspector layout and overflow, protocol filter overflow, recoverable empty states, footer actions, request-table behavior, and tool-window readability — passed.
- The focused test command completed a successful Debug build of the Rockxy app and test bundle.
- Repository-wide strict lint still reports four existing violations outside this promotion diff: `GitHubGistClient.swift`, `HTTPResponseData.swift`, `SessionCodable.swift`, and `WorkspaceWindowManager.swift`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Notes collection for browsing, filtering, editing, and saving transaction notes.
  * Added responsive inspector tabs with overflow menus and improved bottom-inspector controls.
  * Added contextual empty states with recovery actions for traffic, filters, proxy, and recording.
  * Added adaptive protocol filters and live indicators for mapping and breakpoint rules.
  * Added richer investigation reports, evidence views, request details, and multi-selection actions.
* **Improvements**
  * Improved responsive layouts, accessibility labels, tooltips, typography, and inspector sizing.
  * Renamed “Comment” actions and labels to “Note” for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->