### PR TITLE
feat(workspace): harden capture and inspection workflows

### DIFF
--- a/Rockxy.xcodeproj/project.pbxproj
+++ b/Rockxy.xcodeproj/project.pbxproj
@@ -629,7 +629,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "set -e\n\ncase \"$TARGET_BUILD_DIR\" in\n    */DerivedData/*/Build/Products/*) ;;\n    *) exit 0 ;;\nesac\n\nDEST=\"${TARGET_BUILD_DIR}/${EXECUTABLE_FOLDER_PATH}/rockxy-mcp\"\n\n# Xcode can fail to replace the embedded CLI if an MCP client still has the\n# previous DerivedData copy running. Stop only the bridge from this build bundle.\nif [ -n \"$DEST\" ]; then\n    /usr/bin/pkill -f \"$DEST\" 2>/dev/null || true\nfi\n\nif [ -e \"$DEST\" ]; then\n    /bin/chmod u+w \"$DEST\" 2>/dev/null || true\n    /bin/rm -f \"$DEST\"\nfi\n";
+			shellScript = "set -e\n\ncase \"$TARGET_BUILD_DIR\" in\n    */DerivedData/*/Build/Products/*) ;;\n    *) exit 0 ;;\nesac\n\nSOURCE=\"${BUILT_PRODUCTS_DIR}/rockxy-mcp\"\nDEST=\"${TARGET_BUILD_DIR}/${EXECUTABLE_FOLDER_PATH}/rockxy-mcp\"\n\n# Stop only the bridge from this DerivedData bundle before replacing it. Copy the\n# product here as well as in the following Copy Files phase so an incremental build\n# can never leave the app's sealed MCP executable missing.\n/usr/bin/pkill -f \"$DEST\" 2>/dev/null || true\n\nif [ ! -x \"$SOURCE\" ]; then\n    echo \"error: Missing built MCP tool at $SOURCE\" >&2\n    exit 1\nfi\n\n/bin/cp -f \"$SOURCE\" \"$DEST\"\n";
 		};
 		DCA9D0212F700100005B1552 /* Generate Helper LaunchDaemon Plist */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/Rockxy/AppDelegate.swift
+++ b/Rockxy/AppDelegate.swift
@@ -57,7 +57,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSUserInterfaceValidat
     }
 
     func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
-        let showAlert = UserDefaults.standard.bool(forKey: Self.identity.defaultsKey("showAlertOnQuit"))
+        let skipConfirmation = skipNextQuitConfirmation
+        skipNextQuitConfirmation = false
+        let showAlert = !skipConfirmation
+            && UserDefaults.standard.bool(forKey: Self.identity.defaultsKey("showAlertOnQuit"))
         if showAlert {
             let alert = NSAlert()
             alert.messageText = String(localized: "Quit Rockxy?")
@@ -102,6 +105,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSUserInterfaceValidat
         return .terminateLater
     }
 
+    func requestQuitForRequiredReopen() {
+        skipNextQuitConfirmation = true
+        NSApp.terminate(nil)
+    }
+
     func applicationWillTerminate(_ notification: Notification) {
         Self.logger.info("applicationWillTerminate — final proxy cleanup fallback")
         SystemProxyManager.shared.performEmergencyTerminationCleanup(
@@ -115,6 +123,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSUserInterfaceValidat
     }
 
     // MARK: Private
+
+    private var skipNextQuitConfirmation = false
 
     private static let identity = RockxyIdentity.current
 

--- a/Rockxy/ContentView.swift
+++ b/Rockxy/ContentView.swift
@@ -9,9 +9,12 @@ enum MainWindowLayoutMetrics {
     static let defaultHeight: CGFloat = 760
     static let minimumWidth: CGFloat = 960
     static let minimumHeight: CGFloat = 620
-    static let utilityPaneMinimumWidth: CGFloat = 300
-    static let utilityPaneIdealWidth: CGFloat = 380
-    static let utilityPaneMaximumWidth: CGFloat = 520
+    static let sidebarMinimumWidth: CGFloat = 300
+    static let sidebarIdealWidth: CGFloat = 380
+    static let sidebarMaximumWidth: CGFloat = 520
+    static let workspaceMinimumWidth: CGFloat = 320
+    static let contextDockMinimumWidth: CGFloat = 220
+    static let contextDockIdealWidth: CGFloat = 380
 }
 
 // MARK: - ContentView
@@ -40,13 +43,12 @@ struct ContentView: View {
             isSidebarPresented: $isSidebarPresented,
             isInspectorPresented: contextDockVisibility,
             autosaveName: Self.workspaceSplitAutosaveName,
-            sidebarMinimumWidth: MainWindowLayoutMetrics.utilityPaneMinimumWidth,
-            sidebarIdealWidth: MainWindowLayoutMetrics.utilityPaneIdealWidth,
-            sidebarMaximumWidth: MainWindowLayoutMetrics.utilityPaneMaximumWidth,
-            workspaceMinimumWidth: Self.minimumWorkspaceWidth,
-            inspectorMinimumWidth: MainWindowLayoutMetrics.utilityPaneMinimumWidth,
-            inspectorIdealWidth: MainWindowLayoutMetrics.utilityPaneIdealWidth,
-            inspectorMaximumWidth: MainWindowLayoutMetrics.utilityPaneMaximumWidth,
+            sidebarMinimumWidth: MainWindowLayoutMetrics.sidebarMinimumWidth,
+            sidebarIdealWidth: MainWindowLayoutMetrics.sidebarIdealWidth,
+            sidebarMaximumWidth: MainWindowLayoutMetrics.sidebarMaximumWidth,
+            workspaceMinimumWidth: MainWindowLayoutMetrics.workspaceMinimumWidth,
+            inspectorMinimumWidth: MainWindowLayoutMetrics.contextDockMinimumWidth,
+            inspectorIdealWidth: MainWindowLayoutMetrics.contextDockIdealWidth,
             toolbarConfiguration: NativeWorkspaceToolbarConfiguration(
                 coordinator: coordinator,
                 onOpenDeveloperHub: { openWindow(id: "developerSetupHub") }
@@ -223,7 +225,6 @@ struct ContentView: View {
     private let managesLifecycle: Bool
     private let representedWorkspaceID: UUID?
 
-    private static let minimumWorkspaceWidth: CGFloat = 600
     private static let workspaceSplitAutosaveName = RockxyIdentity.current.defaultsKey(
         "nativeWorkspaceSplit.v1"
     )

--- a/Rockxy/ContentView.swift
+++ b/Rockxy/ContentView.swift
@@ -56,26 +56,31 @@ struct ContentView: View {
         ) {
             SidebarView(coordinator: coordinator)
         } workspace: {
-            VStack(spacing: 0) {
-                if let warning = coordinator.systemProxyWarning {
-                    SystemProxyWarningBanner(
-                        message: warning.message,
-                        primaryActionTitle: warning.action?.title,
-                        onPrimaryAction: {
-                            handleSystemProxyWarningAction(warning.action)
-                        },
-                        onDismiss: warning.isDismissible ? {
-                            coordinator.readiness.dismissWarning()
-                        } : nil
+            ZStack(alignment: .bottom) {
+                VStack(spacing: 0) {
+                    if let warning = coordinator.systemProxyWarning {
+                        SystemProxyWarningBanner(
+                            message: warning.message,
+                            primaryActionTitle: warning.action?.title,
+                            onPrimaryAction: {
+                                handleSystemProxyWarningAction(warning.action)
+                            },
+                            onDismiss: warning.isDismissible ? {
+                                coordinator.readiness.dismissWarning()
+                            } : nil
+                        )
+                    }
+
+                    CenterContentView(
+                        coordinator: coordinator,
+                        onOpenToolWindow: { id in openWindow(id: id) }
                     )
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
                 }
 
-                CenterContentView(
-                    coordinator: coordinator,
-                    onOpenToolWindow: { id in openWindow(id: id) }
-                )
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                toastOverlay
             }
+            .animation(.easeOut(duration: 0.18), value: coordinator.activeToast?.id)
         } inspector: {
             ContextDockView(
                 coordinator: coordinator,
@@ -203,13 +208,6 @@ struct ContentView: View {
                 onCancel: { coordinator.gistPublishContext = nil }
             )
         }
-        .overlay(alignment: .bottom) {
-            if let toast = coordinator.activeToast {
-                ToastView(message: toast) {
-                    coordinator.activeToast = nil
-                }
-            }
-        }
         .appUIDisplayMetrics(displayMetrics)
     }
 
@@ -224,6 +222,20 @@ struct ContentView: View {
     private let settingsManager = AppSettingsManager.shared
     private let managesLifecycle: Bool
     private let representedWorkspaceID: UUID?
+
+    @ViewBuilder
+    private var toastOverlay: some View {
+        if let toast = coordinator.activeToast {
+            ToastView(message: toast) {
+                coordinator.dismissToast(id: toast.id)
+            }
+            .id(toast.id)
+            .padding(.horizontal, 16)
+            .padding(.bottom, 24)
+            .allowsHitTesting(false)
+            .zIndex(100)
+        }
+    }
 
     private static let workspaceSplitAutosaveName = RockxyIdentity.current.defaultsKey(
         // Establish compact utility panes once, then preserve every user-adjusted divider

--- a/Rockxy/ContentView.swift
+++ b/Rockxy/ContentView.swift
@@ -9,12 +9,12 @@ enum MainWindowLayoutMetrics {
     static let defaultHeight: CGFloat = 760
     static let minimumWidth: CGFloat = 960
     static let minimumHeight: CGFloat = 620
-    static let sidebarMinimumWidth: CGFloat = 300
-    static let sidebarIdealWidth: CGFloat = 380
-    static let sidebarMaximumWidth: CGFloat = 520
+    static let sidebarMinimumWidth: CGFloat = 200
+    static let sidebarIdealWidth: CGFloat = 250
+    static let sidebarMaximumWidth: CGFloat = 350
     static let workspaceMinimumWidth: CGFloat = 320
-    static let contextDockMinimumWidth: CGFloat = 220
-    static let contextDockIdealWidth: CGFloat = 380
+    static let contextDockMinimumWidth: CGFloat = 260
+    static let contextDockIdealWidth: CGFloat = 320
 }
 
 // MARK: - ContentView
@@ -226,7 +226,9 @@ struct ContentView: View {
     private let representedWorkspaceID: UUID?
 
     private static let workspaceSplitAutosaveName = RockxyIdentity.current.defaultsKey(
-        "nativeWorkspaceSplit.v1"
+        // Establish compact utility panes once, then preserve every user-adjusted divider
+        // position normally again.
+        "nativeWorkspaceSplit.compactUtilityPanes.v1"
     )
 
     private var displayMetrics: AppUIDisplayMetrics {

--- a/Rockxy/Core/ProxyEngine/HelperConnection.swift
+++ b/Rockxy/Core/ProxyEngine/HelperConnection.swift
@@ -15,6 +15,7 @@ enum HelperConnectionError: LocalizedError {
     case certInstallFailed(String)
     case certRemoveFailed(String)
     case bypassDomainsFailed(String)
+    case applicationMustReopen
     case appSignatureInvalid(String)
     case signingIdentityMismatch(app: String, helper: String)
 
@@ -38,8 +39,10 @@ enum HelperConnectionError: LocalizedError {
             "Helper failed to remove root certificate: \(reason)"
         case let .bypassDomainsFailed(reason):
             "Helper failed to set bypass domains: \(reason)"
-        case let .appSignatureInvalid(detail):
-            "This app build has an invalid code signature: \(detail)"
+        case .applicationMustReopen:
+            "Rockxy was updated or replaced while it was open. Quit and reopen Rockxy, then check the helper again."
+        case .appSignatureInvalid:
+            "Rockxy could not verify this app copy. Install a fresh copy of Rockxy, then check the helper again."
         case let .signingIdentityMismatch(app, helper):
             "This app is signed by \"\(app)\" but the installed helper was signed by \"\(helper)\""
         }
@@ -647,6 +650,8 @@ final class HelperConnection {
     private func signingPreflight() async throws {
         let result = await signingCache.evaluate()
         switch result {
+        case .runningCodeChanged:
+            throw HelperConnectionError.applicationMustReopen
         case let .appSignatureInvalid(detail):
             throw HelperConnectionError.appSignatureInvalid(detail)
         case let .signingIdentityMismatch(app, helper):

--- a/Rockxy/Core/ProxyEngine/HelperManager+ForceRemove.swift
+++ b/Rockxy/Core/ProxyEngine/HelperManager+ForceRemove.swift
@@ -1,6 +1,104 @@
 import Foundation
 
 extension HelperManager {
+    enum HelperOperationError: LocalizedError, Equatable {
+        case applicationMustReopen
+        case appSignatureInvalid
+
+        var errorDescription: String? {
+            switch self {
+            case .applicationMustReopen:
+                HelperManager.applicationMustReopenMessage
+            case .appSignatureInvalid:
+                String(
+                    localized: "Rockxy could not verify this app copy. Install a fresh copy of Rockxy, then check the helper again."
+                )
+            }
+        }
+    }
+
+    /// Classify a probe-path `HelperConnectionError` into a normalized outcome.
+    /// Only maps the error cases that actually occur on the probe path
+    /// (`getProxy()` → `getHelperInfo()`).
+    nonisolated static func classifyProbeError(_ error: HelperConnectionError) -> ProbeOutcome {
+        switch error {
+        case .applicationMustReopen:
+            .applicationMustReopen
+        case let .appSignatureInvalid(detail):
+            .appSignatureInvalid(detail: detail)
+        case let .signingIdentityMismatch(app, helper):
+            .signingIdentityMismatch(appSigner: app, helperSigner: helper)
+        default:
+            .xpcFailure
+        }
+    }
+
+    /// Determine recovery action from a normalized probe outcome.
+    nonisolated static func decideRecovery(probe: ProbeOutcome) -> RecoveryAction {
+        switch probe {
+        case .applicationMustReopen:
+            .surfaceApplicationMustReopen
+        case let .appSignatureInvalid(detail):
+            .surfaceAppSignatureInvalid(detail: detail)
+        case let .signingIdentityMismatch(app, helper):
+            .surfaceSigningMismatch(appSigner: app, helperSigner: helper)
+        case .xpcFailure:
+            .surfaceUnreachable
+        }
+    }
+
+    /// Action label for the helper step in Welcome and Settings views.
+    /// Returns `nil` when no action button should be shown.
+    nonisolated static func helperActionLabel(
+        status: HelperStatus,
+        signingIssue: SigningIssue?
+    )
+        -> String?
+    {
+        switch status {
+        case .installedCompatible:
+            nil
+        case .installedOutdated,
+             .installedIncompatible:
+            String(localized: "Update")
+        case .notInstalled:
+            String(localized: "Install")
+        case .requiresApproval:
+            String(localized: "Open Settings")
+        case .unreachable:
+            String(localized: "Retry")
+        case .signingMismatch:
+            switch signingIssue {
+            case .applicationMustReopen:
+                String(localized: "Quit Rockxy")
+            case .appSignatureInvalid:
+                nil
+            case .identityMismatch:
+                String(localized: "Reinstall")
+            case nil:
+                nil
+            }
+        }
+    }
+
+    /// Warning reason text for the signing mismatch case in readiness warnings.
+    nonisolated static func signingMismatchWarningReason(issue: SigningIssue?) -> String {
+        switch issue {
+        case .applicationMustReopen:
+            String(localized: "Rockxy needs to be reopened before it can use the helper tool")
+        case .appSignatureInvalid:
+            String(
+                localized: "Rockxy could not verify this app copy \u{2014} install a fresh copy before using the helper tool"
+            )
+        case .identityMismatch:
+            String(
+                localized: "the installed helper does not match this copy of Rockxy \u{2014} reinstall it before continuing"
+            )
+        case nil:
+            String(localized: "the helper tool has a signing issue")
+        }
+    }
+
     enum ForceRemoveError: LocalizedError, Equatable {
         case commandFailed(exitCode: Int32, output: String)
         case commandTerminated(signal: Int32, output: String)

--- a/Rockxy/Core/ProxyEngine/HelperManager.swift
+++ b/Rockxy/Core/ProxyEngine/HelperManager.swift
@@ -887,18 +887,11 @@ final class HelperManager {
 
         switch Self.installDisposition(for: service.status) {
         case .requiresApproval:
-            if Self.shouldUseLegacyInstallFallbackForCurrentBundle() {
-                try await installLegacyHelperForXcode(
-                    service: service,
-                    reason: "SMAppService requires Login Items approval for an Xcode-run app bundle"
-                )
-                return
-            }
-            Self.logger.info("Helper already registered and awaiting user approval")
-            status = .requiresApproval
-            registrationStatus = "Awaiting Approval"
-            lastErrorMessage = Self.helperApprovalMessage
-            SMAppService.openSystemSettingsLoginItems()
+            try await handleApprovalRequired(
+                service: service,
+                reason: "SMAppService requires Login Items approval for an Xcode-run app bundle",
+                message: Self.helperApprovalMessage
+            )
             return
         case .alreadyEnabled:
             Self.logger.info("Helper tool is already registered")
@@ -913,11 +906,11 @@ final class HelperManager {
             try service.register()
         } catch {
             if Self.requiresApproval(error: error, serviceStatus: service.status) {
-                Self.logger.info("Helper registration requires user approval in System Settings")
-                status = .requiresApproval
-                registrationStatus = "Awaiting Approval"
-                lastErrorMessage = Self.approvalMessage(error: error, serviceStatus: service.status)
-                SMAppService.openSystemSettingsLoginItems()
+                try await handleApprovalRequired(
+                    service: service,
+                    reason: "SMAppService registration was denied for an Xcode-run app bundle",
+                    message: Self.approvalMessage(error: error, serviceStatus: service.status)
+                )
                 return
             }
 
@@ -927,11 +920,11 @@ final class HelperManager {
 
         let currentStatus = service.status
         if currentStatus == .requiresApproval {
-            Self.logger.info("Helper requires user approval in System Settings")
-            status = .requiresApproval
-            registrationStatus = "Awaiting Approval"
-            lastErrorMessage = Self.helperApprovalMessage
-            SMAppService.openSystemSettingsLoginItems()
+            try await handleApprovalRequired(
+                service: service,
+                reason: "SMAppService registration transitioned to requires approval for an Xcode-run app bundle",
+                message: Self.helperApprovalMessage
+            )
         } else if currentStatus == .enabled {
             Self.logger.info("Helper tool installed and enabled")
             registrationStatus = "Enabled"
@@ -943,6 +936,26 @@ final class HelperManager {
             )
             status = .notInstalled
         }
+    }
+
+    /// Resolve every approval transition through the same policy. DerivedData builds
+    /// use the development-only legacy LaunchDaemon path; installed app bundles keep
+    /// the normal macOS Login Items approval flow.
+    private func handleApprovalRequired(
+        service: SMAppService,
+        reason: String,
+        message: String
+    ) async throws {
+        if Self.shouldUseLegacyInstallFallbackForCurrentBundle() {
+            try await installLegacyHelperForXcode(service: service, reason: reason)
+            return
+        }
+
+        Self.logger.info("Helper registration requires user approval in System Settings")
+        status = .requiresApproval
+        registrationStatus = "Awaiting Approval"
+        lastErrorMessage = message
+        SMAppService.openSystemSettingsLoginItems()
     }
 
     /// `SMAppService` can report `.enabled` while launchd is holding a broken submitted job

--- a/Rockxy/Core/ProxyEngine/HelperManager.swift
+++ b/Rockxy/Core/ProxyEngine/HelperManager.swift
@@ -28,12 +28,14 @@ final class HelperManager {
 
     /// Identifies the specific signing issue when status is `.signingMismatch`.
     enum SigningIssue: Equatable {
+        case applicationMustReopen
         case appSignatureInvalid(detail: String)
         case identityMismatch(appSigner: String, helperSigner: String)
     }
 
     /// Normalized result from a helper info probe, scoped to the actual error surface.
     enum ProbeOutcome: Equatable {
+        case applicationMustReopen
         case appSignatureInvalid(detail: String)
         case signingIdentityMismatch(appSigner: String, helperSigner: String)
         case xpcFailure
@@ -41,6 +43,7 @@ final class HelperManager {
 
     /// Recovery action determined from a probe outcome.
     enum RecoveryAction: Equatable {
+        case surfaceApplicationMustReopen
         case surfaceAppSignatureInvalid(detail: String)
         case surfaceSigningMismatch(appSigner: String, helperSigner: String)
         case surfaceUnreachable
@@ -360,80 +363,6 @@ final class HelperManager {
         return helperApprovalMessage
     }
 
-    /// Classify a probe-path `HelperConnectionError` into a normalized outcome.
-    /// Only maps the error cases that actually occur on the probe path
-    /// (`getProxy()` → `getHelperInfo()`).
-    nonisolated static func classifyProbeError(_ error: HelperConnectionError) -> ProbeOutcome {
-        switch error {
-        case let .appSignatureInvalid(detail):
-            .appSignatureInvalid(detail: detail)
-        case let .signingIdentityMismatch(app, helper):
-            .signingIdentityMismatch(appSigner: app, helperSigner: helper)
-        default:
-            .xpcFailure
-        }
-    }
-
-    /// Determine recovery action from a normalized probe outcome.
-    nonisolated static func decideRecovery(probe: ProbeOutcome) -> RecoveryAction {
-        switch probe {
-        case let .appSignatureInvalid(detail):
-            .surfaceAppSignatureInvalid(detail: detail)
-        case let .signingIdentityMismatch(app, helper):
-            .surfaceSigningMismatch(appSigner: app, helperSigner: helper)
-        case .xpcFailure:
-            .surfaceUnreachable
-        }
-    }
-
-    /// Action label for the helper step in Welcome and Settings views.
-    /// Returns `nil` when no action button should be shown.
-    nonisolated static func helperActionLabel(
-        status: HelperStatus,
-        signingIssue: SigningIssue?
-    )
-        -> String?
-    {
-        switch status {
-        case .installedCompatible:
-            nil
-        case .installedOutdated,
-             .installedIncompatible:
-            String(localized: "Update")
-        case .notInstalled:
-            String(localized: "Install")
-        case .requiresApproval:
-            String(localized: "Open Settings")
-        case .unreachable:
-            String(localized: "Retry")
-        case .signingMismatch:
-            switch signingIssue {
-            case .appSignatureInvalid:
-                nil
-            case .identityMismatch:
-                String(localized: "Reinstall")
-            case nil:
-                nil
-            }
-        }
-    }
-
-    /// Warning reason text for the signing mismatch case in readiness warnings.
-    nonisolated static func signingMismatchWarningReason(issue: SigningIssue?) -> String {
-        switch issue {
-        case .appSignatureInvalid:
-            String(
-                localized: "this app build has an invalid code signature \u{2014} clean the build folder and rebuild"
-            )
-        case .identityMismatch:
-            String(
-                localized: "the installed helper was signed by a different Rockxy build \u{2014} reinstall it from the current build"
-            )
-        case nil:
-            String(localized: "the helper tool has a signing issue")
-        }
-    }
-
     /// Detect whether any helper state property changed, including `signingIssue`.
     nonisolated static func helperStateDidChange(
         previousStatus: HelperStatus, currentStatus: HelperStatus,
@@ -470,6 +399,7 @@ final class HelperManager {
                 previousSigningIssue: previousSigningIssue
             )
         }
+        try await ensureHelperMutationCanProceed()
         try await performInstall()
         if status != .requiresApproval {
             await performCheckStatus()
@@ -541,6 +471,7 @@ final class HelperManager {
 
         Self.logger.info("Updating helper tool")
         do {
+            try await ensureHelperMutationCanProceed()
             try await performUninstall()
             try? await Task.sleep(nanoseconds: 500_000_000)
             try await performInstall()
@@ -594,6 +525,7 @@ final class HelperManager {
             )
         }
         do {
+            try await ensureHelperMutationCanProceed()
             try await performUninstall()
             try await performInstall()
             if status != .requiresApproval {
@@ -630,6 +562,7 @@ final class HelperManager {
         }
 
         Self.logger.info("Force-resetting helper registration to recover from BTM desync")
+        try await ensureHelperMutationCanProceed()
         let service = SMAppService.daemon(plistName: Self.plistName)
 
         do {
@@ -683,6 +616,8 @@ final class HelperManager {
         }
 
         Self.logger.info("Hard force-removing helper. resetBackgroundItems=\(resetBackgroundItems)")
+
+        try await ensureHelperMutationCanProceed()
 
         do {
             try await HelperConnection.shared.uninstallHelper()
@@ -755,6 +690,9 @@ final class HelperManager {
         category: "HelperManager"
     )
     private static let plistName = RockxyIdentity.current.helperPlistName
+    nonisolated static let applicationMustReopenMessage = String(
+        localized: "Rockxy was updated or replaced while it was open. Quit and reopen Rockxy, then check the helper again."
+    )
     nonisolated static let bundledHelperBinaryRelativePath = "Contents/Library/HelperTools/RockxyHelperTool"
     nonisolated private static let helperApprovalMessage = String(
         localized: "Approve the helper tool in System Settings > Login Items to finish installation."
@@ -1176,6 +1114,9 @@ final class HelperManager {
             let action = Self.decideRecovery(probe: probe)
 
             switch action {
+            case .surfaceApplicationMustReopen:
+                setSigningMismatchState(.applicationMustReopen)
+
             case let .surfaceAppSignatureInvalid(detail):
                 setSigningMismatchState(.appSignatureInvalid(detail: detail))
 
@@ -1207,6 +1148,9 @@ final class HelperManager {
             let action = Self.decideRecovery(probe: probe)
 
             switch action {
+            case .surfaceApplicationMustReopen:
+                setSigningMismatchState(.applicationMustReopen)
+
             case let .surfaceAppSignatureInvalid(detail):
                 setSigningMismatchState(.appSignatureInvalid(detail: detail))
 
@@ -1241,13 +1185,12 @@ final class HelperManager {
         isReachable = false
         signingIssue = issue
         switch issue {
+        case .applicationMustReopen:
+            lastErrorMessage = Self.applicationMustReopenMessage
         case let .appSignatureInvalid(detail):
+            Self.logger.error("App signature validation failed: \(detail)")
             lastErrorMessage = String(
-                localized: """
-                This app build has an invalid code signature (\(detail)). \
-                Clean the build folder (Product \u{2192} Clean Build Folder) and rebuild, \
-                or use the release version of Rockxy.
-                """
+                localized: "Rockxy could not verify this app copy. Install a fresh copy of Rockxy, then check the helper again."
             )
         case let .identityMismatch(app, helper):
             lastErrorMessage = String(
@@ -1259,6 +1202,30 @@ final class HelperManager {
             )
         }
         status = .signingMismatch
+    }
+
+    /// Prevent destructive helper repair when the running process no longer matches
+    /// the app bundle on disk. The helper's caller validation is expected to reject
+    /// that process, so only reopening Rockxy can recover it safely.
+    private func ensureHelperMutationCanProceed() async throws {
+        HelperConnection.shared.invalidateSigningCache()
+        let result = await HelperConnection.shared.signingCache.evaluate()
+        switch result {
+        case let .runningCodeChanged(detail):
+            Self.logger.warning("Helper mutation blocked because running code changed: \(detail)")
+            setSigningMismatchState(.applicationMustReopen)
+            throw HelperOperationError.applicationMustReopen
+        case let .appSignatureInvalid(detail):
+            Self.logger.error("Helper mutation blocked because app signature is invalid: \(detail)")
+            setSigningMismatchState(.appSignatureInvalid(detail: detail))
+            throw HelperOperationError.appSignatureInvalid
+        case .healthy,
+             .signingIdentityMismatch,
+             .helperBinaryNotFound,
+             .certificateChainUnavailable,
+             .diagnosticError:
+            break
+        }
     }
 
     /// Evaluate helper compatibility based on protocol version and build number.

--- a/Rockxy/Core/ProxyEngine/SSLProxyingManager.swift
+++ b/Rockxy/Core/ProxyEngine/SSLProxyingManager.swift
@@ -214,15 +214,44 @@ final class SSLProxyingManager {
         Self.logger.info("Cleared all auto-passthrough hosts")
     }
 
+    /// Clears the protection fallback for one host so its next connection can retry TLS interception.
+    /// Returns `true` when a recent TLS rejection was present and cleared.
+    @discardableResult
+    nonisolated func retryInterception(for host: String) -> Bool {
+        let normalizedHost = host.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !normalizedHost.isEmpty else {
+            return false
+        }
+
+        passthroughLock.lock()
+        let matchingHost = autoPassthroughHosts.keys.first {
+            $0.caseInsensitiveCompare(normalizedHost) == .orderedSame
+        }
+        if let matchingHost {
+            autoPassthroughHosts.removeValue(forKey: matchingHost)
+        }
+        passthroughLock.unlock()
+
+        guard matchingHost != nil else {
+            return false
+        }
+
+        persistPassthroughHosts()
+        return true
+    }
+
     /// Thread-safe check for hosts that should skip interception due to recent TLS failure.
     nonisolated func isAutoPassthrough(_ host: String) -> Bool {
+        let normalizedHost = host.trimmingCharacters(in: .whitespacesAndNewlines)
         passthroughLock.lock()
         defer { passthroughLock.unlock() }
-        guard let timestamp = autoPassthroughHosts[host] else {
+        guard let matchingHost = autoPassthroughHosts.keys.first(where: {
+            $0.caseInsensitiveCompare(normalizedHost) == .orderedSame
+        }), let timestamp = autoPassthroughHosts[matchingHost] else {
             return false
         }
         if Date().timeIntervalSince(timestamp) > Self.passthroughTTLSeconds {
-            autoPassthroughHosts.removeValue(forKey: host)
+            autoPassthroughHosts.removeValue(forKey: matchingHost)
             return false
         }
         return true

--- a/Rockxy/Core/ProxyEngine/SigningDiagnostics.swift
+++ b/Rockxy/Core/ProxyEngine/SigningDiagnostics.swift
@@ -11,11 +11,20 @@ import Security
 enum SigningDiagnostics {
     // MARK: Internal
 
+    enum AppSignatureValidation: Equatable {
+        case valid
+        /// The executable on disk no longer matches the code already running in this process.
+        case runningCodeChanged(detail: String)
+        case invalid(detail: String)
+    }
+
     // MARK: - Result
 
     enum Result: Equatable, Sendable {
         /// App signature is valid, helper exists, certificate chains match.
         case healthy
+        /// Rockxy was replaced or updated in place while this process was still running.
+        case runningCodeChanged(detail: String)
         /// App bundle code signature is invalid (e.g., missing dylib after stale Xcode build).
         case appSignatureInvalid(detail: String)
         /// App is valid, helper binary exists, but signing identities differ.
@@ -33,8 +42,7 @@ enum SigningDiagnostics {
 
     protocol Environment {
         /// Validate the current app bundle's code signature.
-        /// Returns `nil` if valid, or an error description if invalid.
-        func validateAppSignature() -> String?
+        func validateAppSignature() -> AppSignatureValidation
         /// Check whether the helper binary exists at the expected path.
         func helperBinaryExists() -> Bool
         /// Extract leaf certificate subject summary from the running app.
@@ -66,23 +74,40 @@ enum SigningDiagnostics {
     struct LiveEnvironment: Environment {
         // MARK: Internal
 
-        func validateAppSignature() -> String? {
+        func validateAppSignature() -> AppSignatureValidation {
             var code: SecCode?
             guard SecCodeCopySelf([], &code) == errSecSuccess, let selfCode = code else {
-                return "SecCodeCopySelf failed"
+                return .invalid(detail: "SecCodeCopySelf failed")
             }
+
+            let runningStatus = SecCodeCheckValidity(selfCode, [], nil)
+            if runningStatus == errSecCSStaticCodeChanged {
+                let description = SecCopyErrorMessageString(runningStatus, nil) as String? ?? "unknown"
+                return .runningCodeChanged(
+                    detail: "OSStatus \(runningStatus) (\(description))"
+                )
+            }
+            if runningStatus != errSecSuccess {
+                let description = SecCopyErrorMessageString(runningStatus, nil) as String? ?? "unknown"
+                return .invalid(
+                    detail: "Code signature invalid: OSStatus \(runningStatus) (\(description))"
+                )
+            }
+
             var staticCode: SecStaticCode?
             guard SecCodeCopyStaticCode(selfCode, [], &staticCode) == errSecSuccess,
                   let selfStatic = staticCode else
             {
-                return "SecCodeCopyStaticCode failed"
+                return .invalid(detail: "SecCodeCopyStaticCode failed")
             }
             let status = SecStaticCodeCheckValidity(selfStatic, SecCSFlags([]), nil)
             if status != errSecSuccess {
                 let desc = SecCopyErrorMessageString(status, nil) as String? ?? "unknown"
-                return "Code signature invalid: OSStatus \(status) (\(desc))"
+                return .invalid(
+                    detail: "Code signature invalid: OSStatus \(status) (\(desc))"
+                )
             }
-            return nil
+            return .valid
         }
 
         func helperBinaryExists() -> Bool {
@@ -179,8 +204,13 @@ enum SigningDiagnostics {
 
     /// Pure decision function. Maps environment observations to a diagnostic result.
     static func classify(_ env: some Environment) -> Result {
-        if let invalidReason = env.validateAppSignature() {
-            return .appSignatureInvalid(detail: invalidReason)
+        switch env.validateAppSignature() {
+        case .valid:
+            break
+        case let .runningCodeChanged(detail):
+            return .runningCodeChanged(detail: detail)
+        case let .invalid(detail):
+            return .appSignatureInvalid(detail: detail)
         }
 
         guard env.helperBinaryExists() else {
@@ -223,6 +253,8 @@ enum SigningDiagnostics {
         switch result {
         case .healthy:
             logger.debug("Signing diagnostics: healthy")
+        case let .runningCodeChanged(detail):
+            logger.warning("Signing diagnostics: running code changed — \(detail)")
         case let .appSignatureInvalid(detail):
             logger.warning("Signing diagnostics: app signature invalid — \(detail)")
         case let .signingIdentityMismatch(app, helper):

--- a/Rockxy/Models/UI/AppUIDisplayMetrics.swift
+++ b/Rockxy/Models/UI/AppUIDisplayMetrics.swift
@@ -191,8 +191,8 @@ struct BottomInspectorLayoutMetrics: Equatable {
 
     let appMetrics: AppUIDisplayMetrics
 
-    /// Minimum height that keeps roughly six request rows plus the compact table header and
-    /// surrounding chrome visible. ≈200pt at the default 13pt app font, scaling up with it.
+    /// Compact lower bound that keeps two request rows plus the table header visible while
+    /// allowing the payload inspector to consume most of a tall window when the user wants it.
     var requestListMinimumHeight: CGFloat {
         let rowHeight = appMetrics.tableRowHeight
         let rows = rowHeight * Self.visibleRequestRows
@@ -200,8 +200,9 @@ struct BottomInspectorLayoutMetrics: Equatable {
         return (rows + header + Self.requestChromeInset).rounded()
     }
 
-    /// Minimum height for a compact, native inspector: the tab strip plus a readable stack of
-    /// content lines and vertical chrome. ≈232pt at 13pt, scaling up for larger app fonts.
+    /// Readable lower bound for the tab strip and a useful payload preview. The request list
+    /// deliberately keeps the smaller lower bound so users can still drag the inspector tall,
+    /// but the inspector itself must never collapse into a tab-strip-only sliver.
     var inspectorMinimumHeight: CGFloat {
         let tabStrip = appMetrics.inspectorTabHeight
         let contentLines = appMetrics.tableTextHeight * Self.inspectorVisibleLines
@@ -210,7 +211,7 @@ struct BottomInspectorLayoutMetrics: Equatable {
 
     // MARK: Private
 
-    private static let visibleRequestRows: CGFloat = 6
+    private static let visibleRequestRows: CGFloat = 2
     private static let requestChromeInset: CGFloat = 4
     private static let inspectorVisibleLines: CGFloat = 10
     private static let inspectorChromeInset: CGFloat = 29

--- a/Rockxy/Models/UI/FocusNavigatorState.swift
+++ b/Rockxy/Models/UI/FocusNavigatorState.swift
@@ -165,6 +165,43 @@ struct FocusSet: Identifiable, Codable, Equatable {
         [appName, domain, pathPrefix, excludedDomain, excludedPathPrefix].count { !$0.isEmpty }
     }
 
+    /// Keeps older automatically named Focus Sets useful without rewriting persisted user data.
+    /// Explicit names always win; only the app-generated placeholder is replaced in the sidebar.
+    var displayName: String {
+        usesGeneratedName ? suggestedName : name
+    }
+
+    /// A meaningful starting name for a Focus Set created from the current traffic scope.
+    var suggestedName: String {
+        if let includedScopeName {
+            return includedScopeName
+        }
+        if !excludedDomain.isEmpty {
+            return String(localized: "Hide \(excludedDomain)")
+        }
+        if !excludedPathPrefix.isEmpty {
+            return String(localized: "Hide \(excludedPathPrefix)")
+        }
+        return String(localized: "New Focus Set")
+    }
+
+    /// A collapsed-row summary for user-named sets. Expanded rows expose the same information
+    /// structurally, so the sidebar can hide this sentence instead of repeating every rule.
+    var scopeSummary: String {
+        let included = includedScopeName
+        let excluded = excludedScopeName
+        switch (included, excluded) {
+        case let (.some(included), .some(excluded)):
+            return String(localized: "\(included). Hide \(excluded).")
+        case let (.some(included), .none):
+            return included
+        case let (.none, .some(excluded)):
+            return String(localized: "Hide \(excluded)")
+        case (.none, .none):
+            return String(localized: "No conditions")
+        }
+    }
+
     var includedRules: [FocusSetRuleDescriptor] {
         var rules: [FocusSetRuleDescriptor] = []
         if !appName.isEmpty {
@@ -188,6 +225,104 @@ struct FocusSet: Identifiable, Codable, Equatable {
             rules.append(FocusSetRuleDescriptor(scope: .exclude, kind: .pathPrefix, pattern: excludedPathPrefix))
         }
         return rules
+    }
+
+    /// Rules that still add information after the row title has represented a complete scope.
+    /// For example, a title of “Google Chrome” should not expand into “Application Google Chrome”.
+    var sidebarIncludedRules: [FocusSetRuleDescriptor] {
+        titleRepresentsIncludedScope ? [] : includedRules
+    }
+
+    var sidebarExcludedRules: [FocusSetRuleDescriptor] {
+        titleRepresentsExcludedScope ? [] : excludedRules
+    }
+
+    var hasSidebarRuleDetails: Bool {
+        !sidebarIncludedRules.isEmpty || !sidebarExcludedRules.isEmpty
+    }
+
+    /// Summarizes only the conditions that are not already expressed by the row title.
+    var sidebarScopeSummary: String? {
+        let included = sidebarIncludedRules.isEmpty ? nil : includedScopeName
+        let excluded = sidebarExcludedRules.isEmpty ? nil : excludedScopeName
+        switch (included, excluded) {
+        case let (.some(included), .some(excluded)):
+            return String(localized: "\(included). Hide \(excluded).")
+        case let (.some(included), .none):
+            return included
+        case let (.none, .some(excluded)):
+            return String(localized: "Hide \(excluded)")
+        case (.none, .none):
+            return nil
+        }
+    }
+
+    // MARK: Private
+
+    private var titleRepresentsIncludedScope: Bool {
+        guard let includedScopeName else {
+            return false
+        }
+        return displayName == includedScopeName
+    }
+
+    private var titleRepresentsExcludedScope: Bool {
+        guard let excludedScopeName else {
+            return false
+        }
+        return displayName == String(localized: "Hide \(excludedScopeName)")
+    }
+
+    private var usesGeneratedName: Bool {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        let candidates = [String(localized: "New Focus Set"), "New Focus Set"]
+        return candidates.contains { baseName in
+            if trimmed == baseName {
+                return true
+            }
+            let numberedPrefix = baseName + " "
+            guard trimmed.hasPrefix(numberedPrefix) else {
+                return false
+            }
+            let suffix = trimmed.dropFirst(numberedPrefix.count)
+            return !suffix.isEmpty && suffix.allSatisfy(\.isNumber)
+        }
+    }
+
+    private var includedScopeName: String? {
+        let target: String? = if !domain.isEmpty {
+            pathPrefix.isEmpty ? domain : domain + pathPrefix
+        } else if !pathPrefix.isEmpty {
+            pathPrefix
+        } else {
+            nil
+        }
+
+        switch (appName.isEmpty ? nil : appName, target) {
+        case let (.some(application), .some(target)):
+            return String(localized: "\(application) on \(target)")
+        case let (.some(application), .none):
+            return application
+        case let (.none, .some(target)):
+            return target
+        case (.none, .none):
+            return nil
+        }
+    }
+
+    private var excludedScopeName: String? {
+        switch (excludedDomain.isEmpty ? nil : excludedDomain,
+                excludedPathPrefix.isEmpty ? nil : excludedPathPrefix)
+        {
+        case let (.some(domain), .some(path)):
+            return String(localized: "\(domain) and paths under \(path)")
+        case let (.some(domain), .none):
+            return domain
+        case let (.none, .some(path)):
+            return String(localized: "paths under \(path)")
+        case (.none, .none):
+            return nil
+        }
     }
 }
 

--- a/Rockxy/Models/UI/SidebarSearchFilter.swift
+++ b/Rockxy/Models/UI/SidebarSearchFilter.swift
@@ -66,6 +66,7 @@ enum SidebarSearchFilter {
         values.filter { value in
             [
                 value.name,
+                value.displayName,
                 value.appName,
                 value.domain,
                 value.pathPrefix,

--- a/Rockxy/Models/UI/WorkspaceState.swift
+++ b/Rockxy/Models/UI/WorkspaceState.swift
@@ -100,10 +100,19 @@ final class WorkspaceState: Identifiable {
     var filteredRows: [RequestListRow] = []
     var refreshToken: Int = 0
 
-    /// Set true only by the genuine append fast-path in appendFilteredTransactions.
-    /// The table checks this to decide between insertRows (safe append) and reloadData.
-    /// Reset to false by deriveFilteredRows after each derivation cycle.
+    /// Set true only by the genuine append fast-path in appendFilteredTransactions, and
+    /// cleared by deriveFilteredRows (and reset) once a full derivation replaces the rows.
+    /// The table reads this as the coarse "the last mutation only appended rows" signal.
     var lastDeriveWasAppendOnly: Bool = false
+
+    /// Provenance for the append fast-path: the refreshToken of the base state that the
+    /// current unbroken run of pure appends builds on. `nil` whenever the last row mutation
+    /// was not a pure append (recompute, sort, enrichment, eviction, delete, reset). The
+    /// first append of a chain records the pre-append token and later coalesced appends
+    /// preserve it, so the request table can insert rows incrementally only when this origin
+    /// is <= the token it has already applied — otherwise a non-append mutation was coalesced
+    /// ahead of the append and the displayed prefix no longer matches the model.
+    var appendChainOriginToken: Int?
 
     /// Sort state (user preference, persists across session clears)
     var activeSortDescriptors: [NSSortDescriptor] = []
@@ -124,6 +133,8 @@ final class WorkspaceState: Identifiable {
     func reset() {
         filteredTransactions.removeAll()
         filteredRows.removeAll()
+        lastDeriveWasAppendOnly = false
+        appendChainOriginToken = nil
         refreshToken += 1
         // activeSortDescriptors intentionally preserved — sort is a user preference
         selectedTransaction = nil

--- a/Rockxy/Models/UI/WorkspaceState.swift
+++ b/Rockxy/Models/UI/WorkspaceState.swift
@@ -85,6 +85,11 @@ final class WorkspaceState: Identifiable {
     var selectedLogEntry: LogEntry?
     var selectedTransactionIDs: Set<UUID> = []
 
+    /// Opt-in live-tail mode for this workspace. New visible traffic becomes the primary
+    /// selection until the user deliberately selects a row, at which point the mode yields.
+    /// Owned per-workspace so an inactive workspace can keep advancing independently.
+    var isFollowingLiveTraffic = false
+
     // Filtering
     var filterCriteria: FilterCriteria = .empty
     var filterRules: [FilterRule] = [FilterRule()]

--- a/Rockxy/RockxyApp.swift
+++ b/Rockxy/RockxyApp.swift
@@ -808,9 +808,13 @@ struct RockxyMenuCommands: Commands {
 
             Divider()
 
-            Button(String(localized: "Auto Select the Latest Request")) {
-                actions?.toggleAutoSelect()
-            }
+            Toggle(
+                String(localized: "Follow Live Traffic"),
+                isOn: Binding(
+                    get: { actions?.isFollowingLiveTraffic == true },
+                    set: { actions?.setFollowingLiveTraffic($0) }
+                )
+            )
             .keyboardShortcut("l", modifiers: [.command, .shift])
 
             Divider()

--- a/Rockxy/ViewModels/WelcomeViewModel.swift
+++ b/Rockxy/ViewModels/WelcomeViewModel.swift
@@ -27,6 +27,7 @@ final class WelcomeViewModel {
     enum HelperFailureRecovery: Equatable {
         case repairAndReinstall
         case rebuildApp
+        case reopenApp
     }
 
     var certInstalled = false
@@ -98,18 +99,20 @@ final class WelcomeViewModel {
         case .installedCompatible:
             String(localized: "Installed, compatible, and reachable.")
         case .installedOutdated:
-            String(localized: "An older helper is installed. Update it from this Rockxy build.")
+            String(localized: "An older helper is installed. Update it from this version of Rockxy.")
         case .installedIncompatible:
-            String(localized: "The installed helper is incompatible with this Rockxy build.")
+            String(localized: "The installed helper is incompatible with this version of Rockxy.")
         case .unreachable:
             String(localized: "The helper is registered, but Rockxy cannot reach it.")
         case .signingMismatch:
             switch helperSigningIssue {
+            case .applicationMustReopen:
+                String(localized: "Quit and reopen Rockxy, then check the helper again.")
             case .identityMismatch:
-                String(localized: "The installed helper belongs to a differently signed Rockxy build.")
+                String(localized: "The installed helper does not match this copy of Rockxy.")
             case .appSignatureInvalid,
                  nil:
-                String(localized: "This Rockxy build has a signing problem. Open diagnostics before continuing.")
+                String(localized: "Rockxy could not verify this app copy. Open diagnostics before continuing.")
             }
         }
     }
@@ -119,6 +122,9 @@ final class WelcomeViewModel {
     }
 
     static func resolveHelperFailureRecovery(for error: Error) -> HelperFailureRecovery {
+        if error as? HelperManager.HelperOperationError == .applicationMustReopen {
+            return .reopenApp
+        }
         if error is HelperManager.HelperInstallPreflightError {
             return .rebuildApp
         }

--- a/Rockxy/Views/Inspector/HTTPSInspectionPromptView.swift
+++ b/Rockxy/Views/Inspector/HTTPSInspectionPromptView.swift
@@ -13,6 +13,10 @@ struct HTTPSInspectionPromptView: View {
             VStack(alignment: .leading, spacing: 10) {
                 header
 
+                if let insight = prompt.insight {
+                    connectionInsight(insight)
+                }
+
                 if prompt.requiresCertificateSetup {
                     certificateAction
                 } else {
@@ -29,6 +33,7 @@ struct HTTPSInspectionPromptView: View {
     // MARK: Private
 
     @Environment(\.appUIDisplayMetrics) private var metrics
+    @State private var isInsightExpanded = false
 
     private var header: some View {
         HStack(spacing: 8) {
@@ -65,50 +70,158 @@ struct HTTPSInspectionPromptView: View {
 
     private var certificateAction: some View {
         Button(String(localized: "Install & Trust…")) {
-            onAction(prompt.primaryAction)
+            if let action = prompt.certificateAction {
+                onAction(action)
+            }
         }
         .buttonStyle(.borderedProminent)
         .controlSize(.small)
         .accessibilityHint(String(localized: "Installs and trusts the Rockxy root certificate"))
     }
 
+    private func connectionInsight(_ insight: HTTPSConnectionInsight) -> some View {
+        VStack(alignment: .leading, spacing: 7) {
+            HStack(alignment: .top, spacing: 8) {
+                Image(systemName: insight.systemImage)
+                    .font(.system(size: metrics.controlFontSize, weight: .medium))
+                    .foregroundStyle(
+                        insight.isWarning ?
+                            Color(nsColor: .systemOrange) :
+                            Color(nsColor: .systemBlue)
+                    )
+                    .frame(width: 16)
+                    .accessibilityHidden(true)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(insight.title)
+                        .font(.system(size: metrics.controlFontSize, weight: .semibold))
+                    Text(insight.summary)
+                        .font(.system(size: metrics.metadataFontSize))
+                        .foregroundStyle(Color(nsColor: .secondaryLabelColor))
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                Spacer(minLength: 6)
+
+                Button {
+                    withAnimation(.easeInOut(duration: 0.16)) {
+                        isInsightExpanded.toggle()
+                    }
+                } label: {
+                    HStack(spacing: 3) {
+                        Text(isInsightExpanded ? String(localized: "Hide") : String(localized: "Details"))
+                        Image(systemName: isInsightExpanded ? "chevron.up" : "chevron.down")
+                    }
+                    .font(.system(size: metrics.metadataFontSize, weight: .medium))
+                }
+                .buttonStyle(.borderless)
+                .fixedSize()
+                .accessibilityHint(String(localized: "Shows the evidence and recommended next step"))
+            }
+
+            if isInsightExpanded {
+                VStack(alignment: .leading, spacing: 5) {
+                    insightDetail(label: String(localized: "Evidence"), text: insight.evidence)
+                    insightDetail(label: String(localized: "Next Step"), text: insight.nextStep)
+                }
+                .padding(.leading, 24)
+                .transition(.opacity.combined(with: .move(edge: .top)))
+            }
+        }
+        .padding(9)
+        .background(
+            insight.isWarning ?
+                Color(nsColor: .systemOrange).opacity(0.08) :
+                Color(nsColor: .controlBackgroundColor).opacity(0.7),
+            in: RoundedRectangle(cornerRadius: 7)
+        )
+        .overlay {
+            RoundedRectangle(cornerRadius: 7)
+                .stroke(
+                    insight.isWarning ?
+                        Color(nsColor: .systemOrange).opacity(0.25) :
+                        Color(nsColor: .separatorColor).opacity(0.55),
+                    lineWidth: 0.5
+                )
+        }
+    }
+
+    private func insightDetail(label: String, text: String) -> some View {
+        (Text("\(label): ").bold() + Text(text))
+            .font(.system(size: metrics.metadataFontSize))
+            .foregroundStyle(Color(nsColor: .secondaryLabelColor))
+            .fixedSize(horizontal: false, vertical: true)
+    }
+
     private var scopeControls: some View {
         VStack(spacing: 0) {
             Divider()
-            scopeActionRow(action: prompt.primaryAction)
+            if let hostScope = prompt.hostScope {
+                scopeActionRow(scope: hostScope)
+            }
 
-            if let secondaryAction = prompt.secondaryAction {
+            if let appScope = prompt.appScope {
                 Divider()
                     .padding(.leading, 24)
-                scopeActionRow(action: secondaryAction)
+                scopeActionRow(scope: appScope)
             }
         }
     }
 
     @ViewBuilder
-    private func scopeActionRow(action: HTTPSInspectionPromptAction) -> some View {
-        if let scope = HTTPSInspectionScopePresentation(action: action) {
-            HStack(spacing: 8) {
-                Image(systemName: scope.kind.systemImage)
-                    .font(.system(size: metrics.controlFontSize))
-                    .foregroundStyle(Color(nsColor: .secondaryLabelColor))
-                    .frame(width: 16)
-                    .accessibilityHidden(true)
+    private func scopeActionRow(scope: HTTPSInspectionScopePresentation) -> some View {
+        HStack(spacing: 8) {
+            Image(systemName: scope.kind.systemImage)
+                .font(.system(size: metrics.controlFontSize))
+                .foregroundStyle(Color(nsColor: .secondaryLabelColor))
+                .frame(width: 16)
+                .accessibilityHidden(true)
 
-                VStack(alignment: .leading, spacing: 1) {
-                    Text(scope.kind.title)
-                        .font(.system(size: metrics.controlFontSize, weight: .medium))
+            VStack(alignment: .leading, spacing: 1) {
+                Text(scope.kind.title)
+                    .font(.system(size: metrics.controlFontSize, weight: .medium))
 
+                HStack(spacing: 5) {
                     Text(scope.value)
-                        .font(.system(size: metrics.metadataFontSize))
-                        .foregroundStyle(Color(nsColor: .secondaryLabelColor))
                         .lineLimit(1)
                         .truncationMode(.middle)
-                        .help(scope.value)
-                }
-                .frame(maxWidth: .infinity, alignment: .leading)
 
-                Button(scope.actionTitle) {
+                    if let statusDetail = scope.statusDetail {
+                        Text(statusDetail)
+                            .foregroundStyle(
+                                scope.state == .partial ?
+                                    Color(nsColor: .systemOrange) :
+                                    Color(nsColor: .secondaryLabelColor)
+                            )
+                    }
+                }
+                .font(.system(size: metrics.metadataFontSize))
+                .foregroundStyle(Color(nsColor: .secondaryLabelColor))
+                .help(scope.helpText)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            scopeTrailingControl(scope)
+        }
+        .padding(.horizontal, 4)
+        .frame(minHeight: 42)
+    }
+
+    @ViewBuilder
+    private func scopeTrailingControl(_ scope: HTTPSInspectionScopePresentation) -> some View {
+        if let action = scope.action, let actionTitle = scope.actionTitle {
+            if scope.kind == .host {
+                Button(actionTitle) {
+                    onAction(action)
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.small)
+                .fixedSize()
+                .help(scope.actionDescription)
+                .accessibilityLabel(scope.actionDescription)
+                .accessibilityHint(String(localized: "The current captured response is unchanged"))
+            } else {
+                Button(actionTitle) {
                     onAction(action)
                 }
                 .buttonStyle(.bordered)
@@ -118,8 +231,12 @@ struct HTTPSInspectionPromptView: View {
                 .accessibilityLabel(scope.actionDescription)
                 .accessibilityHint(String(localized: "The current captured response is unchanged"))
             }
-            .padding(.horizontal, 4)
-            .frame(minHeight: 40)
+        } else {
+            Label(String(localized: "Ready"), systemImage: "checkmark.circle.fill")
+                .font(.system(size: metrics.metadataFontSize, weight: .medium))
+                .foregroundStyle(Color(nsColor: .systemGreen))
+                .fixedSize()
+                .accessibilityLabel(scope.actionDescription)
         }
     }
 }
@@ -127,14 +244,20 @@ struct HTTPSInspectionPromptView: View {
 // MARK: - HTTPSInspectionScopePresentation
 
 struct HTTPSInspectionScopePresentation: Equatable {
+    enum State: Equatable {
+        case available
+        case partial
+        case ready
+    }
+
     enum Kind: Equatable {
         case host
         case appHosts
 
         var title: String {
             switch self {
-            case .host: String(localized: "Host")
-            case .appHosts: String(localized: "App Hosts")
+            case .host: String(localized: "This Host")
+            case .appHosts: String(localized: "Known App Hosts")
             }
         }
 
@@ -148,44 +271,87 @@ struct HTTPSInspectionScopePresentation: Equatable {
 
     let kind: Kind
     let value: String
-    let isEnabled: Bool
+    let state: State
+    let statusDetail: String?
+    let action: HTTPSInspectionPromptAction?
+    let actionTitle: String?
+    let actionDescription: String
 
-    var actionTitle: String {
-        isEnabled ? String(localized: "Disable") : String(localized: "Decrypt")
+    var helpText: String {
+        [value, statusDetail].compactMap { $0 }.joined(separator: ", ")
     }
 
-    var actionDescription: String {
-        switch (kind, isEnabled) {
-        case (.host, false):
-            String(localized: "Decrypt new HTTPS connections to \(value)")
-        case (.host, true):
-            String(localized: "Stop decrypting new HTTPS connections to \(value)")
-        case (.appHosts, false):
-            String(localized: "Decrypt new HTTPS connections to known hosts used by \(value)")
-        case (.appHosts, true):
-            String(localized: "Stop decrypting new HTTPS connections to known hosts used by \(value)")
+    static func host(
+        value: String,
+        isReady: Bool,
+        requiresRetry: Bool = false
+    )
+        -> HTTPSInspectionScopePresentation
+    {
+        if requiresRetry {
+            return HTTPSInspectionScopePresentation(
+                kind: .host,
+                value: value,
+                state: .partial,
+                statusDetail: String(localized: "Protected tunnel active"),
+                action: .retryDomain(value),
+                actionTitle: String(localized: "Retry"),
+                actionDescription: String(localized: "Retry HTTPS decryption for \(value) on the next connection")
+            )
         }
+
+        return HTTPSInspectionScopePresentation(
+            kind: .host,
+            value: value,
+            state: isReady ? .ready : .available,
+            statusDetail: isReady ? String(localized: "New connections are ready") : nil,
+            action: isReady ? nil : .enableDomain(value),
+            actionTitle: isReady ? nil : String(localized: "Decrypt Host"),
+            actionDescription: isReady ?
+                String(localized: "HTTPS decryption is enabled for new connections to \(value)") :
+                String(localized: "Decrypt new HTTPS connections to \(value)")
+        )
     }
 
-    init(kind: Kind, value: String, isEnabled: Bool) {
-        self.kind = kind
-        self.value = value
-        self.isEnabled = isEnabled
-    }
-
-    init?(action: HTTPSInspectionPromptAction) {
-        switch action {
-        case let .enableDomain(host):
-            self.init(kind: .host, value: host, isEnabled: false)
-        case let .disableDomain(host):
-            self.init(kind: .host, value: host, isEnabled: true)
-        case let .enableApp(appName, _):
-            self.init(kind: .appHosts, value: appName, isEnabled: false)
-        case let .disableApp(appName, _):
-            self.init(kind: .appHosts, value: appName, isEnabled: true)
-        case .installCertificate,
-             .openSSLProxyingList:
+    static func appHosts(
+        name: String,
+        enabledHostCount: Int,
+        knownHostCount: Int,
+        fallbackDomain: String
+    )
+        -> HTTPSInspectionScopePresentation?
+    {
+        let total = max(knownHostCount, 1)
+        guard total > 1 else {
             return nil
         }
+
+        let enabled = min(max(enabledHostCount, 0), total)
+        let state: State = if enabled == total {
+            .ready
+        } else if enabled > 0 {
+            .partial
+        } else {
+            .available
+        }
+        let remaining = total - enabled
+
+        return HTTPSInspectionScopePresentation(
+            kind: .appHosts,
+            value: name,
+            state: state,
+            statusDetail: state == .ready ?
+                String(localized: "All \(total) known hosts are ready") :
+                String(localized: "\(enabled) of \(total) known hosts ready"),
+            action: state == .ready ? nil : .enableApp(name, fallbackDomain: fallbackDomain),
+            actionTitle: state == .ready ? nil : (
+                state == .partial ?
+                    String(localized: "Decrypt \(remaining) More") :
+                    String(localized: "Decrypt All")
+            ),
+            actionDescription: state == .ready ?
+                String(localized: "HTTPS decryption is enabled for all known hosts used by \(name)") :
+                String(localized: "Decrypt new HTTPS connections to \(remaining) known hosts used by \(name)")
+        )
     }
 }

--- a/Rockxy/Views/Inspector/HTTPSInspectionPromptView.swift
+++ b/Rockxy/Views/Inspector/HTTPSInspectionPromptView.swift
@@ -77,16 +77,43 @@ struct HTTPSInspectionPromptView: View {
         .accessibilityHint(String(localized: "Installs and trusts the Rockxy root certificate"))
     }
 
+    @ViewBuilder
     private func connectionInsight(_ insight: HTTPSConnectionInsight) -> some View {
+        if insight.isWarning {
+            warningInsight(insight)
+        } else {
+            standardInsight(insight)
+        }
+    }
+
+    private func standardInsight(_ insight: HTTPSConnectionInsight) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(alignment: .firstTextBaseline, spacing: 8) {
+                Text(insight.summary)
+                    .font(.system(size: metrics.metadataFontSize))
+                    .foregroundStyle(Color(nsColor: .secondaryLabelColor))
+                    .fixedSize(horizontal: false, vertical: true)
+
+                Spacer(minLength: 6)
+
+                insightDetailsButton
+            }
+
+            if isInsightExpanded {
+                insightDetails(insight)
+                    .transition(.opacity.combined(with: .move(edge: .top)))
+            }
+        }
+    }
+
+    private func warningInsight(_ insight: HTTPSConnectionInsight) -> some View {
         VStack(alignment: .leading, spacing: 6) {
             HStack(alignment: .top, spacing: 8) {
-                if insight.isWarning {
-                    Image(systemName: insight.systemImage)
-                        .font(.system(size: metrics.controlFontSize, weight: .medium))
-                        .foregroundStyle(Color(nsColor: .systemOrange))
-                        .frame(width: 16)
-                        .accessibilityHidden(true)
-                }
+                Image(systemName: insight.systemImage)
+                    .font(.system(size: metrics.controlFontSize, weight: .medium))
+                    .foregroundStyle(Color(nsColor: .systemOrange))
+                    .frame(width: 16)
+                    .accessibilityHidden(true)
 
                 VStack(alignment: .leading, spacing: 2) {
                     Text(insight.title)
@@ -99,47 +126,45 @@ struct HTTPSInspectionPromptView: View {
 
                 Spacer(minLength: 6)
 
-                Button {
-                    withAnimation(.easeInOut(duration: 0.16)) {
-                        isInsightExpanded.toggle()
-                    }
-                } label: {
-                    HStack(spacing: 3) {
-                        Text(isInsightExpanded ? String(localized: "Hide") : String(localized: "Details"))
-                        Image(systemName: isInsightExpanded ? "chevron.up" : "chevron.down")
-                    }
-                    .font(.system(size: metrics.metadataFontSize, weight: .medium))
-                }
-                .buttonStyle(.borderless)
-                .fixedSize()
-                .accessibilityHint(String(localized: "Shows the evidence and recommended next step"))
+                insightDetailsButton
             }
 
             if isInsightExpanded {
-                VStack(alignment: .leading, spacing: 5) {
-                    insightDetail(label: String(localized: "Evidence"), text: insight.evidence)
-                    insightDetail(label: String(localized: "Next Step"), text: insight.nextStep)
-                }
-                .padding(.leading, insight.isWarning ? 24 : 0)
-                .transition(.opacity.combined(with: .move(edge: .top)))
+                insightDetails(insight)
+                    .padding(.leading, 24)
+                    .transition(.opacity.combined(with: .move(edge: .top)))
             }
         }
-        .padding(.horizontal, insight.isWarning ? 8 : 0)
-        .padding(.vertical, insight.isWarning ? 7 : 0)
-        .background(
-            insight.isWarning ?
-                Color(nsColor: .systemOrange).opacity(0.08) :
-                Color.clear,
-            in: RoundedRectangle(cornerRadius: 7)
-        )
+        .padding(.horizontal, 8)
+        .padding(.vertical, 7)
+        .background(Color(nsColor: .systemOrange).opacity(0.08), in: RoundedRectangle(cornerRadius: 7))
         .overlay {
             RoundedRectangle(cornerRadius: 7)
-                .stroke(
-                    insight.isWarning ?
-                        Color(nsColor: .systemOrange).opacity(0.25) :
-                        Color.clear,
-                    lineWidth: 0.5
-                )
+                .stroke(Color(nsColor: .systemOrange).opacity(0.25), lineWidth: 0.5)
+        }
+    }
+
+    private var insightDetailsButton: some View {
+        Button {
+            withAnimation(.easeInOut(duration: 0.16)) {
+                isInsightExpanded.toggle()
+            }
+        } label: {
+            HStack(spacing: 3) {
+                Text(isInsightExpanded ? String(localized: "Hide") : String(localized: "Details"))
+                Image(systemName: isInsightExpanded ? "chevron.up" : "chevron.down")
+            }
+            .font(.system(size: metrics.metadataFontSize, weight: .medium))
+        }
+        .buttonStyle(.borderless)
+        .fixedSize()
+        .accessibilityHint(String(localized: "Shows the evidence and recommended next step"))
+    }
+
+    private func insightDetails(_ insight: HTTPSConnectionInsight) -> some View {
+        VStack(alignment: .leading, spacing: 5) {
+            insightDetail(label: String(localized: "Evidence"), text: insight.evidence)
+            insightDetail(label: String(localized: "Next Step"), text: insight.nextStep)
         }
     }
 
@@ -152,8 +177,8 @@ struct HTTPSInspectionPromptView: View {
 
     private var scopeControls: some View {
         VStack(alignment: .leading, spacing: 6) {
-            Text(String(localized: "Decrypt Future Connections"))
-                .font(.system(size: metrics.metadataFontSize, weight: .semibold))
+            Text(String(localized: "Decryption"))
+                .font(.system(size: metrics.metadataFontSize, weight: .medium))
                 .foregroundStyle(Color(nsColor: .secondaryLabelColor))
 
             VStack(spacing: 0) {
@@ -163,17 +188,11 @@ struct HTTPSInspectionPromptView: View {
 
                 if let appScope = prompt.appScope {
                     Divider()
-                        .padding(.leading, 28)
                     scopeActionRow(scope: appScope)
                 }
             }
-            .background(Color(nsColor: .controlBackgroundColor).opacity(0.55), in: RoundedRectangle(cornerRadius: 7))
-            .overlay {
-                RoundedRectangle(cornerRadius: 7)
-                    .stroke(Color(nsColor: .separatorColor).opacity(0.45), lineWidth: 0.5)
-            }
 
-            Text(String(localized: "Changes apply when the app opens a new connection. This response stays encrypted."))
+            Text(String(localized: "Applies to new connections. This response stays encrypted."))
                 .font(.system(size: metrics.metadataFontSize))
                 .foregroundStyle(Color(nsColor: .tertiaryLabelColor))
                 .fixedSize(horizontal: false, vertical: true)
@@ -315,9 +334,7 @@ struct HTTPSInspectionScopePresentation: Equatable {
             kind: .host,
             value: value,
             state: isReady ? .ready : .available,
-            statusDetail: isReady ?
-                String(localized: "Enabled for new connections") :
-                String(localized: "Off for new connections"),
+            statusDetail: String(localized: "Current host"),
             control: .toggle(isOn: isReady),
             action: isReady ? .disableDomain(value) : .enableDomain(value),
             controlTitle: String(localized: "Decrypt Host"),

--- a/Rockxy/Views/Inspector/HTTPSInspectionPromptView.swift
+++ b/Rockxy/Views/Inspector/HTTPSInspectionPromptView.swift
@@ -220,7 +220,7 @@ struct HTTPSInspectionPromptView: View {
         switch scope.control {
         case let .toggle(isOn):
             Toggle(
-                "",
+                scope.controlTitle ?? String(localized: "Decrypt Host"),
                 isOn: Binding(
                     get: { isOn },
                     set: { _ in
@@ -230,17 +230,17 @@ struct HTTPSInspectionPromptView: View {
                     }
                 )
             )
-            .labelsHidden()
             .toggleStyle(.switch)
             .controlSize(.mini)
+            .font(.system(size: metrics.controlFontSize))
             .fixedSize()
             .help(scope.actionDescription)
-            .accessibilityLabel(scope.actionDescription)
+            .accessibilityLabel(scope.controlTitle ?? String(localized: "Decrypt Host"))
             .accessibilityHint(String(localized: "The current captured response is unchanged"))
 
         case .button:
-            if let action = scope.action, let actionTitle = scope.actionTitle {
-                Button(actionTitle) {
+            if let action = scope.action, let controlTitle = scope.controlTitle {
+                Button(controlTitle) {
                     onAction(action)
                 }
                 .buttonStyle(.bordered)
@@ -301,7 +301,7 @@ struct HTTPSInspectionScopePresentation: Equatable {
     let statusDetail: String?
     let control: Control
     let action: HTTPSInspectionPromptAction?
-    let actionTitle: String?
+    let controlTitle: String?
     let actionDescription: String
 
     var helpText: String {
@@ -323,7 +323,7 @@ struct HTTPSInspectionScopePresentation: Equatable {
                 statusDetail: String(localized: "Protected tunnel active"),
                 control: .button,
                 action: .retryDomain(value),
-                actionTitle: String(localized: "Retry"),
+                controlTitle: String(localized: "Retry"),
                 actionDescription: String(localized: "Retry HTTPS decryption for \(value) on the next connection")
             )
         }
@@ -337,7 +337,7 @@ struct HTTPSInspectionScopePresentation: Equatable {
                 String(localized: "Off for new connections"),
             control: .toggle(isOn: isReady),
             action: isReady ? .disableDomain(value) : .enableDomain(value),
-            actionTitle: nil,
+            controlTitle: String(localized: "Decrypt Host"),
             actionDescription: isReady ?
                 String(localized: "Turn off HTTPS decryption for new connections to \(value)") :
                 String(localized: "Turn on HTTPS decryption for new connections to \(value)")
@@ -376,7 +376,7 @@ struct HTTPSInspectionScopePresentation: Equatable {
                 String(localized: "\(enabled) of \(total) known hosts enabled"),
             control: state == .ready ? .status : .button,
             action: state == .ready ? nil : .enableApp(name, fallbackDomain: fallbackDomain),
-            actionTitle: state == .ready ? nil : String(localized: "Enable All"),
+            controlTitle: state == .ready ? nil : String(localized: "Enable All"),
             actionDescription: state == .ready ?
                 String(localized: "HTTPS decryption is enabled for all known hosts used by \(name)") :
                 String(localized: "Enable HTTPS decryption for \(remaining) more known hosts used by \(name)")

--- a/Rockxy/Views/Inspector/HTTPSInspectionPromptView.swift
+++ b/Rockxy/Views/Inspector/HTTPSInspectionPromptView.swift
@@ -37,15 +37,13 @@ struct HTTPSInspectionPromptView: View {
 
     private var header: some View {
         HStack(spacing: 8) {
-            Image(systemName: prompt.requiresCertificateSetup ? "exclamationmark.lock.fill" : "lock.fill")
-                .font(.system(size: metrics.primaryFontSize, weight: .medium))
-                .foregroundStyle(
-                    prompt.requiresCertificateSetup
-                        ? Color(nsColor: .systemOrange)
-                        : Color(nsColor: .secondaryLabelColor)
-                )
-                .frame(width: 18)
-                .accessibilityHidden(true)
+            if prompt.requiresCertificateSetup {
+                Image(systemName: "exclamationmark.lock.fill")
+                    .font(.system(size: metrics.primaryFontSize, weight: .medium))
+                    .foregroundStyle(Color(nsColor: .systemOrange))
+                    .frame(width: 18)
+                    .accessibilityHidden(true)
+            }
 
             Text(
                 prompt.requiresCertificateSetup
@@ -82,15 +80,13 @@ struct HTTPSInspectionPromptView: View {
     private func connectionInsight(_ insight: HTTPSConnectionInsight) -> some View {
         VStack(alignment: .leading, spacing: 6) {
             HStack(alignment: .top, spacing: 8) {
-                Image(systemName: insight.systemImage)
-                    .font(.system(size: metrics.controlFontSize, weight: .medium))
-                    .foregroundStyle(
-                        insight.isWarning ?
-                            Color(nsColor: .systemOrange) :
-                            Color(nsColor: .secondaryLabelColor)
-                    )
-                    .frame(width: 16)
-                    .accessibilityHidden(true)
+                if insight.isWarning {
+                    Image(systemName: insight.systemImage)
+                        .font(.system(size: metrics.controlFontSize, weight: .medium))
+                        .foregroundStyle(Color(nsColor: .systemOrange))
+                        .frame(width: 16)
+                        .accessibilityHidden(true)
+                }
 
                 VStack(alignment: .leading, spacing: 2) {
                     Text(insight.title)
@@ -124,12 +120,12 @@ struct HTTPSInspectionPromptView: View {
                     insightDetail(label: String(localized: "Evidence"), text: insight.evidence)
                     insightDetail(label: String(localized: "Next Step"), text: insight.nextStep)
                 }
-                .padding(.leading, 24)
+                .padding(.leading, insight.isWarning ? 24 : 0)
                 .transition(.opacity.combined(with: .move(edge: .top)))
             }
         }
-        .padding(.horizontal, 8)
-        .padding(.vertical, 7)
+        .padding(.horizontal, insight.isWarning ? 8 : 0)
+        .padding(.vertical, insight.isWarning ? 7 : 0)
         .background(
             insight.isWarning ?
                 Color(nsColor: .systemOrange).opacity(0.08) :
@@ -187,12 +183,6 @@ struct HTTPSInspectionPromptView: View {
     @ViewBuilder
     private func scopeActionRow(scope: HTTPSInspectionScopePresentation) -> some View {
         HStack(spacing: 8) {
-            Image(systemName: scope.kind.systemImage)
-                .font(.system(size: metrics.controlFontSize))
-                .foregroundStyle(Color(nsColor: .secondaryLabelColor))
-                .frame(width: 16)
-                .accessibilityHidden(true)
-
             VStack(alignment: .leading, spacing: 1) {
                 Text(scope.value)
                     .font(.system(size: metrics.controlFontSize, weight: .medium))
@@ -284,13 +274,6 @@ struct HTTPSInspectionScopePresentation: Equatable {
             switch self {
             case .host: String(localized: "This Host")
             case .appHosts: String(localized: "Known App Hosts")
-            }
-        }
-
-        var systemImage: String {
-            switch self {
-            case .host: "network"
-            case .appHosts: "macwindow"
             }
         }
     }

--- a/Rockxy/Views/Inspector/HTTPSInspectionPromptView.swift
+++ b/Rockxy/Views/Inspector/HTTPSInspectionPromptView.swift
@@ -10,7 +10,7 @@ struct HTTPSInspectionPromptView: View {
 
     var body: some View {
         ScrollView(.vertical) {
-            VStack(alignment: .leading, spacing: 10) {
+            VStack(alignment: .leading, spacing: 12) {
                 header
 
                 if let insight = prompt.insight {
@@ -80,14 +80,14 @@ struct HTTPSInspectionPromptView: View {
     }
 
     private func connectionInsight(_ insight: HTTPSConnectionInsight) -> some View {
-        VStack(alignment: .leading, spacing: 7) {
+        VStack(alignment: .leading, spacing: 6) {
             HStack(alignment: .top, spacing: 8) {
                 Image(systemName: insight.systemImage)
                     .font(.system(size: metrics.controlFontSize, weight: .medium))
                     .foregroundStyle(
                         insight.isWarning ?
                             Color(nsColor: .systemOrange) :
-                            Color(nsColor: .systemBlue)
+                            Color(nsColor: .secondaryLabelColor)
                     )
                     .frame(width: 16)
                     .accessibilityHidden(true)
@@ -128,11 +128,12 @@ struct HTTPSInspectionPromptView: View {
                 .transition(.opacity.combined(with: .move(edge: .top)))
             }
         }
-        .padding(9)
+        .padding(.horizontal, 8)
+        .padding(.vertical, 7)
         .background(
             insight.isWarning ?
                 Color(nsColor: .systemOrange).opacity(0.08) :
-                Color(nsColor: .controlBackgroundColor).opacity(0.7),
+                Color.clear,
             in: RoundedRectangle(cornerRadius: 7)
         )
         .overlay {
@@ -140,7 +141,7 @@ struct HTTPSInspectionPromptView: View {
                 .stroke(
                     insight.isWarning ?
                         Color(nsColor: .systemOrange).opacity(0.25) :
-                        Color(nsColor: .separatorColor).opacity(0.55),
+                        Color.clear,
                     lineWidth: 0.5
                 )
         }
@@ -154,17 +155,32 @@ struct HTTPSInspectionPromptView: View {
     }
 
     private var scopeControls: some View {
-        VStack(spacing: 0) {
-            Divider()
-            if let hostScope = prompt.hostScope {
-                scopeActionRow(scope: hostScope)
+        VStack(alignment: .leading, spacing: 6) {
+            Text(String(localized: "Decrypt Future Connections"))
+                .font(.system(size: metrics.metadataFontSize, weight: .semibold))
+                .foregroundStyle(Color(nsColor: .secondaryLabelColor))
+
+            VStack(spacing: 0) {
+                if let hostScope = prompt.hostScope {
+                    scopeActionRow(scope: hostScope)
+                }
+
+                if let appScope = prompt.appScope {
+                    Divider()
+                        .padding(.leading, 28)
+                    scopeActionRow(scope: appScope)
+                }
+            }
+            .background(Color(nsColor: .controlBackgroundColor).opacity(0.55), in: RoundedRectangle(cornerRadius: 7))
+            .overlay {
+                RoundedRectangle(cornerRadius: 7)
+                    .stroke(Color(nsColor: .separatorColor).opacity(0.45), lineWidth: 0.5)
             }
 
-            if let appScope = prompt.appScope {
-                Divider()
-                    .padding(.leading, 24)
-                scopeActionRow(scope: appScope)
-            }
+            Text(String(localized: "Changes apply when the app opens a new connection. This response stays encrypted."))
+                .font(.system(size: metrics.metadataFontSize))
+                .foregroundStyle(Color(nsColor: .tertiaryLabelColor))
+                .fixedSize(horizontal: false, vertical: true)
         }
     }
 
@@ -178,49 +194,52 @@ struct HTTPSInspectionPromptView: View {
                 .accessibilityHidden(true)
 
             VStack(alignment: .leading, spacing: 1) {
-                Text(scope.kind.title)
+                Text(scope.value)
                     .font(.system(size: metrics.controlFontSize, weight: .medium))
+                    .lineLimit(1)
+                    .truncationMode(.middle)
 
-                HStack(spacing: 5) {
-                    Text(scope.value)
+                if let statusDetail = scope.statusDetail {
+                    Text(statusDetail)
+                        .font(.system(size: metrics.metadataFontSize))
+                        .foregroundStyle(Color(nsColor: .secondaryLabelColor))
                         .lineLimit(1)
-                        .truncationMode(.middle)
-
-                    if let statusDetail = scope.statusDetail {
-                        Text(statusDetail)
-                            .foregroundStyle(
-                                scope.state == .partial ?
-                                    Color(nsColor: .systemOrange) :
-                                    Color(nsColor: .secondaryLabelColor)
-                            )
-                    }
+                        .help(scope.helpText)
                 }
-                .font(.system(size: metrics.metadataFontSize))
-                .foregroundStyle(Color(nsColor: .secondaryLabelColor))
-                .help(scope.helpText)
             }
             .frame(maxWidth: .infinity, alignment: .leading)
 
             scopeTrailingControl(scope)
         }
         .padding(.horizontal, 4)
-        .frame(minHeight: 42)
+        .frame(minHeight: 44)
     }
 
     @ViewBuilder
     private func scopeTrailingControl(_ scope: HTTPSInspectionScopePresentation) -> some View {
-        if let action = scope.action, let actionTitle = scope.actionTitle {
-            if scope.kind == .host {
-                Button(actionTitle) {
-                    onAction(action)
-                }
-                .buttonStyle(.borderedProminent)
-                .controlSize(.small)
-                .fixedSize()
-                .help(scope.actionDescription)
-                .accessibilityLabel(scope.actionDescription)
-                .accessibilityHint(String(localized: "The current captured response is unchanged"))
-            } else {
+        switch scope.control {
+        case let .toggle(isOn):
+            Toggle(
+                "",
+                isOn: Binding(
+                    get: { isOn },
+                    set: { _ in
+                        if let action = scope.action {
+                            onAction(action)
+                        }
+                    }
+                )
+            )
+            .labelsHidden()
+            .toggleStyle(.switch)
+            .controlSize(.mini)
+            .fixedSize()
+            .help(scope.actionDescription)
+            .accessibilityLabel(scope.actionDescription)
+            .accessibilityHint(String(localized: "The current captured response is unchanged"))
+
+        case .button:
+            if let action = scope.action, let actionTitle = scope.actionTitle {
                 Button(actionTitle) {
                     onAction(action)
                 }
@@ -231,7 +250,8 @@ struct HTTPSInspectionPromptView: View {
                 .accessibilityLabel(scope.actionDescription)
                 .accessibilityHint(String(localized: "The current captured response is unchanged"))
             }
-        } else {
+
+        case .status:
             Label(String(localized: "Ready"), systemImage: "checkmark.circle.fill")
                 .font(.system(size: metrics.metadataFontSize, weight: .medium))
                 .foregroundStyle(Color(nsColor: .systemGreen))
@@ -244,6 +264,12 @@ struct HTTPSInspectionPromptView: View {
 // MARK: - HTTPSInspectionScopePresentation
 
 struct HTTPSInspectionScopePresentation: Equatable {
+    enum Control: Equatable {
+        case toggle(isOn: Bool)
+        case button
+        case status
+    }
+
     enum State: Equatable {
         case available
         case partial
@@ -273,6 +299,7 @@ struct HTTPSInspectionScopePresentation: Equatable {
     let value: String
     let state: State
     let statusDetail: String?
+    let control: Control
     let action: HTTPSInspectionPromptAction?
     let actionTitle: String?
     let actionDescription: String
@@ -294,6 +321,7 @@ struct HTTPSInspectionScopePresentation: Equatable {
                 value: value,
                 state: .partial,
                 statusDetail: String(localized: "Protected tunnel active"),
+                control: .button,
                 action: .retryDomain(value),
                 actionTitle: String(localized: "Retry"),
                 actionDescription: String(localized: "Retry HTTPS decryption for \(value) on the next connection")
@@ -304,12 +332,15 @@ struct HTTPSInspectionScopePresentation: Equatable {
             kind: .host,
             value: value,
             state: isReady ? .ready : .available,
-            statusDetail: isReady ? String(localized: "New connections are ready") : nil,
-            action: isReady ? nil : .enableDomain(value),
-            actionTitle: isReady ? nil : String(localized: "Decrypt Host"),
+            statusDetail: isReady ?
+                String(localized: "Enabled for new connections") :
+                String(localized: "Off for new connections"),
+            control: .toggle(isOn: isReady),
+            action: isReady ? .disableDomain(value) : .enableDomain(value),
+            actionTitle: nil,
             actionDescription: isReady ?
-                String(localized: "HTTPS decryption is enabled for new connections to \(value)") :
-                String(localized: "Decrypt new HTTPS connections to \(value)")
+                String(localized: "Turn off HTTPS decryption for new connections to \(value)") :
+                String(localized: "Turn on HTTPS decryption for new connections to \(value)")
         )
     }
 
@@ -341,17 +372,14 @@ struct HTTPSInspectionScopePresentation: Equatable {
             value: name,
             state: state,
             statusDetail: state == .ready ?
-                String(localized: "All \(total) known hosts are ready") :
-                String(localized: "\(enabled) of \(total) known hosts ready"),
+                String(localized: "All \(total) known hosts enabled") :
+                String(localized: "\(enabled) of \(total) known hosts enabled"),
+            control: state == .ready ? .status : .button,
             action: state == .ready ? nil : .enableApp(name, fallbackDomain: fallbackDomain),
-            actionTitle: state == .ready ? nil : (
-                state == .partial ?
-                    String(localized: "Decrypt \(remaining) More") :
-                    String(localized: "Decrypt All")
-            ),
+            actionTitle: state == .ready ? nil : String(localized: "Enable All"),
             actionDescription: state == .ready ?
                 String(localized: "HTTPS decryption is enabled for all known hosts used by \(name)") :
-                String(localized: "Decrypt new HTTPS connections to \(remaining) known hosts used by \(name)")
+                String(localized: "Enable HTTPS decryption for \(remaining) more known hosts used by \(name)")
         )
     }
 }

--- a/Rockxy/Views/Inspector/HTTPSInspectionPromptView.swift
+++ b/Rockxy/Views/Inspector/HTTPSInspectionPromptView.swift
@@ -10,7 +10,7 @@ struct HTTPSInspectionPromptView: View {
 
     var body: some View {
         ScrollView(.vertical) {
-            VStack(alignment: .leading, spacing: 12) {
+            VStack(alignment: .leading, spacing: 10) {
                 header
 
                 if let insight = prompt.insight {
@@ -35,6 +35,10 @@ struct HTTPSInspectionPromptView: View {
     @Environment(\.appUIDisplayMetrics) private var metrics
     @State private var isInsightExpanded = false
 
+    private var promptActionLabelWidth: CGFloat {
+        max(78, metrics.controlFontSize * 6.25)
+    }
+
     private var header: some View {
         HStack(spacing: 8) {
             if prompt.requiresCertificateSetup {
@@ -57,12 +61,15 @@ struct HTTPSInspectionPromptView: View {
             Button {
                 onAction(.openSSLProxyingList)
             } label: {
-                Image(systemName: "slider.horizontal.3")
+                Label(String(localized: "Settings…"), systemImage: "gearshape")
+                    .lineLimit(1)
+                    .frame(width: promptActionLabelWidth)
             }
-            .buttonStyle(.borderless)
+            .buttonStyle(.bordered)
             .controlSize(.small)
-            .help(String(localized: "Manage HTTPS Decryption"))
-            .accessibilityLabel(String(localized: "Manage HTTPS Decryption"))
+            .fixedSize()
+            .help(String(localized: "Open HTTPS Decryption Settings"))
+            .accessibilityLabel(String(localized: "Open HTTPS Decryption Settings"))
         }
     }
 
@@ -87,23 +94,10 @@ struct HTTPSInspectionPromptView: View {
     }
 
     private func standardInsight(_ insight: HTTPSConnectionInsight) -> some View {
-        VStack(alignment: .leading, spacing: 6) {
-            HStack(alignment: .firstTextBaseline, spacing: 8) {
-                Text(insight.summary)
-                    .font(.system(size: metrics.metadataFontSize))
-                    .foregroundStyle(Color(nsColor: .secondaryLabelColor))
-                    .fixedSize(horizontal: false, vertical: true)
-
-                Spacer(minLength: 6)
-
-                insightDetailsButton
-            }
-
-            if isInsightExpanded {
-                insightDetails(insight)
-                    .transition(.opacity.combined(with: .move(edge: .top)))
-            }
-        }
+        Text(insight.summary)
+            .font(.system(size: metrics.metadataFontSize))
+            .foregroundStyle(Color(nsColor: .secondaryLabelColor))
+            .fixedSize(horizontal: false, vertical: true)
     }
 
     private func warningInsight(_ insight: HTTPSConnectionInsight) -> some View {
@@ -177,10 +171,6 @@ struct HTTPSInspectionPromptView: View {
 
     private var scopeControls: some View {
         VStack(alignment: .leading, spacing: 6) {
-            Text(String(localized: "Decryption"))
-                .font(.system(size: metrics.metadataFontSize, weight: .medium))
-                .foregroundStyle(Color(nsColor: .secondaryLabelColor))
-
             VStack(spacing: 0) {
                 if let hostScope = prompt.hostScope {
                     scopeActionRow(scope: hostScope)
@@ -192,73 +182,40 @@ struct HTTPSInspectionPromptView: View {
                 }
             }
 
-            Text(String(localized: "Applies to new connections. This response stays encrypted."))
+            Text(scopeFooter)
                 .font(.system(size: metrics.metadataFontSize))
                 .foregroundStyle(Color(nsColor: .tertiaryLabelColor))
                 .fixedSize(horizontal: false, vertical: true)
         }
     }
 
+    private var scopeFooter: String {
+        if prompt.hostScope?.state == .ready {
+            return String(localized: "Ready for new connections. Repeat the request.")
+        }
+        return String(localized: "This response stays encrypted.")
+    }
+
     @ViewBuilder
     private func scopeActionRow(scope: HTTPSInspectionScopePresentation) -> some View {
         HStack(spacing: 8) {
-            VStack(alignment: .leading, spacing: 1) {
-                Text(scope.value)
-                    .font(.system(size: metrics.controlFontSize, weight: .medium))
-                    .lineLimit(1)
-                    .truncationMode(.middle)
-
-                if let statusDetail = scope.statusDetail {
-                    Text(statusDetail)
-                        .font(.system(size: metrics.metadataFontSize))
-                        .foregroundStyle(Color(nsColor: .secondaryLabelColor))
-                        .lineLimit(1)
-                        .help(scope.helpText)
-                }
-            }
-            .frame(maxWidth: .infinity, alignment: .leading)
+            Text(scope.value)
+                .font(.system(size: metrics.controlFontSize, weight: .medium))
+                .lineLimit(1)
+                .truncationMode(.middle)
+                .frame(maxWidth: .infinity, alignment: .leading)
 
             scopeTrailingControl(scope)
         }
-        .padding(.horizontal, 4)
-        .frame(minHeight: 44)
+        .padding(.horizontal, 2)
+        .frame(minHeight: 36)
     }
 
     @ViewBuilder
     private func scopeTrailingControl(_ scope: HTTPSInspectionScopePresentation) -> some View {
         switch scope.control {
-        case let .toggle(isOn):
-            Toggle(
-                scope.controlTitle ?? String(localized: "Decrypt Host"),
-                isOn: Binding(
-                    get: { isOn },
-                    set: { _ in
-                        if let action = scope.action {
-                            onAction(action)
-                        }
-                    }
-                )
-            )
-            .toggleStyle(.switch)
-            .controlSize(.mini)
-            .font(.system(size: metrics.controlFontSize))
-            .fixedSize()
-            .help(scope.actionDescription)
-            .accessibilityLabel(scope.controlTitle ?? String(localized: "Decrypt Host"))
-            .accessibilityHint(String(localized: "The current captured response is unchanged"))
-
         case .button:
-            if let action = scope.action, let controlTitle = scope.controlTitle {
-                Button(controlTitle) {
-                    onAction(action)
-                }
-                .buttonStyle(.bordered)
-                .controlSize(.small)
-                .fixedSize()
-                .help(scope.actionDescription)
-                .accessibilityLabel(scope.actionDescription)
-                .accessibilityHint(String(localized: "The current captured response is unchanged"))
-            }
+            scopeActionButton(scope)
 
         case .status:
             Label(String(localized: "Ready"), systemImage: "checkmark.circle.fill")
@@ -268,13 +225,31 @@ struct HTTPSInspectionPromptView: View {
                 .accessibilityLabel(scope.actionDescription)
         }
     }
+
+    @ViewBuilder
+    private func scopeActionButton(_ scope: HTTPSInspectionScopePresentation) -> some View {
+        if let action = scope.action, let controlTitle = scope.controlTitle {
+            Button {
+                onAction(action)
+            } label: {
+                Text(controlTitle)
+                    .lineLimit(1)
+                    .frame(width: promptActionLabelWidth)
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.small)
+            .fixedSize()
+            .help(scope.actionDescription)
+            .accessibilityLabel(scope.actionDescription)
+            .accessibilityHint(String(localized: "The current captured response is unchanged"))
+        }
+    }
 }
 
 // MARK: - HTTPSInspectionScopePresentation
 
 struct HTTPSInspectionScopePresentation: Equatable {
     enum Control: Equatable {
-        case toggle(isOn: Bool)
         case button
         case status
     }
@@ -288,27 +263,15 @@ struct HTTPSInspectionScopePresentation: Equatable {
     enum Kind: Equatable {
         case host
         case appHosts
-
-        var title: String {
-            switch self {
-            case .host: String(localized: "This Host")
-            case .appHosts: String(localized: "Known App Hosts")
-            }
-        }
     }
 
     let kind: Kind
     let value: String
     let state: State
-    let statusDetail: String?
     let control: Control
     let action: HTTPSInspectionPromptAction?
     let controlTitle: String?
     let actionDescription: String
-
-    var helpText: String {
-        [value, statusDetail].compactMap { $0 }.joined(separator: ", ")
-    }
 
     static func host(
         value: String,
@@ -322,7 +285,6 @@ struct HTTPSInspectionScopePresentation: Equatable {
                 kind: .host,
                 value: value,
                 state: .partial,
-                statusDetail: String(localized: "Protected tunnel active"),
                 control: .button,
                 action: .retryDomain(value),
                 controlTitle: String(localized: "Retry"),
@@ -334,12 +296,11 @@ struct HTTPSInspectionScopePresentation: Equatable {
             kind: .host,
             value: value,
             state: isReady ? .ready : .available,
-            statusDetail: String(localized: "Current host"),
-            control: .toggle(isOn: isReady),
-            action: isReady ? .disableDomain(value) : .enableDomain(value),
-            controlTitle: String(localized: "Decrypt Host"),
+            control: isReady ? .status : .button,
+            action: isReady ? nil : .enableDomain(value),
+            controlTitle: isReady ? nil : String(localized: "Decrypt Host"),
             actionDescription: isReady ?
-                String(localized: "Turn off HTTPS decryption for new connections to \(value)") :
+                String(localized: "HTTPS decryption is ready for new connections to \(value)") :
                 String(localized: "Turn on HTTPS decryption for new connections to \(value)")
         )
     }
@@ -348,16 +309,19 @@ struct HTTPSInspectionScopePresentation: Equatable {
         name: String,
         enabledHostCount: Int,
         knownHostCount: Int,
+        currentHostEnabled: Bool,
         fallbackDomain: String
     )
         -> HTTPSInspectionScopePresentation?
     {
         let total = max(knownHostCount, 1)
-        guard total > 1 else {
+        let enabled = min(max(enabledHostCount, 0), total)
+        let remaining = total - enabled
+        let additionalDisabledHostCount = max(remaining - (currentHostEnabled ? 0 : 1), 0)
+        guard additionalDisabledHostCount > 0 else {
             return nil
         }
 
-        let enabled = min(max(enabledHostCount, 0), total)
         let state: State = if enabled == total {
             .ready
         } else if enabled > 0 {
@@ -365,21 +329,15 @@ struct HTTPSInspectionScopePresentation: Equatable {
         } else {
             .available
         }
-        let remaining = total - enabled
 
         return HTTPSInspectionScopePresentation(
             kind: .appHosts,
             value: name,
             state: state,
-            statusDetail: state == .ready ?
-                String(localized: "All \(total) known hosts enabled") :
-                String(localized: "\(enabled) of \(total) known hosts enabled"),
-            control: state == .ready ? .status : .button,
-            action: state == .ready ? nil : .enableApp(name, fallbackDomain: fallbackDomain),
-            controlTitle: state == .ready ? nil : String(localized: "Enable All"),
-            actionDescription: state == .ready ?
-                String(localized: "HTTPS decryption is enabled for all known hosts used by \(name)") :
-                String(localized: "Enable HTTPS decryption for \(remaining) more known hosts used by \(name)")
+            control: .button,
+            action: .enableApp(name, fallbackDomain: fallbackDomain),
+            controlTitle: String(localized: "Decrypt App"),
+            actionDescription: String(localized: "Turn on HTTPS decryption for other known hosts used by \(name)")
         )
     }
 }

--- a/Rockxy/Views/Inspector/InspectorPanelView.swift
+++ b/Rockxy/Views/Inspector/InspectorPanelView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
-/// Top-level inspector panel that hosts the URL bar and the request/response split view.
-/// Shown in the rightmost column when a transaction is selected in the request list.
+/// Top-level payload inspector that hosts the URL bar and side-by-side request/response panes.
+/// Shown below the request list when a transaction is selected.
 struct InspectorPanelView: View {
     let coordinator: MainContentCoordinator
     var onOpenToolWindow: (String) -> Void = { _ in }

--- a/Rockxy/Views/Inspector/ResponseInspectorView.swift
+++ b/Rockxy/Views/Inspector/ResponseInspectorView.swift
@@ -742,9 +742,7 @@ enum HTTPSConnectionInsight: Equatable {
     var summary: String {
         switch self {
         case .tunnelEstablished:
-            String(
-                localized: "This connection completed without inspecting HTTPS content."
-            )
+            String(localized: "HTTPS content was not inspected.")
         case .tlsInterceptionRejected:
             String(
                 localized: "Rockxy kept the app connected by returning this host to a protected encrypted tunnel."

--- a/Rockxy/Views/Inspector/ResponseInspectorView.swift
+++ b/Rockxy/Views/Inspector/ResponseInspectorView.swift
@@ -471,8 +471,6 @@ struct ResponseInspectorView: View {
             coordinator.installAndTrustCertificateFromInspector()
         case let .enableDomain(domain):
             coordinator.enableSSLProxyingFromInspector(for: domain)
-        case let .disableDomain(domain):
-            coordinator.disableSSLProxyingFromInspector(for: domain)
         case let .retryDomain(domain):
             coordinator.retrySSLProxyingFromInspector(for: domain)
         case let .enableApp(appName, fallbackDomain):
@@ -639,7 +637,6 @@ private enum ResponseSelectionIntent {
 enum HTTPSInspectionPromptAction: Equatable {
     case installCertificate
     case enableDomain(String)
-    case disableDomain(String)
     case retryDomain(String)
     case enableApp(String, fallbackDomain: String?)
     case openSSLProxyingList
@@ -712,11 +709,12 @@ struct HTTPSInspectionPromptModel: Equatable {
                 isReady: domainRuleEnabled,
                 requiresRetry: hasTLSRejectionEvidence
             ),
-            appScope: appScope.flatMap {
+            appScope: hasTLSRejectionEvidence ? nil : appScope.flatMap {
                 .appHosts(
                     name: $0.name,
                     enabledHostCount: $0.enabledHostCount,
                     knownHostCount: $0.knownHostCount,
+                    currentHostEnabled: domainRuleEnabled,
                     fallbackDomain: host
                 )
             }

--- a/Rockxy/Views/Inspector/ResponseInspectorView.swift
+++ b/Rockxy/Views/Inspector/ResponseInspectorView.swift
@@ -471,6 +471,8 @@ struct ResponseInspectorView: View {
             coordinator.installAndTrustCertificateFromInspector()
         case let .enableDomain(domain):
             coordinator.enableSSLProxyingFromInspector(for: domain)
+        case let .disableDomain(domain):
+            coordinator.disableSSLProxyingFromInspector(for: domain)
         case let .retryDomain(domain):
             coordinator.retrySSLProxyingFromInspector(for: domain)
         case let .enableApp(appName, fallbackDomain):
@@ -637,6 +639,7 @@ private enum ResponseSelectionIntent {
 enum HTTPSInspectionPromptAction: Equatable {
     case installCertificate
     case enableDomain(String)
+    case disableDomain(String)
     case retryDomain(String)
     case enableApp(String, fallbackDomain: String?)
     case openSSLProxyingList
@@ -730,7 +733,7 @@ enum HTTPSConnectionInsight: Equatable {
     var title: String {
         switch self {
         case .tunnelEstablished:
-            String(localized: "Tunnel Established")
+            String(localized: "Content Not Inspected")
         case .tlsInterceptionRejected:
             String(localized: "Decryption Was Declined")
         }
@@ -740,7 +743,7 @@ enum HTTPSConnectionInsight: Equatable {
         switch self {
         case .tunnelEstablished:
             String(
-                localized: "The CONNECT request succeeded. HTTPS content remains encrypted until decryption starts on a new connection."
+                localized: "This connection completed without inspecting HTTPS content."
             )
         case .tlsInterceptionRejected:
             String(
@@ -765,7 +768,7 @@ enum HTTPSConnectionInsight: Equatable {
     var nextStep: String {
         switch self {
         case .tunnelEstablished:
-            String(localized: "Decrypt this host, then repeat the request.")
+            String(localized: "Enable decryption below, then repeat the request.")
         case .tlsInterceptionRejected:
             String(
                 localized: "Retry decryption and repeat the request. If the app rejects it again, leave this host tunneled."

--- a/Rockxy/Views/Inspector/ResponseInspectorView.swift
+++ b/Rockxy/Views/Inspector/ResponseInspectorView.swift
@@ -64,14 +64,24 @@ struct ResponseInspectorView: View {
     @Environment(\.appUIDisplayMetrics) private var metrics
 
     private var httpsPromptModel: HTTPSInspectionPromptModel? {
-        HTTPSInspectionPromptModel.make(
+        let appScope = normalizedClientAppName.map { appName in
+            let domains = coordinator.observedDomainsForApp(
+                named: appName,
+                fallbackDomain: transaction.request.host
+            )
+            return HTTPSInspectionAppScope(
+                name: appName,
+                knownHostCount: domains.count,
+                enabledHostCount: domains.count(where: coordinator.isSSLProxyingEnabled(for:))
+            )
+        }
+
+        return HTTPSInspectionPromptModel.make(
             transaction: transaction,
             canInterceptHTTPS: coordinator.readiness.canInterceptHTTPS,
             domainRuleEnabled: coordinator.isSSLProxyingEnabled(for: transaction.request.host),
-            appName: normalizedClientAppName,
-            appRuleEnabled: normalizedClientAppName.map {
-                coordinator.isSSLProxyingFullyEnabled(forAppNamed: $0, fallbackDomain: transaction.request.host)
-            } ?? false
+            hasRecentTLSRejection: SSLProxyingManager.shared.isAutoPassthrough(transaction.request.host),
+            appScope: appScope
         )
     }
 
@@ -461,12 +471,10 @@ struct ResponseInspectorView: View {
             coordinator.installAndTrustCertificateFromInspector()
         case let .enableDomain(domain):
             coordinator.enableSSLProxyingFromInspector(for: domain)
-        case let .disableDomain(domain):
-            coordinator.disableSSLProxyingFromInspector(for: domain)
+        case let .retryDomain(domain):
+            coordinator.retrySSLProxyingFromInspector(for: domain)
         case let .enableApp(appName, fallbackDomain):
             coordinator.enableSSLProxyingFromInspector(forAppNamed: appName, fallbackDomain: fallbackDomain)
-        case let .disableApp(appName, fallbackDomain):
-            coordinator.disableSSLProxyingFromInspector(forAppNamed: appName, fallbackDomain: fallbackDomain)
         case .openSSLProxyingList:
             onOpenToolWindow("sslProxyingList")
         }
@@ -629,36 +637,43 @@ private enum ResponseSelectionIntent {
 enum HTTPSInspectionPromptAction: Equatable {
     case installCertificate
     case enableDomain(String)
-    case disableDomain(String)
+    case retryDomain(String)
     case enableApp(String, fallbackDomain: String?)
-    case disableApp(String, fallbackDomain: String?)
     case openSSLProxyingList
+}
+
+// MARK: - HTTPSInspectionAppScope
+
+struct HTTPSInspectionAppScope: Equatable {
+    let name: String
+    let knownHostCount: Int
+    let enabledHostCount: Int
 }
 
 // MARK: - HTTPSInspectionPromptModel
 
 struct HTTPSInspectionPromptModel: Equatable {
     let host: String
-    let primaryAction: HTTPSInspectionPromptAction
-    let secondaryAction: HTTPSInspectionPromptAction?
+    let insight: HTTPSConnectionInsight?
+    let certificateAction: HTTPSInspectionPromptAction?
+    let hostScope: HTTPSInspectionScopePresentation?
+    let appScope: HTTPSInspectionScopePresentation?
 
     var requiresCertificateSetup: Bool {
-        primaryAction == .installCertificate
+        certificateAction == .installCertificate
     }
 
     static func make(
         transaction: HTTPTransaction,
         canInterceptHTTPS: Bool,
         domainRuleEnabled: Bool,
-        appName: String?,
-        appRuleEnabled: Bool
+        hasRecentTLSRejection: Bool = false,
+        appScope: HTTPSInspectionAppScope?
     )
         -> HTTPSInspectionPromptModel?
     {
         guard transaction.request.method == "CONNECT",
-              let response = transaction.response,
-              response.statusCode == 200,
-              !transaction.isTLSFailure else
+              let response = transaction.response else
         {
             return nil
         }
@@ -668,33 +683,107 @@ struct HTTPSInspectionPromptModel: Equatable {
             return nil
         }
 
+        let hasTLSRejectionEvidence = transaction.isTLSFailure || hasRecentTLSRejection
+        guard hasTLSRejectionEvidence || (200 ... 299).contains(response.statusCode) else {
+            return nil
+        }
+
         if !canInterceptHTTPS {
             return HTTPSInspectionPromptModel(
                 host: host,
-                primaryAction: .installCertificate,
-                secondaryAction: nil
+                insight: nil,
+                certificateAction: .installCertificate,
+                hostScope: nil,
+                appScope: nil
             )
-        }
-
-        let domainAction: HTTPSInspectionPromptAction = domainRuleEnabled ?
-            .disableDomain(host) :
-            .enableDomain(host)
-
-        let appAction: HTTPSInspectionPromptAction? = if let appName {
-            if appRuleEnabled {
-                HTTPSInspectionPromptAction.disableApp(appName, fallbackDomain: host)
-            } else {
-                HTTPSInspectionPromptAction.enableApp(appName, fallbackDomain: host)
-            }
-        } else {
-            nil
         }
 
         return HTTPSInspectionPromptModel(
             host: host,
-            primaryAction: domainAction,
-            secondaryAction: appAction
+            insight: hasTLSRejectionEvidence ? .tlsInterceptionRejected : .tunnelEstablished(
+                statusCode: response.statusCode
+            ),
+            certificateAction: nil,
+            hostScope: .host(
+                value: host,
+                isReady: domainRuleEnabled,
+                requiresRetry: hasTLSRejectionEvidence
+            ),
+            appScope: appScope.flatMap {
+                .appHosts(
+                    name: $0.name,
+                    enabledHostCount: $0.enabledHostCount,
+                    knownHostCount: $0.knownHostCount,
+                    fallbackDomain: host
+                )
+            }
         )
+    }
+}
+
+// MARK: - HTTPSConnectionInsight
+
+enum HTTPSConnectionInsight: Equatable {
+    case tunnelEstablished(statusCode: Int)
+    case tlsInterceptionRejected
+
+    var title: String {
+        switch self {
+        case .tunnelEstablished:
+            String(localized: "Tunnel Established")
+        case .tlsInterceptionRejected:
+            String(localized: "Decryption Was Declined")
+        }
+    }
+
+    var summary: String {
+        switch self {
+        case .tunnelEstablished:
+            String(
+                localized: "The CONNECT request succeeded. HTTPS content remains encrypted until decryption starts on a new connection."
+            )
+        case .tlsInterceptionRejected:
+            String(
+                localized: "Rockxy kept the app connected by returning this host to a protected encrypted tunnel."
+            )
+        }
+    }
+
+    var evidence: String {
+        switch self {
+        case let .tunnelEstablished(statusCode):
+            String(
+                localized: "Rockxy received status \(statusCode) and has no recent TLS rejection for this host."
+            )
+        case .tlsInterceptionRejected:
+            String(
+                localized: "The app rejected Rockxy’s TLS handshake for this host. Certificate pinning is possible, but a custom trust policy can produce the same signal."
+            )
+        }
+    }
+
+    var nextStep: String {
+        switch self {
+        case .tunnelEstablished:
+            String(localized: "Decrypt this host, then repeat the request.")
+        case .tlsInterceptionRejected:
+            String(
+                localized: "Retry decryption and repeat the request. If the app rejects it again, leave this host tunneled."
+            )
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .tunnelEstablished:
+            "checkmark.shield"
+        case .tlsInterceptionRejected:
+            "exclamationmark.shield"
+        }
+    }
+
+    var isWarning: Bool {
+        self == .tlsInterceptionRejected
     }
 }
 

--- a/Rockxy/Views/Main/Extensions/MainContentCoordinator+Filtering.swift
+++ b/Rockxy/Views/Main/Extensions/MainContentCoordinator+Filtering.swift
@@ -33,6 +33,7 @@ extension MainContentCoordinator {
         // lastDeriveWasAppendOnly is NOT reset here — it persists until the table
         // reads it in updateNSView and the next derive cycle overwrites it.
         workspace.refreshToken += 1
+        reconcileFollowLiveSelection(for: workspace)
     }
 
     private func appendDerivedRows(_ batch: [HTTPTransaction], to workspace: WorkspaceState) {

--- a/Rockxy/Views/Main/Extensions/MainContentCoordinator+Filtering.swift
+++ b/Rockxy/Views/Main/Extensions/MainContentCoordinator+Filtering.swift
@@ -30,8 +30,12 @@ extension MainContentCoordinator {
         if let selected = workspace.selectedTransaction, !visibleIDs.contains(selected.id) {
             workspace.selectedTransaction = nil
         }
-        // lastDeriveWasAppendOnly is NOT reset here — it persists until the table
-        // reads it in updateNSView and the next derive cycle overwrites it.
+        // A full derivation replaces the entire row set, so any in-flight append chain is
+        // void: clear both the append-only signal and its provenance token before bumping the
+        // token. Scattered callers that set lastDeriveWasAppendOnly = false rely on this so a
+        // stale append signal can never survive a recompute.
+        workspace.lastDeriveWasAppendOnly = false
+        workspace.appendChainOriginToken = nil
         workspace.refreshToken += 1
         reconcileFollowLiveSelection(for: workspace)
     }
@@ -45,6 +49,12 @@ extension MainContentCoordinator {
             return
         }
 
+        // Record the base token this append chain builds on. The first append of a chain
+        // captures the current (pre-append) token; later coalesced appends preserve it so the
+        // table can still prove its displayed prefix matches the grown row set.
+        if workspace.appendChainOriginToken == nil {
+            workspace.appendChainOriginToken = workspace.refreshToken
+        }
         workspace.filteredRows.append(contentsOf: appendedRows)
         workspace.refreshToken += 1
     }

--- a/Rockxy/Views/Main/Extensions/MainContentCoordinator+FocusNavigator.swift
+++ b/Rockxy/Views/Main/Extensions/MainContentCoordinator+FocusNavigator.swift
@@ -54,12 +54,14 @@ extension MainContentCoordinator {
     }
 
     func makeFocusSetFromCurrentScope() -> FocusSet {
-        FocusSet(
+        var focusSet = FocusSet(
             name: String(localized: "New Focus Set"),
             appName: filterCriteria.sidebarApp ?? "",
             domain: filterCriteria.sidebarDomain ?? "",
             pathPrefix: filterCriteria.sidebarPathPrefix ?? ""
         )
+        focusSet.name = focusSet.suggestedName
+        return focusSet
     }
 
     func muteTrafficSource(_ source: MutedTrafficSource) {

--- a/Rockxy/Views/Main/Extensions/MainContentCoordinator+ProxyControl.swift
+++ b/Rockxy/Views/Main/Extensions/MainContentCoordinator+ProxyControl.swift
@@ -420,6 +420,7 @@ extension MainContentCoordinator {
         appendObservedDomainsByApp(from: filteredBatch)
 
         updateAllWorkspaces(with: filteredBatch)
+        followLatestVisibleTransaction(from: filteredBatch)
 
         headerColumnStore.updateDiscoveredHeaders(fromBatch: filteredBatch)
     }

--- a/Rockxy/Views/Main/Extensions/MainContentCoordinator+ProxyControl.swift
+++ b/Rockxy/Views/Main/Extensions/MainContentCoordinator+ProxyControl.swift
@@ -462,7 +462,11 @@ extension MainContentCoordinator {
                 guard didUpdateRows else {
                     continue
                 }
+                // In-place enrichment rewrites existing rows without a full derive, so it must
+                // invalidate the append provenance itself — otherwise a later coalesced append
+                // could insert against a prefix this enrichment already mutated.
                 workspace.lastDeriveWasAppendOnly = false
+                workspace.appendChainOriginToken = nil
                 workspace.refreshToken += 1
             }
         }

--- a/Rockxy/Views/Main/Extensions/MainContentCoordinator+Selection.swift
+++ b/Rockxy/Views/Main/Extensions/MainContentCoordinator+Selection.swift
@@ -13,6 +13,43 @@ extension MainContentCoordinator {
         selectedTransaction = transaction
     }
 
+    /// Enables or disables live-tail selection. Enabling immediately reveals the newest
+    /// request already visible in the active workspace so the control has an observable result
+    /// even before another capture batch arrives.
+    func setFollowingLiveTraffic(_ isEnabled: Bool) {
+        isFollowingLiveTraffic = isEnabled
+        guard isEnabled else {
+            return
+        }
+        selectLastFilteredTransaction()
+    }
+
+    func toggleFollowingLiveTraffic() {
+        setFollowingLiveTraffic(!isFollowingLiveTraffic)
+    }
+
+    /// Native table callbacks only reach this path for user-driven selection changes; the
+    /// representable suppresses callbacks while syncing coordinator-owned selection.
+    func userDidSelectTraffic() {
+        isFollowingLiveTraffic = false
+    }
+
+    /// Advances live-tail selection only when the newly accepted batch contributes a request
+    /// that survives the active workspace's scope and filters.
+    func followLatestVisibleTransaction(from batch: [HTTPTransaction]) {
+        guard isFollowingLiveTraffic, !batch.isEmpty else {
+            return
+        }
+        let candidateIDs = Set(batch.map(\.id))
+        guard let latest = filteredTransactions.reversed().first(where: {
+            candidateIDs.contains($0.id)
+        }) else {
+            return
+        }
+        selectedTransactionIDs = [latest.id]
+        selectTransaction(latest)
+    }
+
     func selectLogEntry(_ entry: LogEntry?) {
         selectedLogEntry = entry
     }

--- a/Rockxy/Views/Main/Extensions/MainContentCoordinator+Selection.swift
+++ b/Rockxy/Views/Main/Extensions/MainContentCoordinator+Selection.swift
@@ -13,9 +13,9 @@ extension MainContentCoordinator {
         selectedTransaction = transaction
     }
 
-    /// Enables or disables live-tail selection. Enabling immediately reveals the newest
-    /// request already visible in the active workspace so the control has an observable result
-    /// even before another capture batch arrives.
+    /// Enables or disables live-tail selection on the active workspace. Enabling immediately
+    /// reveals the newest request already visible in the active workspace so the control has an
+    /// observable result even before another capture batch arrives; on an empty view it stays armed.
     func setFollowingLiveTraffic(_ isEnabled: Bool) {
         isFollowingLiveTraffic = isEnabled
         guard isEnabled else {
@@ -28,26 +28,85 @@ extension MainContentCoordinator {
         setFollowingLiveTraffic(!isFollowingLiveTraffic)
     }
 
-    /// Native table callbacks only reach this path for user-driven selection changes; the
-    /// representable suppresses callbacks while syncing coordinator-owned selection.
-    func userDidSelectTraffic() {
+    /// User-driven table navigation yields Follow Live for the active workspace. The request
+    /// table suppresses this callback for coordinator-owned selection and scrolling updates.
+    func userDidNavigateTrafficHistory() {
         isFollowingLiveTraffic = false
     }
 
-    /// Advances live-tail selection only when the newly accepted batch contributes a request
-    /// that survives the active workspace's scope and filters.
+    /// Advances live-tail selection for every workspace with Follow Live enabled — including
+    /// inactive ones — using each workspace's own scope and filters. Workspaces without the mode
+    /// keep their current selection.
     func followLatestVisibleTransaction(from batch: [HTTPTransaction]) {
-        guard isFollowingLiveTraffic, !batch.isEmpty else {
+        guard !batch.isEmpty else {
             return
         }
-        let candidateIDs = Set(batch.map(\.id))
-        guard let latest = filteredTransactions.reversed().first(where: {
-            candidateIDs.contains($0.id)
-        }) else {
+        for workspace in workspaceStore.workspaces {
+            reconcileFollowLiveSelection(for: workspace, acceptedBatch: batch)
+        }
+    }
+
+    /// Reconciles a single workspace's Follow Live selection against its current filtered view.
+    ///
+    /// - With `acceptedBatch`, this is a batch-driven advance: the selection moves only when the
+    ///   batch contributed a newly-visible transaction; otherwise the workspace stays armed and
+    ///   keeps its current selection.
+    /// - Without a batch (`nil`), this is a filter/scope reconcile: the selection snaps to the
+    ///   newest currently-visible transaction, or clears any stale hidden selection while staying
+    ///   armed when nothing is visible.
+    ///
+    /// The newest transaction is always taken from `filteredTransactions` (chronological), never
+    /// the display-sorted `filteredRows`, so a custom column sort cannot change the chosen row.
+    func reconcileFollowLiveSelection(
+        for workspace: WorkspaceState,
+        acceptedBatch batch: [HTTPTransaction]? = nil
+    ) {
+        guard workspace.isFollowingLiveTraffic else {
             return
         }
-        selectedTransactionIDs = [latest.id]
-        selectTransaction(latest)
+
+        let newest: HTTPTransaction?
+        if let batch {
+            let candidateIDs = Set(batch.map(\.id))
+            newest = workspace.filteredTransactions.last { candidateIDs.contains($0.id) }
+        } else {
+            newest = workspace.filteredTransactions.last
+        }
+
+        guard let newest else {
+            if batch == nil {
+                clearFollowLiveSelection(in: workspace)
+            }
+            return
+        }
+        applyFollowLiveSelection(newest, in: workspace)
+    }
+
+    /// Applies a Follow Live selection. The active workspace routes through the coordinator
+    /// selection path so inspector/assistant side effects fire; inactive workspaces are mutated
+    /// directly to avoid triggering the active workspace's side effects.
+    private func applyFollowLiveSelection(_ transaction: HTTPTransaction, in workspace: WorkspaceState) {
+        if workspace === activeWorkspace {
+            selectedTransactionIDs = [transaction.id]
+            selectTransaction(transaction)
+        } else {
+            workspace.selectedTransactionIDs = [transaction.id]
+            workspace.selectedTransaction = transaction
+        }
+    }
+
+    /// Clears a stale Follow Live selection when nothing is currently visible, keeping the mode armed.
+    private func clearFollowLiveSelection(in workspace: WorkspaceState) {
+        if workspace === activeWorkspace {
+            guard selectedTransaction != nil || !selectedTransactionIDs.isEmpty else {
+                return
+            }
+            selectedTransactionIDs = []
+            selectTransaction(nil)
+        } else {
+            workspace.selectedTransactionIDs = []
+            workspace.selectedTransaction = nil
+        }
     }
 
     func selectLogEntry(_ entry: LogEntry?) {

--- a/Rockxy/Views/Main/Extensions/MainContentCoordinator+SidebarMenu.swift
+++ b/Rockxy/Views/Main/Extensions/MainContentCoordinator+SidebarMenu.swift
@@ -171,6 +171,23 @@ extension MainContentCoordinator {
         )
     }
 
+    func retrySSLProxyingFromInspector(for domain: String) {
+        guard !domain.isEmpty else {
+            return
+        }
+
+        enableSSLProxyingForDomain(domain, refreshPresentation: false)
+        SSLProxyingManager.shared.retryInterception(for: domain)
+        refreshSSLProxyingPresentation()
+
+        activeToast = ToastMessage(
+            style: .success,
+            text: String(
+                localized: "Decryption retry is ready for \(domain). Repeat the request or reconnect the app."
+            )
+        )
+    }
+
     func disableSSLProxyingFromInspector(for domain: String) {
         guard !domain.isEmpty else {
             return

--- a/Rockxy/Views/Main/MainContentCommandActions.swift
+++ b/Rockxy/Views/Main/MainContentCommandActions.swift
@@ -172,8 +172,12 @@ struct MainContentCommandActions {
 
     // MARK: - View
 
-    func toggleAutoSelect() {
-        coordinator.isAutoSelectEnabled.toggle()
+    var isFollowingLiveTraffic: Bool {
+        coordinator.isFollowingLiveTraffic
+    }
+
+    func setFollowingLiveTraffic(_ isEnabled: Bool) {
+        coordinator.setFollowingLiveTraffic(isEnabled)
     }
 
     func toggleSourceList() {

--- a/Rockxy/Views/Main/MainContentCoordinator.swift
+++ b/Rockxy/Views/Main/MainContentCoordinator.swift
@@ -261,9 +261,6 @@ final class MainContentCoordinator {
     var trafficSamples: [(timestamp: Date, upload: Int64, download: Int64)] = []
     var bandwidthTimer: Timer?
     var isProxyOverridden = false
-    /// Opt-in live-tail mode. New visible traffic becomes the primary selection until the
-    /// user deliberately selects a row, at which point the mode yields immediately.
-    var isFollowingLiveTraffic = false
     nonisolated(unsafe) var evictionObserver: NSObjectProtocol?
 
     // MARK: - UI State — Engine Status
@@ -412,6 +409,13 @@ final class MainContentCoordinator {
     var focusNavigatorMode: FocusNavigatorMode {
         get { activeWorkspace.focusNavigatorMode }
         set { activeWorkspace.focusNavigatorMode = newValue }
+    }
+
+    /// Opt-in live-tail mode for the active workspace. Forwards to the active `WorkspaceState`
+    /// so existing UI/menu callers keep reading a single flag while the state is owned per-workspace.
+    var isFollowingLiveTraffic: Bool {
+        get { activeWorkspace.isFollowingLiveTraffic }
+        set { activeWorkspace.isFollowingLiveTraffic = newValue }
     }
 
     var selectedLogEntry: LogEntry? {

--- a/Rockxy/Views/Main/MainContentCoordinator.swift
+++ b/Rockxy/Views/Main/MainContentCoordinator.swift
@@ -25,6 +25,57 @@ enum ProxyDisplayState: Equatable {
             String(localized: "Stopped")
         }
     }
+
+    var captureTitle: String {
+        switch self {
+        case .starting:
+            String(localized: "Starting Capture")
+        case .running:
+            String(localized: "Capturing Traffic")
+        case .paused:
+            String(localized: "Capture Paused")
+        case .stopped:
+            String(localized: "Capture Stopped")
+        }
+    }
+
+    var captureDescription: String {
+        switch self {
+        case .starting:
+            String(localized: "Preparing the listener and system routing.")
+        case .running:
+            String(localized: "New traffic is being added to the active workspace.")
+        case .paused:
+            String(localized: "The listener stays available, but new traffic is not being added.")
+        case .stopped:
+            String(localized: "No new traffic is being captured.")
+        }
+    }
+
+    var captureSystemImage: String {
+        switch self {
+        case .starting:
+            "circle.dotted"
+        case .running:
+            "record.circle.fill"
+        case .paused:
+            "pause.circle.fill"
+        case .stopped:
+            "stop.circle"
+        }
+    }
+
+    var captureActionTitle: String {
+        switch self {
+        case .starting:
+            String(localized: "Starting…")
+        case .running,
+             .paused:
+            String(localized: "Stop Capture")
+        case .stopped:
+            String(localized: "Start Capture")
+        }
+    }
 }
 
 // MARK: - ProxyListenerSnapshot
@@ -210,7 +261,9 @@ final class MainContentCoordinator {
     var trafficSamples: [(timestamp: Date, upload: Int64, download: Int64)] = []
     var bandwidthTimer: Timer?
     var isProxyOverridden = false
-    var isAutoSelectEnabled = true
+    /// Opt-in live-tail mode. New visible traffic becomes the primary selection until the
+    /// user deliberately selects a row, at which point the mode yields immediately.
+    var isFollowingLiveTraffic = false
     nonisolated(unsafe) var evictionObserver: NSObjectProtocol?
 
     // MARK: - UI State — Engine Status

--- a/Rockxy/Views/Main/MainContentCoordinator.swift
+++ b/Rockxy/Views/Main/MainContentCoordinator.swift
@@ -480,6 +480,13 @@ final class MainContentCoordinator {
         sidebarFavoritesCache = nil
     }
 
+    func dismissToast(id: UUID) {
+        guard activeToast?.id == id else {
+            return
+        }
+        activeToast = nil
+    }
+
     /// Configure shared policy gates. Called once from the app's main
     /// ContentView after the first coordinator is created. Separated from
     /// init so test-created coordinators do not overwrite shared gate state.

--- a/Rockxy/Views/Main/NativeWorkspaceSplitView.swift
+++ b/Rockxy/Views/Main/NativeWorkspaceSplitView.swift
@@ -1,6 +1,45 @@
 import AppKit
 import SwiftUI
 
+// MARK: - NativeSplitDividerInteraction
+
+/// Keeps thin native dividers visually quiet while giving them a forgiving pointer target.
+/// Twelve points follows the interaction footprint of standard macOS splitters without adding
+/// visible chrome or stealing meaningful space from either pane.
+enum NativeSplitDividerInteraction {
+    static let minimumHitThickness: CGFloat = 12
+    /// AppKit performs user divider drags at priority 490. Pane holding priorities at
+    /// `.defaultHigh` (750) therefore make a divider look draggable while Auto Layout snaps it
+    /// straight back. Keep utility panes just above the flexible workspace, but below drag.
+    static let utilityPaneHoldingPriority = NSLayoutConstraint.Priority(rawValue: 251)
+
+    static func expandedHitRect(
+        systemRect: NSRect,
+        drawnRect: NSRect,
+        isVertical: Bool
+    )
+        -> NSRect
+    {
+        guard systemRect.width.isFinite,
+              systemRect.height.isFinite,
+              drawnRect.width.isFinite,
+              drawnRect.height.isFinite else
+        {
+            return systemRect
+        }
+
+        let expandedDrawnRect: NSRect
+        if isVertical {
+            let expansion = max(0, minimumHitThickness - drawnRect.width) / 2
+            expandedDrawnRect = drawnRect.insetBy(dx: -expansion, dy: 0)
+        } else {
+            let expansion = max(0, minimumHitThickness - drawnRect.height) / 2
+            expandedDrawnRect = drawnRect.insetBy(dx: 0, dy: -expansion)
+        }
+        return systemRect.union(expandedDrawnRect)
+    }
+}
+
 // MARK: - NativeWorkspaceSplitView
 
 /// Hosts the source list, workspace, and Context Dock in one native root split.
@@ -23,7 +62,6 @@ struct NativeWorkspaceSplitView<Sidebar: View, Workspace: View, Inspector: View>
         workspaceMinimumWidth: CGFloat,
         inspectorMinimumWidth: CGFloat,
         inspectorIdealWidth: CGFloat,
-        inspectorMaximumWidth: CGFloat,
         toolbarConfiguration: NativeWorkspaceToolbarConfiguration? = nil,
         @ViewBuilder sidebar: @escaping () -> Sidebar,
         @ViewBuilder workspace: @escaping () -> Workspace,
@@ -38,7 +76,6 @@ struct NativeWorkspaceSplitView<Sidebar: View, Workspace: View, Inspector: View>
         self.workspaceMinimumWidth = workspaceMinimumWidth
         self.inspectorMinimumWidth = inspectorMinimumWidth
         self.inspectorIdealWidth = inspectorIdealWidth
-        self.inspectorMaximumWidth = inspectorMaximumWidth
         self.toolbarConfiguration = toolbarConfiguration
         self.sidebar = sidebar
         self.workspace = workspace
@@ -89,7 +126,6 @@ struct NativeWorkspaceSplitView<Sidebar: View, Workspace: View, Inspector: View>
     let workspaceMinimumWidth: CGFloat
     let inspectorMinimumWidth: CGFloat
     let inspectorIdealWidth: CGFloat
-    let inspectorMaximumWidth: CGFloat
     let toolbarConfiguration: NativeWorkspaceToolbarConfiguration?
     @ViewBuilder let sidebar: () -> Sidebar
     @ViewBuilder let workspace: () -> Workspace
@@ -124,8 +160,7 @@ struct NativeWorkspaceSplitView<Sidebar: View, Workspace: View, Inspector: View>
                 sidebarMaximumWidth: sidebarMaximumWidth,
                 workspaceMinimumWidth: workspaceMinimumWidth,
                 inspectorMinimumWidth: inspectorMinimumWidth,
-                inspectorIdealWidth: inspectorIdealWidth,
-                inspectorMaximumWidth: inspectorMaximumWidth
+                inspectorIdealWidth: inspectorIdealWidth
             )
         )
         updateVisibilityCallbacks(on: controller)
@@ -215,7 +250,6 @@ struct NativeWorkspaceSplitLayout {
     let workspaceMinimumWidth: CGFloat
     let inspectorMinimumWidth: CGFloat
     let inspectorIdealWidth: CGFloat
-    let inspectorMaximumWidth: CGFloat
 }
 
 // MARK: - NativeWorkspaceSplitSizing
@@ -379,6 +413,27 @@ final class NativeWorkspaceSplitViewController: NSSplitViewController {
         isApplyingInitialState = false
     }
 
+    override func splitView(
+        _ splitView: NSSplitView,
+        effectiveRect proposedEffectiveRect: NSRect,
+        forDrawnRect drawnRect: NSRect,
+        ofDividerAt dividerIndex: Int
+    )
+        -> NSRect
+    {
+        let systemRect = super.splitView(
+            splitView,
+            effectiveRect: proposedEffectiveRect,
+            forDrawnRect: drawnRect,
+            ofDividerAt: dividerIndex
+        )
+        return NativeSplitDividerInteraction.expandedHitRect(
+            systemRect: systemRect,
+            drawnRect: drawnRect,
+            isVertical: splitView.isVertical
+        )
+    }
+
     override func viewDidAppear() {
         super.viewDidAppear()
         installWindowChromeIfNeeded()
@@ -404,7 +459,7 @@ final class NativeWorkspaceSplitViewController: NSSplitViewController {
         sidebarItem.canCollapse = true
         sidebarItem.collapseBehavior = .useConstraints
         sidebarItem.isSpringLoaded = true
-        sidebarItem.holdingPriority = .defaultHigh
+        sidebarItem.holdingPriority = NativeSplitDividerInteraction.utilityPaneHoldingPriority
 
         let workspaceItem = NSSplitViewItem(viewController: workspaceController)
         workspaceItem.minimumThickness = layout.workspaceMinimumWidth
@@ -413,11 +468,14 @@ final class NativeWorkspaceSplitViewController: NSSplitViewController {
 
         let inspectorItem = NSSplitViewItem(inspectorWithViewController: inspectorController)
         inspectorItem.minimumThickness = layout.inspectorMinimumWidth
-        inspectorItem.maximumThickness = layout.inspectorMaximumWidth
+        // AppKit's semantic inspector item applies a compact default maximum. A large finite
+        // value keeps the native inspector behavior while making its real upper bound the
+        // window and workspace minimum, without overflowing Auto Layout constraints.
+        inspectorItem.maximumThickness = 10_000
         inspectorItem.canCollapse = true
         inspectorItem.collapseBehavior = .useConstraints
         inspectorItem.isSpringLoaded = true
-        inspectorItem.holdingPriority = .defaultHigh
+        inspectorItem.holdingPriority = NativeSplitDividerInteraction.utilityPaneHoldingPriority
 
         addSplitViewItem(sidebarItem)
         addSplitViewItem(workspaceItem)

--- a/Rockxy/Views/RequestList/CenterContentView.swift
+++ b/Rockxy/Views/RequestList/CenterContentView.swift
@@ -221,7 +221,7 @@ struct CenterContentView: View {
             isAppendOnly: coordinator.activeWorkspace.lastDeriveWasAppendOnly,
             selectedIDs: $selectedIDs,
             onSelectionChanged: { ids, primaryID in
-                coordinator.userDidSelectTraffic()
+                coordinator.userDidNavigateTrafficHistory()
                 coordinator.selectedTransactionIDs = ids
                 if let primaryID,
                    ids.contains(primaryID),
@@ -238,6 +238,9 @@ struct CenterContentView: View {
                 } else {
                     coordinator.selectTransaction(nil)
                 }
+            },
+            onUserScroll: {
+                coordinator.userDidNavigateTrafficHistory()
             },
             mainCoordinator: coordinator,
             headerColumns: coordinator.headerColumnStore.columns

--- a/Rockxy/Views/RequestList/CenterContentView.swift
+++ b/Rockxy/Views/RequestList/CenterContentView.swift
@@ -219,6 +219,7 @@ struct CenterContentView: View {
             rows: coordinator.filteredRows,
             refreshToken: coordinator.refreshToken,
             isAppendOnly: coordinator.activeWorkspace.lastDeriveWasAppendOnly,
+            appendChainOrigin: coordinator.activeWorkspace.appendChainOriginToken,
             selectedIDs: $selectedIDs,
             onSelectionChanged: { ids, primaryID in
                 coordinator.userDidNavigateTrafficHistory()

--- a/Rockxy/Views/RequestList/CenterContentView.swift
+++ b/Rockxy/Views/RequestList/CenterContentView.swift
@@ -136,9 +136,9 @@ struct CenterContentView: View {
     // MARK: Private
 
     private static let bottomInspectorSplitAutosaveName = RockxyIdentity.current.defaultsKey(
-        // v2 intentionally drops the tab-strip-height positions that v1 allowed. AppKit will
-        // establish the balanced default once, then persist every user drag normally again.
-        "workspaceBottomInspectorSplit.v2"
+        // Establish the payload-first split once, then persist every user-adjusted divider
+        // position normally again.
+        "workspaceBottomInspectorSplit.payloadFirst.v1"
     )
 
     @AppStorage(NoCacheHeaderMutator.userDefaultsKey) private var isNoCachingEnabled = false

--- a/Rockxy/Views/RequestList/CenterContentView.swift
+++ b/Rockxy/Views/RequestList/CenterContentView.swift
@@ -87,7 +87,7 @@ struct CenterContentView: View {
                 isProxyOverridden: coordinator.isProxyOverridden,
                 isAllowListActive: allowListManager.isActive,
                 isNoCachingActive: isNoCachingEnabled,
-                isAutoSelectEnabled: coordinator.isAutoSelectEnabled,
+                isFollowingLiveTraffic: coordinator.isFollowingLiveTraffic,
                 isFilterBarVisible: coordinator.isFilterBarVisible,
                 activeFilterCount: activeFilterCount,
                 errorCount: coordinator.errorCount,
@@ -109,8 +109,8 @@ struct CenterContentView: View {
                     coordinator.isFilterBarVisible.toggle()
                     coordinator.recomputeFilteredTransactions()
                 },
-                onAutoSelect: {
-                    coordinator.isAutoSelectEnabled.toggle()
+                onFollowLive: {
+                    coordinator.toggleFollowingLiveTraffic()
                 },
                 onSwitchOffProxyOverride: {
                     coordinator.switchOffSystemProxyOverride()
@@ -136,7 +136,9 @@ struct CenterContentView: View {
     // MARK: Private
 
     private static let bottomInspectorSplitAutosaveName = RockxyIdentity.current.defaultsKey(
-        "workspaceBottomInspectorSplit.v1"
+        // v2 intentionally drops the tab-strip-height positions that v1 allowed. AppKit will
+        // establish the new 55/45 default once, then persist every user drag normally again.
+        "workspaceBottomInspectorSplit.v2"
     )
 
     @AppStorage(NoCacheHeaderMutator.userDefaultsKey) private var isNoCachingEnabled = false
@@ -219,6 +221,7 @@ struct CenterContentView: View {
             isAppendOnly: coordinator.activeWorkspace.lastDeriveWasAppendOnly,
             selectedIDs: $selectedIDs,
             onSelectionChanged: { ids, primaryID in
+                coordinator.userDidSelectTraffic()
                 coordinator.selectedTransactionIDs = ids
                 if let primaryID,
                    ids.contains(primaryID),

--- a/Rockxy/Views/RequestList/CenterContentView.swift
+++ b/Rockxy/Views/RequestList/CenterContentView.swift
@@ -137,7 +137,7 @@ struct CenterContentView: View {
 
     private static let bottomInspectorSplitAutosaveName = RockxyIdentity.current.defaultsKey(
         // v2 intentionally drops the tab-strip-height positions that v1 allowed. AppKit will
-        // establish the new 55/45 default once, then persist every user drag normally again.
+        // establish the balanced default once, then persist every user drag normally again.
         "workspaceBottomInspectorSplit.v2"
     )
 

--- a/Rockxy/Views/RequestList/CenterContentView.swift
+++ b/Rockxy/Views/RequestList/CenterContentView.swift
@@ -136,9 +136,9 @@ struct CenterContentView: View {
     // MARK: Private
 
     private static let bottomInspectorSplitAutosaveName = RockxyIdentity.current.defaultsKey(
-        // Establish the payload-first split once, then persist every user-adjusted divider
-        // position normally again.
-        "workspaceBottomInspectorSplit.payloadFirst.v1"
+        // v2 applies the taller payload-first default once, then preserves every subsequent
+        // user-adjusted divider position normally again.
+        "workspaceBottomInspectorSplit.payloadFirst.v2"
     )
 
     @AppStorage(NoCacheHeaderMutator.userDefaultsKey) private var isNoCachingEnabled = false

--- a/Rockxy/Views/RequestList/NativeBottomInspectorSplitView.swift
+++ b/Rockxy/Views/RequestList/NativeBottomInspectorSplitView.swift
@@ -159,7 +159,7 @@ struct NativeBottomDeferredContent<Content: View>: View {
 enum NativeBottomInspectorSplitSizing {
     /// Fraction of the available height seated above the divider (request list) on a fresh
     /// layout, leaving the inspector a useful working area instead of a preview strip.
-    static let defaultRequestListRatio: CGFloat = 0.36
+    static let defaultRequestListRatio: CGFloat = 0.28
 
     static func resolve(_ proposal: ProposedViewSize, naturalHeight: CGFloat) -> CGSize? {
         let resolved = proposal.replacingUnspecifiedDimensions(

--- a/Rockxy/Views/RequestList/NativeBottomInspectorSplitView.swift
+++ b/Rockxy/Views/RequestList/NativeBottomInspectorSplitView.swift
@@ -158,8 +158,8 @@ struct NativeBottomDeferredContent<Content: View>: View {
 
 enum NativeBottomInspectorSplitSizing {
     /// Fraction of the available height seated above the divider (request list) on a fresh
-    /// layout, leaving the remainder to the inspector — ≈62% / 38%.
-    static let defaultRequestListRatio: CGFloat = 0.62
+    /// layout, leaving the inspector a useful working area instead of a preview strip.
+    static let defaultRequestListRatio: CGFloat = 0.55
 
     static func resolve(_ proposal: ProposedViewSize, naturalHeight: CGFloat) -> CGSize? {
         let resolved = proposal.replacingUnspecifiedDimensions(
@@ -301,6 +301,27 @@ final class NativeBottomInspectorSplitViewController: NSSplitViewController {
         applyDefaultDividerIfNeeded(totalHeight: bounds.height)
     }
 
+    override func splitView(
+        _ splitView: NSSplitView,
+        effectiveRect proposedEffectiveRect: NSRect,
+        forDrawnRect drawnRect: NSRect,
+        ofDividerAt dividerIndex: Int
+    )
+        -> NSRect
+    {
+        let systemRect = super.splitView(
+            splitView,
+            effectiveRect: proposedEffectiveRect,
+            forDrawnRect: drawnRect,
+            ofDividerAt: dividerIndex
+        )
+        return NativeSplitDividerInteraction.expandedHitRect(
+            systemRect: systemRect,
+            drawnRect: drawnRect,
+            isVertical: splitView.isVertical
+        )
+    }
+
     func configure(
         primaryController: NSViewController,
         inspectorController: NSViewController,
@@ -327,7 +348,7 @@ final class NativeBottomInspectorSplitViewController: NSSplitViewController {
         inspectorItem.canCollapse = true
         inspectorItem.collapseBehavior = .useConstraints
         inspectorItem.isSpringLoaded = true
-        inspectorItem.holdingPriority = .defaultHigh
+        inspectorItem.holdingPriority = NativeSplitDividerInteraction.utilityPaneHoldingPriority
 
         if !hasAutosavedFrames {
             primaryItem.preferredThicknessFraction = NativeBottomInspectorSplitSizing

--- a/Rockxy/Views/RequestList/NativeBottomInspectorSplitView.swift
+++ b/Rockxy/Views/RequestList/NativeBottomInspectorSplitView.swift
@@ -159,7 +159,7 @@ struct NativeBottomDeferredContent<Content: View>: View {
 enum NativeBottomInspectorSplitSizing {
     /// Fraction of the available height seated above the divider (request list) on a fresh
     /// layout, leaving the inspector a useful working area instead of a preview strip.
-    static let defaultRequestListRatio: CGFloat = 0.55
+    static let defaultRequestListRatio: CGFloat = 0.50
 
     static func resolve(_ proposal: ProposedViewSize, naturalHeight: CGFloat) -> CGSize? {
         let resolved = proposal.replacingUnspecifiedDimensions(

--- a/Rockxy/Views/RequestList/NativeBottomInspectorSplitView.swift
+++ b/Rockxy/Views/RequestList/NativeBottomInspectorSplitView.swift
@@ -159,7 +159,7 @@ struct NativeBottomDeferredContent<Content: View>: View {
 enum NativeBottomInspectorSplitSizing {
     /// Fraction of the available height seated above the divider (request list) on a fresh
     /// layout, leaving the inspector a useful working area instead of a preview strip.
-    static let defaultRequestListRatio: CGFloat = 0.50
+    static let defaultRequestListRatio: CGFloat = 0.36
 
     static func resolve(_ proposal: ProposedViewSize, naturalHeight: CGFloat) -> CGSize? {
         let resolved = proposal.replacingUnspecifiedDimensions(
@@ -348,7 +348,9 @@ final class NativeBottomInspectorSplitViewController: NSSplitViewController {
         inspectorItem.canCollapse = true
         inspectorItem.collapseBehavior = .useConstraints
         inspectorItem.isSpringLoaded = true
-        inspectorItem.holdingPriority = NativeSplitDividerInteraction.utilityPaneHoldingPriority
+        // A low holding priority lets the horizontal divider win the constraint negotiation.
+        // Higher priorities can show the resize cursor while refusing the drag on newer macOS.
+        inspectorItem.holdingPriority = .defaultLow
 
         if !hasAutosavedFrames {
             primaryItem.preferredThicknessFraction = NativeBottomInspectorSplitSizing
@@ -380,12 +382,18 @@ final class NativeBottomInspectorSplitViewController: NSSplitViewController {
         }
 
         if animated, view.window != nil {
-            NSAnimationContext.runAnimationGroup { context in
-                context.duration = 0.18
-                inspectorItem.animator().isCollapsed = !isPresented
-            }
+            NSAnimationContext.runAnimationGroup(
+                { context in
+                    context.duration = 0.18
+                    inspectorItem.animator().isCollapsed = !isPresented
+                },
+                completionHandler: { [weak self] in
+                    self?.applyDefaultDividerAfterPresentationIfNeeded(isPresented)
+                }
+            )
         } else {
             inspectorItem.isCollapsed = !isPresented
+            applyDefaultDividerAfterPresentationIfNeeded(isPresented)
         }
     }
 
@@ -407,6 +415,14 @@ final class NativeBottomInspectorSplitViewController: NSSplitViewController {
     private var pendingInitialVisibility: Bool?
     private var didApplyDefaultDivider = false
     private var isApplyingInitialState = true
+
+    private func applyDefaultDividerAfterPresentationIfNeeded(_ isPresented: Bool) {
+        guard isPresented else {
+            return
+        }
+        view.layoutSubtreeIfNeeded()
+        applyDefaultDividerIfNeeded(totalHeight: splitView.bounds.height)
+    }
 
     private func applyDefaultDividerIfNeeded(totalHeight: CGFloat) {
         guard !hasAutosavedFrames,

--- a/Rockxy/Views/RequestList/RequestTableView.swift
+++ b/Rockxy/Views/RequestList/RequestTableView.swift
@@ -1113,6 +1113,15 @@ extension RequestTableView {
             isUpdatingSelection = false
             lastSyncedSelectionIDs = ids
 
+            let isFollowingLiveTraffic = MainActor.assumeIsolated {
+                parent.mainCoordinator?.isFollowingLiveTraffic == true
+            }
+            if isFollowingLiveTraffic,
+               let newestSelectedRow = desired.last
+            {
+                tableView.scrollRowToVisible(newestSelectedRow)
+            }
+
             if let visibleOrigin,
                let scrollView = tableView.enclosingScrollView
             {

--- a/Rockxy/Views/RequestList/RequestTableView.swift
+++ b/Rockxy/Views/RequestList/RequestTableView.swift
@@ -19,6 +19,7 @@ struct RequestTableView: NSViewRepresentable {
     let rows: [RequestListRow]
     let refreshToken: Int
     let isAppendOnly: Bool
+    var appendChainOrigin: Int?
     var displayMetricsOverride: AppUIDisplayMetrics?
     @Binding var selectedIDs: Set<UUID>
     @Environment(\.appUIDisplayMetrics) private var displayMetrics
@@ -128,20 +129,27 @@ struct RequestTableView: NSViewRepresentable {
 
         if workspaceChanged || newToken != oldToken {
             let newCount = rows.count
-            if !workspaceChanged,
-               isAppendOnly,
-               newCount > coordinator.previousRowCount,
-               coordinator.previousRowCount > 0
-            {
+            if coordinator.canInsertAppendedRows(
+                newCount: newCount,
+                isAppendOnly: isAppendOnly,
+                appendChainOrigin: appendChainOrigin,
+                lastAppliedToken: oldToken,
+                workspaceChanged: workspaceChanged,
+                tableRowCount: tableView.numberOfRows
+            ) {
                 // Append-only fast path: coordinator confirmed rows were only appended
                 let newIndexes = IndexSet(integersIn: coordinator.previousRowCount ..< newCount)
-                tableView.insertRows(at: newIndexes, withAnimation: [])
+                coordinator.performProgrammaticTableUpdate {
+                    tableView.insertRows(at: newIndexes, withAnimation: [])
+                }
                 if displayChange?.reloadVisibleRows == true {
                     coordinator.reloadVisibleRows(in: tableView)
                     reloadedVisibleRowsForMetrics = true
                 }
             } else {
-                tableView.reloadData()
+                coordinator.performProgrammaticTableUpdate {
+                    tableView.reloadData()
+                }
                 reloadedVisibleRowsForMetrics = displayChange?.reloadVisibleRows == true
             }
             coordinator.previousRowCount = newCount
@@ -436,6 +444,38 @@ extension RequestTableView {
 
         func numberOfRows(in tableView: NSTableView) -> Int {
             rows.count
+        }
+
+        /// Incremental row insertion is valid only when AppKit and the SwiftUI coordinator agree
+        /// on the old row count and the current append chain started from a model snapshot this
+        /// table has already applied.
+        func canInsertAppendedRows(
+            newCount: Int,
+            isAppendOnly: Bool,
+            appendChainOrigin: Int?,
+            lastAppliedToken: Int,
+            workspaceChanged: Bool,
+            tableRowCount: Int
+        ) -> Bool {
+            guard let appendChainOrigin else {
+                return false
+            }
+            return !workspaceChanged
+                && isAppendOnly
+                && previousRowCount > 0
+                && tableRowCount == previousRowCount
+                && appendChainOrigin <= lastAppliedToken
+                && newCount > previousRowCount
+        }
+
+        /// AppKit may emit selection notifications while rows are inserted or reloaded. Treat the
+        /// entire table mutation as coordinator-owned so those callbacks cannot re-enter SwiftUI
+        /// selection/filter state halfway through applying a snapshot.
+        func performProgrammaticTableUpdate(_ update: () -> Void) {
+            let wasUpdatingSelection = isUpdatingSelection
+            isUpdatingSelection = true
+            defer { isUpdatingSelection = wasUpdatingSelection }
+            update()
         }
 
         struct DisplayMetricsChange: Equatable {
@@ -1135,9 +1175,9 @@ extension RequestTableView {
                 ? tableView.enclosingScrollView?.contentView.bounds.origin
                 : nil
 
-            isUpdatingSelection = true
-            tableView.selectRowIndexes(desired, byExtendingSelection: false)
-            isUpdatingSelection = false
+            performProgrammaticTableUpdate {
+                tableView.selectRowIndexes(desired, byExtendingSelection: false)
+            }
             lastSyncedSelectionIDs = ids
 
             let isFollowingLiveTraffic = MainActor.assumeIsolated {
@@ -1755,9 +1795,9 @@ extension RequestTableView {
                 clickedRow: clickedRow,
                 selectedRowIndexes: selection
             )
-            isUpdatingSelection = true
-            tableView.selectRowIndexes(selection, byExtendingSelection: false)
-            isUpdatingSelection = false
+            performProgrammaticTableUpdate {
+                tableView.selectRowIndexes(selection, byExtendingSelection: false)
+            }
             pendingContextSelectionIDs = ids
             pendingContextPrimaryID = rows[clickedRow].id
         }

--- a/Rockxy/Views/RequestList/RequestTableView.swift
+++ b/Rockxy/Views/RequestList/RequestTableView.swift
@@ -24,6 +24,7 @@ struct RequestTableView: NSViewRepresentable {
     @Environment(\.appUIDisplayMetrics) private var displayMetrics
 
     var onSelectionChanged: ((Set<UUID>, UUID?) -> Void)?
+    var onUserScroll: (() -> Void)?
     var onDoubleClick: ((HTTPTransaction) -> Void)?
     var mainCoordinator: MainContentCoordinator?
     var headerColumns: [HeaderColumn] = []
@@ -98,6 +99,7 @@ struct RequestTableView: NSViewRepresentable {
         scrollView.autoresizingMask = [.width, .height]
         tableView.sizeLastColumnToFit()
         context.coordinator.tableView = tableView
+        context.coordinator.observeUserScrolling(in: scrollView)
         context.coordinator.applyDisplayMetrics(to: tableView)
 
         return scrollView
@@ -392,6 +394,7 @@ extension RequestTableView {
         private var lastAppliedRequestTableMetrics: RequestTableAppliedMetrics?
         private var pendingContextSelectionIDs: Set<UUID>?
         private var pendingContextPrimaryID: UUID?
+        private var userScrollObserver: NSObjectProtocol?
 
         /// Guard flag to prevent feedback loops: when we programmatically update NSTableView
         /// selection from SwiftUI state, we suppress the delegate callback that would
@@ -405,7 +408,31 @@ extension RequestTableView {
         private var lastSyncedSelectionIDs: Set<UUID> = []
         private var visibleMetricsRefreshGeneration = 0
 
+        deinit {
+            if let userScrollObserver {
+                NotificationCenter.default.removeObserver(userScrollObserver)
+            }
+        }
+
         // MARK: - NSTableViewDataSource
+
+        /// AppKit posts this notification only for user-initiated live scrolling, including
+        /// trackpad gestures and scroller tracking. Programmatic Follow Live scrolling does not
+        /// pass through this path, so it cannot turn itself off.
+        func observeUserScrolling(in scrollView: NSScrollView) {
+            if let userScrollObserver {
+                NotificationCenter.default.removeObserver(userScrollObserver)
+            }
+            userScrollObserver = NotificationCenter.default.addObserver(
+                forName: NSScrollView.didLiveScrollNotification,
+                object: scrollView,
+                queue: .main
+            ) { [weak self] _ in
+                MainActor.assumeIsolated {
+                    self?.parent.onUserScroll?()
+                }
+            }
+        }
 
         func numberOfRows(in tableView: NSTableView) -> Int {
             rows.count

--- a/Rockxy/Views/RequestList/StatusBarView.swift
+++ b/Rockxy/Views/RequestList/StatusBarView.swift
@@ -539,12 +539,10 @@ struct StatusBarView: View {
             HStack(spacing: 0) {
                 FooterPrimaryButton(
                     title: String(localized: "Follow Live"),
-                    systemImage: isFollowingLiveTraffic
-                        ? "dot.radiowaves.right"
-                        : "arrow.down.to.line",
+                    systemImage: "dot.radiowaves.right",
                     help: isFollowingLiveTraffic
-                        ? String(localized: "Following the newest visible request. Select a row to stop following.")
-                        : String(localized: "Follow the newest request that matches the current view."),
+                        ? String(localized: "Follow Live is on. Scroll, select a row, or click again to stop.")
+                        : String(localized: "Keep the newest request in the current view selected."),
                     isActive: isFollowingLiveTraffic,
                     action: onFollowLive
                 )

--- a/Rockxy/Views/RequestList/StatusBarView.swift
+++ b/Rockxy/Views/RequestList/StatusBarView.swift
@@ -431,20 +431,28 @@ private struct FooterToolingChrome: ViewModifier {
 
 private struct FooterPrimaryButton: View {
     let title: String
+    let systemImage: String
+    let help: String
     var isActive = false
     let action: () -> Void
 
     var body: some View {
         Button(action: action) {
-            Text(title)
-                .font(metrics.swiftUIFont())
-                .foregroundStyle(isActive ? Color.accentColor : Color(nsColor: .labelColor))
-                .lineLimit(1)
-                .padding(.horizontal, 16)
-                .padding(.vertical, 6)
-                .background(backgroundColor, in: RoundedRectangle(cornerRadius: 7, style: .continuous))
+            ViewThatFits(in: .horizontal) {
+                Label(title, systemImage: systemImage)
+                Image(systemName: systemImage)
+            }
+            .font(metrics.swiftUIFont())
+            .foregroundStyle(isActive ? Color.accentColor : Color(nsColor: .labelColor))
+            .lineLimit(1)
+            .padding(.horizontal, 9)
+            .padding(.vertical, 4)
+            .background(backgroundColor, in: RoundedRectangle(cornerRadius: 6, style: .continuous))
         }
         .buttonStyle(.plain)
+        .help(help)
+        .accessibilityLabel(title)
+        .accessibilityValue(isActive ? String(localized: "On") : String(localized: "Off"))
         .onHover { isHovered = $0 }
     }
 
@@ -475,7 +483,7 @@ enum StatusBarRequestSummary {
     ) -> String {
         if activeFilterCount > 0, visibleCount != availableCount {
             if selectedCount > 0 {
-                return String(localized: "\(selectedCount) selected · \(visibleCount) of \(availableCount) shown")
+                return String(localized: "\(selectedCount) selected, \(visibleCount) of \(availableCount) shown")
             }
             return String(localized: "\(visibleCount) of \(availableCount) requests")
         }
@@ -492,7 +500,7 @@ enum StatusBarRequestSummary {
 // MARK: - StatusBarView
 
 /// Bottom status bar showing request counts, bandwidth stats (upload/download speed),
-/// and quick-action buttons for clearing, toggling filters, and auto-select mode.
+/// and quick-action buttons for clearing, filtering, and opt-in live-tail selection.
 struct StatusBarView: View {
     // MARK: Internal
 
@@ -508,7 +516,7 @@ struct StatusBarView: View {
     var isProxyOverridden: Bool = false
     var isAllowListActive: Bool = false
     var isNoCachingActive: Bool = false
-    var isAutoSelectEnabled: Bool = true
+    var isFollowingLiveTraffic: Bool = false
     var isFilterBarVisible: Bool = false
     var activeFilterCount: Int = 0
     var errorCount: Int = 0
@@ -522,13 +530,29 @@ struct StatusBarView: View {
 
     var onClear: () -> Void = {}
     var onFilter: () -> Void = {}
-    var onAutoSelect: () -> Void = {}
+    var onFollowLive: () -> Void = {}
     var onSwitchOffProxyOverride: () -> Void = {}
     var onOpenToolWindow: (String) -> Void = { _ in }
 
     var body: some View {
         WorkspaceFooterBar(horizontalPadding: 12) {
             HStack(spacing: 0) {
+                FooterPrimaryButton(
+                    title: String(localized: "Follow Live"),
+                    systemImage: isFollowingLiveTraffic
+                        ? "dot.radiowaves.right"
+                        : "arrow.down.to.line",
+                    help: isFollowingLiveTraffic
+                        ? String(localized: "Following the newest visible request. Select a row to stop following.")
+                        : String(localized: "Follow the newest request that matches the current view."),
+                    isActive: isFollowingLiveTraffic,
+                    action: onFollowLive
+                )
+
+                Divider()
+                    .frame(height: 12)
+                    .padding(.horizontal, 8)
+
                 quickTools
                 mutationIndicators
                 Spacer(minLength: 24)

--- a/Rockxy/Views/Rules/MapLocalWindowView.swift
+++ b/Rockxy/Views/Rules/MapLocalWindowView.swift
@@ -915,7 +915,7 @@ struct MapLocalEditorWindowView: View {
             .textFieldStyle(.roundedBorder)
             .frame(width: 84, height: toolMetrics.formControlHeight)
             .accessibilityLabel(String(localized: "HTTP response status code"))
-            Text(String(localized: "Applied to every response from this rule · Valid range: 100–599"))
+            Text(String(localized: "Applied to every response from this rule. Valid range: 100–599."))
                 .font(toolMetrics.secondaryFont())
                 .foregroundStyle(.secondary)
             Spacer()

--- a/Rockxy/Views/Settings/AdvancedProxySettingsView.swift
+++ b/Rockxy/Views/Settings/AdvancedProxySettingsView.swift
@@ -187,7 +187,9 @@ struct AdvancedProxySettingsView: View {
         case .unreachable:
             "xmark.circle.fill"
         case .signingMismatch:
-            if case .appSignatureInvalid = helperManager.signingIssue {
+            if case .applicationMustReopen = helperManager.signingIssue {
+                "arrow.clockwise.circle.fill"
+            } else if case .appSignatureInvalid = helperManager.signingIssue {
                 "xmark.seal.fill"
             } else {
                 "exclamationmark.triangle.fill"
@@ -209,7 +211,9 @@ struct AdvancedProxySettingsView: View {
         case .unreachable:
             .red
         case .signingMismatch:
-            if case .appSignatureInvalid = helperManager.signingIssue {
+            if case .applicationMustReopen = helperManager.signingIssue {
+                .orange
+            } else if case .appSignatureInvalid = helperManager.signingIssue {
                 .red
             } else {
                 .orange
@@ -232,7 +236,9 @@ struct AdvancedProxySettingsView: View {
         case .unreachable:
             String(localized: "Installed But Unreachable")
         case .signingMismatch:
-            if case .appSignatureInvalid = helperManager.signingIssue {
+            if case .applicationMustReopen = helperManager.signingIssue {
+                String(localized: "Reopen Required")
+            } else if case .appSignatureInvalid = helperManager.signingIssue {
                 String(localized: "Invalid App Signature")
             } else {
                 String(localized: "Signing Mismatch")
@@ -633,7 +639,11 @@ struct AdvancedProxySettingsView: View {
                 .disabled(helperManager.isBusy)
 
             case .signingMismatch:
-                if case .identityMismatch = helperManager.signingIssue {
+                if case .applicationMustReopen = helperManager.signingIssue {
+                    Button(String(localized: "Quit Rockxy")) {
+                        HelperRecoveryPresenter.requestRequiredReopen()
+                    }
+                } else if case .identityMismatch = helperManager.signingIssue {
                     Button(String(localized: "Reinstall Helper")) {
                         reinstallHelper()
                     }
@@ -652,12 +662,14 @@ struct AdvancedProxySettingsView: View {
             }
         }
 
-        Button(role: .destructive) {
-            HelperRecoveryPresenter.presentForceReset()
-        } label: {
-            Text(String(localized: "Force Reset…"))
+        if helperManager.signingIssue != .applicationMustReopen {
+            Button(role: .destructive) {
+                HelperRecoveryPresenter.presentForceReset()
+            } label: {
+                Text(String(localized: "Force Reset…"))
+            }
+            .disabled(helperManager.isBusy)
         }
-        .disabled(helperManager.isBusy)
     }
 
     // MARK: - Footer

--- a/Rockxy/Views/Settings/AdvancedSettingsTab.swift
+++ b/Rockxy/Views/Settings/AdvancedSettingsTab.swift
@@ -141,7 +141,11 @@ struct AdvancedSettingsTab: View {
                                 }
                                 .disabled(helperManager.isBusy)
                             case .signingMismatch:
-                                if case .identityMismatch = helperManager.signingIssue {
+                                if case .applicationMustReopen = helperManager.signingIssue {
+                                    Button(String(localized: "Quit Rockxy")) {
+                                        HelperRecoveryPresenter.requestRequiredReopen()
+                                    }
+                                } else if case .identityMismatch = helperManager.signingIssue {
                                     Button(String(localized: "Reinstall Helper")) {
                                         reinstallHelper()
                                     }
@@ -158,12 +162,14 @@ struct AdvancedSettingsTab: View {
                                 }
                             }
 
-                            Button(role: .destructive) {
-                                HelperRecoveryPresenter.presentForceReset()
-                            } label: {
-                                Text(String(localized: "Force Reset…"))
+                            if helperManager.signingIssue != .applicationMustReopen {
+                                Button(role: .destructive) {
+                                    HelperRecoveryPresenter.presentForceReset()
+                                } label: {
+                                    Text(String(localized: "Force Reset…"))
+                                }
+                                .disabled(helperManager.isBusy)
                             }
-                            .disabled(helperManager.isBusy)
                         }
                     }
                 }
@@ -233,7 +239,9 @@ struct AdvancedSettingsTab: View {
         case .unreachable:
             "xmark.circle.fill"
         case .signingMismatch:
-            if case .appSignatureInvalid = helperManager.signingIssue {
+            if case .applicationMustReopen = helperManager.signingIssue {
+                "arrow.clockwise.circle.fill"
+            } else if case .appSignatureInvalid = helperManager.signingIssue {
                 "xmark.seal.fill"
             } else {
                 "exclamationmark.triangle.fill"
@@ -255,7 +263,9 @@ struct AdvancedSettingsTab: View {
         case .unreachable:
             .red
         case .signingMismatch:
-            if case .appSignatureInvalid = helperManager.signingIssue {
+            if case .applicationMustReopen = helperManager.signingIssue {
+                .orange
+            } else if case .appSignatureInvalid = helperManager.signingIssue {
                 .red
             } else {
                 .orange
@@ -277,7 +287,9 @@ struct AdvancedSettingsTab: View {
         case .unreachable:
             String(localized: "Unreachable")
         case .signingMismatch:
-            if case .appSignatureInvalid = helperManager.signingIssue {
+            if case .applicationMustReopen = helperManager.signingIssue {
+                String(localized: "Reopen Required")
+            } else if case .appSignatureInvalid = helperManager.signingIssue {
                 String(localized: "Invalid App Signature")
             } else {
                 String(localized: "Signing Mismatch")

--- a/Rockxy/Views/Settings/AssistantRuntimeSetupSheet.swift
+++ b/Rockxy/Views/Settings/AssistantRuntimeSetupSheet.swift
@@ -274,10 +274,10 @@ struct AssistantRuntimeSetupSheet: View {
     private func downloadStatus(receivedBytes: Int64, totalBytes: Int64?) -> String {
         let received = ByteCountFormatter.string(fromByteCount: receivedBytes, countStyle: .file)
         guard let totalBytes, totalBytes > 0 else {
-            return String(localized: "Downloading official runtime · \(received)")
+            return String(localized: "Downloading official runtime: \(received)")
         }
         let total = ByteCountFormatter.string(fromByteCount: totalBytes, countStyle: .file)
-        return String(localized: "Downloading official runtime · \(received) of \(total)")
+        return String(localized: "Downloading official runtime: \(received) of \(total)")
     }
 }
 

--- a/Rockxy/Views/Settings/AssistantSettingsTab.swift
+++ b/Rockxy/Views/Settings/AssistantSettingsTab.swift
@@ -439,7 +439,7 @@ struct AssistantSettingsTab: View {
                     VStack(alignment: .leading, spacing: 6) {
                         SecureField(
                             viewModel.hasStoredCredential
-                                ? String(localized: "Saved in Keychain · enter to replace")
+                                ? String(localized: "Saved in Keychain. Enter a new key to replace it.")
                                 : String(localized: "API key"),
                             text: $viewModel.credentialInput
                         )
@@ -706,7 +706,7 @@ struct AssistantSettingsTab: View {
         guard !provider.isImplemented else {
             return provider.title
         }
-        return String(localized: "\(provider.title) · adapter pending")
+        return String(localized: "Adapter pending for \(provider.title)")
     }
 
     @ViewBuilder private var endpointSecurityLabel: some View {
@@ -842,9 +842,9 @@ final class AssistantSettingsViewModel {
 
     var availableModelsDetail: String {
         if models.count == 1 {
-            return String(localized: "1 model available · refreshes automatically after local downloads.")
+            return String(localized: "1 model available. The list refreshes after local downloads.")
         }
-        return String(localized: "\(models.count) models available · refreshes automatically after local downloads.")
+        return String(localized: "\(models.count) models available. The list refreshes after local downloads.")
     }
 
     var ollamaRuntimeTitle: String {

--- a/Rockxy/Views/Settings/HelperRecoveryPresenter.swift
+++ b/Rockxy/Views/Settings/HelperRecoveryPresenter.swift
@@ -5,6 +5,14 @@ import ServiceManagement
 enum HelperRecoveryPresenter {
     // MARK: Internal
 
+    static func requestRequiredReopen() {
+        if let appDelegate = NSApp.delegate as? AppDelegate {
+            appDelegate.requestQuitForRequiredReopen()
+        } else {
+            NSApp.terminate(nil)
+        }
+    }
+
     static func presentForceReset(stopCapture: (() -> Void)? = nil) {
         let confirmation = NSAlert()
         confirmation.alertStyle = .critical
@@ -77,6 +85,11 @@ enum HelperRecoveryPresenter {
         stopCapture: (() -> Void)?,
         canTryBackgroundItemsReset: Bool
     ) {
+        if error as? HelperManager.HelperOperationError == .applicationMustReopen {
+            presentRequiredReopen()
+            return
+        }
+
         let alert = NSAlert()
         alert.alertStyle = .critical
         alert.messageText = String(localized: "Helper reset failed")
@@ -101,6 +114,20 @@ enum HelperRecoveryPresenter {
             NSPasteboard.general.clearContents()
             NSPasteboard.general.setString(error.localizedDescription, forType: .string)
         }
+    }
+
+    private static func presentRequiredReopen() {
+        let alert = NSAlert()
+        alert.alertStyle = .warning
+        alert.messageText = String(localized: "Reopen Rockxy to continue")
+        alert.informativeText = HelperManager.applicationMustReopenMessage
+        alert.addButton(withTitle: String(localized: "Quit Rockxy"))
+        alert.addButton(withTitle: String(localized: "Not Now"))
+
+        guard alert.runModal() == .alertFirstButtonReturn else {
+            return
+        }
+        requestRequiredReopen()
     }
 
     private static func presentBackgroundItemsResetConfirmation(stopCapture: (() -> Void)?) {

--- a/Rockxy/Views/Sidebar/FocusSetEditorSheet.swift
+++ b/Rockxy/Views/Sidebar/FocusSetEditorSheet.swift
@@ -18,6 +18,7 @@ struct FocusSetEditorSheet: View {
         self.onSave = onSave
         suggestions = FocusSetEditorSuggestions(transactions: transactions)
         _draft = State(initialValue: initialValue)
+        _usesSuggestedName = State(initialValue: isCreating && initialValue.name == initialValue.suggestedName)
     }
 
     // MARK: Internal
@@ -36,12 +37,25 @@ struct FocusSetEditorSheet: View {
             actionBar
         }
         .frame(width: 600, height: 570)
+        .onChange(of: draft.suggestedName) { _, suggestedName in
+            guard isCreating, usesSuggestedName else {
+                return
+            }
+            draft.name = suggestedName
+        }
+        .onChange(of: draft.name) { _, name in
+            guard isCreating, name != draft.suggestedName else {
+                return
+            }
+            usesSuggestedName = false
+        }
     }
 
     // MARK: Private
 
     @Environment(\.dismiss) private var dismiss
     @State private var draft: FocusSet
+    @State private var usesSuggestedName: Bool
 
     private let suggestions: FocusSetEditorSuggestions
 

--- a/Rockxy/Views/Sidebar/FocusSetSidebarRow.swift
+++ b/Rockxy/Views/Sidebar/FocusSetSidebarRow.swift
@@ -13,83 +13,18 @@ struct FocusSetSidebarRow: View {
     let onApply: () -> Void
 
     var body: some View {
-        DisclosureGroup(isExpanded: $isExpanded) {
-            VStack(alignment: .leading, spacing: 7) {
-                if !focusSet.includedRules.isEmpty {
-                    ruleGroup(
-                        title: String(localized: "Include · all must match"),
-                        systemImage: "checkmark.circle",
-                        rules: focusSet.includedRules
-                    )
-                }
-                if !focusSet.excludedRules.isEmpty {
-                    ruleGroup(
-                        title: String(localized: "Exclude · any match is hidden"),
-                        systemImage: "minus.circle",
-                        rules: focusSet.excludedRules
-                    )
-                }
+        if focusSet.hasSidebarRuleDetails {
+            DisclosureGroup(isExpanded: $isExpanded) {
+                ruleDetails
+            } label: {
+                rowLabel
             }
-            .padding(.top, 4)
-            .padding(.leading, 2)
-        } label: {
-            Button(action: onApply) {
-                HStack(alignment: .top, spacing: 7) {
-                    leadingIcon
-
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text(focusSet.name)
-                            .font(.body)
-                            .foregroundStyle(.primary)
-                            .lineLimit(1)
-                        Text(compactSummary)
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                            .lineLimit(2)
-                            .truncationMode(.middle)
-                    }
-
-                    Spacer(minLength: 6)
-
-                    Text(ruleCountLabel)
-                        .font(.caption.monospacedDigit())
-                        .foregroundStyle(.secondary)
-
-                    if isActive {
-                        Image(systemName: "checkmark")
-                            .font(.caption.weight(.semibold))
-                            .foregroundStyle(Color.accentColor)
-                            .accessibilityLabel(String(localized: "Active"))
-                    }
-                }
-                .contentShape(Rectangle())
-            }
-            .buttonStyle(.plain)
-            .help(isActive
-                ? String(localized: "This Focus Set is active. Click to reapply it.")
-                : String(localized: "Apply this Focus Set."))
+        } else {
+            rowLabel
         }
     }
 
     // MARK: Private
-
-    private var compactSummary: String {
-        let includes = focusSet.includedRules.map(compactRule).joined(separator: " · ")
-        let excludes = focusSet.excludedRules.map(compactRule).joined(separator: " · ")
-        guard !excludes.isEmpty else {
-            return includes
-        }
-        guard !includes.isEmpty else {
-            return String(localized: "Exclude \(excludes)")
-        }
-        return String(localized: "\(includes) · except \(excludes)")
-    }
-
-    private var ruleCountLabel: String {
-        focusSet.ruleCount == 1
-            ? String(localized: "1 rule")
-            : String(localized: "\(focusSet.ruleCount) rules")
-    }
 
     @ViewBuilder private var leadingIcon: some View {
         if focusSet.appName.isEmpty {
@@ -99,6 +34,69 @@ struct FocusSetSidebarRow: View {
         } else {
             CapturedApplicationIconView(name: focusSet.appName, size: 20)
         }
+    }
+
+    private var rowLabel: some View {
+        Button(action: onApply) {
+            HStack(alignment: .top, spacing: 7) {
+                leadingIcon
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(focusSet.displayName)
+                        .font(.body)
+                        .foregroundStyle(.primary)
+                        .lineLimit(1)
+
+                    if !isExpanded, let summary = focusSet.sidebarScopeSummary {
+                        Text(summary)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(2)
+                            .truncationMode(.middle)
+                    }
+                }
+
+                Spacer(minLength: 6)
+
+                if isActive {
+                    Image(systemName: "checkmark")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(Color.accentColor)
+                        .accessibilityLabel(String(localized: "Active"))
+                }
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .help(isActive
+            ? String(localized: "This Focus Set is active. Click to reapply it.")
+            : String(localized: "Apply this Focus Set."))
+        .accessibilityValue(
+            focusSet.ruleCount == 1
+                ? String(localized: "1 condition")
+                : String(localized: "\(focusSet.ruleCount) conditions")
+        )
+    }
+
+    @ViewBuilder private var ruleDetails: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            if !focusSet.sidebarIncludedRules.isEmpty {
+                ruleGroup(
+                    title: String(localized: "Show when all match"),
+                    systemImage: "checkmark.circle",
+                    rules: focusSet.sidebarIncludedRules
+                )
+            }
+            if !focusSet.sidebarExcludedRules.isEmpty {
+                ruleGroup(
+                    title: String(localized: "Hide when any match"),
+                    systemImage: "eye.slash",
+                    rules: focusSet.sidebarExcludedRules
+                )
+            }
+        }
+        .padding(.top, 4)
+        .padding(.leading, 2)
     }
 
     private func ruleGroup(
@@ -114,14 +112,11 @@ struct FocusSetSidebarRow: View {
                 .foregroundStyle(.secondary)
 
             ForEach(rules) { rule in
-                HStack(alignment: .firstTextBaseline, spacing: 6) {
-                    Image(systemName: "arrow.turn.down.right")
-                        .font(.caption2)
-                        .foregroundStyle(.tertiary)
-                        .frame(width: 14)
+                HStack(alignment: .firstTextBaseline, spacing: 8) {
                     Text(ruleLabel(rule.kind))
                         .font(.caption)
                         .foregroundStyle(.secondary)
+                        .frame(width: 68, alignment: .leading)
                     Text(rule.pattern)
                         .font(.caption.monospaced())
                         .lineLimit(1)
@@ -132,14 +127,10 @@ struct FocusSetSidebarRow: View {
         }
     }
 
-    private func compactRule(_ rule: FocusSetRuleDescriptor) -> String {
-        "\(ruleLabel(rule.kind)): \(rule.pattern)"
-    }
-
     private func ruleLabel(_ kind: FocusSetRuleDescriptor.Kind) -> String {
         switch kind {
         case .application:
-            String(localized: "App")
+            String(localized: "Application")
         case .domain:
             String(localized: "Domain")
         case .pathPrefix:

--- a/Rockxy/Views/Sidebar/SidebarView.swift
+++ b/Rockxy/Views/Sidebar/SidebarView.swift
@@ -310,7 +310,8 @@ struct SidebarView: View {
             } header: {
                 sidebarSectionHeader(
                     title: String(localized: "Focus Sets"),
-                    actionTitle: String(localized: "Add"),
+                    actionTitle: nil,
+                    actionSystemImage: "plus",
                     actionLabel: String(localized: "Create Focus Set"),
                     action: { editingFocusSet = coordinator.makeFocusSetFromCurrentScope() }
                 )
@@ -322,7 +323,8 @@ struct SidebarView: View {
             } header: {
                 sidebarSectionHeader(
                     title: String(localized: "Noise Control"),
-                    actionTitle: String(localized: "Configure"),
+                    actionTitle: nil,
+                    actionSystemImage: "slider.horizontal.3",
                     actionLabel: String(localized: "Configure Noise Control"),
                     action: { isMutedSourcesPresented = true }
                 )
@@ -358,7 +360,8 @@ struct SidebarView: View {
 
     private func sidebarSectionHeader(
         title: String,
-        actionTitle: String,
+        actionTitle: String?,
+        actionSystemImage: String?,
         actionLabel: String,
         action: @escaping () -> Void
     )
@@ -368,13 +371,17 @@ struct SidebarView: View {
             Text(title)
             Spacer(minLength: 8)
             Button(action: action) {
-                Label(actionTitle, systemImage: "plus")
-                    .labelStyle(.titleAndIcon)
-                    .font(.caption.weight(.medium))
+                if let actionSystemImage {
+                    Image(systemName: actionSystemImage)
+                        .frame(width: 18, height: 18)
+                } else if let actionTitle {
+                    Text(actionTitle)
+                        .font(.caption.weight(.medium))
+                }
             }
-            .buttonStyle(.bordered)
+            .buttonStyle(.borderless)
             .controlSize(.small)
-            .foregroundStyle(.primary)
+            .foregroundStyle(.secondary)
             .help(actionLabel)
             .accessibilityLabel(actionLabel)
         }
@@ -405,8 +412,8 @@ struct SidebarView: View {
         .buttonStyle(.plain)
         .listRowBackground(isActive ? Color.accentColor.opacity(0.12) : Color.clear)
         .help(isActive
-            ? String(localized: "Clear \(signal.title) · \(signal.explanation)")
-            : String(localized: "Show \(signal.title) · \(signal.explanation)"))
+            ? String(localized: "Clear the \(signal.title) filter. \(signal.explanation)")
+            : String(localized: "Show \(signal.title) traffic. \(signal.explanation)"))
     }
 
     private var favoritesSection: some View {

--- a/Rockxy/Views/Sidebar/SidebarView.swift
+++ b/Rockxy/Views/Sidebar/SidebarView.swift
@@ -196,8 +196,8 @@ struct SidebarView: View {
     @State private var editingFocusSet: FocusSet?
     @State private var isMutedSourcesPresented = false
     @State private var expandedFocusSetIDs: Set<UUID> = []
-    @State private var isAppsExpanded = false
-    @State private var isDomainsExpanded = false
+    @State private var isAppsExpanded = SidebarDisclosureDefaults.appsExpanded
+    @State private var isDomainsExpanded = SidebarDisclosureDefaults.domainsExpanded
     @State private var isPinnedExpanded = false
     @State private var isSavedExpanded = false
     @State private var isNotesExpanded = false
@@ -1178,4 +1178,11 @@ struct SidebarView: View {
             Label(String(localized: "Delete"), systemImage: "trash")
         }
     }
+}
+
+// MARK: - SidebarDisclosureDefaults
+
+enum SidebarDisclosureDefaults {
+    static let appsExpanded = true
+    static let domainsExpanded = true
 }

--- a/Rockxy/Views/Sidebar/SidebarView.swift
+++ b/Rockxy/Views/Sidebar/SidebarView.swift
@@ -379,7 +379,7 @@ struct SidebarView: View {
                         .font(.caption.weight(.medium))
                 }
             }
-            .buttonStyle(.borderless)
+            .buttonStyle(.bordered)
             .controlSize(.small)
             .foregroundStyle(.secondary)
             .help(actionLabel)

--- a/Rockxy/Views/Toolbar/ActiveFilterSummaryBar.swift
+++ b/Rockxy/Views/Toolbar/ActiveFilterSummaryBar.swift
@@ -23,7 +23,7 @@ struct ActiveFilterSummaryBar: View {
                     }
 
                     if let focusSet = coordinator.activeWorkspace.activeFocusSet {
-                        FilterChip(label: String(localized: "Focus: \(focusSet.name)")) {
+                        FilterChip(label: String(localized: "Focus: \(focusSet.displayName)")) {
                             coordinator.applyFocusSet(nil)
                         }
                     }

--- a/Rockxy/Views/Toolbar/ProxyStatusIndicator.swift
+++ b/Rockxy/Views/Toolbar/ProxyStatusIndicator.swift
@@ -18,6 +18,9 @@ struct ProxyStatusIndicator: View {
     let port: Int
     let updateStatusSummary: AppUpdater.UpdateStatusSummary?
     let openUpdates: () -> Void
+    let readiness: ReadinessCoordinator
+    let isSystemProxyConfigured: Bool
+    let onToggleCapture: () -> Void
 
     @Binding var showPopover: Bool
 
@@ -34,14 +37,17 @@ struct ProxyStatusIndicator: View {
                         .foregroundStyle(.secondary)
                         .lineLimit(1)
 
-                    if updateStatusSummary != nil {
-                        Text("|")
-                            .font(.system(size: metrics.badgeFontSize))
-                            .foregroundStyle(Color(nsColor: .tertiaryLabelColor))
-                    }
+                    Divider()
+                        .frame(height: 12)
+                        .accessibilityHidden(true)
+
+                    Text(listenerText)
+                        .font(.system(size: metrics.chromeFontSize, weight: .regular, design: .monospaced))
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
                 }
                 .padding(.leading, ProxyStatusChromeMetrics.horizontalPadding)
-                .padding(.trailing, updateStatusSummary == nil ? ProxyStatusChromeMetrics.horizontalPadding : 7)
+                .padding(.trailing, updateStatusSummary == nil ? ProxyStatusChromeMetrics.horizontalPadding : 8)
                 .frame(height: metrics.chromeControlHeight)
                 .contentShape(Capsule(style: .continuous))
             }
@@ -49,6 +55,11 @@ struct ProxyStatusIndicator: View {
             .help(statusHelpText)
 
             if let updateStatusSummary {
+                Divider()
+                    .frame(height: 13)
+                    .padding(.horizontal, 2)
+                    .accessibilityHidden(true)
+
                 updateStatus(updateStatusSummary)
                     .padding(.trailing, ProxyStatusChromeMetrics.horizontalPadding)
                     .frame(height: metrics.chromeControlHeight)
@@ -58,9 +69,12 @@ struct ProxyStatusIndicator: View {
         .contentShape(Rectangle())
         .popover(isPresented: $showPopover) {
             ProxyStatusPopover(
+                displayState: displayState,
                 listenAddress: listenAddress,
                 port: port,
-                loopbackAddress: AppSettingsManager.shared.settings.loopbackAddress,
+                readiness: readiness,
+                isSystemProxyConfigured: isSystemProxyConfigured,
+                onToggleCapture: onToggleCapture,
                 showPopover: $showPopover
             )
         }
@@ -110,22 +124,28 @@ struct ProxyStatusIndicator: View {
     }
 
     private var statusText: String {
-        "Rockxy | \(listenAddress):\(port) | \(displayState.title)"
+        displayState.captureTitle
+    }
+
+    private var listenerText: String {
+        CaptureStatusPresentation.listener(address: listenAddress, port: port)
     }
 
     private var statusHelpText: String {
+        let captureContext = [
+            statusText,
+            String(localized: "Listening on \(listenerText)"),
+        ]
         if let updateStatusSummary {
-            [
-                statusText,
+            return (captureContext + [
                 updateStatusSummary.title,
                 updateStatusSummary.versionLine,
                 updateStatusSummary.countLine,
-            ]
+            ])
             .compactMap { $0 }
             .joined(separator: "\n")
-        } else {
-            statusText
         }
+        return captureContext.joined(separator: "\n")
     }
 
     @ViewBuilder

--- a/Rockxy/Views/Toolbar/ProxyStatusPopover.swift
+++ b/Rockxy/Views/Toolbar/ProxyStatusPopover.swift
@@ -1,55 +1,215 @@
 import SwiftUI
 
-// Presents the proxy status popover for toolbar controls and filtering.
+// Presents capture readiness and listener context from the main toolbar.
+
+// MARK: - CaptureReadinessLevel
+
+enum CaptureReadinessLevel: Equatable {
+    case ready
+    case attention
+    case neutral
+}
+
+// MARK: - CaptureReadinessItem
+
+struct CaptureReadinessItem: Equatable {
+    let value: String
+    let systemImage: String
+    let level: CaptureReadinessLevel
+}
+
+// MARK: - CaptureStatusPresentation
+
+/// Pure presentation decisions for the capture-status popover. Keeping listener scope and
+/// readiness wording outside the SwiftUI layout makes the security-sensitive state easy to test.
+struct CaptureStatusPresentation: Equatable {
+    // MARK: Lifecycle
+
+    init(
+        displayState: ProxyDisplayState,
+        listenAddress: String,
+        port: Int,
+        certReadiness: CertReadiness,
+        helperReadiness: HelperManager.HelperStatus,
+        isSystemProxyConfigured: Bool
+    ) {
+        title = displayState.captureTitle
+        description = displayState.captureDescription
+        systemImage = displayState.captureSystemImage
+        actionTitle = displayState.captureActionTitle
+        isActionEnabled = displayState != .starting
+        listener = Self.listener(address: listenAddress, port: port)
+        listenerScope = Self.listenerScope(address: listenAddress)
+        https = Self.httpsItem(certReadiness)
+        systemRouting = Self.systemRoutingItem(
+            displayState: displayState,
+            helperReadiness: helperReadiness,
+            isConfigured: isSystemProxyConfigured
+        )
+    }
+
+    // MARK: Internal
+
+    let title: String
+    let description: String
+    let systemImage: String
+    let actionTitle: String
+    let isActionEnabled: Bool
+    let listener: String
+    let listenerScope: String
+    let https: CaptureReadinessItem
+    let systemRouting: CaptureReadinessItem
+
+    static func listener(address: String, port: Int) -> String {
+        address.contains(":") ? "[\(address)]:\(port)" : "\(address):\(port)"
+    }
+
+    static func listenerScope(address: String) -> String {
+        switch address.lowercased() {
+        case "0.0.0.0",
+             "::":
+            String(localized: "This Mac and local network")
+        case "127.0.0.1",
+             "::1",
+             "localhost":
+            String(localized: "This Mac only")
+        default:
+            String(localized: "Selected network interface")
+        }
+    }
+
+    // MARK: Private
+
+    private static func httpsItem(_ readiness: CertReadiness) -> CaptureReadinessItem {
+        if readiness == .trusted {
+            return CaptureReadinessItem(
+                value: String(localized: "Ready"),
+                systemImage: "checkmark.circle.fill",
+                level: .ready
+            )
+        }
+        return CaptureReadinessItem(
+            value: readiness.localizedDescription,
+            systemImage: "exclamationmark.triangle.fill",
+            level: .attention
+        )
+    }
+
+    private static func systemRoutingItem(
+        displayState: ProxyDisplayState,
+        helperReadiness: HelperManager.HelperStatus,
+        isConfigured: Bool
+    )
+        -> CaptureReadinessItem
+    {
+        if isConfigured {
+            return CaptureReadinessItem(
+                value: String(localized: "Routing active"),
+                systemImage: "checkmark.circle.fill",
+                level: .ready
+            )
+        }
+        if displayState != .stopped {
+            return CaptureReadinessItem(
+                value: String(localized: "Manual app setup"),
+                systemImage: "arrow.triangle.branch",
+                level: .attention
+            )
+        }
+        if helperReadiness == .installedCompatible {
+            return CaptureReadinessItem(
+                value: String(localized: "Ready on start"),
+                systemImage: "checkmark.circle",
+                level: .ready
+            )
+        }
+        let value: String = switch helperReadiness {
+        case .requiresApproval:
+            String(localized: "Approval needed")
+        case .installedOutdated,
+             .installedIncompatible:
+            String(localized: "Update needed")
+        case .unreachable,
+             .signingMismatch:
+            String(localized: "Needs attention")
+        case .notInstalled:
+            String(localized: "Developer setup needed")
+        case .installedCompatible:
+            String(localized: "Ready on start")
+        }
+        return CaptureReadinessItem(
+            value: value,
+            systemImage: "wrench.and.screwdriver.fill",
+            level: .attention
+        )
+    }
+}
 
 // MARK: - ProxyStatusPopover
 
-/// Popover shown when clicking the toolbar status indicator. Displays the current
-/// proxy connection details (IP, port, loopback) and provides quick access to
-/// the Advanced Proxy Settings window.
+/// A capture-focused status surface. It explains readiness and listener reachability instead
+/// of repeating low-level address fields without telling the user whether capture will work.
 struct ProxyStatusPopover: View {
     // MARK: Internal
 
+    let displayState: ProxyDisplayState
     let listenAddress: String
     let port: Int
-    let loopbackAddress: String
+    let readiness: ReadinessCoordinator
+    let isSystemProxyConfigured: Bool
+    let onToggleCapture: () -> Void
 
     @Binding var showPopover: Bool
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            infoRow(label: String(localized: "IP:"), value: listenAddress)
-
-            HStack(spacing: 4) {
-                Text(String(localized: "Proxy Port:"))
-                    .font(.system(size: metrics.chromeFontSize))
-                    .foregroundStyle(.secondary)
-                Text("\(port)")
-                    .font(.system(size: metrics.chromeFontSize, weight: .medium, design: .monospaced))
-                Button {
-                    openWindow(id: "advancedProxySettings")
-                    showPopover = false
-                } label: {
-                    Image(systemName: "pencil")
-                        .font(.system(size: metrics.badgeFontSize))
-                        .foregroundStyle(.secondary)
-                }
-                .buttonStyle(.plain)
-                .help(String(localized: "Edit port in Advanced Settings"))
-            }
-
-            infoRow(label: String(localized: "Loopback:"), value: loopbackAddress)
+        VStack(alignment: .leading, spacing: 14) {
+            captureHeader
 
             Divider()
 
-            Button(String(localized: "Advanced Settings…")) {
-                openWindow(id: "advancedProxySettings")
-                showPopover = false
+            Grid(alignment: .leading, horizontalSpacing: 12, verticalSpacing: 9) {
+                valueRow(
+                    label: String(localized: "Listening"),
+                    value: presentation.listener,
+                    systemImage: "network",
+                    level: .neutral,
+                    isMonospaced: true
+                )
+                valueRow(
+                    label: String(localized: "Reachable from"),
+                    value: presentation.listenerScope,
+                    systemImage: "macbook.and.iphone",
+                    level: .neutral
+                )
+                valueRow(
+                    label: String(localized: "HTTPS decryption"),
+                    item: presentation.https
+                )
+                valueRow(
+                    label: String(localized: "System routing"),
+                    item: presentation.systemRouting
+                )
             }
-            .controlSize(.regular)
+
+            Divider()
+
+            HStack(spacing: 8) {
+                Button(String(localized: "Developer Setup…")) {
+                    openWindow(id: "developerSetupHub")
+                    showPopover = false
+                }
+
+                Spacer()
+
+                Button(String(localized: "Advanced Settings…")) {
+                    openWindow(id: "advancedProxySettings")
+                    showPopover = false
+                }
+            }
+            .controlSize(.small)
         }
-        .padding(14)
-        .frame(width: 240)
+        .padding(16)
+        .frame(width: 360)
     }
 
     // MARK: Private
@@ -57,13 +217,116 @@ struct ProxyStatusPopover: View {
     @Environment(\.openWindow) private var openWindow
     @Environment(\.appUIDisplayMetrics) private var metrics
 
-    private func infoRow(label: String, value: String) -> some View {
-        HStack(spacing: 4) {
+    private var presentation: CaptureStatusPresentation {
+        CaptureStatusPresentation(
+            displayState: displayState,
+            listenAddress: listenAddress,
+            port: port,
+            certReadiness: readiness.certReadiness,
+            helperReadiness: readiness.helperReadiness,
+            isSystemProxyConfigured: isSystemProxyConfigured
+        )
+    }
+
+    private var captureHeader: some View {
+        HStack(alignment: .top, spacing: 12) {
+            Image(systemName: presentation.systemImage)
+                .font(.system(size: 24, weight: .medium))
+                .foregroundStyle(headerColor)
+                .frame(width: 30, height: 30)
+                .accessibilityHidden(true)
+
+            VStack(alignment: .leading, spacing: 3) {
+                Text(presentation.title)
+                    .font(.headline)
+                Text(presentation.description)
+                    .font(.system(size: metrics.secondaryFontSize))
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Spacer(minLength: 4)
+
+            if displayState == .starting {
+                ProgressView()
+                    .controlSize(.small)
+                    .accessibilityLabel(presentation.actionTitle)
+            } else {
+                Button(presentation.actionTitle) {
+                    onToggleCapture()
+                    showPopover = false
+                }
+                .controlSize(.small)
+                .disabled(!presentation.isActionEnabled)
+            }
+        }
+    }
+
+    private var headerColor: Color {
+        switch displayState {
+        case .running:
+            Color(nsColor: .systemGreen)
+        case .paused:
+            Color(nsColor: .systemOrange)
+        case .starting:
+            Color.accentColor
+        case .stopped:
+            Color(nsColor: .secondaryLabelColor)
+        }
+    }
+
+    private func valueRow(
+        label: String,
+        item: CaptureReadinessItem
+    )
+        -> some View
+    {
+        valueRow(
+            label: label,
+            value: item.value,
+            systemImage: item.systemImage,
+            level: item.level
+        )
+    }
+
+    private func valueRow(
+        label: String,
+        value: String,
+        systemImage: String,
+        level: CaptureReadinessLevel,
+        isMonospaced: Bool = false
+    )
+        -> some View
+    {
+        GridRow {
             Text(label)
                 .font(.system(size: metrics.chromeFontSize))
                 .foregroundStyle(.secondary)
-            Text(value)
-                .font(.system(size: metrics.chromeFontSize, weight: .medium, design: .monospaced))
+
+            HStack(spacing: 6) {
+                Image(systemName: systemImage)
+                    .font(.system(size: metrics.badgeFontSize, weight: .semibold))
+                    .foregroundStyle(color(for: level))
+                    .accessibilityHidden(true)
+                Text(value)
+                    .font(isMonospaced
+                        ? .system(size: metrics.chromeFontSize, weight: .medium, design: .monospaced)
+                        : .system(size: metrics.chromeFontSize, weight: .medium))
+                    .lineLimit(2)
+            }
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(value)
+    }
+
+    private func color(for level: CaptureReadinessLevel) -> Color {
+        switch level {
+        case .ready:
+            Color(nsColor: .systemGreen)
+        case .attention:
+            Color(nsColor: .systemOrange)
+        case .neutral:
+            Color(nsColor: .secondaryLabelColor)
         }
     }
 }

--- a/Rockxy/Views/Toolbar/ProxyToolbarContent.swift
+++ b/Rockxy/Views/Toolbar/ProxyToolbarContent.swift
@@ -77,6 +77,15 @@ struct ProxyToolbarContent: ToolbarContent {
                 openUpdates: {
                     updater.showUpdatesFromStatusBadge()
                 },
+                readiness: coordinator.readiness,
+                isSystemProxyConfigured: coordinator.isSystemProxyConfigured,
+                onToggleCapture: {
+                    if coordinator.isProxyRunning {
+                        coordinator.stopProxy()
+                    } else {
+                        coordinator.startProxy()
+                    }
+                },
                 showPopover: $coordinator.showProxyStatusPopover
             )
         }
@@ -106,6 +115,15 @@ struct ProxyToolbarStatusView: View {
             updateStatusSummary: updater.updateStatusSummary,
             openUpdates: {
                 updater.showUpdatesFromStatusBadge()
+            },
+            readiness: coordinator.readiness,
+            isSystemProxyConfigured: coordinator.isSystemProxyConfigured,
+            onToggleCapture: {
+                if coordinator.isProxyRunning {
+                    coordinator.stopProxy()
+                } else {
+                    coordinator.startProxy()
+                }
             },
             showPopover: $coordinator.showProxyStatusPopover
         )

--- a/Rockxy/Views/Welcome/WelcomeView.swift
+++ b/Rockxy/Views/Welcome/WelcomeView.swift
@@ -426,7 +426,9 @@ struct WelcomeView: View {
              .installedIncompatible:
             await viewModel.updateHelper()
         case .signingMismatch:
-            if case .identityMismatch = viewModel.helperSigningIssue {
+            if case .applicationMustReopen = viewModel.helperSigningIssue {
+                HelperRecoveryPresenter.requestRequiredReopen()
+            } else if case .identityMismatch = viewModel.helperSigningIssue {
                 await viewModel.reinstallHelper()
             }
         case .unreachable:

--- a/RockxyTests/Core/ProxyEngine/HelperConnectionTests.swift
+++ b/RockxyTests/Core/ProxyEngine/HelperConnectionTests.swift
@@ -42,12 +42,19 @@ struct HelperConnectionErrorTests {
         #expect(description.contains("timed out"))
     }
 
-    @Test("appSignatureInvalid includes detail in description")
+    @Test("appSignatureInvalid keeps technical detail out of end-user copy")
     func appSignatureInvalidDescription() {
         let error = HelperConnectionError.appSignatureInvalid("stale build")
         let description = error.errorDescription ?? ""
-        #expect(description.contains("code signature"))
-        #expect(description.contains("stale build"))
+        #expect(description.contains("fresh copy"))
+        #expect(!description.contains("stale build"))
+    }
+
+    @Test("applicationMustReopen gives an end-user recovery step")
+    func applicationMustReopenDescription() {
+        let description = HelperConnectionError.applicationMustReopen.errorDescription ?? ""
+        #expect(description.contains("Quit and reopen Rockxy"))
+        #expect(!description.localizedLowercase.contains("rebuild"))
     }
 
     @Test("signingIdentityMismatch includes signer names in description")
@@ -66,6 +73,7 @@ struct HelperConnectionErrorTests {
             .proxyRestoreFailed("test"),
             .uninstallFailed,
             .xpcTimeout,
+            .applicationMustReopen,
             .appSignatureInvalid("test"),
             .signingIdentityMismatch(app: "test", helper: "test"),
         ]

--- a/RockxyTests/Core/ProxyEngine/HelperManagerTests.swift
+++ b/RockxyTests/Core/ProxyEngine/HelperManagerTests.swift
@@ -335,6 +335,14 @@ struct HelperManagerTests {
 
     // MARK: - Probe Error Classification
 
+    @Test("classifyProbeError preserves required reopen recovery")
+    @MainActor
+    func classifyProbeErrorApplicationMustReopen() {
+        let probe = HelperManager.classifyProbeError(.applicationMustReopen)
+        #expect(probe == .applicationMustReopen)
+        #expect(HelperManager.decideRecovery(probe: probe) == .surfaceApplicationMustReopen)
+    }
+
     @Test("classifyProbeError maps appSignatureInvalid")
     @MainActor
     func classifyProbeErrorAppSignature() {
@@ -412,6 +420,22 @@ struct HelperManagerTests {
         #expect(label == nil)
     }
 
+    @Test("required reopen produces a quit action without developer wording")
+    @MainActor
+    func requiredReopenActionAndWarning() {
+        let label = HelperManager.helperActionLabel(
+            status: .signingMismatch,
+            signingIssue: .applicationMustReopen
+        )
+        let reason = HelperManager.signingMismatchWarningReason(
+            issue: .applicationMustReopen
+        )
+
+        #expect(label == String(localized: "Quit Rockxy"))
+        #expect(reason.localizedLowercase.contains("reopened"))
+        #expect(!reason.localizedLowercase.contains("rebuild"))
+    }
+
     @Test("identityMismatch produces reinstall action label")
     @MainActor
     func identityMismatchReinstallLabel() {
@@ -432,12 +456,13 @@ struct HelperManagerTests {
         #expect(label == nil)
     }
 
-    @Test("appSignatureInvalid warning mentions clean build")
+    @Test("appSignatureInvalid warning guides a fresh install")
     func appSignatureInvalidWarning() {
         let reason = HelperManager.signingMismatchWarningReason(
             issue: .appSignatureInvalid(detail: "stale")
         )
-        #expect(reason.localizedLowercase.contains("clean"))
+        #expect(reason.localizedLowercase.contains("fresh copy"))
+        #expect(!reason.localizedLowercase.contains("rebuild"))
     }
 
     @Test("identityMismatch warning mentions reinstall")

--- a/RockxyTests/Core/ProxyEngine/SSLProxyingManagerTests.swift
+++ b/RockxyTests/Core/ProxyEngine/SSLProxyingManagerTests.swift
@@ -197,6 +197,18 @@ struct SSLProxyingManagerTests {
         #expect(!manager.isAutoPassthrough("other.com"))
     }
 
+    @Test("retrying interception clears only the requested auto passthrough host")
+    func retryInterceptionClearsRequestedHost() {
+        let manager = makeManager()
+        manager.markHostForPassthrough("API.example.com")
+        manager.markHostForPassthrough("other.com")
+
+        #expect(manager.retryInterception(for: "api.example.com"))
+        #expect(!manager.isAutoPassthrough("API.example.com"))
+        #expect(manager.isAutoPassthrough("other.com"))
+        #expect(!manager.retryInterception(for: "missing.example.com"))
+    }
+
     // MARK: - Bypass Domains
 
     @Test("shouldIntercept returns false for bypass domain")

--- a/RockxyTests/Core/ProxyEngine/SigningDiagnosticsTests.swift
+++ b/RockxyTests/Core/ProxyEngine/SigningDiagnosticsTests.swift
@@ -6,15 +6,15 @@ import Testing
 // MARK: - MockSigningEnvironment
 
 private struct MockSigningEnvironment: SigningDiagnostics.Environment {
-    var appSignatureError: String?
+    var appSignatureValidation: SigningDiagnostics.AppSignatureValidation = .valid
     var helperExists: Bool = true
     var appSigner: String? = "Apple Development: dev@example.com"
     var helperSigner: String? = "Developer ID Application: Dev Corp"
     var appChain: [Data]? = [Data([1, 2, 3]), Data([4, 5, 6])]
     var helperChain: [Data]? = [Data([1, 2, 3]), Data([4, 5, 6])]
 
-    func validateAppSignature() -> String? {
-        appSignatureError
+    func validateAppSignature() -> SigningDiagnostics.AppSignatureValidation {
+        appSignatureValidation
     }
 
     func helperBinaryExists() -> Bool {
@@ -70,13 +70,28 @@ struct SigningDiagnosticsClassifyTests {
     @Test("app signature invalid returns appSignatureInvalid")
     func appSignatureInvalid() {
         var env = MockSigningEnvironment()
-        env.appSignatureError = "Code signature invalid (OSStatus -67054)"
+        env.appSignatureValidation = .invalid(
+            detail: "Code signature invalid (OSStatus -67054)"
+        )
 
         let result = SigningDiagnostics.classify(env)
 
         #expect(result == .appSignatureInvalid(
             detail: "Code signature invalid (OSStatus -67054)"
         ))
+    }
+
+    @Test("running code change requires reopening before helper checks")
+    func runningCodeChanged() {
+        var env = MockSigningEnvironment()
+        env.appSignatureValidation = .runningCodeChanged(
+            detail: "OSStatus -67034"
+        )
+        env.helperExists = false
+
+        let result = SigningDiagnostics.classify(env)
+
+        #expect(result == .runningCodeChanged(detail: "OSStatus -67034"))
     }
 
     @Test("healthy when app valid and certificates match")
@@ -147,7 +162,7 @@ struct SigningDiagnosticsClassifyTests {
     @Test("app signature check runs before helper existence check")
     func appSignatureBeforeHelperCheck() {
         var env = MockSigningEnvironment()
-        env.appSignatureError = "invalid"
+        env.appSignatureValidation = .invalid(detail: "invalid")
         env.helperExists = false
 
         let result = SigningDiagnostics.classify(env)
@@ -198,12 +213,11 @@ struct SigningDiagnosticsLiveTests {
             return
         }
         let env = SigningDiagnostics.LiveEnvironment()
-        guard env.validateAppSignature() == nil else {
+        guard env.validateAppSignature() == .valid else {
             return
         }
 
-        let error = env.validateAppSignature()
-        #expect(error == nil)
+        #expect(env.validateAppSignature() == .valid)
     }
 
     @Test("LiveEnvironment resolves the bundled helper executable from the app package")
@@ -227,7 +241,7 @@ struct SigningDiagnosticsLiveTests {
             return
         }
         let env = SigningDiagnostics.LiveEnvironment()
-        guard env.validateAppSignature() == nil else {
+        guard env.validateAppSignature() == .valid else {
             return
         }
 
@@ -242,7 +256,7 @@ struct SigningDiagnosticsLiveTests {
             return
         }
         let env = SigningDiagnostics.LiveEnvironment()
-        guard env.validateAppSignature() == nil else {
+        guard env.validateAppSignature() == .valid else {
             return
         }
 
@@ -260,7 +274,7 @@ struct SigningDiagnosticsLiveTests {
             return
         }
         let env = SigningDiagnostics.LiveEnvironment()
-        guard env.validateAppSignature() == nil else {
+        guard env.validateAppSignature() == .valid else {
             return
         }
 
@@ -278,7 +292,8 @@ struct SigningDiagnosticsLiveTests {
              .signingIdentityMismatch,
              .certificateChainUnavailable:
             break
-        case .appSignatureInvalid,
+        case .runningCodeChanged,
+             .appSignatureInvalid,
              .diagnosticError:
             Issue.record("Live classify returned unexpected result: \(result)")
         }

--- a/RockxyTests/Models/UI/FocusNavigatorStateTests.swift
+++ b/RockxyTests/Models/UI/FocusNavigatorStateTests.swift
@@ -201,6 +201,57 @@ struct FocusNavigatorStateTests {
         #expect(focus.ruleCount == focus.includedRules.count + focus.excludedRules.count)
     }
 
+    @Test("Generated Focus Set names become meaningful without replacing custom names")
+    func focusSetDisplayNames() {
+        let legacyApplication = FocusSet(name: "New Focus Set 2", appName: "ChatGPT")
+        let legacyExclusion = FocusSet(name: "New Focus Set", excludedDomain: "exp.notion.so")
+        let scoped = FocusSet(
+            name: "New Focus Set",
+            appName: "Google Chrome",
+            domain: "api.example.com",
+            pathPrefix: "/v1"
+        )
+        let custom = FocusSet(name: "Checkout Debugging", appName: "Safari")
+
+        #expect(legacyApplication.displayName == "ChatGPT")
+        #expect(legacyExclusion.displayName == "Hide exp.notion.so")
+        #expect(scoped.displayName == "Google Chrome on api.example.com/v1")
+        #expect(custom.displayName == "Checkout Debugging")
+        #expect(custom.scopeSummary == "Safari")
+
+        #expect(legacyApplication.sidebarIncludedRules.isEmpty)
+        #expect(!legacyApplication.hasSidebarRuleDetails)
+        #expect(legacyExclusion.sidebarExcludedRules.isEmpty)
+        #expect(!legacyExclusion.hasSidebarRuleDetails)
+        #expect(scoped.sidebarIncludedRules.isEmpty)
+        #expect(!scoped.hasSidebarRuleDetails)
+        #expect(custom.sidebarIncludedRules == custom.includedRules)
+        #expect(custom.hasSidebarRuleDetails)
+        #expect(custom.sidebarScopeSummary == "Safari")
+
+        let scopedWithExclusion = FocusSet(
+            name: "Google Chrome",
+            appName: "Google Chrome",
+            excludedDomain: "telemetry.example.com"
+        )
+        #expect(scopedWithExclusion.sidebarIncludedRules.isEmpty)
+        #expect(scopedWithExclusion.sidebarExcludedRules == scopedWithExclusion.excludedRules)
+        #expect(scopedWithExclusion.sidebarScopeSummary == "Hide telemetry.example.com")
+    }
+
+    @Test("New Focus Sets start with the current scope as their editable name")
+    @MainActor
+    func focusSetNameFromCurrentScope() {
+        let coordinator = MainContentCoordinator()
+        coordinator.filterCriteria.sidebarApp = "Google Chrome"
+        coordinator.filterCriteria.sidebarDomain = "api.example.com"
+
+        let focus = coordinator.makeFocusSetFromCurrentScope()
+
+        #expect(focus.name == "Google Chrome on api.example.com")
+        #expect(focus.displayName == focus.name)
+    }
+
     @Test("Muted traffic source matches only its scope")
     func mutedSourceMatching() {
         let transaction = TestFixtures.makeTransaction(url: "https://telemetry.example.com/events")

--- a/RockxyTests/Models/UI/SidebarSearchFilterTests.swift
+++ b/RockxyTests/Models/UI/SidebarSearchFilterTests.swift
@@ -99,4 +99,11 @@ struct SidebarSearchFilterTests {
         #expect(SidebarSearchFilter.transactions([checkout, health], query: "safari").map(\.id) == [checkout.id])
         #expect(SidebarSearchFilter.transactions([checkout, health], query: "health").map(\.id) == [health.id])
     }
+
+    @Test("Focus Set search includes a meaningful derived legacy name")
+    func focusSetDerivedNameFiltering() {
+        let focus = FocusSet(name: "New Focus Set 1", excludedDomain: "exp.notion.so")
+
+        #expect(SidebarSearchFilter.focusSets([focus], query: "hide").map(\.id) == [focus.id])
+    }
 }

--- a/RockxyTests/ViewModels/WelcomeViewModelTests.swift
+++ b/RockxyTests/ViewModels/WelcomeViewModelTests.swift
@@ -66,6 +66,7 @@ struct WelcomeViewModelTests {
             (.installedOutdated, nil, String(localized: "Update")),
             (.installedIncompatible, nil, String(localized: "Update")),
             (.unreachable, nil, String(localized: "Retry")),
+            (.signingMismatch, .applicationMustReopen, String(localized: "Quit Rockxy")),
             (.signingMismatch, .appSignatureInvalid(detail: "x"), nil),
             (.signingMismatch, .identityMismatch(appSigner: "a", helperSigner: "b"), String(localized: "Reinstall")),
             (.signingMismatch, nil, nil),
@@ -113,6 +114,13 @@ struct WelcomeViewModelTests {
         )
 
         #expect(WelcomeViewModel.resolveHelperFailureRecovery(for: error) == .rebuildApp)
+    }
+
+    @Test("required reopen does not offer destructive helper repair")
+    func requiredReopenDoesNotOfferDestructiveRepair() {
+        let error = HelperManager.HelperOperationError.applicationMustReopen
+
+        #expect(WelcomeViewModel.resolveHelperFailureRecovery(for: error) == .reopenApp)
     }
 
     @Test("normal helper registration errors can use repair and reinstall")

--- a/RockxyTests/Views/FocusSidebarPresentationTests.swift
+++ b/RockxyTests/Views/FocusSidebarPresentationTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+@testable import Rockxy
 import Testing
 
 // MARK: - FocusSidebarPresentationTests
@@ -13,6 +14,12 @@ struct FocusSidebarPresentationTests {
         #expect(source.contains(".buttonStyle(.bordered)"))
         #expect(source.contains(".controlSize(.small)"))
         #expect(source.contains(".accessibilityLabel(actionLabel)"))
+    }
+
+    @Test("Browse reveals captured apps and domains without extra disclosure clicks")
+    func browseGroupsStartExpanded() {
+        #expect(SidebarDisclosureDefaults.appsExpanded)
+        #expect(SidebarDisclosureDefaults.domainsExpanded)
     }
 
     private func readProjectFile(_ relativePath: String) throws -> String {

--- a/RockxyTests/Views/FocusSidebarPresentationTests.swift
+++ b/RockxyTests/Views/FocusSidebarPresentationTests.swift
@@ -1,0 +1,26 @@
+import Foundation
+import Testing
+
+// MARK: - FocusSidebarPresentationTests
+
+struct FocusSidebarPresentationTests {
+    @Test("Focus section actions use visible native buttons")
+    func focusSectionActionsUseVisibleNativeButtons() throws {
+        let source = try readProjectFile("Rockxy/Views/Sidebar/SidebarView.swift")
+
+        #expect(source.contains("actionLabel: String(localized: \"Create Focus Set\")"))
+        #expect(source.contains("actionLabel: String(localized: \"Configure Noise Control\")"))
+        #expect(source.contains(".buttonStyle(.bordered)"))
+        #expect(source.contains(".controlSize(.small)"))
+        #expect(source.contains(".accessibilityLabel(actionLabel)"))
+    }
+
+    private func readProjectFile(_ relativePath: String) throws -> String {
+        var url = URL(fileURLWithPath: #filePath)
+        while url.lastPathComponent != "RockxyTests", url.path != "/" {
+            url.deleteLastPathComponent()
+        }
+        url.deleteLastPathComponent()
+        return try String(contentsOf: url.appendingPathComponent(relativePath), encoding: .utf8)
+    }
+}

--- a/RockxyTests/Views/Inspector/InspectorRoutingTests.swift
+++ b/RockxyTests/Views/Inspector/InspectorRoutingTests.swift
@@ -432,18 +432,22 @@ struct InspectorRoutingTests {
             transaction: transaction,
             canInterceptHTTPS: true,
             domainRuleEnabled: false,
-            appName: transaction.clientApp,
-            appRuleEnabled: false
+            appScope: HTTPSInspectionAppScope(
+                name: "Brave Browser Helper",
+                knownHostCount: 3,
+                enabledHostCount: 0
+            )
         )
 
         #expect(prompt?.host == "api.example.com")
-        #expect(prompt?.primaryAction == .enableDomain("api.example.com"))
-        #expect(prompt?.secondaryAction == .enableApp("Brave Browser Helper", fallbackDomain: "api.example.com"))
+        #expect(prompt?.hostScope?.action == .enableDomain("api.example.com"))
+        #expect(prompt?.appScope?.action == .enableApp("Brave Browser Helper", fallbackDomain: "api.example.com"))
         #expect(prompt?.requiresCertificateSetup == false)
+        #expect(prompt?.insight == .tunnelEstablished(statusCode: 200))
     }
 
-    @Test("CONNECT tunnel still shows app SSL action when app cache is empty")
-    func connectTunnelShowsAppActionWithoutObservedDomains() {
+    @Test("CONNECT tunnel hides duplicate app action when only the current host is known")
+    func connectTunnelHidesDuplicateAppAction() {
         let transaction = TestFixtures.makeTransaction(
             method: "CONNECT",
             url: "https://api.example.com:443",
@@ -455,12 +459,15 @@ struct InspectorRoutingTests {
             transaction: transaction,
             canInterceptHTTPS: true,
             domainRuleEnabled: false,
-            appName: transaction.clientApp,
-            appRuleEnabled: false
+            appScope: HTTPSInspectionAppScope(
+                name: "Google Chrome",
+                knownHostCount: 1,
+                enabledHostCount: 0
+            )
         )
 
-        #expect(prompt?.primaryAction == .enableDomain("api.example.com"))
-        #expect(prompt?.secondaryAction == .enableApp("Google Chrome", fallbackDomain: "api.example.com"))
+        #expect(prompt?.hostScope?.action == .enableDomain("api.example.com"))
+        #expect(prompt?.appScope == nil)
     }
 
     @Test("CONNECT tunnel prefers certificate guidance when HTTPS interception is unavailable")
@@ -475,14 +482,57 @@ struct InspectorRoutingTests {
             transaction: transaction,
             canInterceptHTTPS: false,
             domainRuleEnabled: false,
-            appName: nil,
-            appRuleEnabled: false
+            appScope: nil
         )
 
         #expect(prompt?.host == "api.example.com")
-        #expect(prompt?.primaryAction == .installCertificate)
-        #expect(prompt?.secondaryAction == nil)
+        #expect(prompt?.certificateAction == .installCertificate)
+        #expect(prompt?.hostScope == nil)
+        #expect(prompt?.appScope == nil)
         #expect(prompt?.requiresCertificateSetup == true)
+        #expect(prompt?.insight == nil)
+    }
+
+    @Test("CONNECT tunnel reports TLS rejection evidence without claiming pinning as fact")
+    func connectTunnelShowsTLSRejectionInsight() {
+        let transaction = TestFixtures.makeTransaction(
+            method: "CONNECT",
+            url: "https://api.example.com:443",
+            statusCode: 200
+        )
+
+        let prompt = HTTPSInspectionPromptModel.make(
+            transaction: transaction,
+            canInterceptHTTPS: true,
+            domainRuleEnabled: true,
+            hasRecentTLSRejection: true,
+            appScope: nil
+        )
+
+        #expect(prompt?.insight == .tlsInterceptionRejected)
+        #expect(prompt?.insight?.evidence.contains("Certificate pinning is possible") == true)
+        #expect(prompt?.hostScope?.action == .retryDomain("api.example.com"))
+        #expect(prompt?.hostScope?.actionTitle == "Retry")
+    }
+
+    @Test("TLS failure transaction exposes the rejection insight directly")
+    func tlsFailureShowsRejectionInsight() {
+        let transaction = TestFixtures.makeTransaction(
+            method: "CONNECT",
+            url: "https://secure.example.com:443",
+            statusCode: 0
+        )
+        transaction.isTLSFailure = true
+
+        let prompt = HTTPSInspectionPromptModel.make(
+            transaction: transaction,
+            canInterceptHTTPS: true,
+            domainRuleEnabled: true,
+            appScope: nil
+        )
+
+        #expect(prompt?.insight == .tlsInterceptionRejected)
+        #expect(prompt?.hostScope?.action == .retryDomain("secure.example.com"))
     }
 
     // MARK: - Compression Helpers
@@ -605,8 +655,8 @@ struct InspectorRoutingTests {
         return HTTPTransaction(request: request, response: response, state: .completed)
     }
 
-    @Test("CONNECT tunnel with existing SSL rule shows disable guidance")
-    func connectTunnelWithExistingRuleShowsDisableGuidance() {
+    @Test("CONNECT tunnel with an existing host rule shows ready state instead of a disable action")
+    func connectTunnelWithExistingRuleShowsReadyState() {
         let transaction = TestFixtures.makeTransaction(
             method: "CONNECT",
             url: "https://api.example.com:443",
@@ -617,16 +667,16 @@ struct InspectorRoutingTests {
             transaction: transaction,
             canInterceptHTTPS: true,
             domainRuleEnabled: true,
-            appName: nil,
-            appRuleEnabled: false
+            appScope: nil
         )
 
-        #expect(prompt?.primaryAction == .disableDomain("api.example.com"))
-        #expect(prompt?.secondaryAction == nil)
+        #expect(prompt?.hostScope?.state == .ready)
+        #expect(prompt?.hostScope?.action == nil)
+        #expect(prompt?.appScope == nil)
     }
 
-    @Test("CONNECT tunnel with known app-host rules shows disable guidance")
-    func connectTunnelWithExistingAppHostRulesShowsDisableGuidance() {
+    @Test("CONNECT tunnel distinguishes partial app-host coverage from the current host")
+    func connectTunnelShowsPartialAppHostCoverage() {
         let transaction = TestFixtures.makeTransaction(
             method: "CONNECT",
             url: "https://api.example.com:443",
@@ -637,53 +687,48 @@ struct InspectorRoutingTests {
         let prompt = HTTPSInspectionPromptModel.make(
             transaction: transaction,
             canInterceptHTTPS: true,
-            domainRuleEnabled: false,
-            appName: transaction.clientApp,
-            appRuleEnabled: true
+            domainRuleEnabled: true,
+            appScope: HTTPSInspectionAppScope(
+                name: "Google Chrome",
+                knownHostCount: 4,
+                enabledHostCount: 1
+            )
         )
 
-        #expect(prompt?.primaryAction == .enableDomain("api.example.com"))
-        #expect(prompt?.secondaryAction == .disableApp("Google Chrome", fallbackDomain: "api.example.com"))
+        #expect(prompt?.hostScope?.state == .ready)
+        #expect(prompt?.hostScope?.action == nil)
+        #expect(prompt?.appScope?.state == .partial)
+        #expect(prompt?.appScope?.actionTitle == "Decrypt 3 More")
+        #expect(prompt?.appScope?.action == .enableApp("Google Chrome", fallbackDomain: "api.example.com"))
     }
 
     @Test("HTTPS prompt scope presentation exposes host and app-host state")
     func httpsPromptScopePresentation() {
-        let host = HTTPSInspectionScopePresentation(action: .enableDomain("api.example.com"))
-        let appHosts = HTTPSInspectionScopePresentation(
-            action: .disableApp("Brave Browser Helper", fallbackDomain: "api.example.com")
+        let host = HTTPSInspectionScopePresentation.host(value: "api.example.com", isReady: false)
+        let appHosts = HTTPSInspectionScopePresentation.appHosts(
+            name: "Brave Browser Helper",
+            enabledHostCount: 2,
+            knownHostCount: 2,
+            fallbackDomain: "api.example.com"
         )
 
-        #expect(host == HTTPSInspectionScopePresentation(kind: .host, value: "api.example.com", isEnabled: false))
-        #expect(host?.kind.title == "Host")
-        #expect(host?.actionTitle == "Decrypt")
-        #expect(host?.actionDescription == "Decrypt new HTTPS connections to api.example.com")
-        #expect(
-            HTTPSInspectionScopePresentation(action: .disableDomain("api.example.com"))?.actionDescription ==
-                "Stop decrypting new HTTPS connections to api.example.com"
-        )
+        #expect(host.kind.title == "This Host")
+        #expect(host.actionTitle == "Decrypt Host")
+        #expect(host.actionDescription == "Decrypt new HTTPS connections to api.example.com")
 
-        #expect(
-            appHosts == HTTPSInspectionScopePresentation(
-                kind: .appHosts,
-                value: "Brave Browser Helper",
-                isEnabled: true
-            )
-        )
-        #expect(appHosts?.kind.title == "App Hosts")
+        #expect(appHosts?.kind.title == "Known App Hosts")
         #expect(appHosts?.kind.systemImage == "macwindow")
-        #expect(appHosts?.actionTitle == "Disable")
-        #expect(
-            appHosts?.actionDescription ==
-                "Stop decrypting new HTTPS connections to known hosts used by Brave Browser Helper"
+        #expect(appHosts?.state == .ready)
+        #expect(appHosts?.action == nil)
+        #expect(appHosts?.actionTitle == nil)
+
+        let duplicateScope = HTTPSInspectionScopePresentation.appHosts(
+            name: "curl",
+            enabledHostCount: 0,
+            knownHostCount: 1,
+            fallbackDomain: "api.example.com"
         )
-        #expect(
-            HTTPSInspectionScopePresentation(
-                action: .enableApp("Brave Browser Helper", fallbackDomain: "api.example.com")
-            )?.actionDescription ==
-                "Decrypt new HTTPS connections to known hosts used by Brave Browser Helper"
-        )
-        #expect(HTTPSInspectionScopePresentation(action: .installCertificate) == nil)
-        #expect(HTTPSInspectionScopePresentation(action: .openSSLProxyingList) == nil)
+        #expect(duplicateScope == nil)
     }
 
     @Test("Plain HTTP response does not show HTTPS prompt")
@@ -694,8 +739,7 @@ struct InspectorRoutingTests {
             transaction: transaction,
             canInterceptHTTPS: true,
             domainRuleEnabled: false,
-            appName: nil,
-            appRuleEnabled: false
+            appScope: nil
         )
 
         #expect(prompt == nil)

--- a/RockxyTests/Views/Inspector/InspectorRoutingTests.swift
+++ b/RockxyTests/Views/Inspector/InspectorRoutingTests.swift
@@ -440,10 +440,12 @@ struct InspectorRoutingTests {
         )
 
         #expect(prompt?.host == "api.example.com")
+        #expect(prompt?.hostScope?.control == .toggle(isOn: false))
         #expect(prompt?.hostScope?.action == .enableDomain("api.example.com"))
         #expect(prompt?.appScope?.action == .enableApp("Brave Browser Helper", fallbackDomain: "api.example.com"))
         #expect(prompt?.requiresCertificateSetup == false)
         #expect(prompt?.insight == .tunnelEstablished(statusCode: 200))
+        #expect(prompt?.insight?.title == "Content Not Inspected")
     }
 
     @Test("CONNECT tunnel hides duplicate app action when only the current host is known")
@@ -511,6 +513,7 @@ struct InspectorRoutingTests {
 
         #expect(prompt?.insight == .tlsInterceptionRejected)
         #expect(prompt?.insight?.evidence.contains("Certificate pinning is possible") == true)
+        #expect(prompt?.hostScope?.control == .button)
         #expect(prompt?.hostScope?.action == .retryDomain("api.example.com"))
         #expect(prompt?.hostScope?.actionTitle == "Retry")
     }
@@ -655,8 +658,8 @@ struct InspectorRoutingTests {
         return HTTPTransaction(request: request, response: response, state: .completed)
     }
 
-    @Test("CONNECT tunnel with an existing host rule shows ready state instead of a disable action")
-    func connectTunnelWithExistingRuleShowsReadyState() {
+    @Test("CONNECT tunnel with an existing host rule exposes an on toggle and disable action")
+    func connectTunnelWithExistingRuleShowsEnabledToggle() {
         let transaction = TestFixtures.makeTransaction(
             method: "CONNECT",
             url: "https://api.example.com:443",
@@ -671,7 +674,8 @@ struct InspectorRoutingTests {
         )
 
         #expect(prompt?.hostScope?.state == .ready)
-        #expect(prompt?.hostScope?.action == nil)
+        #expect(prompt?.hostScope?.control == .toggle(isOn: true))
+        #expect(prompt?.hostScope?.action == .disableDomain("api.example.com"))
         #expect(prompt?.appScope == nil)
     }
 
@@ -696,9 +700,10 @@ struct InspectorRoutingTests {
         )
 
         #expect(prompt?.hostScope?.state == .ready)
-        #expect(prompt?.hostScope?.action == nil)
+        #expect(prompt?.hostScope?.action == .disableDomain("api.example.com"))
         #expect(prompt?.appScope?.state == .partial)
-        #expect(prompt?.appScope?.actionTitle == "Decrypt 3 More")
+        #expect(prompt?.appScope?.control == .button)
+        #expect(prompt?.appScope?.actionTitle == "Enable All")
         #expect(prompt?.appScope?.action == .enableApp("Google Chrome", fallbackDomain: "api.example.com"))
     }
 
@@ -713,12 +718,14 @@ struct InspectorRoutingTests {
         )
 
         #expect(host.kind.title == "This Host")
-        #expect(host.actionTitle == "Decrypt Host")
-        #expect(host.actionDescription == "Decrypt new HTTPS connections to api.example.com")
+        #expect(host.control == .toggle(isOn: false))
+        #expect(host.actionTitle == nil)
+        #expect(host.actionDescription == "Turn on HTTPS decryption for new connections to api.example.com")
 
         #expect(appHosts?.kind.title == "Known App Hosts")
         #expect(appHosts?.kind.systemImage == "macwindow")
         #expect(appHosts?.state == .ready)
+        #expect(appHosts?.control == .status)
         #expect(appHosts?.action == nil)
         #expect(appHosts?.actionTitle == nil)
 

--- a/RockxyTests/Views/Inspector/InspectorRoutingTests.swift
+++ b/RockxyTests/Views/Inspector/InspectorRoutingTests.swift
@@ -440,8 +440,11 @@ struct InspectorRoutingTests {
         )
 
         #expect(prompt?.host == "api.example.com")
-        #expect(prompt?.hostScope?.control == .toggle(isOn: false))
+        #expect(prompt?.hostScope?.control == .button)
+        #expect(prompt?.hostScope?.controlTitle == "Decrypt Host")
         #expect(prompt?.hostScope?.action == .enableDomain("api.example.com"))
+        #expect(prompt?.appScope?.control == .button)
+        #expect(prompt?.appScope?.controlTitle == "Decrypt App")
         #expect(prompt?.appScope?.action == .enableApp("Brave Browser Helper", fallbackDomain: "api.example.com"))
         #expect(prompt?.requiresCertificateSetup == false)
         #expect(prompt?.insight == .tunnelEstablished(statusCode: 200))
@@ -473,6 +476,30 @@ struct InspectorRoutingTests {
         #expect(prompt?.appScope == nil)
     }
 
+    @Test("CONNECT tunnel hides app action when it only adds the current disabled host")
+    func connectTunnelHidesEquivalentPartialAppAction() {
+        let transaction = TestFixtures.makeTransaction(
+            method: "CONNECT",
+            url: "https://client.crisp.chat:443",
+            statusCode: 200
+        )
+        transaction.clientApp = "ChatGPT"
+
+        let prompt = HTTPSInspectionPromptModel.make(
+            transaction: transaction,
+            canInterceptHTTPS: true,
+            domainRuleEnabled: false,
+            appScope: HTTPSInspectionAppScope(
+                name: "ChatGPT",
+                knownHostCount: 2,
+                enabledHostCount: 1
+            )
+        )
+
+        #expect(prompt?.hostScope?.action == .enableDomain("client.crisp.chat"))
+        #expect(prompt?.appScope == nil)
+    }
+
     @Test("CONNECT tunnel prefers certificate guidance when HTTPS interception is unavailable")
     func connectTunnelShowsCertificateGuidance() {
         let transaction = TestFixtures.makeTransaction(
@@ -485,7 +512,11 @@ struct InspectorRoutingTests {
             transaction: transaction,
             canInterceptHTTPS: false,
             domainRuleEnabled: false,
-            appScope: nil
+            appScope: HTTPSInspectionAppScope(
+                name: "Secure Client",
+                knownHostCount: 3,
+                enabledHostCount: 1
+            )
         )
 
         #expect(prompt?.host == "api.example.com")
@@ -509,7 +540,11 @@ struct InspectorRoutingTests {
             canInterceptHTTPS: true,
             domainRuleEnabled: true,
             hasRecentTLSRejection: true,
-            appScope: nil
+            appScope: HTTPSInspectionAppScope(
+                name: "Secure Client",
+                knownHostCount: 3,
+                enabledHostCount: 1
+            )
         )
 
         #expect(prompt?.insight == .tlsInterceptionRejected)
@@ -517,6 +552,7 @@ struct InspectorRoutingTests {
         #expect(prompt?.hostScope?.control == .button)
         #expect(prompt?.hostScope?.action == .retryDomain("api.example.com"))
         #expect(prompt?.hostScope?.controlTitle == "Retry")
+        #expect(prompt?.appScope == nil)
     }
 
     @Test("TLS failure transaction exposes the rejection insight directly")
@@ -659,8 +695,8 @@ struct InspectorRoutingTests {
         return HTTPTransaction(request: request, response: response, state: .completed)
     }
 
-    @Test("CONNECT tunnel with an existing host rule exposes an on toggle and disable action")
-    func connectTunnelWithExistingRuleShowsEnabledToggle() {
+    @Test("CONNECT tunnel with an existing host rule exposes ready status")
+    func connectTunnelWithExistingRuleShowsReadyStatus() {
         let transaction = TestFixtures.makeTransaction(
             method: "CONNECT",
             url: "https://api.example.com:443",
@@ -675,8 +711,9 @@ struct InspectorRoutingTests {
         )
 
         #expect(prompt?.hostScope?.state == .ready)
-        #expect(prompt?.hostScope?.control == .toggle(isOn: true))
-        #expect(prompt?.hostScope?.action == .disableDomain("api.example.com"))
+        #expect(prompt?.hostScope?.control == .status)
+        #expect(prompt?.hostScope?.action == nil)
+        #expect(prompt?.hostScope?.controlTitle == nil)
         #expect(prompt?.appScope == nil)
     }
 
@@ -701,10 +738,11 @@ struct InspectorRoutingTests {
         )
 
         #expect(prompt?.hostScope?.state == .ready)
-        #expect(prompt?.hostScope?.action == .disableDomain("api.example.com"))
+        #expect(prompt?.hostScope?.control == .status)
+        #expect(prompt?.hostScope?.action == nil)
         #expect(prompt?.appScope?.state == .partial)
         #expect(prompt?.appScope?.control == .button)
-        #expect(prompt?.appScope?.controlTitle == "Enable All")
+        #expect(prompt?.appScope?.controlTitle == "Decrypt App")
         #expect(prompt?.appScope?.action == .enableApp("Google Chrome", fallbackDomain: "api.example.com"))
     }
 
@@ -713,30 +751,40 @@ struct InspectorRoutingTests {
         let host = HTTPSInspectionScopePresentation.host(value: "api.example.com", isReady: false)
         let appHosts = HTTPSInspectionScopePresentation.appHosts(
             name: "Brave Browser Helper",
-            enabledHostCount: 2,
-            knownHostCount: 2,
+            enabledHostCount: 1,
+            knownHostCount: 3,
+            currentHostEnabled: true,
             fallbackDomain: "api.example.com"
         )
 
-        #expect(host.kind.title == "This Host")
-        #expect(host.control == .toggle(isOn: false))
-        #expect(host.statusDetail == "Current host")
+        #expect(host.kind == .host)
+        #expect(host.control == .button)
         #expect(host.controlTitle == "Decrypt Host")
         #expect(host.actionDescription == "Turn on HTTPS decryption for new connections to api.example.com")
 
-        #expect(appHosts?.kind.title == "Known App Hosts")
-        #expect(appHosts?.state == .ready)
-        #expect(appHosts?.control == .status)
-        #expect(appHosts?.action == nil)
-        #expect(appHosts?.controlTitle == nil)
+        #expect(appHosts?.kind == .appHosts)
+        #expect(appHosts?.state == .partial)
+        #expect(appHosts?.control == .button)
+        #expect(appHosts?.action == .enableApp("Brave Browser Helper", fallbackDomain: "api.example.com"))
+        #expect(appHosts?.controlTitle == "Decrypt App")
 
         let duplicateScope = HTTPSInspectionScopePresentation.appHosts(
             name: "curl",
             enabledHostCount: 0,
             knownHostCount: 1,
+            currentHostEnabled: false,
             fallbackDomain: "api.example.com"
         )
         #expect(duplicateScope == nil)
+
+        let equivalentScope = HTTPSInspectionScopePresentation.appHosts(
+            name: "ChatGPT",
+            enabledHostCount: 1,
+            knownHostCount: 2,
+            currentHostEnabled: false,
+            fallbackDomain: "client.crisp.chat"
+        )
+        #expect(equivalentScope == nil)
     }
 
     @Test("Plain HTTP response does not show HTTPS prompt")

--- a/RockxyTests/Views/Inspector/InspectorRoutingTests.swift
+++ b/RockxyTests/Views/Inspector/InspectorRoutingTests.swift
@@ -446,6 +446,7 @@ struct InspectorRoutingTests {
         #expect(prompt?.requiresCertificateSetup == false)
         #expect(prompt?.insight == .tunnelEstablished(statusCode: 200))
         #expect(prompt?.insight?.title == "Content Not Inspected")
+        #expect(prompt?.insight?.summary == "HTTPS content was not inspected.")
     }
 
     @Test("CONNECT tunnel hides duplicate app action when only the current host is known")
@@ -719,6 +720,7 @@ struct InspectorRoutingTests {
 
         #expect(host.kind.title == "This Host")
         #expect(host.control == .toggle(isOn: false))
+        #expect(host.statusDetail == "Current host")
         #expect(host.controlTitle == "Decrypt Host")
         #expect(host.actionDescription == "Turn on HTTPS decryption for new connections to api.example.com")
 

--- a/RockxyTests/Views/Inspector/InspectorRoutingTests.swift
+++ b/RockxyTests/Views/Inspector/InspectorRoutingTests.swift
@@ -515,7 +515,7 @@ struct InspectorRoutingTests {
         #expect(prompt?.insight?.evidence.contains("Certificate pinning is possible") == true)
         #expect(prompt?.hostScope?.control == .button)
         #expect(prompt?.hostScope?.action == .retryDomain("api.example.com"))
-        #expect(prompt?.hostScope?.actionTitle == "Retry")
+        #expect(prompt?.hostScope?.controlTitle == "Retry")
     }
 
     @Test("TLS failure transaction exposes the rejection insight directly")
@@ -703,7 +703,7 @@ struct InspectorRoutingTests {
         #expect(prompt?.hostScope?.action == .disableDomain("api.example.com"))
         #expect(prompt?.appScope?.state == .partial)
         #expect(prompt?.appScope?.control == .button)
-        #expect(prompt?.appScope?.actionTitle == "Enable All")
+        #expect(prompt?.appScope?.controlTitle == "Enable All")
         #expect(prompt?.appScope?.action == .enableApp("Google Chrome", fallbackDomain: "api.example.com"))
     }
 
@@ -719,7 +719,7 @@ struct InspectorRoutingTests {
 
         #expect(host.kind.title == "This Host")
         #expect(host.control == .toggle(isOn: false))
-        #expect(host.actionTitle == nil)
+        #expect(host.controlTitle == "Decrypt Host")
         #expect(host.actionDescription == "Turn on HTTPS decryption for new connections to api.example.com")
 
         #expect(appHosts?.kind.title == "Known App Hosts")
@@ -727,7 +727,7 @@ struct InspectorRoutingTests {
         #expect(appHosts?.state == .ready)
         #expect(appHosts?.control == .status)
         #expect(appHosts?.action == nil)
-        #expect(appHosts?.actionTitle == nil)
+        #expect(appHosts?.controlTitle == nil)
 
         let duplicateScope = HTTPSInspectionScopePresentation.appHosts(
             name: "curl",

--- a/RockxyTests/Views/Inspector/InspectorRoutingTests.swift
+++ b/RockxyTests/Views/Inspector/InspectorRoutingTests.swift
@@ -723,7 +723,6 @@ struct InspectorRoutingTests {
         #expect(host.actionDescription == "Turn on HTTPS decryption for new connections to api.example.com")
 
         #expect(appHosts?.kind.title == "Known App Hosts")
-        #expect(appHosts?.kind.systemImage == "macwindow")
         #expect(appHosts?.state == .ready)
         #expect(appHosts?.control == .status)
         #expect(appHosts?.action == nil)

--- a/RockxyTests/Views/Main/HistoryRetentionTests.swift
+++ b/RockxyTests/Views/Main/HistoryRetentionTests.swift
@@ -118,9 +118,150 @@ struct HistoryRetentionTests {
         let coordinator = MainContentCoordinator()
         coordinator.setFollowingLiveTraffic(true)
 
-        coordinator.userDidSelectTraffic()
+        coordinator.userDidNavigateTrafficHistory()
 
         #expect(!coordinator.isFollowingLiveTraffic)
+    }
+
+    @Test("Enabling Follow Live on an empty view stays armed without a selection")
+    @MainActor
+    func followLiveArmedWhenEmpty() {
+        let coordinator = MainContentCoordinator()
+        coordinator.filterCriteria.sidebarDomain = "nothing.example.com"
+        coordinator.recomputeFilteredTransactions()
+
+        coordinator.setFollowingLiveTraffic(true)
+
+        #expect(coordinator.isFollowingLiveTraffic)
+        #expect(coordinator.selectedTransaction == nil)
+    }
+
+    @Test("Follow Live state is per-workspace and reflects the active workspace")
+    @MainActor
+    func followLiveIsPerWorkspace() {
+        let coordinator = MainContentCoordinator()
+        let first = coordinator.activeWorkspace
+        let second = coordinator.workspaceStore.createWorkspace(title: "Second")
+
+        // createWorkspace makes `second` active; it starts not following.
+        #expect(!coordinator.isFollowingLiveTraffic)
+        coordinator.setFollowingLiveTraffic(true)
+        #expect(second.isFollowingLiveTraffic)
+        #expect(!first.isFollowingLiveTraffic)
+
+        coordinator.workspaceStore.selectWorkspace(id: first.id)
+        #expect(!coordinator.isFollowingLiveTraffic)
+
+        coordinator.workspaceStore.selectWorkspace(id: second.id)
+        #expect(coordinator.isFollowingLiveTraffic)
+    }
+
+    @Test("Manual selection exits Follow Live only for the active workspace")
+    @MainActor
+    func manualSelectionScopedToActiveWorkspace() {
+        let coordinator = MainContentCoordinator()
+        let active = coordinator.activeWorkspace
+        let other = coordinator.workspaceStore.createWorkspace(title: "Other")
+        other.isFollowingLiveTraffic = true
+        coordinator.workspaceStore.selectWorkspace(id: active.id)
+        active.isFollowingLiveTraffic = true
+
+        coordinator.userDidNavigateTrafficHistory()
+
+        #expect(!active.isFollowingLiveTraffic)
+        #expect(other.isFollowingLiveTraffic)
+    }
+
+    @Test("Follow Live advances an inactive workspace from a background batch")
+    @MainActor
+    func followLiveAdvancesInactiveWorkspace() {
+        let coordinator = MainContentCoordinator()
+        coordinator.isRecording = true
+
+        let active = coordinator.activeWorkspace
+        let follower = coordinator.workspaceStore.createWorkspace(title: "Follower")
+        follower.isFollowingLiveTraffic = true
+        // Return focus to the default workspace so `follower` is inactive.
+        coordinator.workspaceStore.selectWorkspace(id: active.id)
+
+        // Anchor a manual selection on the active, non-following workspace.
+        let anchor = TestFixtures.makeTransaction(url: "https://anchor.example.com/keep")
+        coordinator.processBatch([anchor], generation: coordinator.sessionGeneration)
+        active.selectedTransaction = anchor
+        active.selectedTransactionIDs = [anchor.id]
+
+        let latest = TestFixtures.makeTransaction(url: "https://live.example.com/new")
+        coordinator.processBatch([latest], generation: coordinator.sessionGeneration)
+
+        // The inactive follower advanced to the newest batch transaction.
+        #expect(follower.selectedTransaction?.id == latest.id)
+        #expect(follower.selectedTransactionIDs == [latest.id])
+        // The active, non-following workspace retained its manual selection.
+        #expect(active.selectedTransaction?.id == anchor.id)
+        #expect(!active.isFollowingLiveTraffic)
+    }
+
+    @Test("Recomputing a followed workspace reconciles to the newest visible transaction in scope")
+    @MainActor
+    func followLiveReconcilesOnFilterChange() {
+        let coordinator = MainContentCoordinator()
+        coordinator.isRecording = true
+
+        let alpha = TestFixtures.makeTransaction(url: "https://alpha.example.com/1")
+        let betaOld = TestFixtures.makeTransaction(url: "https://beta.example.com/1")
+        let betaNew = TestFixtures.makeTransaction(url: "https://beta.example.com/2")
+        coordinator.processBatch([alpha, betaOld, betaNew], generation: coordinator.sessionGeneration)
+
+        coordinator.setFollowingLiveTraffic(true)
+        #expect(coordinator.selectedTransaction?.id == betaNew.id)
+
+        coordinator.filterCriteria.sidebarDomain = "beta.example.com"
+        coordinator.recomputeFilteredTransactions()
+        #expect(coordinator.selectedTransaction?.id == betaNew.id)
+
+        // Narrowing to a scope whose only visible request is older snaps the selection to it.
+        coordinator.filterCriteria.sidebarDomain = "alpha.example.com"
+        coordinator.recomputeFilteredTransactions()
+        #expect(coordinator.selectedTransaction?.id == alpha.id)
+        #expect(coordinator.isFollowingLiveTraffic)
+    }
+
+    @Test("Recomputing a followed workspace with nothing visible clears the stale selection but stays armed")
+    @MainActor
+    func followLiveClearsStaleSelectionWhenScopeEmpties() {
+        let coordinator = MainContentCoordinator()
+        coordinator.isRecording = true
+
+        let alpha = TestFixtures.makeTransaction(url: "https://alpha.example.com/1")
+        coordinator.processBatch([alpha], generation: coordinator.sessionGeneration)
+        coordinator.setFollowingLiveTraffic(true)
+        #expect(coordinator.selectedTransaction?.id == alpha.id)
+
+        coordinator.filterCriteria.sidebarDomain = "empty.example.com"
+        coordinator.recomputeFilteredTransactions()
+
+        #expect(coordinator.selectedTransaction == nil)
+        #expect(coordinator.selectedTransactionIDs.isEmpty)
+        #expect(coordinator.isFollowingLiveTraffic)
+    }
+
+    @Test("Follow Live picks the chronological newest even under a custom display sort")
+    @MainActor
+    func followLiveIgnoresDisplaySort() {
+        let coordinator = MainContentCoordinator()
+        coordinator.isRecording = true
+        // Sort by URL so display order diverges from chronological capture order.
+        coordinator.activeSortDescriptors = [NSSortDescriptor(key: "url", ascending: true)]
+        coordinator.setFollowingLiveTraffic(true)
+
+        let firstByTime = TestFixtures.makeTransaction(url: "https://aaa.example.com/first")
+        let newestByTime = TestFixtures.makeTransaction(url: "https://zzz.example.com/second")
+        coordinator.processBatch([firstByTime, newestByTime], generation: coordinator.sessionGeneration)
+
+        // Display order (URL ascending) puts the older `firstByTime` first, but Follow Live must
+        // still choose the chronological newest, `newestByTime`.
+        #expect(coordinator.filteredRows.first?.id == firstByTime.id)
+        #expect(coordinator.selectedTransaction?.id == newestByTime.id)
     }
 
     @Test("Live buffer caps at policy limit during capture")

--- a/RockxyTests/Views/Main/HistoryRetentionTests.swift
+++ b/RockxyTests/Views/Main/HistoryRetentionTests.swift
@@ -73,6 +73,56 @@ struct HistoryRetentionTests {
         #expect(coordinator.observedDomainsByApp[String(localized: "Unknown")]?.count == 20)
     }
 
+    @Test("Follow Live selects the newest request that survives the active view")
+    @MainActor
+    func followLiveSelectsNewestVisibleRequest() {
+        let coordinator = MainContentCoordinator()
+        coordinator.isRecording = true
+        coordinator.filterCriteria.sidebarDomain = "visible.example.com"
+        coordinator.recomputeFilteredTransactions()
+        coordinator.setFollowingLiveTraffic(true)
+
+        let hidden = TestFixtures.makeTransaction(url: "https://hidden.example.com/first")
+        let firstVisible = TestFixtures.makeTransaction(url: "https://visible.example.com/one")
+        let latestVisible = TestFixtures.makeTransaction(url: "https://visible.example.com/two")
+        coordinator.processBatch(
+            [hidden, firstVisible, latestVisible],
+            generation: coordinator.sessionGeneration
+        )
+
+        #expect(coordinator.isFollowingLiveTraffic)
+        #expect(coordinator.selectedTransaction?.id == latestVisible.id)
+        #expect(coordinator.selectedTransactionIDs == [latestVisible.id])
+    }
+
+    @Test("Follow Live waits when a capture batch has no request in the active view")
+    @MainActor
+    func followLiveWaitsForVisibleRequest() {
+        let coordinator = MainContentCoordinator()
+        let existing = TestFixtures.makeTransaction(url: "https://visible.example.com/existing")
+        coordinator.transactions = [existing]
+        coordinator.filterCriteria.sidebarDomain = "visible.example.com"
+        coordinator.recomputeFilteredTransactions()
+        coordinator.setFollowingLiveTraffic(true)
+
+        let hidden = TestFixtures.makeTransaction(url: "https://hidden.example.com/new")
+        coordinator.processBatch([hidden], generation: coordinator.sessionGeneration)
+
+        #expect(coordinator.selectedTransaction?.id == existing.id)
+        #expect(coordinator.isFollowingLiveTraffic)
+    }
+
+    @Test("Manual table selection exits Follow Live")
+    @MainActor
+    func manualSelectionStopsFollowLive() {
+        let coordinator = MainContentCoordinator()
+        coordinator.setFollowingLiveTraffic(true)
+
+        coordinator.userDidSelectTraffic()
+
+        #expect(!coordinator.isFollowingLiveTraffic)
+    }
+
     @Test("Live buffer caps at policy limit during capture")
     @MainActor
     func bufferCapDuringCapture() {

--- a/RockxyTests/Views/Main/NativeBottomInspectorSplitViewTests.swift
+++ b/RockxyTests/Views/Main/NativeBottomInspectorSplitViewTests.swift
@@ -17,7 +17,7 @@ struct NativeBottomInspectorSplitViewTests {
             appMetrics: AppUIDisplayMetrics(settings: largeSettings)
         )
 
-        #expect(defaultMetrics.requestListMinimumHeight == 200)
+        #expect(defaultMetrics.requestListMinimumHeight == 88)
         #expect(defaultMetrics.inspectorMinimumHeight == 232)
         #expect(largeMetrics.requestListMinimumHeight > defaultMetrics.requestListMinimumHeight)
         #expect(largeMetrics.inspectorMinimumHeight > defaultMetrics.inspectorMinimumHeight)
@@ -42,11 +42,22 @@ struct NativeBottomInspectorSplitViewTests {
         #expect(controller.splitViewItems.count == 2)
         #expect(!controller.splitViewItems[0].canCollapse)
         #expect(controller.splitViewItems[1].canCollapse)
-        #expect(controller.splitViewItems[0].minimumThickness == 200)
+        #expect(controller.splitViewItems[0].minimumThickness == 88)
         #expect(controller.splitViewItems[1].minimumThickness == 232)
     }
 
-    @Test("Fresh bottom split configures a sixty-two percent request list")
+    @Test("Bottom inspector sizing policy permits nearly all available height")
+    func bottomInspectorSupportsTallResize() {
+        let controller = makeController(isInspectorPresented: true)
+        let availableInspectorHeight = 900
+            - controller.splitView.dividerThickness
+            - controller.splitViewItems[0].minimumThickness
+
+        #expect(availableInspectorHeight > 700)
+        #expect(controller.splitViewItems[1].minimumThickness == 232)
+    }
+
+    @Test("Fresh bottom split gives the payload inspector forty-five percent")
     func freshLayoutUsesBalancedDefaultRatio() {
         let autosaveName = uniqueAutosaveName()
         removeSplitViewAutosaveDefaults(autosaveName)
@@ -64,15 +75,49 @@ struct NativeBottomInspectorSplitViewTests {
             totalHeight: 700,
             dividerThickness: divider,
             requestListRatio: NativeBottomInspectorSplitSizing.defaultRequestListRatio,
-            primaryMinimumHeight: 200,
+            primaryMinimumHeight: 88,
             inspectorMinimumHeight: 232
         )
 
         #expect(primaryHeight == expectedPrimaryHeight)
-        #expect(abs(controller.splitViewItems[0].preferredThicknessFraction - 0.62) < 0.0001)
-        #expect(abs(controller.splitViewItems[1].preferredThicknessFraction - 0.38) < 0.0001)
+        #expect(abs(controller.splitViewItems[0].preferredThicknessFraction - 0.55) < 0.0001)
+        #expect(abs(controller.splitViewItems[1].preferredThicknessFraction - 0.45) < 0.0001)
+        #expect(controller.splitViewItems[1].viewController.view.frame.height > 300)
         #expect(controller.defaultDividerApplicationCount == 1)
         removeSplitViewAutosaveDefaults(autosaveName)
+    }
+
+    @Test("Horizontal divider has a forgiving vertical drag target")
+    func horizontalDividerHitTarget() {
+        let controller = makeController(isInspectorPresented: true)
+        let drawnRect = NSRect(x: 0, y: 300, width: 1_200, height: 1)
+        let effectiveRect = controller.splitView(
+            controller.splitView,
+            effectiveRect: drawnRect,
+            forDrawnRect: drawnRect,
+            ofDividerAt: 0
+        )
+
+        #expect(effectiveRect.height >= NativeSplitDividerInteraction.minimumHitThickness)
+        #expect(effectiveRect.minY < drawnRect.minY)
+        #expect(effectiveRect.maxY > drawnRect.maxY)
+    }
+
+    @Test("Horizontal divider moves through a useful height range after layout")
+    func horizontalDividerMovesAfterLayout() {
+        let controller = makeController(isInspectorPresented: true)
+
+        controller.splitView.setPosition(180, ofDividerAt: 0)
+        controller.view.layoutSubtreeIfNeeded()
+        let tallInspectorHeight = controller.splitViewItems[1].viewController.view.frame.height
+
+        controller.splitView.setPosition(450, ofDividerAt: 0)
+        controller.view.layoutSubtreeIfNeeded()
+        let compactInspectorHeight = controller.splitViewItems[1].viewController.view.frame.height
+
+        #expect(tallInspectorHeight > compactInspectorHeight)
+        #expect(tallInspectorHeight > 450)
+        #expect(compactInspectorHeight >= 232)
     }
 
     @Test("Autosaved split frames take precedence over the default ratio")
@@ -88,6 +133,7 @@ struct NativeBottomInspectorSplitViewTests {
 
         #expect(controller.hasAutosavedFrames)
         #expect(controller.defaultDividerApplicationCount == 0)
+        #expect(controller.splitViewItems[1].viewController.view.frame.height >= 232)
         expectNonNegativeArrangedGeometry(controller)
         removeSplitViewAutosaveDefaults(autosaveName)
     }
@@ -179,24 +225,24 @@ struct NativeBottomInspectorSplitViewTests {
     @Test("Bottom split readiness includes both pane minima and the divider")
     func minimumReadinessIncludesDivider() {
         #expect(!NativeBottomInspectorSplitSizing.canSeatRequestedMinima(
-            totalHeight: 432,
+            totalHeight: 320,
             dividerThickness: 1,
             inspectorPresented: true,
-            primaryMinimumHeight: 200,
+            primaryMinimumHeight: 88,
             inspectorMinimumHeight: 232
         ))
         #expect(NativeBottomInspectorSplitSizing.canSeatRequestedMinima(
-            totalHeight: 433,
+            totalHeight: 321,
             dividerThickness: 1,
             inspectorPresented: true,
-            primaryMinimumHeight: 200,
+            primaryMinimumHeight: 88,
             inspectorMinimumHeight: 232
         ))
         #expect(NativeBottomInspectorSplitSizing.canSeatRequestedMinima(
-            totalHeight: 200,
+            totalHeight: 88,
             dividerThickness: 1,
             inspectorPresented: false,
-            primaryMinimumHeight: 200,
+            primaryMinimumHeight: 88,
             inspectorMinimumHeight: 232
         ))
     }
@@ -240,7 +286,7 @@ struct NativeBottomInspectorSplitViewTests {
         )
 
         // Positive but below the combined primary + inspector minimum height.
-        layout(controller, at: CGRect(x: 0, y: 0, width: 1_200, height: 400))
+        layout(controller, at: CGRect(x: 0, y: 0, width: 1_200, height: 150))
 
         #expect(controller.isInspectorPresented)
         expectNonNegativeArrangedGeometry(controller)
@@ -278,7 +324,7 @@ struct NativeBottomInspectorSplitViewTests {
             inspectorController: NSHostingController(rootView: Color.clear),
             isInspectorPresented: isInspectorPresented,
             autosaveName: autosaveName,
-            primaryMinimumHeight: 200,
+            primaryMinimumHeight: 88,
             inspectorMinimumHeight: 232
         )
         return controller
@@ -307,8 +353,8 @@ struct NativeBottomInspectorSplitViewTests {
     private func setSplitViewAutosaveFrames(_ autosaveName: String) {
         UserDefaults.standard.set(
             [
-                "0.000000, 0.000000, 1200.000000, 300.000000, NO, NO",
-                "0.000000, 301.000000, 1200.000000, 399.000000, NO, NO",
+                "0.000000, 0.000000, 1200.000000, 593.000000, NO, NO",
+                "0.000000, 594.000000, 1200.000000, 106.000000, NO, NO",
             ],
             forKey: "NSSplitView Subview Frames \(autosaveName)"
         )

--- a/RockxyTests/Views/Main/NativeBottomInspectorSplitViewTests.swift
+++ b/RockxyTests/Views/Main/NativeBottomInspectorSplitViewTests.swift
@@ -80,9 +80,9 @@ struct NativeBottomInspectorSplitViewTests {
         )
 
         #expect(primaryHeight == expectedPrimaryHeight)
-        #expect(abs(controller.splitViewItems[0].preferredThicknessFraction - 0.36) < 0.0001)
-        #expect(abs(controller.splitViewItems[1].preferredThicknessFraction - 0.64) < 0.0001)
-        #expect(controller.splitViewItems[1].viewController.view.frame.height > 440)
+        #expect(abs(controller.splitViewItems[0].preferredThicknessFraction - 0.28) < 0.0001)
+        #expect(abs(controller.splitViewItems[1].preferredThicknessFraction - 0.72) < 0.0001)
+        #expect(controller.splitViewItems[1].viewController.view.frame.height > 500)
         #expect(controller.defaultDividerApplicationCount == 1)
         removeSplitViewAutosaveDefaults(autosaveName)
     }
@@ -181,7 +181,7 @@ struct NativeBottomInspectorSplitViewTests {
         layout(controller, at: CGRect(x: 0, y: 0, width: 1_200, height: 700))
 
         #expect(controller.isInspectorPresented)
-        #expect(controller.splitViewItems[1].viewController.view.frame.height > 440)
+        #expect(controller.splitViewItems[1].viewController.view.frame.height > 500)
         #expect(controller.defaultDividerApplicationCount == 1)
         removeSplitViewAutosaveDefaults(autosaveName)
     }

--- a/RockxyTests/Views/Main/NativeBottomInspectorSplitViewTests.swift
+++ b/RockxyTests/Views/Main/NativeBottomInspectorSplitViewTests.swift
@@ -57,7 +57,7 @@ struct NativeBottomInspectorSplitViewTests {
         #expect(controller.splitViewItems[1].minimumThickness == 232)
     }
 
-    @Test("Fresh bottom split gives the payload inspector forty-five percent")
+    @Test("Fresh bottom split gives the request list and payload inspector equal height")
     func freshLayoutUsesBalancedDefaultRatio() {
         let autosaveName = uniqueAutosaveName()
         removeSplitViewAutosaveDefaults(autosaveName)
@@ -80,9 +80,9 @@ struct NativeBottomInspectorSplitViewTests {
         )
 
         #expect(primaryHeight == expectedPrimaryHeight)
-        #expect(abs(controller.splitViewItems[0].preferredThicknessFraction - 0.55) < 0.0001)
-        #expect(abs(controller.splitViewItems[1].preferredThicknessFraction - 0.45) < 0.0001)
-        #expect(controller.splitViewItems[1].viewController.view.frame.height > 300)
+        #expect(abs(controller.splitViewItems[0].preferredThicknessFraction - 0.50) < 0.0001)
+        #expect(abs(controller.splitViewItems[1].preferredThicknessFraction - 0.50) < 0.0001)
+        #expect(controller.splitViewItems[1].viewController.view.frame.height > 340)
         #expect(controller.defaultDividerApplicationCount == 1)
         removeSplitViewAutosaveDefaults(autosaveName)
     }

--- a/RockxyTests/Views/Main/NativeBottomInspectorSplitViewTests.swift
+++ b/RockxyTests/Views/Main/NativeBottomInspectorSplitViewTests.swift
@@ -57,8 +57,8 @@ struct NativeBottomInspectorSplitViewTests {
         #expect(controller.splitViewItems[1].minimumThickness == 232)
     }
 
-    @Test("Fresh bottom split gives the request list and payload inspector equal height")
-    func freshLayoutUsesBalancedDefaultRatio() {
+    @Test("Fresh bottom split gives the payload inspector most of the available height")
+    func freshLayoutFavorsPayloadInspector() {
         let autosaveName = uniqueAutosaveName()
         removeSplitViewAutosaveDefaults(autosaveName)
         let controller = makeConfiguredController(
@@ -80,11 +80,19 @@ struct NativeBottomInspectorSplitViewTests {
         )
 
         #expect(primaryHeight == expectedPrimaryHeight)
-        #expect(abs(controller.splitViewItems[0].preferredThicknessFraction - 0.50) < 0.0001)
-        #expect(abs(controller.splitViewItems[1].preferredThicknessFraction - 0.50) < 0.0001)
-        #expect(controller.splitViewItems[1].viewController.view.frame.height > 340)
+        #expect(abs(controller.splitViewItems[0].preferredThicknessFraction - 0.36) < 0.0001)
+        #expect(abs(controller.splitViewItems[1].preferredThicknessFraction - 0.64) < 0.0001)
+        #expect(controller.splitViewItems[1].viewController.view.frame.height > 440)
         #expect(controller.defaultDividerApplicationCount == 1)
         removeSplitViewAutosaveDefaults(autosaveName)
+    }
+
+    @Test("Bottom inspector keeps a low holding priority so its divider remains draggable")
+    func bottomInspectorUsesResizableHoldingPriority() {
+        let controller = makeController(isInspectorPresented: true)
+
+        #expect(controller.splitViewItems[0].holdingPriority == .defaultLow)
+        #expect(controller.splitViewItems[1].holdingPriority == .defaultLow)
     }
 
     @Test("Horizontal divider has a forgiving vertical drag target")
@@ -153,6 +161,28 @@ struct NativeBottomInspectorSplitViewTests {
 
         #expect(controller.defaultDividerApplicationCount == 1)
         expectNonNegativeArrangedGeometry(controller)
+        removeSplitViewAutosaveDefaults(autosaveName)
+    }
+
+    @Test("First selection expands a fresh payload inspector at its default height")
+    func firstExpansionAppliesDefaultRatio() {
+        let autosaveName = uniqueAutosaveName()
+        removeSplitViewAutosaveDefaults(autosaveName)
+        let controller = makeConfiguredController(
+            isInspectorPresented: false,
+            autosaveName: autosaveName
+        )
+        layout(controller, at: CGRect(x: 0, y: 0, width: 1_200, height: 700))
+
+        #expect(!controller.isInspectorPresented)
+        #expect(controller.defaultDividerApplicationCount == 0)
+
+        controller.setInspectorPresented(true, animated: false)
+        layout(controller, at: CGRect(x: 0, y: 0, width: 1_200, height: 700))
+
+        #expect(controller.isInspectorPresented)
+        #expect(controller.splitViewItems[1].viewController.view.frame.height > 440)
+        #expect(controller.defaultDividerApplicationCount == 1)
         removeSplitViewAutosaveDefaults(autosaveName)
     }
 

--- a/RockxyTests/Views/Main/NativeWorkspaceSplitViewTests.swift
+++ b/RockxyTests/Views/Main/NativeWorkspaceSplitViewTests.swift
@@ -7,14 +7,15 @@ import Testing
 struct NativeWorkspaceSplitViewTests {
     // MARK: Internal
 
-    @Test("Workspace panes keep balanced defaults with a flexible Context Dock")
+    @Test("Workspace defaults favor the Context Dock over the navigation sidebar")
     func flexibleInspectorWidthPolicy() {
-        #expect(MainWindowLayoutMetrics.sidebarMinimumWidth == 300)
-        #expect(MainWindowLayoutMetrics.sidebarIdealWidth == 380)
-        #expect(MainWindowLayoutMetrics.sidebarMaximumWidth == 520)
+        #expect(MainWindowLayoutMetrics.sidebarMinimumWidth == 200)
+        #expect(MainWindowLayoutMetrics.sidebarIdealWidth == 250)
+        #expect(MainWindowLayoutMetrics.sidebarMaximumWidth == 350)
         #expect(MainWindowLayoutMetrics.workspaceMinimumWidth == 320)
-        #expect(MainWindowLayoutMetrics.contextDockMinimumWidth == 220)
-        #expect(MainWindowLayoutMetrics.contextDockIdealWidth == 380)
+        #expect(MainWindowLayoutMetrics.contextDockMinimumWidth == 260)
+        #expect(MainWindowLayoutMetrics.contextDockIdealWidth == 320)
+        #expect(MainWindowLayoutMetrics.sidebarIdealWidth < MainWindowLayoutMetrics.contextDockIdealWidth)
     }
 
     @Test("Workspace uses one native vertical split for both utility columns")

--- a/RockxyTests/Views/Main/NativeWorkspaceSplitViewTests.swift
+++ b/RockxyTests/Views/Main/NativeWorkspaceSplitViewTests.swift
@@ -7,11 +7,14 @@ import Testing
 struct NativeWorkspaceSplitViewTests {
     // MARK: Internal
 
-    @Test("Sidebar and inspector share one balanced width policy")
-    func balancedUtilityPaneWidths() {
-        #expect(MainWindowLayoutMetrics.utilityPaneMinimumWidth == 300)
-        #expect(MainWindowLayoutMetrics.utilityPaneIdealWidth == 380)
-        #expect(MainWindowLayoutMetrics.utilityPaneMaximumWidth == 520)
+    @Test("Workspace panes keep balanced defaults with a flexible Context Dock")
+    func flexibleInspectorWidthPolicy() {
+        #expect(MainWindowLayoutMetrics.sidebarMinimumWidth == 300)
+        #expect(MainWindowLayoutMetrics.sidebarIdealWidth == 380)
+        #expect(MainWindowLayoutMetrics.sidebarMaximumWidth == 520)
+        #expect(MainWindowLayoutMetrics.workspaceMinimumWidth == 320)
+        #expect(MainWindowLayoutMetrics.contextDockMinimumWidth == 220)
+        #expect(MainWindowLayoutMetrics.contextDockIdealWidth == 380)
     }
 
     @Test("Workspace uses one native vertical split for both utility columns")
@@ -26,9 +29,59 @@ struct NativeWorkspaceSplitViewTests {
         #expect(controller.splitViewItems[2].canCollapse)
         #expect(controller.splitViewItems[0].minimumThickness == 200)
         #expect(controller.splitViewItems[0].maximumThickness == 350)
-        #expect(controller.splitViewItems[1].minimumThickness == 600)
-        #expect(controller.splitViewItems[2].minimumThickness == 300)
-        #expect(controller.splitViewItems[2].maximumThickness == 520)
+        #expect(controller.splitViewItems[1].minimumThickness == 320)
+        #expect(controller.splitViewItems[2].minimumThickness == 220)
+        #expect(controller.splitViewItems[2].maximumThickness == 10_000)
+    }
+
+    @Test("Context Dock sizing policy permits widths beyond the former maximum")
+    func contextDockSupportsWideResize() {
+        let controller = makeController(sidebarPresented: true, inspectorPresented: true)
+        let availableInspectorWidth = 1_600
+            - controller.splitView.dividerThickness * 2
+            - controller.splitViewItems[0].minimumThickness
+            - controller.splitViewItems[1].minimumThickness
+
+        #expect(availableInspectorWidth > 520)
+        #expect(controller.splitViewItems[2].maximumThickness >= availableInspectorWidth)
+    }
+
+    @Test("Vertical dividers have a forgiving horizontal drag target")
+    func verticalDividerHitTarget() {
+        let controller = makeController(sidebarPresented: true, inspectorPresented: true)
+        let drawnRect = NSRect(x: 800, y: 0, width: 1, height: 700)
+        let effectiveRect = controller.splitView(
+            controller.splitView,
+            effectiveRect: drawnRect,
+            forDrawnRect: drawnRect,
+            ofDividerAt: 1
+        )
+
+        #expect(effectiveRect.width >= NativeSplitDividerInteraction.minimumHitThickness)
+        #expect(effectiveRect.minX < drawnRect.minX)
+        #expect(effectiveRect.maxX > drawnRect.maxX)
+    }
+
+    @Test("Context Dock divider moves through a useful width range after layout")
+    func contextDockDividerMovesAfterLayout() {
+        let controller = makeConfiguredController(
+            sidebarPresented: true,
+            inspectorPresented: true,
+            autosaveName: uniqueAutosaveName()
+        )
+        layout(controller, at: CGRect(x: 0, y: 0, width: 1_600, height: 700))
+
+        controller.splitView.setPosition(900, ofDividerAt: 1)
+        controller.view.layoutSubtreeIfNeeded()
+        let wideInspectorWidth = controller.splitViewItems[2].viewController.view.frame.width
+
+        controller.splitView.setPosition(1_250, ofDividerAt: 1)
+        controller.view.layoutSubtreeIfNeeded()
+        let compactInspectorWidth = controller.splitViewItems[2].viewController.view.frame.width
+
+        #expect(wideInspectorWidth > compactInspectorWidth)
+        #expect(wideInspectorWidth > 600)
+        #expect(compactInspectorWidth >= 220)
     }
 
     @Test("Collapsing utility columns preserves all hosted pane controllers")
@@ -378,10 +431,9 @@ struct NativeWorkspaceSplitViewTests {
                 sidebarMinimumWidth: 200,
                 sidebarIdealWidth: 250,
                 sidebarMaximumWidth: 350,
-                workspaceMinimumWidth: 600,
-                inspectorMinimumWidth: 300,
-                inspectorIdealWidth: 380,
-                inspectorMaximumWidth: 520
+                workspaceMinimumWidth: 320,
+                inspectorMinimumWidth: 220,
+                inspectorIdealWidth: 380
             )
         )
         return controller

--- a/RockxyTests/Views/Main/ProxyDisplayStateTests.swift
+++ b/RockxyTests/Views/Main/ProxyDisplayStateTests.swift
@@ -49,4 +49,48 @@ struct ProxyDisplayStateTests {
 
         #expect(coordinator.proxyDisplayState == .stopped)
     }
+
+    @Test("Capture presentation explains wildcard reachability and stopped readiness")
+    func stoppedCapturePresentation() {
+        let presentation = CaptureStatusPresentation(
+            displayState: .stopped,
+            listenAddress: "0.0.0.0",
+            port: 8_888,
+            certReadiness: .trusted,
+            helperReadiness: .installedCompatible,
+            isSystemProxyConfigured: false
+        )
+
+        #expect(presentation.title == "Capture Stopped")
+        #expect(presentation.listener == "0.0.0.0:8888")
+        #expect(presentation.listenerScope == "This Mac and local network")
+        #expect(presentation.https.level == .ready)
+        #expect(presentation.systemRouting.level == .ready)
+        #expect(presentation.actionTitle == "Start Capture")
+        #expect(presentation.isActionEnabled)
+    }
+
+    @Test("Running capture surfaces degraded readiness without relying on color")
+    func degradedRunningCapturePresentation() {
+        let presentation = CaptureStatusPresentation(
+            displayState: .running,
+            listenAddress: "127.0.0.1",
+            port: 9_090,
+            certReadiness: .installedNotTrusted,
+            helperReadiness: .notInstalled,
+            isSystemProxyConfigured: false
+        )
+
+        #expect(presentation.listenerScope == "This Mac only")
+        #expect(presentation.https.level == .attention)
+        #expect(presentation.https.value == "Root CA installed but not trusted")
+        #expect(presentation.systemRouting.level == .attention)
+        #expect(presentation.systemRouting.value == "Manual app setup")
+        #expect(presentation.actionTitle == "Stop Capture")
+    }
+
+    @Test("Capture listener formats IPv6 endpoints without ambiguity")
+    func ipv6ListenerFormatting() {
+        #expect(CaptureStatusPresentation.listener(address: "::1", port: 8_888) == "[::1]:8888")
+    }
 }

--- a/RockxyTests/Views/Main/SidebarSSLProxyingTests.swift
+++ b/RockxyTests/Views/Main/SidebarSSLProxyingTests.swift
@@ -11,6 +11,22 @@ import Testing
 @Suite(.serialized)
 @MainActor
 struct SidebarSSLProxyingTests {
+    @Test("Stale toast dismissal keeps the replacement notification visible")
+    func staleToastDismissalKeepsReplacement() {
+        let coordinator = MainContentCoordinator()
+        let first = ToastMessage(style: .success, text: "First")
+        let replacement = ToastMessage(style: .success, text: "Replacement")
+
+        coordinator.activeToast = first
+        coordinator.activeToast = replacement
+        coordinator.dismissToast(id: first.id)
+
+        #expect(coordinator.activeToast?.id == replacement.id)
+
+        coordinator.dismissToast(id: replacement.id)
+        #expect(coordinator.activeToast == nil)
+    }
+
     // MARK: - isSSLProxyingEnabled(for:)
 
     @Test("exclude rule is not treated as enabled by isSSLProxyingEnabled")

--- a/RockxyTests/Views/RequestList/RequestTableRefreshTests.swift
+++ b/RockxyTests/Views/RequestList/RequestTableRefreshTests.swift
@@ -899,4 +899,132 @@ struct RequestTableRefreshTests {
 
         #expect(coordinator.selectedTransaction == nil)
     }
+
+    // MARK: - Append-Chain Provenance
+
+    @Test("First append records the pre-append token as the append-chain origin")
+    func firstAppendRecordsChainOrigin() {
+        let coordinator = MainContentCoordinator()
+        coordinator.transactions = [TestFixtures.makeTransaction()]
+        coordinator.recomputeFilteredTransactions()
+        #expect(coordinator.activeWorkspace.appendChainOriginToken == nil)
+
+        let baseToken = coordinator.refreshToken
+        let appended = TestFixtures.makeTransaction()
+        coordinator.transactions.append(appended)
+        coordinator.appendFilteredTransactions([appended])
+
+        #expect(coordinator.activeWorkspace.appendChainOriginToken == baseToken)
+    }
+
+    @Test("Coalesced pure appends preserve the original append-chain origin")
+    func coalescedAppendsPreserveChainOrigin() {
+        let coordinator = MainContentCoordinator()
+        coordinator.transactions = [TestFixtures.makeTransaction()]
+        coordinator.recomputeFilteredTransactions()
+
+        let baseToken = coordinator.refreshToken
+        for _ in 0 ..< 3 {
+            let appended = TestFixtures.makeTransaction()
+            coordinator.transactions.append(appended)
+            coordinator.appendFilteredTransactions([appended])
+        }
+
+        // Several batches were coalesced and the token advanced each time, but the origin
+        // still points at the base state the table last applied.
+        #expect(coordinator.activeWorkspace.appendChainOriginToken == baseToken)
+        #expect(coordinator.refreshToken > baseToken)
+    }
+
+    @Test("Recompute invalidates the append-chain origin")
+    func recomputeInvalidatesChainOrigin() {
+        let coordinator = MainContentCoordinator()
+        coordinator.transactions = [TestFixtures.makeTransaction()]
+        coordinator.recomputeFilteredTransactions()
+        let appended = TestFixtures.makeTransaction()
+        coordinator.transactions.append(appended)
+        coordinator.appendFilteredTransactions([appended])
+        #expect(coordinator.activeWorkspace.appendChainOriginToken != nil)
+
+        coordinator.recomputeFilteredTransactions()
+
+        #expect(coordinator.activeWorkspace.appendChainOriginToken == nil)
+    }
+
+    @Test("Same-count sort invalidates the append-chain origin")
+    func sortInvalidatesChainOrigin() {
+        let coordinator = MainContentCoordinator()
+        let t1 = TestFixtures.makeTransaction(url: "https://beta.example.com/test")
+        let t2 = TestFixtures.makeTransaction(url: "https://alpha.example.com/test")
+        coordinator.transactions = [t1, t2]
+        coordinator.recomputeFilteredTransactions()
+        let appended = TestFixtures.makeTransaction()
+        coordinator.transactions.append(appended)
+        coordinator.appendFilteredTransactions([appended])
+        #expect(coordinator.activeWorkspace.appendChainOriginToken != nil)
+
+        coordinator.activeSortDescriptors = [NSSortDescriptor(key: "url", ascending: true)]
+        coordinator.deriveFilteredRows()
+
+        #expect(coordinator.activeWorkspace.appendChainOriginToken == nil)
+    }
+
+    @Test("Client-app enrichment invalidates the append-chain origin")
+    func enrichmentInvalidatesChainOrigin() {
+        let coordinator = MainContentCoordinator()
+        let transaction = TestFixtures.makeTransaction()
+        coordinator.transactions = [transaction]
+        coordinator.recomputeFilteredTransactions()
+        let appended = TestFixtures.makeTransaction()
+        coordinator.transactions.append(appended)
+        coordinator.appendFilteredTransactions([appended])
+        #expect(coordinator.activeWorkspace.appendChainOriginToken != nil)
+
+        let tokenBefore = coordinator.refreshToken
+        transaction.clientApp = "Safari"
+        coordinator.handleClientAppEnrichment([transaction])
+
+        // In-place enrichment rewrote an existing row without a full derive, so it must have
+        // cleared the append provenance and still bumped the token for the table to reload.
+        #expect(coordinator.activeWorkspace.appendChainOriginToken == nil)
+        #expect(coordinator.refreshToken > tokenBefore)
+    }
+
+    @Test("Append after enrichment starts beyond the table's previously applied token")
+    func appendAfterEnrichmentStartsNewChain() throws {
+        let coordinator = MainContentCoordinator()
+        let original = TestFixtures.makeTransaction()
+        coordinator.transactions = [original]
+        coordinator.recomputeFilteredTransactions()
+
+        let firstAppend = TestFixtures.makeTransaction()
+        coordinator.transactions.append(firstAppend)
+        coordinator.appendFilteredTransactions([firstAppend])
+        let tableAppliedToken = coordinator.refreshToken
+
+        original.clientApp = "Safari"
+        coordinator.handleClientAppEnrichment([original])
+        let enrichmentToken = coordinator.refreshToken
+
+        let coalescedAppend = TestFixtures.makeTransaction()
+        coordinator.transactions.append(coalescedAppend)
+        coordinator.appendFilteredTransactions([coalescedAppend])
+
+        let origin = try #require(coordinator.activeWorkspace.appendChainOriginToken)
+        #expect(origin == enrichmentToken)
+        #expect(origin > tableAppliedToken)
+        #expect(coordinator.activeWorkspace.lastDeriveWasAppendOnly)
+    }
+
+    @Test("Reset invalidates append provenance")
+    func resetInvalidatesChainOrigin() {
+        let workspace = WorkspaceState()
+        workspace.appendChainOriginToken = 5
+        workspace.lastDeriveWasAppendOnly = true
+
+        workspace.reset()
+
+        #expect(workspace.appendChainOriginToken == nil)
+        #expect(!workspace.lastDeriveWasAppendOnly)
+    }
 }

--- a/RockxyTests/Views/RequestList/RequestTableSelectionScrollTests.swift
+++ b/RockxyTests/Views/RequestList/RequestTableSelectionScrollTests.swift
@@ -228,6 +228,39 @@ struct RequestTableSelectionScrollTests {
         #expect(scrollView.contentView.bounds.origin.y == preservedOrigin.y)
     }
 
+    @Test("Only user-initiated scrolling yields Follow Live")
+    func userInitiatedScrollingYieldsFollowLive() {
+        var selectedIDs = Set<UUID>()
+        var userScrollCount = 0
+        let parent = RequestTableView(
+            workspaceID: UUID(),
+            rows: [],
+            refreshToken: 0,
+            isAppendOnly: false,
+            selectedIDs: Binding(
+                get: { selectedIDs },
+                set: { selectedIDs = $0 }
+            ),
+            onUserScroll: {
+                userScrollCount += 1
+            }
+        )
+        let coordinator = RequestTableView.Coordinator(parent: parent)
+        let tableView = makeTableView(rowCount: 20, coordinator: coordinator)
+        let scrollView = makeScrollView(documentView: tableView)
+        coordinator.observeUserScrolling(in: scrollView)
+
+        scrollView.contentView.scroll(to: NSPoint(x: 0, y: 40))
+        scrollView.reflectScrolledClipView(scrollView.contentView)
+        #expect(userScrollCount == 0)
+
+        NotificationCenter.default.post(
+            name: NSScrollView.didLiveScrollNotification,
+            object: scrollView
+        )
+        #expect(userScrollCount == 1)
+    }
+
     @Test("Context actions preserve a selected group and isolate an unselected clicked row")
     func contextActionsFollowNativeSelectionSemantics() {
         let transactions = TestFixtures.makeBulkTransactions(count: 3)

--- a/RockxyTests/Views/RequestList/RequestTableSelectionScrollTests.swift
+++ b/RockxyTests/Views/RequestList/RequestTableSelectionScrollTests.swift
@@ -261,6 +261,42 @@ struct RequestTableSelectionScrollTests {
         #expect(userScrollCount == 1)
     }
 
+    @Test("Programmatic table reload suppresses selection delegate re-entry")
+    func programmaticReloadSuppressesSelectionDelegateReentry() {
+        let transactions = TestFixtures.makeBulkTransactions(count: 3)
+        let rows = transactions.map {
+            RequestListRow(from: $0, sslState: .insecure)
+        }
+        var selectedIDs: Set<UUID> = [rows[1].id]
+        var selectionChangeCount = 0
+        let parent = RequestTableView(
+            workspaceID: UUID(),
+            rows: rows,
+            refreshToken: 0,
+            isAppendOnly: false,
+            selectedIDs: Binding(
+                get: { selectedIDs },
+                set: { selectedIDs = $0 }
+            ),
+            onSelectionChanged: { _, _ in
+                selectionChangeCount += 1
+            }
+        )
+        let coordinator = RequestTableView.Coordinator(parent: parent)
+        coordinator.rows = rows
+        let tableView = makeTableView(rowCount: rows.count, coordinator: coordinator)
+        tableView.selectRowIndexes(IndexSet(integer: 1), byExtendingSelection: false)
+        selectionChangeCount = 0
+
+        coordinator.rows = [rows[0]]
+        coordinator.performProgrammaticTableUpdate {
+            tableView.reloadData()
+        }
+
+        #expect(selectionChangeCount == 0)
+        #expect(tableView.numberOfRows == 1)
+    }
+
     @Test("Context actions preserve a selected group and isolate an unselected clicked row")
     func contextActionsFollowNativeSelectionSemantics() {
         let transactions = TestFixtures.makeBulkTransactions(count: 3)
@@ -1153,5 +1189,124 @@ struct RequestTableSelectionScrollTests {
                 && constraint.secondItem as AnyObject? === container
                 && constraint.firstAttribute == .leading
         }.count
+    }
+}
+
+// MARK: - RequestTableAppendProvenanceTests
+
+@MainActor
+struct RequestTableAppendProvenanceTests {
+    @Test("Append-only refresh requires AppKit and coordinator row counts to agree")
+    func appendOnlyRefreshRejectsStaleTableCount() {
+        let coordinator = makeCoordinator()
+        coordinator.previousRowCount = 20
+
+        #expect(
+            coordinator.canInsertAppendedRows(
+                newCount: 24,
+                isAppendOnly: true,
+                appendChainOrigin: 7,
+                lastAppliedToken: 7,
+                workspaceChanged: false,
+                tableRowCount: 20
+            )
+        )
+        #expect(
+            !coordinator.canInsertAppendedRows(
+                newCount: 24,
+                isAppendOnly: true,
+                appendChainOrigin: 7,
+                lastAppliedToken: 7,
+                workspaceChanged: false,
+                tableRowCount: 12
+            )
+        )
+        #expect(
+            !coordinator.canInsertAppendedRows(
+                newCount: 24,
+                isAppendOnly: true,
+                appendChainOrigin: 7,
+                lastAppliedToken: 7,
+                workspaceChanged: true,
+                tableRowCount: 20
+            )
+        )
+        coordinator.previousRowCount = 0
+        #expect(
+            !coordinator.canInsertAppendedRows(
+                newCount: 1,
+                isAppendOnly: true,
+                appendChainOrigin: 7,
+                lastAppliedToken: 7,
+                workspaceChanged: false,
+                tableRowCount: 0
+            )
+        )
+    }
+
+    @Test("Coalesced non-append before an append rejects the incremental insert")
+    func coalescedNonAppendRejectsIncrementalInsert() {
+        let coordinator = makeCoordinator()
+        coordinator.previousRowCount = 20
+
+        #expect(
+            !coordinator.canInsertAppendedRows(
+                newCount: 24,
+                isAppendOnly: true,
+                appendChainOrigin: 9,
+                lastAppliedToken: 8,
+                workspaceChanged: false,
+                tableRowCount: 20
+            )
+        )
+    }
+
+    @Test("A missing append-chain origin rejects the incremental insert")
+    func missingAppendChainOriginRejectsInsert() {
+        let coordinator = makeCoordinator()
+        coordinator.previousRowCount = 20
+
+        #expect(
+            !coordinator.canInsertAppendedRows(
+                newCount: 24,
+                isAppendOnly: true,
+                appendChainOrigin: nil,
+                lastAppliedToken: 40,
+                workspaceChanged: false,
+                tableRowCount: 20
+            )
+        )
+    }
+
+    @Test("An append after a safe reload returns to the fast path once its origin is applied")
+    func appendAfterReloadReturnsToFastPath() {
+        let coordinator = makeCoordinator()
+        coordinator.previousRowCount = 24
+
+        #expect(
+            coordinator.canInsertAppendedRows(
+                newCount: 30,
+                isAppendOnly: true,
+                appendChainOrigin: 9,
+                lastAppliedToken: 11,
+                workspaceChanged: false,
+                tableRowCount: 24
+            )
+        )
+    }
+
+    private func makeCoordinator() -> RequestTableView.Coordinator {
+        var selectedIDs = Set<UUID>()
+        let parent = RequestTableView(
+            workspaceID: UUID(),
+            rows: [],
+            refreshToken: 0,
+            isAppendOnly: false,
+            selectedIDs: Binding(
+                get: { selectedIDs },
+                set: { selectedIDs = $0 }
+            )
+        )
+        return RequestTableView.Coordinator(parent: parent)
     }
 }

--- a/RockxyTests/Views/RequestList/StatusBarRequestSummaryTests.swift
+++ b/RockxyTests/Views/RequestList/StatusBarRequestSummaryTests.swift
@@ -31,7 +31,7 @@ struct StatusBarRequestSummaryTests {
             availableCount: 238,
             selectedCount: 2,
             activeFilterCount: 1
-        ) == "2 selected · 5 of 238 shown")
+        ) == "2 selected, 5 of 238 shown")
         #expect(StatusBarRequestSummary.text(
             visibleCount: 238,
             availableCount: 238,


### PR DESCRIPTION
## Description

Hardens Rockxy's capture and inspection workspace across helper recovery, live traffic updates, HTTPS diagnostics, and native split-view behavior. The changes make failure recovery deterministic, prevent stale AppKit table mutations during continuous capture, and improve the clarity and usable space of the primary debugging workflow.

## Changes

- preserve helper reset recovery across debug app replacement and explicitly require a reopen when the installed app changes underneath an active process
- stabilize coalesced request-table refreshes, selection callbacks, filtering, enrichment, and Follow Live behavior under continuous traffic
- keep Apps and Domains discoverable by default while refining Focus actions, sidebar sizing, Context Dock sizing, and workspace-scoped navigation state
- restore freely resizable bottom-inspector behavior and provide a taller default Request/Response workspace
- distinguish host- and app-scoped HTTPS decryption actions with consistent controls, duplicate-action protection, and visible success or error notifications
- expand focused regression coverage for helper recovery, HTTPS state, split-view geometry, sidebar behavior, history retention, request refresh, and selection scrolling

## Related issues

- Refs #10
- Refs #11
- Refs #14
- Refs #256

## Validation

- `swiftlint lint --strict` — passed with 0 violations across 526 files
- focused helper, HTTPS inspection, workspace split, sidebar, live-table refresh, selection, and history-retention test suites — passed
- `xcodebuild -project Rockxy.xcodeproj -scheme Rockxy -configuration Debug build` — succeeded
- `scripts/run-rockxy.sh --no-build` — launched the validated Debug build successfully

## Checklist

- [x] Tests added or updated
- [ ] `CHANGELOG.md` updated under `[Unreleased]` — deferred to release aggregation
- [x] Documentation impact reviewed; no documentation change is required for these in-app workflow refinements
- [x] User-facing strings retain the project's existing localization behavior
- [x] SwiftLint strict validation passes
- [ ] SwiftFormat lint — the existing repository baseline is not clean (287 of 832 files; 28 of 59 touched Swift files)
- [x] Helper packaging and platform compatibility validation are not applicable; this PR does not change packaging, release scripts, or compatibility claims

## CLA

This project requires acceptance of the
[Individual Contributor License Agreement v2.0](../legal/cla/ICLA-v2.0.md).
The `Rockxy CLA` check will comment with the exact acceptance statement. You
must accept that version before this PR can be merged. If an employer or
another organization owns or controls the contribution, contact
`rockxyapp@gmail.com` about the CCLA first.
