### PR TITLE
Fix encrypted HTTPS controls in the response inspector

### DIFF
--- a/Rockxy/Views/Inspector/HTTPSInspectionPromptView.swift
+++ b/Rockxy/Views/Inspector/HTTPSInspectionPromptView.swift
@@ -1,0 +1,191 @@
+import AppKit
+import SwiftUI
+
+// MARK: - HTTPSInspectionPromptView
+
+/// Compact controls for CONNECT tunnels whose payload was not decrypted.
+struct HTTPSInspectionPromptView: View {
+    let prompt: HTTPSInspectionPromptModel
+    let onAction: (HTTPSInspectionPromptAction) -> Void
+
+    var body: some View {
+        ScrollView(.vertical) {
+            VStack(alignment: .leading, spacing: 10) {
+                header
+
+                if prompt.requiresCertificateSetup {
+                    certificateAction
+                } else {
+                    scopeControls
+                }
+            }
+            .padding(12)
+            .frame(maxWidth: .infinity, alignment: .topLeading)
+        }
+        .scrollBounceBehavior(.basedOnSize)
+        .background(Color(nsColor: .textBackgroundColor))
+    }
+
+    // MARK: Private
+
+    @Environment(\.appUIDisplayMetrics) private var metrics
+
+    private var header: some View {
+        HStack(spacing: 8) {
+            Image(systemName: prompt.requiresCertificateSetup ? "exclamationmark.lock.fill" : "lock.fill")
+                .font(.system(size: metrics.primaryFontSize, weight: .medium))
+                .foregroundStyle(
+                    prompt.requiresCertificateSetup
+                        ? Color(nsColor: .systemOrange)
+                        : Color(nsColor: .secondaryLabelColor)
+                )
+                .frame(width: 18)
+                .accessibilityHidden(true)
+
+            Text(
+                prompt.requiresCertificateSetup
+                    ? String(localized: "Certificate Required")
+                    : String(localized: "Encrypted HTTPS")
+            )
+            .font(.system(size: metrics.controlFontSize, weight: .semibold))
+
+            Spacer(minLength: 8)
+
+            Button {
+                onAction(.openSSLProxyingList)
+            } label: {
+                Image(systemName: "slider.horizontal.3")
+            }
+            .buttonStyle(.borderless)
+            .controlSize(.small)
+            .help(String(localized: "Manage HTTPS Decryption"))
+            .accessibilityLabel(String(localized: "Manage HTTPS Decryption"))
+        }
+    }
+
+    private var certificateAction: some View {
+        Button(String(localized: "Install & Trust…")) {
+            onAction(prompt.primaryAction)
+        }
+        .buttonStyle(.borderedProminent)
+        .controlSize(.small)
+        .accessibilityHint(String(localized: "Installs and trusts the Rockxy root certificate"))
+    }
+
+    private var scopeControls: some View {
+        VStack(spacing: 0) {
+            Divider()
+            scopeActionRow(action: prompt.primaryAction)
+
+            if let secondaryAction = prompt.secondaryAction {
+                Divider()
+                    .padding(.leading, 24)
+                scopeActionRow(action: secondaryAction)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func scopeActionRow(action: HTTPSInspectionPromptAction) -> some View {
+        if let scope = HTTPSInspectionScopePresentation(action: action) {
+            HStack(spacing: 8) {
+                Image(systemName: scope.kind.systemImage)
+                    .font(.system(size: metrics.controlFontSize))
+                    .foregroundStyle(Color(nsColor: .secondaryLabelColor))
+                    .frame(width: 16)
+                    .accessibilityHidden(true)
+
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(scope.kind.title)
+                        .font(.system(size: metrics.controlFontSize, weight: .medium))
+
+                    Text(scope.value)
+                        .font(.system(size: metrics.metadataFontSize))
+                        .foregroundStyle(Color(nsColor: .secondaryLabelColor))
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                        .help(scope.value)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+                Button(scope.actionTitle) {
+                    onAction(action)
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+                .fixedSize()
+                .help(scope.actionDescription)
+                .accessibilityLabel(scope.actionDescription)
+                .accessibilityHint(String(localized: "The current captured response is unchanged"))
+            }
+            .padding(.horizontal, 4)
+            .frame(minHeight: 40)
+        }
+    }
+}
+
+// MARK: - HTTPSInspectionScopePresentation
+
+struct HTTPSInspectionScopePresentation: Equatable {
+    enum Kind: Equatable {
+        case host
+        case appHosts
+
+        var title: String {
+            switch self {
+            case .host: String(localized: "Host")
+            case .appHosts: String(localized: "App Hosts")
+            }
+        }
+
+        var systemImage: String {
+            switch self {
+            case .host: "network"
+            case .appHosts: "macwindow"
+            }
+        }
+    }
+
+    let kind: Kind
+    let value: String
+    let isEnabled: Bool
+
+    var actionTitle: String {
+        isEnabled ? String(localized: "Disable") : String(localized: "Decrypt")
+    }
+
+    var actionDescription: String {
+        switch (kind, isEnabled) {
+        case (.host, false):
+            String(localized: "Decrypt new HTTPS connections to \(value)")
+        case (.host, true):
+            String(localized: "Stop decrypting new HTTPS connections to \(value)")
+        case (.appHosts, false):
+            String(localized: "Decrypt new HTTPS connections to known hosts used by \(value)")
+        case (.appHosts, true):
+            String(localized: "Stop decrypting new HTTPS connections to known hosts used by \(value)")
+        }
+    }
+
+    init(kind: Kind, value: String, isEnabled: Bool) {
+        self.kind = kind
+        self.value = value
+        self.isEnabled = isEnabled
+    }
+
+    init?(action: HTTPSInspectionPromptAction) {
+        switch action {
+        case let .enableDomain(host):
+            self.init(kind: .host, value: host, isEnabled: false)
+        case let .disableDomain(host):
+            self.init(kind: .host, value: host, isEnabled: true)
+        case let .enableApp(appName, _):
+            self.init(kind: .appHosts, value: appName, isEnabled: false)
+        case let .disableApp(appName, _):
+            self.init(kind: .appHosts, value: appName, isEnabled: true)
+        case .installCertificate,
+             .openSSLProxyingList:
+            return nil
+        }
+    }
+}

--- a/Rockxy/Views/Inspector/ResponseInspectorView.swift
+++ b/Rockxy/Views/Inspector/ResponseInspectorView.swift
@@ -66,7 +66,6 @@ struct ResponseInspectorView: View {
     private var httpsPromptModel: HTTPSInspectionPromptModel? {
         HTTPSInspectionPromptModel.make(
             transaction: transaction,
-            sslProxyingEnabled: SSLProxyingManager.shared.isEnabled,
             canInterceptHTTPS: coordinator.readiness.canInterceptHTTPS,
             domainRuleEnabled: coordinator.isSSLProxyingEnabled(for: transaction.request.host),
             appName: normalizedClientAppName,
@@ -452,59 +451,8 @@ struct ResponseInspectorView: View {
     }
 
     private func encryptedHTTPSPrompt(_ prompt: HTTPSInspectionPromptModel) -> some View {
-        VStack(spacing: 0) {
-            Spacer()
-
-            VStack(spacing: 18) {
-                HStack(spacing: 10) {
-                    Image(systemName: "lock")
-                        .font(.system(size: max(24, metrics.primaryFontSize + 15), weight: .regular))
-                        .foregroundStyle(Color(nsColor: .secondaryLabelColor))
-
-                    Text(prompt.title)
-                        .font(.system(size: max(20, metrics.primaryFontSize + 11), weight: .regular))
-                        .foregroundStyle(Color(nsColor: .secondaryLabelColor))
-                }
-
-                Text(prompt.message)
-                    .font(.system(size: max(metrics.primaryFontSize, metrics.controlFontSize), weight: .regular))
-                    .foregroundStyle(Color(nsColor: .tertiaryLabelColor))
-                    .multilineTextAlignment(.center)
-                    .frame(maxWidth: 320)
-
-                Button {
-                    handleHTTPSPromptAction(prompt.primaryAction)
-                } label: {
-                    Text(prompt.primaryTitle)
-                        .frame(minWidth: 220)
-                }
-                .buttonStyle(.bordered)
-                .controlSize(.large)
-
-                if let secondaryTitle = prompt.secondaryTitle,
-                   let secondaryAction = prompt.secondaryAction
-                {
-                    Text(String(localized: "or"))
-                        .font(.system(size: metrics.controlFontSize, weight: .medium))
-                        .foregroundStyle(Color(nsColor: .tertiaryLabelColor))
-
-                    Button {
-                        handleHTTPSPromptAction(secondaryAction)
-                    } label: {
-                        Text(secondaryTitle)
-                            .multilineTextAlignment(.center)
-                            .frame(minWidth: 220)
-                    }
-                    .buttonStyle(.bordered)
-                    .controlSize(.large)
-                }
-            }
-            .padding(.horizontal, 24)
-
-            Spacer()
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .background(Color(nsColor: .textBackgroundColor))
+        HTTPSInspectionPromptView(prompt: prompt, onAction: handleHTTPSPromptAction)
+            .id(transaction.id)
     }
 
     private func handleHTTPSPromptAction(_ action: HTTPSInspectionPromptAction) {
@@ -690,16 +638,16 @@ enum HTTPSInspectionPromptAction: Equatable {
 // MARK: - HTTPSInspectionPromptModel
 
 struct HTTPSInspectionPromptModel: Equatable {
-    let title: String
-    let message: String
-    let primaryTitle: String
+    let host: String
     let primaryAction: HTTPSInspectionPromptAction
-    let secondaryTitle: String?
     let secondaryAction: HTTPSInspectionPromptAction?
+
+    var requiresCertificateSetup: Bool {
+        primaryAction == .installCertificate
+    }
 
     static func make(
         transaction: HTTPTransaction,
-        sslProxyingEnabled: Bool,
         canInterceptHTTPS: Bool,
         domainRuleEnabled: Bool,
         appName: String?,
@@ -722,55 +670,30 @@ struct HTTPSInspectionPromptModel: Equatable {
 
         if !canInterceptHTTPS {
             return HTTPSInspectionPromptModel(
-                title: String(localized: "HTTPS Response"),
-                message: String(
-                    localized: "This HTTPS response is encrypted. Install and trust the certificate to see the content."
-                ),
-                primaryTitle: String(localized: "Install & Trust Certificate"),
+                host: host,
                 primaryAction: .installCertificate,
-                secondaryTitle: nil,
                 secondaryAction: nil
             )
         }
 
-        let domainTitle = domainRuleEnabled ?
-            String(localized: "Disable only this domain") :
-            String(localized: "Enable only this domain")
         let domainAction: HTTPSInspectionPromptAction = domainRuleEnabled ?
             .disableDomain(host) :
             .enableDomain(host)
 
-        let message: String
-        if domainRuleEnabled || appRuleEnabled {
-            message = String(
-                localized: "SSL Proxying is enabled for this HTTPS target. You can adjust the scope below."
-            )
-        } else if sslProxyingEnabled {
-            message = String(localized: "This HTTPS response is encrypted. Enable SSL Proxying to see the content.")
+        let appAction: HTTPSInspectionPromptAction? = if let appName {
+            if appRuleEnabled {
+                HTTPSInspectionPromptAction.disableApp(appName, fallbackDomain: host)
+            } else {
+                HTTPSInspectionPromptAction.enableApp(appName, fallbackDomain: host)
+            }
         } else {
-            message = String(localized: "SSL Proxying is off. Enable it to see the encrypted content.")
-        }
-
-        let appAction: (String?, HTTPSInspectionPromptAction?) = if let appName {
-            (
-                appRuleEnabled ?
-                    String(localized: "Disable all domains from \"\(appName)\"") :
-                    String(localized: "Enable all domains from \"\(appName)\""),
-                appRuleEnabled ?
-                    .disableApp(appName, fallbackDomain: host) :
-                    .enableApp(appName, fallbackDomain: host)
-            )
-        } else {
-            (nil, nil)
+            nil
         }
 
         return HTTPSInspectionPromptModel(
-            title: String(localized: "HTTPS Response"),
-            message: message,
-            primaryTitle: domainTitle,
+            host: host,
             primaryAction: domainAction,
-            secondaryTitle: appAction.0,
-            secondaryAction: appAction.1
+            secondaryAction: appAction
         )
     }
 }

--- a/RockxyTests/Views/Inspector/InspectorRoutingTests.swift
+++ b/RockxyTests/Views/Inspector/InspectorRoutingTests.swift
@@ -430,18 +430,16 @@ struct InspectorRoutingTests {
 
         let prompt = HTTPSInspectionPromptModel.make(
             transaction: transaction,
-            sslProxyingEnabled: true,
             canInterceptHTTPS: true,
             domainRuleEnabled: false,
             appName: transaction.clientApp,
             appRuleEnabled: false
         )
 
-        #expect(prompt?.title == "HTTPS Response")
-        #expect(prompt?.primaryTitle == "Enable only this domain")
+        #expect(prompt?.host == "api.example.com")
         #expect(prompt?.primaryAction == .enableDomain("api.example.com"))
-        #expect(prompt?.secondaryTitle == "Enable all domains from \"Brave Browser Helper\"")
         #expect(prompt?.secondaryAction == .enableApp("Brave Browser Helper", fallbackDomain: "api.example.com"))
+        #expect(prompt?.requiresCertificateSetup == false)
     }
 
     @Test("CONNECT tunnel still shows app SSL action when app cache is empty")
@@ -455,7 +453,6 @@ struct InspectorRoutingTests {
 
         let prompt = HTTPSInspectionPromptModel.make(
             transaction: transaction,
-            sslProxyingEnabled: true,
             canInterceptHTTPS: true,
             domainRuleEnabled: false,
             appName: transaction.clientApp,
@@ -463,7 +460,6 @@ struct InspectorRoutingTests {
         )
 
         #expect(prompt?.primaryAction == .enableDomain("api.example.com"))
-        #expect(prompt?.secondaryTitle == "Enable all domains from \"Google Chrome\"")
         #expect(prompt?.secondaryAction == .enableApp("Google Chrome", fallbackDomain: "api.example.com"))
     }
 
@@ -477,15 +473,16 @@ struct InspectorRoutingTests {
 
         let prompt = HTTPSInspectionPromptModel.make(
             transaction: transaction,
-            sslProxyingEnabled: true,
             canInterceptHTTPS: false,
             domainRuleEnabled: false,
             appName: nil,
             appRuleEnabled: false
         )
 
+        #expect(prompt?.host == "api.example.com")
         #expect(prompt?.primaryAction == .installCertificate)
         #expect(prompt?.secondaryAction == nil)
+        #expect(prompt?.requiresCertificateSetup == true)
     }
 
     // MARK: - Compression Helpers
@@ -618,21 +615,18 @@ struct InspectorRoutingTests {
 
         let prompt = HTTPSInspectionPromptModel.make(
             transaction: transaction,
-            sslProxyingEnabled: true,
             canInterceptHTTPS: true,
             domainRuleEnabled: true,
             appName: nil,
             appRuleEnabled: false
         )
 
-        #expect(prompt?.message == "SSL Proxying is enabled for this HTTPS target. You can adjust the scope below.")
-        #expect(prompt?.primaryTitle == "Disable only this domain")
         #expect(prompt?.primaryAction == .disableDomain("api.example.com"))
         #expect(prompt?.secondaryAction == nil)
     }
 
-    @Test("CONNECT tunnel with app-wide SSL rule shows disable-all guidance")
-    func connectTunnelWithExistingAppRuleShowsDisableGuidance() {
+    @Test("CONNECT tunnel with known app-host rules shows disable guidance")
+    func connectTunnelWithExistingAppHostRulesShowsDisableGuidance() {
         let transaction = TestFixtures.makeTransaction(
             method: "CONNECT",
             url: "https://api.example.com:443",
@@ -642,38 +636,54 @@ struct InspectorRoutingTests {
 
         let prompt = HTTPSInspectionPromptModel.make(
             transaction: transaction,
-            sslProxyingEnabled: true,
             canInterceptHTTPS: true,
             domainRuleEnabled: false,
             appName: transaction.clientApp,
             appRuleEnabled: true
         )
 
-        #expect(prompt?.primaryTitle == "Enable only this domain")
         #expect(prompt?.primaryAction == .enableDomain("api.example.com"))
-        #expect(prompt?.secondaryTitle == "Disable all domains from \"Google Chrome\"")
         #expect(prompt?.secondaryAction == .disableApp("Google Chrome", fallbackDomain: "api.example.com"))
     }
 
-    @Test("CONNECT tunnel shows alternate message when SSL proxying is globally off")
-    func connectTunnelShowsSSLDisabledMessage() {
-        let transaction = TestFixtures.makeTransaction(
-            method: "CONNECT",
-            url: "https://api.example.com:443",
-            statusCode: 200
-        )
-        transaction.clientApp = "Brave Browser Helper"
-
-        let prompt = HTTPSInspectionPromptModel.make(
-            transaction: transaction,
-            sslProxyingEnabled: false,
-            canInterceptHTTPS: true,
-            domainRuleEnabled: false,
-            appName: transaction.clientApp,
-            appRuleEnabled: false
+    @Test("HTTPS prompt scope presentation exposes host and app-host state")
+    func httpsPromptScopePresentation() {
+        let host = HTTPSInspectionScopePresentation(action: .enableDomain("api.example.com"))
+        let appHosts = HTTPSInspectionScopePresentation(
+            action: .disableApp("Brave Browser Helper", fallbackDomain: "api.example.com")
         )
 
-        #expect(prompt?.message == "SSL Proxying is off. Enable it to see the encrypted content.")
+        #expect(host == HTTPSInspectionScopePresentation(kind: .host, value: "api.example.com", isEnabled: false))
+        #expect(host?.kind.title == "Host")
+        #expect(host?.actionTitle == "Decrypt")
+        #expect(host?.actionDescription == "Decrypt new HTTPS connections to api.example.com")
+        #expect(
+            HTTPSInspectionScopePresentation(action: .disableDomain("api.example.com"))?.actionDescription ==
+                "Stop decrypting new HTTPS connections to api.example.com"
+        )
+
+        #expect(
+            appHosts == HTTPSInspectionScopePresentation(
+                kind: .appHosts,
+                value: "Brave Browser Helper",
+                isEnabled: true
+            )
+        )
+        #expect(appHosts?.kind.title == "App Hosts")
+        #expect(appHosts?.kind.systemImage == "macwindow")
+        #expect(appHosts?.actionTitle == "Disable")
+        #expect(
+            appHosts?.actionDescription ==
+                "Stop decrypting new HTTPS connections to known hosts used by Brave Browser Helper"
+        )
+        #expect(
+            HTTPSInspectionScopePresentation(
+                action: .enableApp("Brave Browser Helper", fallbackDomain: "api.example.com")
+            )?.actionDescription ==
+                "Decrypt new HTTPS connections to known hosts used by Brave Browser Helper"
+        )
+        #expect(HTTPSInspectionScopePresentation(action: .installCertificate) == nil)
+        #expect(HTTPSInspectionScopePresentation(action: .openSSLProxyingList) == nil)
     }
 
     @Test("Plain HTTP response does not show HTTPS prompt")
@@ -682,7 +692,6 @@ struct InspectorRoutingTests {
 
         let prompt = HTTPSInspectionPromptModel.make(
             transaction: transaction,
-            sslProxyingEnabled: true,
             canInterceptHTTPS: true,
             domainRuleEnabled: false,
             appName: nil,


### PR DESCRIPTION
## Summary

- replace the oversized encrypted-response empty state with compact, native inspector controls
- keep host and known app-host decryption actions reachable in constrained response panes
- add contextual help, accessibility descriptions, and focused regression coverage

## Why

The previous centered prompt could hide its lower action when the response inspector was short, leaving no usable scrolling path. It also described application scope more broadly than the implementation, which applies rules to hosts Rockxy has already observed for that app.

## Impact

- encrypted CONNECT responses now present dense, scrollable controls
- users can distinguish the current host from known hosts associated with the client app
- certificate setup and HTTPS decryption management remain available from the same inspector state
- action labels switch between `Decrypt` and `Disable` based on the current rule state
- existing proxy and rule behavior is unchanged

## Related issues

Refs #11
Refs #14

## Validation

- `swiftlint lint --strict`
- `xcodebuild -project Rockxy.xcodeproj -scheme Rockxy -destination 'platform=macOS' -only-testing:RockxyTests/InspectorRoutingTests test`
- `xcodebuild -project Rockxy.xcodeproj -scheme Rockxy -configuration Debug build`
- rendered the SwiftUI state at a 480 × 180 response-pane size to verify both actions remain visible