### PR TITLE
fix(README): restore the broken star history chart

### DIFF
--- a/README.ar.md
+++ b/README.ar.md
@@ -432,11 +432,11 @@ open Rockxy.xcodeproj
 
 ## تاريخ النجوم
 
-<a href="https://www.star-history.com/?repos=RockxyApp%2FRockxy&type=date&legend=top-left">
+<a href="https://star-history.dera.page/#RockxyApp/Rockxy&type=date&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=RockxyApp/Rockxy&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=RockxyApp/Rockxy&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=RockxyApp/Rockxy&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=RockxyApp/Rockxy&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=RockxyApp/Rockxy&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=RockxyApp/Rockxy&type=date&legend=top-left" />
  </picture>
 </a>
 

--- a/README.bn.md
+++ b/README.bn.md
@@ -430,11 +430,11 @@ Rockxy আর্থিকভাবে [Open Source Collective](https://docs.osco
 
 ## তারকা ইতিহাস
 
-<a href="https://www.star-history.com/?repos=RockxyApp%2FRockxy&type=date&legend=top-left">
+<a href="https://star-history.dera.page/#RockxyApp/Rockxy&type=date&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=RockxyApp/Rockxy&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=RockxyApp/Rockxy&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=RockxyApp/Rockxy&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=RockxyApp/Rockxy&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=RockxyApp/Rockxy&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=RockxyApp/Rockxy&type=date&legend=top-left" />
  </picture>
 </a>
 

--- a/README.de.md
+++ b/README.de.md
@@ -430,11 +430,11 @@ Rockxy wird finanziell vom [Open Source Collective](https://docs.oscollective.or
 
 ## Sterne-Verlauf
 
-<a href="https://www.star-history.com/?repos=RockxyApp%2FRockxy&type=date&legend=top-left">
+<a href="https://star-history.dera.page/#RockxyApp/Rockxy&type=date&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=RockxyApp/Rockxy&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=RockxyApp/Rockxy&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=RockxyApp/Rockxy&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=RockxyApp/Rockxy&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=RockxyApp/Rockxy&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=RockxyApp/Rockxy&type=date&legend=top-left" />
  </picture>
 </a>
 

--- a/README.es.md
+++ b/README.es.md
@@ -430,11 +430,11 @@ Rockxy cuenta con el patrocinio fiscal de [Open Source Collective](https://docs.
 
 ## Star History
 
-<a href="https://www.star-history.com/?repos=RockxyApp%2FRockxy&type=date&legend=top-left">
+<a href="https://star-history.dera.page/#RockxyApp/Rockxy&type=date&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=RockxyApp/Rockxy&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=RockxyApp/Rockxy&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=RockxyApp/Rockxy&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=RockxyApp/Rockxy&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=RockxyApp/Rockxy&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=RockxyApp/Rockxy&type=date&legend=top-left" />
  </picture>
 </a>
 

--- a/README.fa.md
+++ b/README.fa.md
@@ -432,11 +432,11 @@ Rockxy از نظر مالی توسط [Open Source Collective](https://docs.oscol
 
 ## تاریخچه ستاره
 
-<a href="https://www.star-history.com/?repos=RockxyApp%2FRockxy&type=date&legend=top-left">
+<a href="https://star-history.dera.page/#RockxyApp/Rockxy&type=date&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=RockxyApp/Rockxy&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=RockxyApp/Rockxy&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=RockxyApp/Rockxy&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=RockxyApp/Rockxy&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=RockxyApp/Rockxy&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=RockxyApp/Rockxy&type=date&legend=top-left" />
  </picture>
 </a>
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -430,11 +430,11 @@ Rockxy est h&eacute;berg&eacute; fiscalement par [Open Source Collective](https:
 
 ## Historique des Étoiles
 
-<a href="https://www.star-history.com/?repos=RockxyApp%2FRockxy&type=date&legend=top-left">
+<a href="https://star-history.dera.page/#RockxyApp/Rockxy&type=date&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=RockxyApp/Rockxy&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=RockxyApp/Rockxy&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=RockxyApp/Rockxy&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=RockxyApp/Rockxy&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=RockxyApp/Rockxy&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=RockxyApp/Rockxy&type=date&legend=top-left" />
  </picture>
 </a>
 

--- a/README.it.md
+++ b/README.it.md
@@ -430,11 +430,11 @@ Rockxy &egrave; ospitato fiscalmente da [Open Source Collective](https://docs.os
 
 ## Storia delle stelle
 
-<a href="https://www.star-history.com/?repos=RockxyApp%2FRockxy&type=date&legend=top-left">
+<a href="https://star-history.dera.page/#RockxyApp/Rockxy&type=date&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=RockxyApp/Rockxy&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=RockxyApp/Rockxy&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=RockxyApp/Rockxy&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=RockxyApp/Rockxy&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=RockxyApp/Rockxy&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=RockxyApp/Rockxy&type=date&legend=top-left" />
  </picture>
 </a>
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -430,11 +430,11 @@ Rockxy は [Open Source Collective](https://docs.oscollective.org/) による財
 
 ## スター履歴
 
-<a href="https://www.star-history.com/?repos=RockxyApp%2FRockxy&type=date&legend=top-left">
+<a href="https://star-history.dera.page/#RockxyApp/Rockxy&type=date&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=RockxyApp/Rockxy&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=RockxyApp/Rockxy&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=RockxyApp/Rockxy&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=RockxyApp/Rockxy&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=RockxyApp/Rockxy&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=RockxyApp/Rockxy&type=date&legend=top-left" />
  </picture>
 </a>
 

--- a/README.ka.md
+++ b/README.ka.md
@@ -430,11 +430,11 @@ Rockxy-ს ფინანსურ მასპინძლობას უზ�
 
 ## ვარსკვლავის ისტორია
 
-<a href="https://www.star-history.com/?repos=RockxyApp%2FRockxy&type=date&legend=top-left">
+<a href="https://star-history.dera.page/#RockxyApp/Rockxy&type=date&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=RockxyApp/Rockxy&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=RockxyApp/Rockxy&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=RockxyApp/Rockxy&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=RockxyApp/Rockxy&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=RockxyApp/Rockxy&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=RockxyApp/Rockxy&type=date&legend=top-left" />
  </picture>
 </a>
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -430,11 +430,11 @@ Rockxy는 [Open Source Collective](https://docs.oscollective.org/)의 재정 호
 
 ## 스타 히스토리
 
-<a href="https://www.star-history.com/?repos=RockxyApp%2FRockxy&type=date&legend=top-left">
+<a href="https://star-history.dera.page/#RockxyApp/Rockxy&type=date&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=RockxyApp/Rockxy&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=RockxyApp/Rockxy&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=RockxyApp/Rockxy&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=RockxyApp/Rockxy&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=RockxyApp/Rockxy&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=RockxyApp/Rockxy&type=date&legend=top-left" />
  </picture>
 </a>
 

--- a/README.md
+++ b/README.md
@@ -451,11 +451,11 @@ Binary EULA v1.0 are governed by that
 
 ## Star History
 
-<a href="https://www.star-history.com/?repos=RockxyApp%2FRockxy&type=date&legend=top-left">
+<a href="https://star-history.dera.page/#RockxyApp/Rockxy&type=date&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=RockxyApp/Rockxy&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=RockxyApp/Rockxy&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=RockxyApp/Rockxy&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=RockxyApp/Rockxy&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=RockxyApp/Rockxy&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=RockxyApp/Rockxy&type=date&legend=top-left" />
  </picture>
 </a>
 

--- a/README.nl.md
+++ b/README.nl.md
@@ -430,11 +430,11 @@ Rockxy wordt fiscaal gehost door [Open Source Collective](https://docs.oscollect
 
 ## Sterrengeschiedenis
 
-<a href="https://www.star-history.com/?repos=RockxyApp%2FRockxy&type=date&legend=top-left">
+<a href="https://star-history.dera.page/#RockxyApp/Rockxy&type=date&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=RockxyApp/Rockxy&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=RockxyApp/Rockxy&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=RockxyApp/Rockxy&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=RockxyApp/Rockxy&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=RockxyApp/Rockxy&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=RockxyApp/Rockxy&type=date&legend=top-left" />
  </picture>
 </a>
 

--- a/README.pl.md
+++ b/README.pl.md
@@ -430,11 +430,11 @@ Rockxy jest objęty obsługą fiskalną przez [Open Source Collective](https://d
 
 ## Historia gwiazd
 
-<a href="https://www.star-history.com/?repos=RockxyApp%2FRockxy&type=date&legend=top-left">
+<a href="https://star-history.dera.page/#RockxyApp/Rockxy&type=date&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=RockxyApp/Rockxy&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=RockxyApp/Rockxy&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=RockxyApp/Rockxy&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=RockxyApp/Rockxy&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=RockxyApp/Rockxy&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=RockxyApp/Rockxy&type=date&legend=top-left" />
  </picture>
 </a>
 

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -430,11 +430,11 @@ Rockxy é hospedado fiscalmente pela [Open Source Collective](https://docs.oscol
 
 ## Star History
 
-<a href="https://www.star-history.com/?repos=RockxyApp%2FRockxy&type=date&legend=top-left">
+<a href="https://star-history.dera.page/#RockxyApp/Rockxy&type=date&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=RockxyApp/Rockxy&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=RockxyApp/Rockxy&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=RockxyApp/Rockxy&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=RockxyApp/Rockxy&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=RockxyApp/Rockxy&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=RockxyApp/Rockxy&type=date&legend=top-left" />
  </picture>
 </a>
 

--- a/README.ro.md
+++ b/README.ro.md
@@ -430,11 +430,11 @@ Rockxy este găzduit fiscal de [Open Source Collective](https://docs.oscollectiv
 
 ## Istoria stelelor
 
-<a href="https://www.star-history.com/?repos=RockxyApp%2FRockxy&type=date&legend=top-left">
+<a href="https://star-history.dera.page/#RockxyApp/Rockxy&type=date&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=RockxyApp/Rockxy&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=RockxyApp/Rockxy&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=RockxyApp/Rockxy&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=RockxyApp/Rockxy&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=RockxyApp/Rockxy&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=RockxyApp/Rockxy&type=date&legend=top-left" />
  </picture>
 </a>
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -430,11 +430,11 @@ Rockxy получает фискальное сопровождение от [Op
 
 ## Звездная история
 
-<a href="https://www.star-history.com/?repos=RockxyApp%2FRockxy&type=date&legend=top-left">
+<a href="https://star-history.dera.page/#RockxyApp/Rockxy&type=date&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=RockxyApp/Rockxy&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=RockxyApp/Rockxy&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=RockxyApp/Rockxy&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=RockxyApp/Rockxy&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=RockxyApp/Rockxy&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=RockxyApp/Rockxy&type=date&legend=top-left" />
  </picture>
 </a>
 

--- a/README.tr.md
+++ b/README.tr.md
@@ -430,11 +430,11 @@ Rockxy, [Open Source Collective](https://docs.oscollective.org/) tarafından mal
 
 ## Yıldız Tarihi
 
-<a href="https://www.star-history.com/?repos=RockxyApp%2FRockxy&type=date&legend=top-left">
+<a href="https://star-history.dera.page/#RockxyApp/Rockxy&type=date&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=RockxyApp/Rockxy&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=RockxyApp/Rockxy&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=RockxyApp/Rockxy&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=RockxyApp/Rockxy&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=RockxyApp/Rockxy&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=RockxyApp/Rockxy&type=date&legend=top-left" />
  </picture>
 </a>
 

--- a/README.uk.md
+++ b/README.uk.md
@@ -430,11 +430,11 @@ Rockxy отримує фіскальний супровід від [Open Source 
 
 ## Зоряна історія
 
-<a href="https://www.star-history.com/?repos=RockxyApp%2FRockxy&type=date&legend=top-left">
+<a href="https://star-history.dera.page/#RockxyApp/Rockxy&type=date&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=RockxyApp/Rockxy&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=RockxyApp/Rockxy&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=RockxyApp/Rockxy&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=RockxyApp/Rockxy&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=RockxyApp/Rockxy&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=RockxyApp/Rockxy&type=date&legend=top-left" />
  </picture>
 </a>
 

--- a/README.vi.md
+++ b/README.vi.md
@@ -430,11 +430,11 @@ Rockxy được bảo trợ tài chính bởi [Open Source Collective](https://d
 
 ## Lịch Sử Stars
 
-<a href="https://www.star-history.com/?repos=RockxyApp%2FRockxy&type=date&legend=top-left">
+<a href="https://star-history.dera.page/#RockxyApp/Rockxy&type=date&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=RockxyApp/Rockxy&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=RockxyApp/Rockxy&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=RockxyApp/Rockxy&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=RockxyApp/Rockxy&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=RockxyApp/Rockxy&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=RockxyApp/Rockxy&type=date&legend=top-left" />
  </picture>
 </a>
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -430,11 +430,11 @@ Rockxy 由 [Open Source Collective](https://docs.oscollective.org/) 提供財務
 
 ## 明星歷史
 
-<a href="https://www.star-history.com/?repos=RockxyApp%2FRockxy&type=date&legend=top-left">
+<a href="https://star-history.dera.page/#RockxyApp/Rockxy&type=date&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=RockxyApp/Rockxy&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=RockxyApp/Rockxy&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=RockxyApp/Rockxy&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=RockxyApp/Rockxy&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=RockxyApp/Rockxy&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=RockxyApp/Rockxy&type=date&legend=top-left" />
  </picture>
 </a>
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -430,11 +430,11 @@ Rockxy 由 [Open Source Collective](https://docs.oscollective.org/) 提供财务
 
 ## 星标历史
 
-<a href="https://www.star-history.com/?repos=RockxyApp%2FRockxy&type=date&legend=top-left">
+<a href="https://star-history.dera.page/#RockxyApp/Rockxy&type=date&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=RockxyApp/Rockxy&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=RockxyApp/Rockxy&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=RockxyApp/Rockxy&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=RockxyApp/Rockxy&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=RockxyApp/Rockxy&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=RockxyApp/Rockxy&type=date&legend=top-left" />
  </picture>
 </a>
 


### PR DESCRIPTION
## Summary

- Restore Star History charts across all localized README files.
- Preserve the existing repository target, date mode, legend position, and light/dark appearance.

## Why

The previous chart endpoint no longer returns usable public history after GitHub restricted stargazer history access. The replacement endpoint generates the chart from its own indexed dataset without requiring a repository token.

## Impact

This is a documentation-only change. It does not affect the Rockxy application, build, release workflow, dependencies, or user traffic. The external chart service may refresh its indexed data on a delayed cadence.

## Validation

- Confirmed the final diff contains only the 21 localized README files.
- Verified the chart page opens the Rockxy repository.
- Verified light and dark SVG endpoints return valid SVG content.
- Confirmed the returned SVG contains no scripts, event handlers, foreign objects, or external resource references.
- Confirmed `git diff --check` passes.