### PR TITLE
fix: harden high-volume traffic workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,30 +29,73 @@ defaults:
     shell: bash
 
 jobs:
+  changes:
+    name: Classify changes
+    runs-on: ubuntu-latest
+    outputs:
+      metadata-only: ${{ steps.classify.outputs.metadata-only }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # immutable commit
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - id: classify
+        name: Detect release-metadata-only changes
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          metadata_only=false
+          if { [ "$EVENT_NAME" = "pull_request" ] || [ "$EVENT_NAME" = "push" ]; } &&
+             [ -n "$BASE_SHA" ] && [ -n "$HEAD_SHA" ] &&
+             [ "$BASE_SHA" != "0000000000000000000000000000000000000000" ]; then
+            changed_files="$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")"
+            if [ -n "$changed_files" ]; then
+              metadata_only=true
+              while IFS= read -r path; do
+                case "$path" in
+                  CHANGELOG.md|docs/changelog.mdx|appcast.xml|releases/latest.json|releases/catalog.json|README.md|README.*.md) ;;
+                  *) metadata_only=false; break ;;
+                esac
+              done <<<"$changed_files"
+            fi
+          fi
+          echo "metadata-only=$metadata_only" >> "$GITHUB_OUTPUT"
+          echo "metadata-only: $metadata_only"
+
   lint:
     name: SwiftLint
-    runs-on: macos-15
+    needs: changes
+    runs-on: "${{ needs.changes.outputs.metadata-only == 'true' && 'ubuntu-latest' || 'macos-15' }}"
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # immutable commit
         with:
           persist-credentials: false
       - name: Install SwiftLint
+        if: needs.changes.outputs.metadata-only != 'true'
         run: brew install swiftlint
       - name: Test release metadata policy
         run: python3 -m unittest discover -s releases/tests -p 'test_*.py'
       - name: Lint
+        if: needs.changes.outputs.metadata-only != 'true'
         run: swiftlint lint --strict
+      - name: Validate release metadata
+        if: needs.changes.outputs.metadata-only == 'true'
+        run: python3 releases/validate_metadata.py
 
   test:
     name: Test
-    runs-on: macos-15
+    needs: changes
+    runs-on: "${{ needs.changes.outputs.metadata-only == 'true' && 'ubuntu-latest' || 'macos-15' }}"
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # immutable commit
         with:
           persist-credentials: false
       - name: Prepare CI developer config
+        if: needs.changes.outputs.metadata-only != 'true'
         run: |
           cat > Configuration/Developer.xcconfig <<'EOF'
           #include "LocalDev.xcconfig"
@@ -62,6 +105,7 @@ jobs:
           DEVELOPMENT_TEAM =
           EOF
       - name: Select Xcode
+        if: needs.changes.outputs.metadata-only != 'true'
         run: |
           for candidate in \
             /Applications/Xcode_16.4.app \
@@ -80,6 +124,7 @@ jobs:
           ls -1 /Applications | grep '^Xcode' || true
           exit 1
       - name: Run tests
+        if: needs.changes.outputs.metadata-only != 'true'
         run: |
           mkdir -p build/test-results
           xcodebuild -project Rockxy.xcodeproj \
@@ -95,19 +140,21 @@ jobs:
             PROVISIONING_PROFILE="" \
             PROVISIONING_PROFILE_SPECIFIER="" \
             test
+      - name: Run release metadata tests
+        if: needs.changes.outputs.metadata-only == 'true'
+        run: python3 -m unittest discover -s releases/tests -p 'test_*.py'
 
   build-universal:
     name: Build (Universal)
-    needs:
-      - lint
-      - test
-    runs-on: macos-15
+    needs: changes
+    runs-on: "${{ needs.changes.outputs.metadata-only == 'true' && 'ubuntu-latest' || 'macos-15' }}"
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # immutable commit
         with:
           persist-credentials: false
       - name: Prepare CI developer config
+        if: needs.changes.outputs.metadata-only != 'true'
         run: |
           cat > Configuration/Developer.xcconfig <<'EOF'
           #include "LocalDev.xcconfig"
@@ -117,6 +164,7 @@ jobs:
           DEVELOPMENT_TEAM =
           EOF
       - name: Select Xcode
+        if: needs.changes.outputs.metadata-only != 'true'
         run: |
           for candidate in \
             /Applications/Xcode_16.4.app \
@@ -135,6 +183,7 @@ jobs:
           ls -1 /Applications | grep '^Xcode' || true
           exit 1
       - name: Build arm64
+        if: needs.changes.outputs.metadata-only != 'true'
         run: |
           xcodebuild -project Rockxy.xcodeproj \
             -scheme Rockxy \
@@ -150,6 +199,7 @@ jobs:
             PROVISIONING_PROFILE_SPECIFIER="" \
             build
       - name: Build x86_64
+        if: needs.changes.outputs.metadata-only != 'true'
         run: |
           xcodebuild -project Rockxy.xcodeproj \
             -scheme Rockxy \
@@ -165,6 +215,7 @@ jobs:
             PROVISIONING_PROFILE_SPECIFIER="" \
             build
       - name: Create universal binary
+        if: needs.changes.outputs.metadata-only != 'true'
         run: |
           helper_plist_name_from_app() {
             /usr/libexec/PlistBuddy -c 'Print :RockxyHelperPlistName' "$1/Contents/Info.plist"
@@ -224,6 +275,7 @@ jobs:
 
           cd artifacts && zip -r "$ARTIFACT_BASENAME-universal.zip" "$APP_NAME.app"
       - name: Verify bundled helper resources
+        if: needs.changes.outputs.metadata-only != 'true'
         run: |
           verify_helper_resources_in_app() {
             local app_path="$1"
@@ -279,3 +331,6 @@ jobs:
           verify_helper_resources_in_app "build/arm64/Build/Products/Release/Rockxy.app" "arm64 app bundle"
           verify_helper_resources_in_app "build/x86_64/Build/Products/Release/Rockxy.app" "x86_64 app bundle"
           verify_helper_resources_in_app "artifacts/Rockxy.app" "universal app bundle"
+      - name: Validate release metadata without rebuilding application binaries
+        if: needs.changes.outputs.metadata-only == 'true'
+        run: python3 releases/validate_metadata.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - Improved sidebar grouping cleanup when selected domain/app groups disappear, keeping active filters and sidebar state aligned.
+- Made Clear Session and Follow Live discoverable in a dedicated traffic command bar above protocol filters while keeping filtering and footer tools in their existing workflows.
 
 ### Changed
 

--- a/Rockxy/Core/ProxyEngine/BreakpointRequestBuilder.swift
+++ b/Rockxy/Core/ProxyEngine/BreakpointRequestBuilder.swift
@@ -90,9 +90,11 @@ enum BreakpointRequestBuilder {
         }
 
         // 4. Build body
-        let body: Data? = modifiedData.body.isEmpty
-            ? nil
-            : modifiedData.body.data(using: .utf8)
+        let body: Data? = if modifiedData.isBodyEditable {
+            modifiedData.body.isEmpty ? nil : modifiedData.body.data(using: .utf8)
+        } else {
+            originalRequestData.body
+        }
 
         // 5. Reconcile Content-Length and Transfer-Encoding with the actual body
         if let body, !body.isEmpty {

--- a/Rockxy/Core/ProxyEngine/BreakpointResponseBuilder.swift
+++ b/Rockxy/Core/ProxyEngine/BreakpointResponseBuilder.swift
@@ -16,7 +16,8 @@ enum BreakpointResponseBuilder {
 
     static func build(
         modifiedData: BreakpointRequestData,
-        originalHead: HTTPResponseHead
+        originalHead: HTTPResponseHead,
+        originalBody: Data? = nil
     )
         -> Result
     {
@@ -31,7 +32,15 @@ enum BreakpointResponseBuilder {
         }
 
         let body: Data?
-        if modifiedData.body.isEmpty {
+        if !modifiedData.isBodyEditable {
+            body = originalBody
+            headers.remove(name: "Transfer-Encoding")
+            if let originalBody {
+                headers.replaceOrAdd(name: "Content-Length", value: "\(originalBody.count)")
+            } else {
+                headers.remove(name: "Content-Length")
+            }
+        } else if modifiedData.body.isEmpty {
             body = nil
             headers.remove(name: "Content-Length")
             headers.remove(name: "Transfer-Encoding")

--- a/Rockxy/Core/ProxyEngine/HTTPProxyHandler.swift
+++ b/Rockxy/Core/ProxyEngine/HTTPProxyHandler.swift
@@ -53,20 +53,22 @@ final class HTTPProxyHandler: ChannelInboundHandler, RemovableChannelHandler, @u
     typealias OutboundOut = HTTPServerResponsePart
 
     nonisolated func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+        guard !requestBodyLimitState.isRejected else {
+            return
+        }
         let part = unwrapInboundIn(data)
         switch part {
         case let .head(head):
             requestHead = head
             requestBody = context.channel.allocator.buffer(capacity: 0)
             requestStartTime = .now()
-            accumulatedBodySize = 0
+            requestBodyLimitState.reset()
             if clientSourcePort == nil, let port = context.channel.remoteAddress?.port {
                 clientSourcePort = UInt16(port)
             }
 
         case let .body(buffer):
-            accumulatedBodySize += buffer.readableBytes
-            guard accumulatedBodySize <= ProxyLimits.maxRequestBodySize else {
+            guard requestBodyLimitState.accept(buffer.readableBytes) else {
                 proxyHandlerLogger
                     .warning("SECURITY: Request body exceeds \(ProxyLimits.maxRequestBodySize) bytes, rejecting")
                 let head = requestHead ?? HTTPRequestHead(version: .http1_1, method: .POST, uri: "/")
@@ -117,7 +119,7 @@ final class HTTPProxyHandler: ChannelInboundHandler, RemovableChannelHandler, @u
     private var requestBody: ByteBuffer?
     private var requestStartTime: DispatchTime?
     private var clientSourcePort: UInt16?
-    private var accumulatedBodySize: Int = 0
+    private var requestBodyLimitState = RequestBodyLimitState()
 
     nonisolated private func makeTransactionCallback(
         for matchedRule: ProxyRule?
@@ -194,6 +196,10 @@ final class HTTPProxyHandler: ChannelInboundHandler, RemovableChannelHandler, @u
                 }
                 self.handleConnect(context: context, head: head)
                 return
+            }
+
+            if let responsePhase = breakpointRule?.action.responseBreakpointPhase {
+                self.pendingBreakpointPhase = responsePhase
             }
 
             if let breakpointRule,

--- a/Rockxy/Core/ProxyEngine/HTTPSProxyRelayHandler.swift
+++ b/Rockxy/Core/ProxyEngine/HTTPSProxyRelayHandler.swift
@@ -61,20 +61,28 @@ final class HTTPSProxyRelayHandler: ChannelInboundHandler, @unchecked Sendable {
     }
 
     nonisolated func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+        guard !requestBodyLimitState.isRejected else {
+            return
+        }
         let part = unwrapInboundIn(data)
         switch part {
         case let .head(head):
             requestHead = head
             requestBody = context.channel.allocator.buffer(capacity: 0)
             requestStartTime = .now()
-            accumulatedBodySize = 0
+            requestBodyLimitState.reset()
 
         case let .body(buffer):
-            accumulatedBodySize += buffer.readableBytes
-            guard accumulatedBodySize <= ProxyLimits.maxRequestBodySize else {
+            guard requestBodyLimitState.accept(buffer.readableBytes) else {
                 httpsRelayLogger
                     .warning("SECURITY: HTTPS request body exceeds \(ProxyLimits.maxRequestBodySize) bytes, rejecting")
-                sendErrorResponse(context: context, status: 413)
+                let head = requestHead ?? HTTPRequestHead(version: .http1_1, method: .POST, uri: "/")
+                sendErrorResponse(
+                    context: context,
+                    status: 413,
+                    requestData: buildRequestData(from: head),
+                    callback: onTransactionComplete
+                )
                 requestHead = nil
                 requestBody = nil
                 return
@@ -121,7 +129,7 @@ final class HTTPSProxyRelayHandler: ChannelInboundHandler, @unchecked Sendable {
     private var requestHead: HTTPRequestHead?
     private var requestBody: ByteBuffer?
     private var requestStartTime: DispatchTime?
-    private var accumulatedBodySize: Int = 0
+    private var requestBodyLimitState = RequestBodyLimitState()
 
     nonisolated private func makeTransactionCallback(
         for matchedRule: ProxyRule?
@@ -139,27 +147,7 @@ final class HTTPSProxyRelayHandler: ChannelInboundHandler, @unchecked Sendable {
         head: HTTPRequestHead
     ) {
         pendingBreakpointPhase = nil
-        let headers = head.headers.map { HTTPHeader(name: $0.name, value: $0.value) }
-        let body: Data? = if let buf = requestBody, buf.readableBytes > 0 {
-            if let bytes = buf.getBytes(at: buf.readerIndex, length: buf.readableBytes) {
-                Data(bytes)
-            } else {
-                nil
-            }
-        } else {
-            nil
-        }
-        let urlString = "https://\(host)\(head.uri)"
-        let fallbackURL = URL(string: "https://localhost/")!
-        let parsedURL = URL(string: urlString) ?? URL(string: "https://\(host)/") ?? fallbackURL
-        var requestData = HTTPRequestData(
-            method: head.method.rawValue,
-            url: parsedURL,
-            httpVersion: "\(head.version.major).\(head.version.minor)",
-            headers: headers,
-            body: body,
-            contentType: ContentTypeDetector.detect(headers: headers, body: body)
-        )
+        var requestData = buildRequestData(from: head)
 
         var head = head
         if NoCacheHeaderMutator.isEnabled {
@@ -177,12 +165,12 @@ final class HTTPSProxyRelayHandler: ChannelInboundHandler, @unchecked Sendable {
         eventLoop.makeFutureWithTask {
             let breakpointRule = await ruleEngine.evaluateBreakpointRule(
                 method: head.method.rawValue,
-                url: parsedURL,
+                url: requestData.url,
                 headers: requestData.headers
             )
             let matchedRule = await ruleEngine.evaluateRule(
                 method: head.method.rawValue,
-                url: parsedURL,
+                url: requestData.url,
                 headers: requestData.headers
             )
             return (breakpointRule, matchedRule)
@@ -194,6 +182,10 @@ final class HTTPSProxyRelayHandler: ChannelInboundHandler, @unchecked Sendable {
             let breakpointRule = evaluation?.0
             let matchedRule = evaluation?.1
             let matchedRuleCallback = self.makeTransactionCallback(for: matchedRule)
+
+            if let responsePhase = breakpointRule?.action.responseBreakpointPhase {
+                self.pendingBreakpointPhase = responsePhase
+            }
 
             if let breakpointRule,
                case let .breakpoint(phase) = breakpointRule.action,
@@ -280,6 +272,32 @@ final class HTTPSProxyRelayHandler: ChannelInboundHandler, @unchecked Sendable {
         }
     }
 
+    nonisolated private func buildRequestData(from head: HTTPRequestHead) -> HTTPRequestData {
+        let headers = head.headers.map { HTTPHeader(name: $0.name, value: $0.value) }
+        let body: Data? = if let buffer = requestBody, buffer.readableBytes > 0,
+                            let bytes = buffer.getBytes(
+                                at: buffer.readerIndex,
+                                length: buffer.readableBytes
+                            )
+        {
+            Data(bytes)
+        } else {
+            nil
+        }
+        let fallbackURL = URL(string: "https://localhost/")!
+        let parsedURL = URL(string: "https://\(host)\(head.uri)")
+            ?? URL(string: "https://\(host)/")
+            ?? fallbackURL
+        return HTTPRequestData(
+            method: head.method.rawValue,
+            url: parsedURL,
+            httpVersion: "\(head.version.major).\(head.version.minor)",
+            headers: headers,
+            body: body,
+            contentType: ContentTypeDetector.detect(headers: headers, body: body)
+        )
+    }
+
     nonisolated private func connectToUpstream(
         context: ChannelHandlerContext,
         head: HTTPRequestHead,
@@ -295,7 +313,12 @@ final class HTTPSProxyRelayHandler: ChannelInboundHandler, @unchecked Sendable {
 
         guard connectionLimiter.acquire(host: upstreamHost, port: upstreamPort) else {
             httpsRelayLogger.warning("Connection limit reached for \(upstreamHost):\(upstreamPort)")
-            sendErrorResponse(context: context, status: 503)
+            sendErrorResponse(
+                context: context,
+                status: 503,
+                requestData: requestData,
+                callback: callback
+            )
             return
         }
 
@@ -346,7 +369,12 @@ final class HTTPSProxyRelayHandler: ChannelInboundHandler, @unchecked Sendable {
         } catch {
             httpsRelayLogger.error("Client TLS setup failed: \(error.localizedDescription)")
             limiter.release(host: upstreamHost, port: upstreamPort)
-            sendErrorResponse(context: context, status: 502)
+            sendErrorResponse(
+                context: context,
+                status: 502,
+                requestData: requestData,
+                callback: callback
+            )
         }
     }
 
@@ -808,22 +836,6 @@ final class HTTPSProxyRelayHandler: ChannelInboundHandler, @unchecked Sendable {
         transaction.measuredDuration = requestElapsedDuration()
         transaction.sourcePort = clientSourcePort
         callback(transaction)
-    }
-
-    nonisolated private func sendErrorResponse(
-        context: ChannelHandlerContext,
-        status: Int
-    ) {
-        guard context.channel.isActive else {
-            return
-        }
-        let httpStatus = HTTPResponseStatus(statusCode: status)
-        var responseHead = HTTPResponseHead(version: .http1_1, status: httpStatus)
-        responseHead.headers.add(name: "Connection", value: "close")
-        context.write(NIOAny(HTTPServerResponsePart.head(responseHead)), promise: nil)
-        context.writeAndFlush(NIOAny(HTTPServerResponsePart.end(nil))).whenComplete { _ in
-            context.close(promise: nil)
-        }
     }
 
     nonisolated private func sendErrorResponse(

--- a/Rockxy/Core/ProxyEngine/ProxyHandlerShared.swift
+++ b/Rockxy/Core/ProxyEngine/ProxyHandlerShared.swift
@@ -24,11 +24,11 @@ enum ProxyHandlerShared {
 
     /// Decision returned by `oversizeRelayDecision` when a response body chunk
     /// pushes the capture buffer past the cap. Drives both the script-deferral
-    /// flush logic and the response-breakpoint preservation.
+    /// flush logic and response-breakpoint safety.
     enum OversizeRelayDecision: Equatable {
-        /// Continue buffering for the breakpoint UI, do not flush. Reached when
-        /// a response breakpoint is armed even if the script hook was deferring.
-        case keepBufferingForBreakpoint
+        /// Suppress the breakpoint, flush the captured prefix, and resume streaming.
+        /// A breakpoint cannot safely own a response after the capture buffer truncates.
+        case suppressBreakpointAndResumeStreaming
         /// Flush the buffered head + body to the client and resume streaming.
         /// Reached when scripting was deferring but no breakpoint is in play.
         case flushBufferedAndResumeStreaming
@@ -46,8 +46,8 @@ enum ProxyHandlerShared {
     )
         -> OversizeRelayDecision
     {
-        if deferRelayForScript, shouldBreakOnResponse {
-            return .keepBufferingForBreakpoint
+        if shouldBreakOnResponse {
+            return .suppressBreakpointAndResumeStreaming
         }
         if deferRelayForScript {
             return .flushBufferedAndResumeStreaming

--- a/Rockxy/Core/ProxyEngine/ProxyLimits.swift
+++ b/Rockxy/Core/ProxyEngine/ProxyLimits.swift
@@ -11,6 +11,10 @@ enum ProxyLimits {
     /// Maximum total WebSocket payload per connection (100 MB).
     static let maxWebSocketConnectionSize = 100 * 1_024 * 1_024
 
+    /// Maximum captured frames retained for one WebSocket connection. This count cap
+    /// complements the byte cap so empty-frame floods cannot grow memory without bound.
+    static let maxWebSocketFrameCount = 100_000
+
     /// Maximum HTTP response body size retained for capture/inspection (100 MB).
     /// Bodies exceeding this limit are truncated in the capture buffer while the full
     /// response continues to relay to the client.
@@ -30,4 +34,33 @@ enum ProxyLimits {
 
     /// Maximum uploaded .proto schema file size (1 MB).
     static let maxProtobufSchemaFileSize = 1 * 1_024 * 1_024
+}
+
+struct RequestBodyLimitState {
+    private(set) var isRejected = false
+
+    mutating func reset() {
+        accumulatedBytes = 0
+        isRejected = false
+    }
+
+    mutating func accept(
+        _ byteCount: Int,
+        maximum: Int = ProxyLimits.maxRequestBodySize
+    )
+        -> Bool
+    {
+        guard !isRejected,
+              byteCount >= 0,
+              byteCount <= maximum,
+              accumulatedBytes <= maximum - byteCount else
+        {
+            isRejected = true
+            return false
+        }
+        accumulatedBytes += byteCount
+        return true
+    }
+
+    private var accumulatedBytes = 0
 }

--- a/Rockxy/Core/ProxyEngine/UpstreamResponseHandler.swift
+++ b/Rockxy/Core/ProxyEngine/UpstreamResponseHandler.swift
@@ -227,14 +227,21 @@ final class UpstreamResponseHandler: ChannelInboundHandler, @unchecked Sendable 
                         shouldBreakOnResponse: shouldBreakOnResponse
                     )
                     switch decision {
-                    case .keepBufferingForBreakpoint:
-                        // Response breakpoint is armed — the breakpoint still owns the
-                        // relay decision in `.end`. Drop scripting deferral so we don't
-                        // run the script on the truncated body, but keep buffering for
-                        // the breakpoint UI to act on.
+                    case .suppressBreakpointAndResumeStreaming:
+                        // The complete original body is no longer available, so allowing
+                        // the breakpoint to Execute or Cancel would relay only a prefix.
+                        // Suppress it, flush the captured prefix, and preserve the live
+                        // response by streaming this and all subsequent chunks.
+                        responseBreakpointSuppressed = true
                         deferRelayForScript = false
+                        if let head = responseHead {
+                            relayResponseHead(head)
+                        }
+                        if let buffered = responseBody, buffered.readableBytes > 0 {
+                            relayResponseBody(buffered)
+                        }
                         upstreamLogger.warning(
-                            "Response exceeded capture cap; skipping script mutation but preserving breakpoint for \(self.requestData.url, privacy: .private)"
+                            "Response exceeded capture cap; skipping response breakpoint and script mutation for \(self.requestData.url, privacy: .private)"
                         )
                     case .flushBufferedAndResumeStreaming:
                         // No breakpoint in play; abandon deferral, flush prefix, resume streaming.
@@ -323,6 +330,7 @@ final class UpstreamResponseHandler: ChannelInboundHandler, @unchecked Sendable 
     private var channelClosedCalled = false
     private var responseBody: ByteBuffer?
     private var responseBodyTruncated = false
+    private var responseBreakpointSuppressed = false
     private var firstByteTime: DispatchTime?
     private var completed = false
     private var readTimeoutTask: Scheduled<Void>?
@@ -336,7 +344,10 @@ final class UpstreamResponseHandler: ChannelInboundHandler, @unchecked Sendable 
     private var deferRelayForScript: Bool = false
 
     private var shouldBreakOnResponse: Bool {
-        guard let phase = breakpointPhase else {
+        guard !responseBreakpointSuppressed,
+              onBreakpointHit != nil,
+              let phase = breakpointPhase else
+        {
             return false
         }
         return phase == .response || phase == .both
@@ -587,9 +598,16 @@ final class UpstreamResponseHandler: ChannelInboundHandler, @unchecked Sendable 
     ) {
         switch decision {
         case .execute:
+            let originalBody = responseBody.flatMap { buffer -> Data? in
+                guard let bytes = buffer.getBytes(at: buffer.readerIndex, length: buffer.readableBytes) else {
+                    return nil
+                }
+                return Data(bytes)
+            }
             let built = BreakpointResponseBuilder.build(
                 modifiedData: modifiedData,
-                originalHead: originalHead
+                originalHead: originalHead,
+                originalBody: originalBody
             )
             self.responseHead = built.head
             if let body = built.body {

--- a/Rockxy/Core/ProxyEngine/WebSocketFrameHandler.swift
+++ b/Rockxy/Core/ProxyEngine/WebSocketFrameHandler.swift
@@ -55,7 +55,7 @@ final class WebSocketFrameHandler: ChannelInboundHandler, @unchecked Sendable {
 
     nonisolated func channelRead(context: ChannelHandlerContext, data: NIOAny) {
         let frame = unwrapInboundIn(data)
-        captureFrame(frame, context: context)
+        captureFrame(frame)
         forwardFrame(frame, context: context)
     }
 
@@ -80,26 +80,23 @@ final class WebSocketFrameHandler: ChannelInboundHandler, @unchecked Sendable {
 
     /// Unmasks the frame payload (WebSocket client frames are always masked per RFC 6455)
     /// and records it in the shared connection model before forwarding.
-    nonisolated private func captureFrame(
-        _ frame: WebSocketFrame,
-        context: ChannelHandlerContext
-    ) {
+    nonisolated private func captureFrame(_ frame: WebSocketFrame) {
+        guard !webSocketConnection.isCaptureLimitReached else {
+            return
+        }
         let opcode = mapOpcode(frame.opcode)
         var dataBuffer = frame.unmaskedData
         let payloadBytes = dataBuffer.readBytes(length: dataBuffer.readableBytes) ?? []
         let payload = Data(payloadBytes)
 
         guard payload.count <= ProxyLimits.maxWebSocketFrameSize else {
-            wsLogger.warning("SECURITY: WebSocket frame exceeds \(ProxyLimits.maxWebSocketFrameSize) bytes, closing")
-            context.close(promise: nil)
+            webSocketConnection.stopCaptureAtLimit()
+            notifyTransactionUpdate()
+            wsLogger.warning(
+                "WebSocket frame exceeds capture limit; capture stopped while relay remains active"
+            )
             return
         }
-        guard webSocketConnection.totalPayloadSize + payload.count <= ProxyLimits.maxWebSocketConnectionSize else {
-            wsLogger.warning("SECURITY: WebSocket connection exceeds total payload limit, closing")
-            context.close(promise: nil)
-            return
-        }
-
         let frameData = WebSocketFrameData(
             direction: direction,
             opcode: opcode,
@@ -107,8 +104,22 @@ final class WebSocketFrameHandler: ChannelInboundHandler, @unchecked Sendable {
             isFinal: frame.fin
         )
 
-        webSocketConnection.addFrame(frameData)
+        guard webSocketConnection.addFrame(
+            frameData,
+            maximumTotalPayloadSize: ProxyLimits.maxWebSocketConnectionSize,
+            maximumFrameCount: ProxyLimits.maxWebSocketFrameCount
+        ) else {
+            notifyTransactionUpdate()
+            wsLogger.warning(
+                "WebSocket connection exceeds capture limits; capture stopped while relay remains active"
+            )
+            return
+        }
 
+        notifyTransactionUpdate()
+    }
+
+    nonisolated private func notifyTransactionUpdate() {
         let transaction = parentTransaction
         Task { @MainActor in
             transaction.webSocketFrameVersion += 1

--- a/Rockxy/Core/RuleEngine/BreakpointManager.swift
+++ b/Rockxy/Core/RuleEngine/BreakpointManager.swift
@@ -90,10 +90,9 @@ final class BreakpointManager {
         }
         let item = pausedItems[index]
         pausedItems.remove(at: index)
-        let resolvedDecision = safeDecision(decision, for: item)
 
         if let continuation = continuations.removeValue(forKey: id) {
-            continuation.resume(returning: (resolvedDecision, item.editableDraft))
+            continuation.resume(returning: (decision, item.editableDraft))
         }
 
         if selectedItemId == id {
@@ -103,15 +102,14 @@ final class BreakpointManager {
             selectedItemId = pausedItems.isEmpty ? nil : pausedItems[min(index, pausedItems.count - 1)].id
         }
 
-        Self.logger.info("Breakpoint resolved (\(String(describing: resolvedDecision)))")
+        Self.logger.info("Breakpoint resolved (\(String(describing: decision)))")
     }
 
     /// Resolve all paused items at once with the same decision.
     func resolveAll(decision: BreakpointDecision) {
         for item in pausedItems {
             if let continuation = continuations.removeValue(forKey: item.id) {
-                let resolvedDecision = safeDecision(decision, for: item)
-                continuation.resume(returning: (resolvedDecision, item.editableDraft))
+                continuation.resume(returning: (decision, item.editableDraft))
             }
         }
         let count = pausedItems.count
@@ -151,19 +149,6 @@ final class BreakpointManager {
             return false
         }
         return pausedItems.contains { $0.id == selectedItemId }
-    }
-
-    private func safeDecision(
-        _ decision: BreakpointDecision,
-        for item: PausedBreakpointItem
-    )
-        -> BreakpointDecision
-    {
-        if case .execute = decision, !item.editableDraft.isBodyEditable {
-            Self.logger.warning("Protected breakpoint payload cannot be edited; continuing original")
-            return .cancel
-        }
-        return decision
     }
 
     private static func displayURL(from urlString: String) -> String {

--- a/Rockxy/Models/Network/WebSocketConnection.swift
+++ b/Rockxy/Models/Network/WebSocketConnection.swift
@@ -27,6 +27,10 @@ final class WebSocketConnection: @unchecked Sendable {
         lock.withLock { _frames.count }
     }
 
+    var isCaptureLimitReached: Bool {
+        lock.withLock { _isCaptureLimitReached }
+    }
+
     var sentFrames: [WebSocketFrameData] {
         lock.withLock { _frames.filter { $0.direction == .sent } }
     }
@@ -44,10 +48,30 @@ final class WebSocketConnection: @unchecked Sendable {
 
     @discardableResult
     func addFrame(_ frame: WebSocketFrameData, maximumTotalPayloadSize: Int) -> Bool {
+        addFrame(
+            frame,
+            maximumTotalPayloadSize: maximumTotalPayloadSize,
+            maximumFrameCount: .max
+        )
+    }
+
+    @discardableResult
+    func addFrame(
+        _ frame: WebSocketFrameData,
+        maximumTotalPayloadSize: Int,
+        maximumFrameCount: Int
+    )
+        -> Bool
+    {
         lock.withLock {
-            guard frame.payload.count <= maximumTotalPayloadSize,
+            guard !_isCaptureLimitReached else {
+                return false
+            }
+            guard _frames.count < maximumFrameCount,
+                  frame.payload.count <= maximumTotalPayloadSize,
                   _totalPayloadSize <= maximumTotalPayloadSize - frame.payload.count else
             {
+                _isCaptureLimitReached = true
                 return false
             }
             _frames.append(frame)
@@ -56,9 +80,16 @@ final class WebSocketConnection: @unchecked Sendable {
         }
     }
 
+    func stopCaptureAtLimit() {
+        lock.withLock {
+            _isCaptureLimitReached = true
+        }
+    }
+
     // MARK: Private
 
     private let lock = NSLock()
     private var _frames: [WebSocketFrameData]
     private var _totalPayloadSize: Int
+    private var _isCaptureLimitReached = false
 }

--- a/Rockxy/Models/Rules/RuleAction.swift
+++ b/Rockxy/Models/Rules/RuleAction.swift
@@ -33,6 +33,15 @@ enum RuleAction {
 }
 
 extension RuleAction {
+    var responseBreakpointPhase: BreakpointRulePhase? {
+        guard case let .breakpoint(phase) = self,
+              phase == .response || phase == .both else
+        {
+            return nil
+        }
+        return phase
+    }
+
     var toolCategory: String {
         switch self {
         case .breakpoint: "breakpoint"

--- a/Rockxy/Models/UI/KeyboardShortcutReference.swift
+++ b/Rockxy/Models/UI/KeyboardShortcutReference.swift
@@ -71,10 +71,11 @@ enum KeyboardShortcutCatalog {
             ),
         ]),
         KeyboardShortcutSection(id: "main", title: "Main Capture", shortcuts: [
-            row("main.clear", "Main Capture", "Clear capture", "⌘K", "Main capture window", "Flow", nil),
-            row("main.clearAll", "Main Capture", "Clear capture and filters", "⇧⌘K", "Main capture window", "Flow", nil),
+            row("main.clear", "Main Capture", "Clear session", "⌘K", "Main capture window", "Flow", nil),
+            row("main.clearAll", "Main Capture", "Clear session and filters", "⇧⌘K", "Main capture window", "Flow", nil),
             row("main.pause", "Main Capture", "Pause or resume capture", "⌘P", "Main capture window", "Tools", nil),
             row("main.search", "Main Capture", "Focus the search bar", "⌘L", "Main capture search field", "Edit", nil),
+            row("main.followLive", "Main Capture", "Follow the newest visible request", "⇧⌘L", "Active workspace tab", "View", nil),
             row("main.first", "Main Capture", "Jump to the first or last captured row", "⌘↑", "Request table selection", "View", nil),
             row("main.last", "Main Capture", "Jump to the first or last captured row", "⌘↓", "Request table selection", "View", nil),
             row("main.move", "Main Capture", "Move row selection", "↑ / ↓", "Focused request table", nil, "Native table behavior."),

--- a/Rockxy/Models/UI/ResponseInspectorTab.swift
+++ b/Rockxy/Models/UI/ResponseInspectorTab.swift
@@ -11,7 +11,7 @@ enum ResponseInspectorTab: String, CaseIterable {
 
     // MARK: Internal
 
-    static func availableTabs(hasAIInspection _: Bool) -> [ResponseInspectorTab] {
+    static func availableTabs() -> [ResponseInspectorTab] {
         allCases.filter { tab in
             tab != .ai
         }

--- a/Rockxy/Models/UI/WorkspaceState.swift
+++ b/Rockxy/Models/UI/WorkspaceState.swift
@@ -10,6 +10,11 @@ enum ContextDockTab: Equatable {
     case aiAssistant
 }
 
+struct TrafficSelectionIndexEntry {
+    let transaction: HTTPTransaction
+    let rowIndex: Int
+}
+
 // MARK: - WorkspaceState
 
 @MainActor @Observable
@@ -98,6 +103,7 @@ final class WorkspaceState: Identifiable {
 
     // Table-facing derived state (derived from filteredTransactions via deriveFilteredRows)
     var filteredRows: [RequestListRow] = []
+    @ObservationIgnored var trafficSelectionIndex: [UUID: TrafficSelectionIndexEntry] = [:]
     var refreshToken: Int = 0
 
     /// Set true only by the genuine append fast-path in appendFilteredTransactions, and
@@ -133,6 +139,7 @@ final class WorkspaceState: Identifiable {
     func reset() {
         filteredTransactions.removeAll()
         filteredRows.removeAll()
+        trafficSelectionIndex.removeAll()
         lastDeriveWasAppendOnly = false
         appendChainOriginToken = nil
         refreshToken += 1

--- a/Rockxy/RockxyApp.swift
+++ b/Rockxy/RockxyApp.swift
@@ -358,6 +358,8 @@ struct RockxyApp: App {
 
         composeWindow
 
+        detachedInspectorWindow
+
         Settings {
             AppUIDisplayMetricsProvider {
                 SettingsView()
@@ -389,6 +391,46 @@ struct RockxyApp: App {
 
     private var composeWindow: some Scene {
         ComposeWindowScene()
+    }
+
+    private var detachedInspectorWindow: some Scene {
+        DetachedInspectorWindowScene(coordinator: mainCoordinator)
+    }
+}
+
+// MARK: - DetachedInspectorWindowScene
+
+/// Standalone Inspector window pinned to one transaction. It is an intent-dependent
+/// utility window, so restoration is disabled on macOS 15+ (mirroring the Compose /
+/// Certificate scene wrappers) rather than re-opening empty after a relaunch.
+private struct DetachedInspectorWindowScene: Scene {
+    // MARK: Internal
+
+    let coordinator: MainContentCoordinator
+
+    var body: some Scene {
+        detachedInspectorWindow
+    }
+
+    // MARK: Private
+
+    private var detachedInspectorWindow: some Scene {
+        let base = Window(String(localized: "Inspector"), id: "detachedInspector") {
+            AppUIDisplayMetricsProvider {
+                DetachedInspectorWindowView(coordinator: coordinator)
+            }
+        }
+        .commandsRemoved()
+        .defaultSize(width: 1_040, height: 680)
+        .defaultPosition(.center)
+        .windowToolbarStyle(.unifiedCompact)
+        .windowResizability(.contentMinSize)
+
+        if #available(macOS 15.0, *) {
+            return base.restorationBehavior(.disabled)
+        } else {
+            return base
+        }
     }
 }
 

--- a/Rockxy/RockxyApp.swift
+++ b/Rockxy/RockxyApp.swift
@@ -863,13 +863,13 @@ struct RockxyMenuCommands: Commands {
                 actions?.selectFirstTransaction()
             }
             .keyboardShortcut(.upArrow, modifiers: [.command])
-            .disabled(actions?.hasSelectedTransaction != true)
+            .disabled(actions?.hasVisibleTransactions != true)
 
             Button(String(localized: "Jump to Last Request")) {
                 actions?.selectLastTransaction()
             }
             .keyboardShortcut(.downArrow, modifiers: [.command])
-            .disabled(actions?.hasSelectedTransaction != true)
+            .disabled(actions?.hasVisibleTransactions != true)
         }
     }
 
@@ -895,11 +895,6 @@ struct RockxyMenuCommands: Commands {
             .disabled(actions?.hasSelectedTransaction != true)
 
             Divider()
-
-            Button(String(localized: "Save Requests")) {
-                actions?.saveSession()
-            }
-            .keyboardShortcut("s", modifiers: [.command, .shift])
 
             Menu(String(localized: "Export")) {
                 Button(String(localized: "Export as HAR…")) {
@@ -963,11 +958,6 @@ struct RockxyMenuCommands: Commands {
             }
             .keyboardShortcut(.delete, modifiers: [.command])
             .disabled(actions?.hasSelectedTransaction != true)
-
-            Button(String(localized: "Delete All")) {
-                actions?.deleteAll()
-            }
-            .keyboardShortcut(.delete, modifiers: [.command, .shift])
         }
     }
 
@@ -988,6 +978,7 @@ struct RockxyMenuCommands: Commands {
                 actions?.toggleRecording()
             }
             .keyboardShortcut("p", modifiers: [.command])
+            .disabled(actions?.canToggleRecording != true)
 
             Button(String(localized: "Toggle System Proxy")) {
                 actions?.toggleSystemProxyOverride()
@@ -1083,7 +1074,6 @@ struct RockxyMenuCommands: Commands {
             Button(String(localized: "Protobuf…")) {
                 openWindow(id: "protobufSettings")
             }
-            .keyboardShortcut("u", modifiers: [.command, .option])
 
             Button(String(localized: "Network Conditions…")) {
                 openWindow(id: "networkConditions")

--- a/Rockxy/Views/Breakpoint/BreakpointEditorView.swift
+++ b/Rockxy/Views/Breakpoint/BreakpointEditorView.swift
@@ -90,7 +90,6 @@ struct BreakpointEditorView: View {
                     Divider()
                 }
                 requestLine(itemId: itemId)
-                    .disabled(!item.editableDraft.isBodyEditable)
                 Divider()
                 tabContent(itemId: itemId)
             }
@@ -131,7 +130,7 @@ struct BreakpointEditorView: View {
                     .font(toolMetrics.secondaryFont(weight: .semibold))
                 Text(
                     String(
-                        localized: "This body is not UTF-8 text, so Rockxy cannot safely apply edits. Continue Original preserves every byte."
+                        localized: "This body is not UTF-8 text, so body edits are disabled. Applying request-line, status, or header changes preserves every body byte."
                     )
                 )
                 .font(toolMetrics.secondaryFont())
@@ -283,7 +282,6 @@ struct BreakpointEditorView: View {
                 }
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-            .disabled(draftFor(itemId)?.isBodyEditable == false)
         }
     }
 
@@ -372,7 +370,11 @@ struct BreakpointEditorView: View {
         ContentUnavailableView {
             Label(String(localized: "Binary Body"), systemImage: "doc.badge.lock")
         } description: {
-            Text(String(localized: "Editing is unavailable for this payload. Continue Original preserves it unchanged."))
+            Text(
+                String(
+                    localized: "Body editing is unavailable. Applying metadata changes or continuing original preserves every body byte."
+                )
+            )
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
@@ -615,7 +617,7 @@ struct BreakpointEditorView: View {
             canApplySelectedChanges = false
             return
         }
-        canApplySelectedChanges = draft.isBodyEditable
+        canApplySelectedChanges = true
     }
 
     private func syncRawMessageFromDraft(itemId: UUID, force: Bool = false) {
@@ -626,7 +628,7 @@ struct BreakpointEditorView: View {
         }
         rawMessageItemID = itemId
         rawMessage = BreakpointRawMessage.rawMessage(from: draft, kind: rawKind(for: itemId))
-        canApplySelectedChanges = draft.isBodyEditable
+        canApplySelectedChanges = true
     }
 
     private func updateRawMessage(_ newValue: String, itemId: UUID) {

--- a/Rockxy/Views/Breakpoint/BreakpointWindowView.swift
+++ b/Rockxy/Views/Breakpoint/BreakpointWindowView.swift
@@ -311,12 +311,11 @@ struct BreakpointWindowView: View {
 
     private var canApplySelection: Bool {
         guard canApplySelectedChanges,
-              let selectedItemId = manager.selectedItemId,
-              let item = manager.pausedItems.first(where: { $0.id == selectedItemId })
+              let selectedItemId = manager.selectedItemId
         else {
             return false
         }
-        return item.editableDraft.isBodyEditable
+        return manager.pausedItems.contains(where: { $0.id == selectedItemId })
     }
 
     private var applyButtonHelp: String {
@@ -328,7 +327,7 @@ struct BreakpointWindowView: View {
            !item.editableDraft.isBodyEditable
         {
             return String(
-                localized: "This message cannot be safely edited. Continue Original preserves its payload."
+                localized: "The body is protected. Request-line, status, and header changes can still be applied."
             )
         }
         if !canApplySelectedChanges {

--- a/Rockxy/Views/Inspector/ContextDockView.swift
+++ b/Rockxy/Views/Inspector/ContextDockView.swift
@@ -341,8 +341,7 @@ private struct AIAssistantDockView: View {
             }
             .buttonStyle(.borderless)
             .controlSize(.small)
-            .keyboardShortcut("k", modifiers: .command)
-            .help(String(localized: "Search conversations (⌘K)"))
+            .help(String(localized: "Search conversations"))
             .accessibilityLabel(String(localized: "Conversation History"))
             .popover(isPresented: $isConversationSwitcherPresented, arrowEdge: .top) {
                 conversationSwitcher

--- a/Rockxy/Views/Inspector/DetachedInspectorStore.swift
+++ b/Rockxy/Views/Inspector/DetachedInspectorStore.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+// Coordinates the handoff of a single transaction from the main inspector URL bar
+// to the standalone detached Inspector window.
+
+// MARK: - DetachedInspectorSelection
+
+/// Tiny value that pins the detached Inspector window to one transaction. Holds a
+/// strong reference to the `HTTPTransaction` so the open window keeps live-updating
+/// it even after the main-window selection changes or the live buffer evicts it.
+struct DetachedInspectorSelection {
+    let id = UUID()
+    let transaction: HTTPTransaction
+    let highlightContext: InspectorHighlightContext
+}
+
+// MARK: - DetachedInspectorStore
+
+/// Singleton that handles the handoff of an `HTTPTransaction` from the inspector URL
+/// bar to the detached Inspector window. The requested selection stays retained while
+/// the window is open so it survives live-buffer eviction and scene reevaluation; each
+/// new request retargets the window and bumps `version`.
+@MainActor @Observable
+final class DetachedInspectorStore {
+    // MARK: Lifecycle
+
+    private init() {}
+
+    // MARK: Internal
+
+    static let shared = DetachedInspectorStore()
+
+    /// The transaction (plus its highlight context) the detached window should show.
+    /// Set by the coordinator before opening the window; observed by
+    /// `DetachedInspectorWindowView` to adopt a strong reference of its own.
+    private(set) var requestedSelection: DetachedInspectorSelection?
+
+    /// Incremented each time a new selection is requested. The detached window observes
+    /// this to detect re-targeting when the window is already open.
+    private(set) var version: UInt64 = 0
+
+    func present(transaction: HTTPTransaction, highlightContext: InspectorHighlightContext) {
+        requestedSelection = DetachedInspectorSelection(
+            transaction: transaction,
+            highlightContext: highlightContext
+        )
+        version &+= 1
+    }
+
+    /// Releases a closed window's retained transaction without clearing a newer
+    /// request that may already have re-targeted the singleton window.
+    func dismiss(selectionID: UUID) {
+        guard requestedSelection?.id == selectionID else {
+            return
+        }
+        requestedSelection = nil
+    }
+}

--- a/Rockxy/Views/Inspector/DetachedInspectorWindowView.swift
+++ b/Rockxy/Views/Inspector/DetachedInspectorWindowView.swift
@@ -1,0 +1,76 @@
+import SwiftUI
+
+// Standalone Inspector window that mirrors the main horizontal request/response
+// inspector for one pinned transaction.
+
+// MARK: - DetachedInspectorWindowView
+
+/// Detached Inspector window. Adopts the latest requested selection on appear and
+/// whenever the handoff store re-targets it, then renders the URL bar plus the same
+/// side-by-side request/response inspector as the main window. The selection is held
+/// as a strong `@State` reference so main-window selection changes or live-buffer
+/// eviction never blank this window; it keeps live-updating its pinned transaction.
+struct DetachedInspectorWindowView: View {
+    // MARK: Internal
+
+    let coordinator: MainContentCoordinator
+
+    var body: some View {
+        VStack(spacing: 0) {
+            if let selection {
+                InspectorURLBar(
+                    transaction: selection.transaction,
+                    highlightContext: selection.highlightContext
+                )
+                Divider()
+                HSplitView {
+                    RequestInspectorView(
+                        transaction: selection.transaction,
+                        coordinator: coordinator,
+                        previewTabStore: coordinator.previewTabStore,
+                        highlightContext: selection.highlightContext
+                    )
+                    .frame(minWidth: 250, maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+                    ResponseInspectorView(
+                        transaction: selection.transaction,
+                        coordinator: coordinator,
+                        previewTabStore: coordinator.previewTabStore,
+                        highlightContext: selection.highlightContext,
+                        onOpenToolWindow: { id in openWindow(id: id) }
+                    )
+                    .frame(minWidth: 250, maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+                }
+            } else {
+                InspectorEmptyStateView(
+                    requestSelectionDescription: String(localized: "Select a request to inspect")
+                )
+            }
+        }
+        .frame(minWidth: 640, maxWidth: .infinity, minHeight: 400, maxHeight: .infinity)
+        .onAppear {
+            adoptLatestSelection()
+        }
+        .onChange(of: DetachedInspectorStore.shared.version) {
+            adoptLatestSelection()
+        }
+        .onDisappear {
+            guard let selection else {
+                return
+            }
+            DetachedInspectorStore.shared.dismiss(selectionID: selection.id)
+        }
+    }
+
+    // MARK: Private
+
+    @Environment(\.openWindow) private var openWindow
+
+    @State private var selection: DetachedInspectorSelection?
+
+    private func adoptLatestSelection() {
+        guard let requested = DetachedInspectorStore.shared.requestedSelection else {
+            return
+        }
+        selection = requested
+    }
+}

--- a/Rockxy/Views/Inspector/InspectorPanelView.swift
+++ b/Rockxy/Views/Inspector/InspectorPanelView.swift
@@ -1,8 +1,12 @@
 import SwiftUI
 
+// MARK: - InspectorPanelView
+
 /// Top-level payload inspector that hosts the URL bar and side-by-side request/response panes.
 /// Shown below the request list when a transaction is selected.
 struct InspectorPanelView: View {
+    // MARK: Internal
+
     let coordinator: MainContentCoordinator
     var onOpenToolWindow: (String) -> Void = { _ in }
 
@@ -12,7 +16,17 @@ struct InspectorPanelView: View {
                 InspectorSelectionSummaryView(coordinator: coordinator)
             } else if let transaction = coordinator.selectedTransaction {
                 let highlightContext = coordinator.activeInspectorHighlightContext()
-                InspectorURLBar(transaction: transaction, highlightContext: highlightContext)
+                InspectorURLBar(
+                    transaction: transaction,
+                    highlightContext: highlightContext,
+                    onOpenDetachedInspector: {
+                        DetachedInspectorStore.shared.present(
+                            transaction: transaction,
+                            highlightContext: highlightContext
+                        )
+                        openWindow(id: "detachedInspector")
+                    }
+                )
                 Divider()
                 HSplitView {
                     RequestInspectorView(
@@ -39,9 +53,17 @@ struct InspectorPanelView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
+
+    // MARK: Private
+
+    @Environment(\.openWindow) private var openWindow
 }
 
+// MARK: - InspectorSelectionSummaryView
+
 private struct InspectorSelectionSummaryView: View {
+    // MARK: Internal
+
     let coordinator: MainContentCoordinator
 
     var body: some View {
@@ -64,6 +86,8 @@ private struct InspectorSelectionSummaryView: View {
         .padding(16)
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
     }
+
+    // MARK: Private
 
     private var transactions: [HTTPTransaction] {
         coordinator.selectedTransactionIDs.compactMap(coordinator.transaction(for:))

--- a/Rockxy/Views/Inspector/InspectorURLBar.swift
+++ b/Rockxy/Views/Inspector/InspectorURLBar.swift
@@ -8,6 +8,10 @@ struct InspectorURLBar: View {
     let transaction: HTTPTransaction
     var highlightContext: InspectorHighlightContext = .empty
 
+    /// When supplied, a restrained trailing button pops the inspector into its own
+    /// window. Omitted in the detached window itself so it never offers to detach again.
+    var onOpenDetachedInspector: (() -> Void)?
+
     var body: some View {
         HStack(spacing: 8) {
             methodBadge
@@ -21,6 +25,9 @@ struct InspectorURLBar: View {
             }
             urlText
             Spacer()
+            if let onOpenDetachedInspector {
+                detachedInspectorButton(action: onOpenDetachedInspector)
+            }
         }
         .padding(.horizontal, 8)
         .padding(.vertical, 6)
@@ -28,6 +35,8 @@ struct InspectorURLBar: View {
     }
 
     // MARK: Private
+
+    @Environment(\.appUIDisplayMetrics) private var metrics
 
     @ViewBuilder private var methodBadge: some View {
         if transaction.request.method == "CONNECT" {
@@ -100,10 +109,18 @@ struct InspectorURLBar: View {
                     .font(.system(size: metrics.controlFontSize, design: .monospaced))
             }
         }
-            .lineLimit(1)
-            .truncationMode(.middle)
-            .textSelection(.enabled))
+        .lineLimit(1)
+        .truncationMode(.middle)
+        .textSelection(.enabled))
     }
 
-    @Environment(\.appUIDisplayMetrics) private var metrics
+    private func detachedInspectorButton(action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Image(systemName: "macwindow.on.rectangle")
+                .font(.system(size: metrics.controlFontSize))
+        }
+        .buttonStyle(.borderless)
+        .help(String(localized: "Open Inspector in New Window"))
+        .accessibilityLabel(String(localized: "Open Inspector in New Window"))
+    }
 }

--- a/Rockxy/Views/Inspector/ResponseInspectorView.swift
+++ b/Rockxy/Views/Inspector/ResponseInspectorView.swift
@@ -64,7 +64,28 @@ struct ResponseInspectorView: View {
     @Environment(\.appUIDisplayMetrics) private var metrics
 
     private var httpsPromptModel: HTTPSInspectionPromptModel? {
-        let appScope = normalizedClientAppName.map { appName in
+        guard transaction.request.method == "CONNECT", transaction.response != nil else {
+            return nil
+        }
+        let canInterceptHTTPS = coordinator.readiness.canInterceptHTTPS
+        let domainRuleEnabled = coordinator.isSSLProxyingEnabled(for: transaction.request.host)
+        let hasRecentTLSRejection = SSLProxyingManager.shared.isAutoPassthrough(transaction.request.host)
+        let promptWithoutAppScope = HTTPSInspectionPromptModel.make(
+            transaction: transaction,
+            canInterceptHTTPS: canInterceptHTTPS,
+            domainRuleEnabled: domainRuleEnabled,
+            hasRecentTLSRejection: hasRecentTLSRejection,
+            appScope: nil
+        )
+        guard let promptWithoutAppScope,
+              promptWithoutAppScope.certificateAction == nil,
+              promptWithoutAppScope.insight?.isWarning == false,
+              let appName = normalizedClientAppName else
+        {
+            return promptWithoutAppScope
+        }
+
+        let appScope: HTTPSInspectionAppScope = {
             let domains = coordinator.observedDomainsForApp(
                 named: appName,
                 fallbackDomain: transaction.request.host
@@ -74,13 +95,13 @@ struct ResponseInspectorView: View {
                 knownHostCount: domains.count,
                 enabledHostCount: domains.count(where: coordinator.isSSLProxyingEnabled(for:))
             )
-        }
+        }()
 
         return HTTPSInspectionPromptModel.make(
             transaction: transaction,
-            canInterceptHTTPS: coordinator.readiness.canInterceptHTTPS,
-            domainRuleEnabled: coordinator.isSSLProxyingEnabled(for: transaction.request.host),
-            hasRecentTLSRejection: SSLProxyingManager.shared.isAutoPassthrough(transaction.request.host),
+            canInterceptHTTPS: canInterceptHTTPS,
+            domainRuleEnabled: domainRuleEnabled,
+            hasRecentTLSRejection: hasRecentTLSRejection,
             appScope: appScope
         )
     }
@@ -96,7 +117,7 @@ struct ResponseInspectorView: View {
 
     private var tabDescriptors: [InspectorTabDescriptor] {
         var descriptors: [InspectorTabDescriptor] = ResponseInspectorTab
-            .availableTabs(hasAIInspection: hasAIInspection)
+            .availableTabs()
             .map { tab in
                 InspectorTabDescriptor(
                     id: "native.\(tab.rawValue)",

--- a/Rockxy/Views/Inspector/WebSocketInspectorView.swift
+++ b/Rockxy/Views/Inspector/WebSocketInspectorView.swift
@@ -153,6 +153,14 @@ struct WebSocketInspectorView: View {
                     value: "\(connection.receivedFrames.count) (\(totalSize(connection.receivedFrames)))"
                 )
             }
+            if connection.isCaptureLimitReached {
+                Label(
+                    String(localized: "Frame capture stopped at the safety limit; the live connection remains active."),
+                    systemImage: "exclamationmark.triangle.fill"
+                )
+                .font(.system(size: metrics.secondaryFontSize))
+                .foregroundStyle(.orange)
+            }
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 8)

--- a/Rockxy/Views/Main/Extensions/MainContentCoordinator+ContextMenu.swift
+++ b/Rockxy/Views/Main/Extensions/MainContentCoordinator+ContextMenu.swift
@@ -512,6 +512,7 @@ extension MainContentCoordinator {
         let ids = Set(transactionsToDelete.map(\.id))
         transactions.removeAll { ids.contains($0.id) }
         rebuildObservedDomainsByApp()
+        recomputeErrorCount()
         persistedFavorites.removeAll { ids.contains($0.id) }
         invalidateSidebarFavoriteCache()
 

--- a/Rockxy/Views/Main/Extensions/MainContentCoordinator+Eviction.swift
+++ b/Rockxy/Views/Main/Extensions/MainContentCoordinator+Eviction.swift
@@ -15,6 +15,7 @@ extension MainContentCoordinator {
 
         transactions.removeFirst(removeCount)
         rebuildObservedDomainsByApp()
+        recomputeErrorCount()
         evictFromAllWorkspaces(removedIDs: removedIDs)
 
         Self.logger.info("Evicted \(removeCount) oldest transactions (remaining: \(self.transactions.count))")

--- a/Rockxy/Views/Main/Extensions/MainContentCoordinator+Filtering.swift
+++ b/Rockxy/Views/Main/Extensions/MainContentCoordinator+Filtering.swift
@@ -124,15 +124,29 @@ extension MainContentCoordinator {
     /// then recompute. Single source of truth for the filter-summary "Clear All" chip and the
     /// request-list empty-state recovery actions so they cannot drift apart.
     func clearAllWorkspaceFilters() {
-        filterCriteria = .empty
-        filterCriteria.sidebarScope = .allTraffic
-        sidebarSelection = nil
-        isFilterBarVisible = false
-        filterRules = [FilterRule()]
-        activeWorkspace.activeTrafficSignal = nil
-        activeWorkspace.activeFocusSetID = nil
-        activeWorkspace.mutedTrafficSources.removeAll()
+        resetFilters(in: activeWorkspace)
         recomputeFilteredTransactions()
+    }
+
+    /// Session-level reset used by "Clear Session and Filters". Session data spans every
+    /// workspace, so leaving an inactive workspace's visibility lenses behind would silently
+    /// hide newly captured traffic when the user returns to it.
+    func clearFiltersAcrossAllWorkspaces() {
+        for workspace in workspaceStore.workspaces {
+            resetFilters(in: workspace)
+        }
+        recomputeAllWorkspaces()
+    }
+
+    private func resetFilters(in workspace: WorkspaceState) {
+        workspace.filterCriteria = .empty
+        workspace.filterCriteria.sidebarScope = .allTraffic
+        workspace.sidebarSelection = nil
+        workspace.isFilterBarVisible = false
+        workspace.filterRules = [FilterRule()]
+        workspace.activeTrafficSignal = nil
+        workspace.activeFocusSetID = nil
+        workspace.mutedTrafficSources.removeAll()
     }
 
     var availableTransactionCountForCurrentScope: Int {

--- a/Rockxy/Views/Main/Extensions/MainContentCoordinator+Filtering.swift
+++ b/Rockxy/Views/Main/Extensions/MainContentCoordinator+Filtering.swift
@@ -25,6 +25,18 @@ extension MainContentCoordinator {
             }
         }
         workspace.filteredRows = rows
+        let transactionsByID = Dictionary(
+            workspace.filteredTransactions.map { ($0.id, $0) },
+            uniquingKeysWith: { _, latest in latest }
+        )
+        workspace.trafficSelectionIndex = Dictionary(
+            rows.enumerated().compactMap { index, row in
+                transactionsByID[row.id].map {
+                    (row.id, TrafficSelectionIndexEntry(transaction: $0, rowIndex: index))
+                }
+            },
+            uniquingKeysWith: { _, latest in latest }
+        )
         let visibleIDs = Set(workspace.filteredTransactions.map(\.id))
         workspace.selectedTransactionIDs.formIntersection(visibleIDs)
         if let selected = workspace.selectedTransaction, !visibleIDs.contains(selected.id) {
@@ -41,8 +53,8 @@ extension MainContentCoordinator {
     }
 
     private func appendDerivedRows(_ batch: [HTTPTransaction], to workspace: WorkspaceState) {
-        let appendedRows = batch
-            .filter { !$0.isTLSFailure }
+        let visibleTransactions = batch.filter { !$0.isTLSFailure }
+        let appendedRows = visibleTransactions
             .map { RequestListRow(from: $0, sslState: sslState(for: $0)) }
 
         guard !appendedRows.isEmpty else {
@@ -55,7 +67,14 @@ extension MainContentCoordinator {
         if workspace.appendChainOriginToken == nil {
             workspace.appendChainOriginToken = workspace.refreshToken
         }
+        let firstAppendedIndex = workspace.filteredRows.count
         workspace.filteredRows.append(contentsOf: appendedRows)
+        for (offset, transaction) in visibleTransactions.enumerated() {
+            workspace.trafficSelectionIndex[transaction.id] = TrafficSelectionIndexEntry(
+                transaction: transaction,
+                rowIndex: firstAppendedIndex + offset
+            )
+        }
         workspace.refreshToken += 1
     }
 

--- a/Rockxy/Views/Main/Extensions/MainContentCoordinator+FocusNavigator.swift
+++ b/Rockxy/Views/Main/Extensions/MainContentCoordinator+FocusNavigator.swift
@@ -98,10 +98,13 @@ extension MainContentCoordinator {
         FocusSetPersistence.save(focusSets)
         for workspace in workspaceStore.workspaces where workspace.id != activeWorkspace.id {
             workspace.focusSets = focusSets
+            let hadActiveFocusSet = workspace.activeFocusSetID != nil
             if let activeID = workspace.activeFocusSetID,
                !focusSets.contains(where: { $0.id == activeID })
             {
                 workspace.activeFocusSetID = nil
+            }
+            if hadActiveFocusSet {
                 recomputeFilteredTransactions(for: workspace)
             }
         }

--- a/Rockxy/Views/Main/Extensions/MainContentCoordinator+GistPublish.swift
+++ b/Rockxy/Views/Main/Extensions/MainContentCoordinator+GistPublish.swift
@@ -72,7 +72,11 @@ extension MainContentCoordinator {
     // MARK: Private
 
     private func presentGistPublish(transactions: [HTTPTransaction]) {
-        if AppSettingsManager.shared.settings.githubGistAskBeforePublishing {
+        let settings = AppSettingsManager.shared.settings
+        if GistPublishConfirmationPolicy.requiresReview(
+            askBeforePublishing: settings.githubGistAskBeforePublishing,
+            redactsSensitiveData: settings.githubGistRedactSensitiveData
+        ) {
             gistPublishContext = GistPublishContext(transactions: transactions)
             return
         }
@@ -90,6 +94,12 @@ extension MainContentCoordinator {
                 )
             }
         }
+    }
+}
+
+enum GistPublishConfirmationPolicy {
+    static func requiresReview(askBeforePublishing: Bool, redactsSensitiveData: Bool) -> Bool {
+        askBeforePublishing || !redactsSensitiveData
     }
 }
 

--- a/Rockxy/Views/Main/Extensions/MainContentCoordinator+ProxyControl.swift
+++ b/Rockxy/Views/Main/Extensions/MainContentCoordinator+ProxyControl.swift
@@ -159,6 +159,9 @@ extension MainContentCoordinator {
     }
 
     func toggleRecording() {
+        guard isProxyRunning else {
+            return
+        }
         isRecording.toggle()
     }
 
@@ -299,6 +302,17 @@ extension MainContentCoordinator {
         }
 
         NotificationCenter.default.post(name: .sessionCleared, object: nil)
+    }
+
+    func clearCaptureAndFilters() async {
+        await clearSession()
+        clearFiltersAcrossAllWorkspaces()
+    }
+
+    func recomputeErrorCount() {
+        errorCount = transactions.count { transaction in
+            (transaction.response?.statusCode ?? 0) >= 400
+        }
     }
 
     // MARK: - Proxy Configuration

--- a/Rockxy/Views/Main/Extensions/MainContentCoordinator+Selection.swift
+++ b/Rockxy/Views/Main/Extensions/MainContentCoordinator+Selection.swift
@@ -215,10 +215,14 @@ extension MainContentCoordinator {
     }
 
     func deleteSelectedTransaction() {
-        guard let selected = selectedTransaction else {
+        var selected = resolveSelectedTransactions()
+        if selected.isEmpty, let selectedTransaction {
+            selected = [selectedTransaction]
+        }
+        guard !selected.isEmpty else {
             return
         }
-        deleteTransactions([selected])
+        deleteTransactions(selected)
     }
 
     func selectFirstFilteredTransaction() {

--- a/Rockxy/Views/Main/Extensions/MainContentCoordinator+Selection.swift
+++ b/Rockxy/Views/Main/Extensions/MainContentCoordinator+Selection.swift
@@ -13,6 +13,48 @@ extension MainContentCoordinator {
         selectedTransaction = transaction
     }
 
+    /// Applies a request-table selection as one coordinator transition. The table-facing
+    /// indexes keep this path proportional to the number of selected rows instead of the
+    /// total captured history, which is critical when the inspector opens over large sessions.
+    func selectTransactions(_ ids: Set<UUID>, primaryID: UUID?) {
+        let workspace = activeWorkspace
+
+        func validEntry(for id: UUID) -> TrafficSelectionIndexEntry? {
+            guard let entry = workspace.trafficSelectionIndex[id],
+                  workspace.filteredRows.indices.contains(entry.rowIndex),
+                  workspace.filteredRows[entry.rowIndex].id == id else
+            {
+                return nil
+            }
+            return entry
+        }
+
+        let resolvedPrimaryID: UUID? = if let primaryID,
+                                          ids.contains(primaryID),
+                                          validEntry(for: primaryID) != nil
+        {
+            primaryID
+        } else {
+            ids.min { lhs, rhs in
+                (validEntry(for: lhs)?.rowIndex ?? .max)
+                    < (validEntry(for: rhs)?.rowIndex ?? .max)
+            }
+        }
+        let transaction = resolvedPrimaryID.flatMap { validEntry(for: $0)?.transaction }
+        let selectionChanged = workspace.selectedTransactionIDs != ids
+            || workspace.selectedTransaction?.id != transaction?.id
+
+        workspace.selectedTransactionIDs = ids
+        workspace.selectedTransaction = transaction
+
+        if selectionChanged {
+            resetDebugAssistantForSelectionChange()
+        }
+        if transaction != nil {
+            revealInspectorForSelectionIfNeeded()
+        }
+    }
+
     /// Enables or disables live-tail selection on the active workspace. Enabling immediately
     /// reveals the newest request already visible in the active workspace so the control has an
     /// observable result even before another capture batch arrives; on an empty view it stays armed.

--- a/Rockxy/Views/Main/MainContentCommandActions.swift
+++ b/Rockxy/Views/Main/MainContentCommandActions.swift
@@ -20,8 +20,16 @@ struct MainContentCommandActions {
         coordinator.isProxyRunning
     }
 
+    var canToggleRecording: Bool {
+        coordinator.isProxyRunning
+    }
+
     var hasSelectedTransaction: Bool {
         coordinator.selectedTransaction != nil
+    }
+
+    var hasVisibleTransactions: Bool {
+        !coordinator.filteredTransactions.isEmpty
     }
 
     var isBottomInspectorVisible: Bool {
@@ -80,11 +88,7 @@ struct MainContentCommandActions {
 
     func clearCaptureAndFilters() {
         Task { @MainActor in
-            await coordinator.clearSession()
-            coordinator.filterCriteria = .empty
-            coordinator.filterCriteria.sidebarScope = .allTraffic
-            coordinator.filterRules = [FilterRule()]
-            coordinator.recomputeFilteredTransactions()
+            await coordinator.clearCaptureAndFilters()
         }
     }
 
@@ -162,12 +166,6 @@ struct MainContentCommandActions {
             return
         }
         coordinator.setHighlight(color, for: transaction)
-    }
-
-    func deleteAll() {
-        Task { @MainActor in
-            await coordinator.clearSession()
-        }
     }
 
     // MARK: - View

--- a/Rockxy/Views/RequestList/CenterContentView.swift
+++ b/Rockxy/Views/RequestList/CenterContentView.swift
@@ -4,10 +4,14 @@ import SwiftUI
 
 // MARK: - CenterContentView
 
-/// Primary content area composing the protocol filter bar, optional advanced filter bar,
-/// the NSTableView-backed request list, an optional bottom inspector panel,
+/// Primary content area composing the traffic command strip, the protocol filter bar, the optional
+/// advanced filter bar, the NSTableView-backed request list, an optional bottom inspector panel,
 /// and the status bar. Manages the bridge between NSTableView selection (Set<UUID>) and the
 /// coordinator's single-selection model.
+///
+/// The `TrafficCommandBar` owns session, live-navigation, and selected-request handoffs.
+/// Persistent tool launchers stay in the footer, while filtering stays exclusively with
+/// `SearchFilterBar` / `AdvancedFilterBar`.
 struct CenterContentView: View {
     // MARK: Internal
 
@@ -16,6 +20,8 @@ struct CenterContentView: View {
 
     var body: some View {
         VStack(spacing: 0) {
+            TrafficCommandBar(coordinator: coordinator, onOpenToolWindow: onOpenToolWindow)
+
             ProtocolFilterBar(
                 activeFilters: Binding(
                     get: { coordinator.filterCriteria.activeProtocolFilters },
@@ -87,8 +93,6 @@ struct CenterContentView: View {
                 isProxyOverridden: coordinator.isProxyOverridden,
                 isAllowListActive: allowListManager.isActive,
                 isNoCachingActive: isNoCachingEnabled,
-                isFollowingLiveTraffic: coordinator.isFollowingLiveTraffic,
-                isFilterBarVisible: coordinator.isFilterBarVisible,
                 activeFilterCount: activeFilterCount,
                 errorCount: coordinator.errorCount,
                 proxyStartedAt: coordinator.proxyStartedAt,
@@ -100,18 +104,6 @@ struct CenterContentView: View {
                 mapLocalToolEnabled: mapLocalToolEnabled,
                 mapRemoteToolEnabled: mapRemoteToolEnabled,
                 breakpointToolEnabled: breakpointToolEnabled,
-                onClear: {
-                    Task { @MainActor in
-                        await coordinator.clearSession()
-                    }
-                },
-                onFilter: {
-                    coordinator.isFilterBarVisible.toggle()
-                    coordinator.recomputeFilteredTransactions()
-                },
-                onFollowLive: {
-                    coordinator.toggleFollowingLiveTraffic()
-                },
                 onSwitchOffProxyOverride: {
                     coordinator.switchOffSystemProxyOverride()
                 },

--- a/Rockxy/Views/RequestList/CenterContentView.swift
+++ b/Rockxy/Views/RequestList/CenterContentView.swift
@@ -212,25 +212,11 @@ struct CenterContentView: View {
             refreshToken: coordinator.refreshToken,
             isAppendOnly: coordinator.activeWorkspace.lastDeriveWasAppendOnly,
             appendChainOrigin: coordinator.activeWorkspace.appendChainOriginToken,
+            selectionIndex: coordinator.activeWorkspace.trafficSelectionIndex,
             selectedIDs: $selectedIDs,
             onSelectionChanged: { ids, primaryID in
                 coordinator.userDidNavigateTrafficHistory()
-                coordinator.selectedTransactionIDs = ids
-                if let primaryID,
-                   ids.contains(primaryID),
-                   let transaction = coordinator.transaction(for: primaryID)
-                {
-                    coordinator.selectTransaction(transaction)
-                } else if let firstVisibleID = coordinator.filteredRows
-                    .lazy
-                    .map(\.id)
-                    .first(where: ids.contains),
-                    let transaction = coordinator.transaction(for: firstVisibleID)
-                {
-                    coordinator.selectTransaction(transaction)
-                } else {
-                    coordinator.selectTransaction(nil)
-                }
+                coordinator.selectTransactions(ids, primaryID: primaryID)
             },
             onUserScroll: {
                 coordinator.userDidNavigateTrafficHistory()

--- a/Rockxy/Views/RequestList/RequestTableView.swift
+++ b/Rockxy/Views/RequestList/RequestTableView.swift
@@ -20,6 +20,7 @@ struct RequestTableView: NSViewRepresentable {
     let refreshToken: Int
     let isAppendOnly: Bool
     var appendChainOrigin: Int?
+    var selectionIndex: [UUID: TrafficSelectionIndexEntry] = [:]
     var displayMetricsOverride: AppUIDisplayMetrics?
     @Binding var selectedIDs: Set<UUID>
     @Environment(\.appUIDisplayMetrics) private var displayMetrics
@@ -1160,9 +1161,18 @@ extension RequestTableView {
 
         func syncSelection(to ids: Set<UUID>, in tableView: NSTableView) {
             let currentSelected = tableView.selectedRowIndexes
-            var desired = IndexSet()
-            for (index, rowData) in rows.enumerated() where ids.contains(rowData.id) {
-                desired.insert(index)
+            let desired = if parent.selectionIndex.isEmpty, !rows.isEmpty {
+                IndexSet(rows.indices.filter { ids.contains(rows[$0].id) })
+            } else {
+                IndexSet(ids.compactMap { id in
+                    guard let index = parent.selectionIndex[id]?.rowIndex,
+                          rows.indices.contains(index),
+                          rows[index].id == id else
+                    {
+                        return nil
+                    }
+                    return index
+                })
             }
 
             guard currentSelected != desired else {

--- a/Rockxy/Views/RequestList/RequestTableView.swift
+++ b/Rockxy/Views/RequestList/RequestTableView.swift
@@ -1405,15 +1405,14 @@ extension RequestTableView {
         private func menuItem(
             _ title: String,
             action: Selector,
-            key: String = "",
-            modifiers: NSEvent.ModifierFlags = .command,
             symbol: String? = nil,
             transaction: HTTPTransaction
         )
             -> NSMenuItem
         {
-            let item = NSMenuItem(title: title, action: action, keyEquivalent: key)
-            item.keyEquivalentModifierMask = modifiers
+            // Apple context menus expose relevant actions, not shortcut ownership. Main-menu
+            // equivalents remain the single source for key commands and their enabled state.
+            let item = NSMenuItem(title: title, action: action, keyEquivalent: "")
             item.target = self
             item.representedObject = transaction
             if let symbol {
@@ -1425,11 +1424,11 @@ extension RequestTableView {
         private func buildCopyGroup(_ menu: NSMenu, transaction: HTTPTransaction) {
             menu.addItem(menuItem(
                 String(localized: "Copy URL"), action: #selector(handleCopyURL(_:)),
-                key: "c", symbol: "doc.on.doc", transaction: transaction
+                symbol: "doc.on.doc", transaction: transaction
             ))
             menu.addItem(menuItem(
                 String(localized: "Copy cURL"), action: #selector(handleCopyCURL(_:)),
-                key: "c", modifiers: [.command, .shift], transaction: transaction
+                transaction: transaction
             ))
             menu.addItem(menuItem(
                 String(localized: "Copy Cell Value"), action: #selector(handleCopyCellValue(_:)),
@@ -1518,11 +1517,11 @@ extension RequestTableView {
         private func buildRepeatGroup(_ menu: NSMenu, transaction: HTTPTransaction) {
             menu.addItem(menuItem(
                 String(localized: "Repeat"), action: #selector(handleRepeat(_:)),
-                key: "\r", symbol: "arrow.clockwise", transaction: transaction
+                symbol: "arrow.clockwise", transaction: transaction
             ))
             menu.addItem(menuItem(
                 String(localized: "Edit and Repeat…"), action: #selector(handleEditAndRepeat(_:)),
-                key: "\r", modifiers: [.command, .option], transaction: transaction
+                transaction: transaction
             ))
         }
 
@@ -1541,7 +1540,7 @@ extension RequestTableView {
             let saveSymbol = transaction.isSaved ? "tray.full.fill" : "tray.and.arrow.down.fill"
             menu.addItem(menuItem(
                 saveTitle, action: #selector(handleSaveRequest(_:)),
-                key: "s", modifiers: [.command, .shift], symbol: saveSymbol, transaction: transaction
+                symbol: saveSymbol, transaction: transaction
             ))
         }
 
@@ -1625,7 +1624,7 @@ extension RequestTableView {
         private func buildAnnotationGroup(_ menu: NSMenu, transaction: HTTPTransaction) {
             menu.addItem(menuItem(
                 String(localized: "Add Note…"), action: #selector(handleAddComment(_:)),
-                key: "l", symbol: "pencil.line", transaction: transaction
+                symbol: "pencil.line", transaction: transaction
             ))
 
             let highlightSubmenu = NSMenu()
@@ -1774,7 +1773,7 @@ extension RequestTableView {
         private func buildDeleteGroup(_ menu: NSMenu, transaction: HTTPTransaction) {
             let item = menuItem(
                 String(localized: "Delete"), action: #selector(handleDelete(_:)),
-                key: "\u{8}", modifiers: [], symbol: "trash", transaction: transaction
+                symbol: "trash", transaction: transaction
             )
             menu.addItem(item)
         }

--- a/Rockxy/Views/RequestList/StatusBarView.swift
+++ b/Rockxy/Views/RequestList/StatusBarView.swift
@@ -15,6 +15,8 @@ enum FooterActionKind: String, CaseIterable {
     case networkConditions
     case proxyOverride
 
+    // MARK: Internal
+
     static let defaultQuickTools: [Self] = [.breakpoint, .mapLocal, .scripting, .networkConditions]
 }
 
@@ -32,7 +34,9 @@ struct FooterActionDescriptor: Identifiable, Equatable {
         isAllowListActive: Bool,
         isProxyOverridden: Bool = false,
         quickTools: [FooterActionKind] = FooterActionKind.defaultQuickTools
-    ) -> [Self] {
+    )
+        -> [Self]
+    {
         let catalog: [Self] = [
             .init(
                 id: .blockList,
@@ -248,7 +252,11 @@ enum FooterMutationIndicatorBuilder {
 
 // MARK: - FooterToolingButton
 
-private struct FooterToolingButton: View {
+/// Shared capsule launcher rendered identically in the top command bar and the footer. This is the
+/// single visual source of truth for Quick Tools chrome — never fork a top-only variant.
+struct FooterToolingButton: View {
+    // MARK: Internal
+
     let descriptor: FooterActionDescriptor
     let action: () -> Void
 
@@ -264,6 +272,8 @@ private struct FooterToolingButton: View {
         .buttonStyle(.plain)
         .disabled(!descriptor.isEnabled)
         .help(descriptor.help)
+        .accessibilityLabel(descriptor.title)
+        .accessibilityValue(descriptor.isActive ? String(localized: "Active") : "")
         .onHover { isHovered = $0 }
     }
 
@@ -302,7 +312,8 @@ private struct FooterMutationIndicatorButton: View {
 
     private var indicatorColor: Color {
         switch indicator.id {
-        case .mapLocal, .mapRemote:
+        case .mapLocal,
+             .mapRemote:
             Color(nsColor: .systemOrange)
         case .breakpoint:
             Color(nsColor: .systemPurple)
@@ -334,6 +345,8 @@ private struct FooterMutationIndicatorButton: View {
 // MARK: - FooterProxyOverrideButton
 
 private struct FooterProxyOverrideButton: View {
+    // MARK: Internal
+
     let descriptor: FooterActionDescriptor
     let proxyHost: String
     let proxyPort: Int
@@ -361,9 +374,12 @@ private struct FooterProxyOverrideButton: View {
 // MARK: - FooterProxyOverridePopover
 
 private struct FooterProxyOverridePopover: View {
+    // MARK: Internal
+
     let proxyHost: String
     let proxyPort: Int
     @Binding var isPresented: Bool
+
     let onSwitchOff: () -> Void
 
     var body: some View {
@@ -389,6 +405,8 @@ private struct FooterProxyOverridePopover: View {
         .frame(width: 660, alignment: .leading)
     }
 
+    // MARK: Private
+
     @Environment(\.appUIDisplayMetrics) private var metrics
 
     private var statusText: String {
@@ -398,7 +416,9 @@ private struct FooterProxyOverridePopover: View {
 
 // MARK: - FooterToolingChrome
 
-private struct FooterToolingChrome: ViewModifier {
+struct FooterToolingChrome: ViewModifier {
+    // MARK: Internal
+
     let isActive: Bool
     let isEnabled: Bool
     let isHovered: Bool
@@ -414,6 +434,8 @@ private struct FooterToolingChrome: ViewModifier {
             .opacity(isEnabled ? 1 : 0.45)
     }
 
+    // MARK: Private
+
     @Environment(\.appUIDisplayMetrics) private var metrics
 
     private var backgroundColor: Color {
@@ -427,51 +449,6 @@ private struct FooterToolingChrome: ViewModifier {
     }
 }
 
-// MARK: - FooterPrimaryButton
-
-private struct FooterPrimaryButton: View {
-    let title: String
-    let systemImage: String
-    let help: String
-    var isActive = false
-    let action: () -> Void
-
-    var body: some View {
-        Button(action: action) {
-            ViewThatFits(in: .horizontal) {
-                Label(title, systemImage: systemImage)
-                Image(systemName: systemImage)
-            }
-            .font(metrics.swiftUIFont())
-            .foregroundStyle(isActive ? Color.accentColor : Color(nsColor: .labelColor))
-            .lineLimit(1)
-            .padding(.horizontal, 9)
-            .padding(.vertical, 4)
-            .background(backgroundColor, in: RoundedRectangle(cornerRadius: 6, style: .continuous))
-        }
-        .buttonStyle(.plain)
-        .help(help)
-        .accessibilityLabel(title)
-        .accessibilityValue(isActive ? String(localized: "On") : String(localized: "Off"))
-        .onHover { isHovered = $0 }
-    }
-
-    // MARK: Private
-
-    @State private var isHovered = false
-    @Environment(\.appUIDisplayMetrics) private var metrics
-
-    private var backgroundColor: Color {
-        if isActive {
-            return Color.accentColor.opacity(0.12)
-        }
-        if isHovered {
-            return Color(nsColor: .controlBackgroundColor)
-        }
-        return Color(nsColor: .controlBackgroundColor).opacity(0.72)
-    }
-}
-
 // MARK: - StatusBarRequestSummary
 
 enum StatusBarRequestSummary {
@@ -480,7 +457,9 @@ enum StatusBarRequestSummary {
         availableCount: Int,
         selectedCount: Int,
         activeFilterCount: Int
-    ) -> String {
+    )
+        -> String
+    {
         if activeFilterCount > 0, visibleCount != availableCount {
             if selectedCount > 0 {
                 return String(localized: "\(selectedCount) selected, \(visibleCount) of \(availableCount) shown")
@@ -499,8 +478,9 @@ enum StatusBarRequestSummary {
 
 // MARK: - StatusBarView
 
-/// Bottom status bar showing request counts, bandwidth stats (upload/download speed),
-/// and quick-action buttons for clearing, filtering, and opt-in live-tail selection.
+/// Bottom status bar showing request counts, bandwidth stats (upload/download speed), active
+/// mutation indicators, quick tools, request status, and the proxy-override control. The primary
+/// Clear Session and Follow Live workflows live in the top `TrafficCommandBar`, not here.
 struct StatusBarView: View {
     // MARK: Internal
 
@@ -516,8 +496,6 @@ struct StatusBarView: View {
     var isProxyOverridden: Bool = false
     var isAllowListActive: Bool = false
     var isNoCachingActive: Bool = false
-    var isFollowingLiveTraffic: Bool = false
-    var isFilterBarVisible: Bool = false
     var activeFilterCount: Int = 0
     var errorCount: Int = 0
     var proxyStartedAt: Date?
@@ -528,29 +506,12 @@ struct StatusBarView: View {
     var mapRemoteToolEnabled: Bool = true
     var breakpointToolEnabled: Bool = true
 
-    var onClear: () -> Void = {}
-    var onFilter: () -> Void = {}
-    var onFollowLive: () -> Void = {}
     var onSwitchOffProxyOverride: () -> Void = {}
     var onOpenToolWindow: (String) -> Void = { _ in }
 
     var body: some View {
         WorkspaceFooterBar(horizontalPadding: 12) {
             HStack(spacing: 0) {
-                FooterPrimaryButton(
-                    title: String(localized: "Follow Live"),
-                    systemImage: "dot.radiowaves.right",
-                    help: isFollowingLiveTraffic
-                        ? String(localized: "Follow Live is on. Scroll, select a row, or click again to stop.")
-                        : String(localized: "Keep the newest request in the current view selected."),
-                    isActive: isFollowingLiveTraffic,
-                    action: onFollowLive
-                )
-
-                Divider()
-                    .frame(height: 12)
-                    .padding(.horizontal, 8)
-
                 quickTools
                 mutationIndicators
                 Spacer(minLength: 24)
@@ -562,6 +523,11 @@ struct StatusBarView: View {
     }
 
     // MARK: Private
+
+    @Environment(\.appUIDisplayMetrics) private var metrics
+    @AppStorage(QuickToolsLayout.storageKey) private var quickToolsLayoutRaw = ""
+    @AppStorage(QuickToolsLayout.legacyFooterStorageKey) private var legacyFooterQuickToolOrder = ""
+    @State private var isCustomizingQuickTools = false
 
     private var statusText: String {
         StatusBarRequestSummary.text(
@@ -585,6 +551,13 @@ struct StatusBarView: View {
         )
     }
 
+    private var quickToolsLayout: QuickToolsLayout {
+        QuickToolsLayout.resolved(
+            storageRaw: quickToolsLayoutRaw,
+            legacyFooterRaw: legacyFooterQuickToolOrder
+        )
+    }
+
     @ViewBuilder private var mutationIndicators: some View {
         let indicators = mutationIndicatorList
         if !indicators.isEmpty {
@@ -602,59 +575,17 @@ struct StatusBarView: View {
         }
     }
 
-    private func mutationIndicatorRow(
-        _ indicators: [FooterMutationIndicator],
-        showsTitles: Bool
-    ) -> some View {
-        HStack(spacing: 6) {
-            ForEach(indicators) { indicator in
-                FooterMutationIndicatorButton(indicator: indicator, showsTitle: showsTitles) {
-                    onOpenToolWindow(indicator.windowID)
-                }
-            }
-        }
-    }
-
-    private func mutationIndicatorMenu(_ indicators: [FooterMutationIndicator]) -> some View {
-        Menu {
-            ForEach(indicators) { indicator in
-                Button {
-                    onOpenToolWindow(indicator.windowID)
-                } label: {
-                    Label("\(indicator.title)  \(indicator.count)", systemImage: indicator.systemImage)
-                }
-            }
-        } label: {
-            Label(
-                "\(indicators.reduce(0) { $0 + $1.count })",
-                systemImage: "bolt.horizontal.circle"
-            )
-            .font(.system(size: metrics.badgeFontSize, weight: .semibold))
-            .foregroundStyle(Color(nsColor: .systemOrange))
-            .padding(.horizontal, 7)
-            .padding(.vertical, 2)
-            .background(Color(nsColor: .systemOrange).opacity(0.14), in: Capsule())
-        }
-        .menuStyle(.borderlessButton)
-        .menuIndicator(.hidden)
-        .fixedSize()
-        .help(String(localized: "Active mutation rules"))
-        .accessibilityLabel(String(localized: "Active mutation rules"))
-    }
-
-    private var centerStatus: some View {
-        Group {
-            if let provenance = sessionProvenance {
-                Text(provenance.displayText)
-                    .font(.system(size: metrics.secondaryFontSize, weight: .medium))
-                    .foregroundStyle(Color.accentColor)
-                    .lineLimit(1)
-                    .truncationMode(.middle)
-            } else {
-                Text(statusText)
-                    .font(.system(size: metrics.secondaryFontSize))
-                    .foregroundStyle(Color(nsColor: .secondaryLabelColor))
-            }
+    @ViewBuilder private var centerStatus: some View {
+        if let provenance = sessionProvenance {
+            Text(provenance.displayText)
+                .font(.system(size: metrics.secondaryFontSize, weight: .medium))
+                .foregroundStyle(Color.accentColor)
+                .lineLimit(1)
+                .truncationMode(.middle)
+        } else {
+            Text(statusText)
+                .font(.system(size: metrics.secondaryFontSize))
+                .foregroundStyle(Color(nsColor: .secondaryLabelColor))
         }
     }
 
@@ -723,36 +654,11 @@ struct StatusBarView: View {
         .lineLimit(1)
     }
 
-    private func formattedSpeed(_ bytesPerSecond: Int64) -> String {
-        if bytesPerSecond < 1_024 {
-            return "\(bytesPerSecond) B/s"
-        } else if bytesPerSecond < 1_048_576 {
-            return "\(bytesPerSecond / 1_024) KB/s"
-        } else {
-            let mb = Double(bytesPerSecond) / 1_048_576
-            return String(format: "%.1f MB/s", mb)
-        }
-    }
-
-    @Environment(\.appUIDisplayMetrics) private var metrics
-    @AppStorage("footerQuickToolOrder") private var quickToolOrder = FooterActionKind.defaultQuickTools
-        .map(\.rawValue)
-        .joined(separator: ",")
-    @State private var isCustomizingQuickTools = false
-
-    private var selectedQuickTools: [FooterActionKind] {
-        let decoded = quickToolOrder.split(separator: ",").compactMap { FooterActionKind(rawValue: String($0)) }
-        let unique = decoded.reduce(into: [FooterActionKind]()) { result, item in
-            if item != .proxyOverride, !result.contains(item) { result.append(item) }
-        }
-        return unique.count == 4 ? unique : FooterActionKind.defaultQuickTools
-    }
-
     private var quickTools: some View {
         HStack(spacing: 6) {
             ForEach(FooterActionDescriptor.toolingActions(
                 isAllowListActive: isAllowListActive,
-                quickTools: selectedQuickTools
+                quickTools: quickToolsLayout.footer
             )) { descriptor in
                 FooterToolingButton(descriptor: descriptor) {
                     performAction(descriptor.id)
@@ -766,18 +672,56 @@ struct StatusBarView: View {
             .buttonStyle(.plain)
             .help(String(localized: "Customize Quick Tools"))
             .popover(isPresented: $isCustomizingQuickTools, arrowEdge: .bottom) {
-                FooterQuickToolsEditor(
-                    selection: selectedQuickTools,
-                    onSave: { quickToolOrder = $0.map(\.rawValue).joined(separator: ",") },
-                    onReset: {
-                        quickToolOrder = FooterActionKind.defaultQuickTools.map(\.rawValue).joined(separator: ",")
-                    },
-                    onDone: {
-                        isCustomizingQuickTools = false
-                    }
+                QuickToolsEditor(
+                    layout: quickToolsLayout,
+                    onSave: { quickToolsLayoutRaw = $0.encoded },
+                    onReset: { quickToolsLayoutRaw = QuickToolsLayout.default.encoded },
+                    onDone: { isCustomizingQuickTools = false }
                 )
             }
         }
+    }
+
+    private func mutationIndicatorRow(
+        _ indicators: [FooterMutationIndicator],
+        showsTitles: Bool
+    )
+        -> some View
+    {
+        HStack(spacing: 6) {
+            ForEach(indicators) { indicator in
+                FooterMutationIndicatorButton(indicator: indicator, showsTitle: showsTitles) {
+                    onOpenToolWindow(indicator.windowID)
+                }
+            }
+        }
+    }
+
+    private func mutationIndicatorMenu(_ indicators: [FooterMutationIndicator]) -> some View {
+        Menu {
+            ForEach(indicators) { indicator in
+                Button {
+                    onOpenToolWindow(indicator.windowID)
+                } label: {
+                    Label("\(indicator.title)  \(indicator.count)", systemImage: indicator.systemImage)
+                }
+            }
+        } label: {
+            Label(
+                "\(indicators.reduce(0) { $0 + $1.count })",
+                systemImage: "bolt.horizontal.circle"
+            )
+            .font(.system(size: metrics.badgeFontSize, weight: .semibold))
+            .foregroundStyle(Color(nsColor: .systemOrange))
+            .padding(.horizontal, 7)
+            .padding(.vertical, 2)
+            .background(Color(nsColor: .systemOrange).opacity(0.14), in: Capsule())
+        }
+        .menuStyle(.borderlessButton)
+        .menuIndicator(.hidden)
+        .fixedSize()
+        .help(String(localized: "Active mutation rules"))
+        .accessibilityLabel(String(localized: "Active mutation rules"))
     }
 
     private func statusPill(_ title: String, color: Color) -> some View {
@@ -790,25 +734,22 @@ struct StatusBarView: View {
             .background(color, in: Capsule())
     }
 
-    private func performAction(_ action: FooterActionKind) {
-        switch action {
-        case .blockList:
-            onOpenToolWindow("blockList")
-        case .allowList:
-            onOpenToolWindow("allowList")
-        case .mapLocal:
-            onOpenToolWindow("mapLocal")
-        case .scripting:
-            onOpenToolWindow("scriptingList")
-        case .mapRemote:
-            onOpenToolWindow("mapRemote")
-        case .breakpoint:
-            onOpenToolWindow("breakpointRules")
-        case .networkConditions:
-            onOpenToolWindow("networkConditions")
-        case .proxyOverride:
-            break
+    private func formattedSpeed(_ bytesPerSecond: Int64) -> String {
+        if bytesPerSecond < 1_024 {
+            return "\(bytesPerSecond) B/s"
+        } else if bytesPerSecond < 1_048_576 {
+            return "\(bytesPerSecond / 1_024) KB/s"
+        } else {
+            let mb = Double(bytesPerSecond) / 1_048_576
+            return String(format: "%.1f MB/s", mb)
         }
+    }
+
+    private func performAction(_ action: FooterActionKind) {
+        guard let windowID = action.toolWindowID else {
+            return
+        }
+        onOpenToolWindow(windowID)
     }
 }
 
@@ -817,6 +758,8 @@ struct StatusBarView: View {
 /// Shared bottom-edge chrome for the traffic workspace and its native inspector.
 /// Keeping height and separator construction in one view guarantees both panes meet on one pixel row.
 struct WorkspaceFooterBar<Content: View>: View {
+    // MARK: Internal
+
     let horizontalPadding: CGFloat
     @ViewBuilder let content: () -> Content
 
@@ -831,112 +774,9 @@ struct WorkspaceFooterBar<Content: View>: View {
             }
     }
 
+    // MARK: Private
+
     @Environment(\.appUIDisplayMetrics) private var metrics
-}
-
-private struct FooterQuickToolsEditor: View {
-    let onSave: ([FooterActionKind]) -> Void
-    let onReset: () -> Void
-    let onDone: () -> Void
-
-    init(
-        selection: [FooterActionKind],
-        onSave: @escaping ([FooterActionKind]) -> Void,
-        onReset: @escaping () -> Void,
-        onDone: @escaping () -> Void
-    ) {
-        _selection = State(initialValue: selection)
-        self.onSave = onSave
-        self.onReset = onReset
-        self.onDone = onDone
-    }
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            Text(String(localized: "Customize Quick Tools"))
-                .font(.headline)
-            Grid(alignment: .leading, horizontalSpacing: 10, verticalSpacing: 8) {
-                ForEach(selection.indices, id: \.self) { index in
-                    GridRow {
-                        Text(String(localized: "Slot \(index + 1)"))
-                            .frame(width: 44, alignment: .leading)
-                        Menu {
-                            ForEach(availableKinds(for: index), id: \.self) { kind in
-                                Button {
-                                    selection[index] = kind
-                                } label: {
-                                    if selection[index] == kind {
-                                        Label(descriptor(for: kind).title, systemImage: "checkmark")
-                                    } else {
-                                        Text(descriptor(for: kind).title)
-                                    }
-                                }
-                            }
-                        } label: {
-                            ZStack {
-                                RoundedRectangle(cornerRadius: 5, style: .continuous)
-                                    .fill(Color(nsColor: .controlBackgroundColor))
-                                RoundedRectangle(cornerRadius: 5, style: .continuous)
-                                    .stroke(Color(nsColor: .separatorColor), lineWidth: 0.5)
-                                HStack(spacing: 8) {
-                                    Text(descriptor(for: selection[index]).title)
-                                        .lineLimit(1)
-                                        .truncationMode(.tail)
-                                    Spacer(minLength: 8)
-                                    Image(systemName: "chevron.down")
-                                        .font(.caption2)
-                                        .foregroundStyle(.secondary)
-                                }
-                                .padding(.horizontal, 8)
-                            }
-                            .frame(width: 126, height: 24)
-                            .contentShape(Rectangle())
-                        }
-                        .menuStyle(.button)
-                        .buttonStyle(.plain)
-                        .menuIndicator(.hidden)
-                        .controlSize(.small)
-                        .frame(width: 126, height: 24, alignment: .leading)
-                        .contentShape(Rectangle())
-                        .accessibilityLabel(descriptor(for: selection[index]).title)
-                        .accessibilityIdentifier("footerQuickTools.slot\(index + 1)")
-                    }
-                }
-            }
-            .frame(maxWidth: .infinity, alignment: .leading)
-            Divider()
-            HStack {
-                Button(String(localized: "Reset Defaults")) {
-                    selection = FooterActionKind.defaultQuickTools
-                    onReset()
-                }
-                Spacer()
-                Button(String(localized: "Done")) {
-                    onSave(selection)
-                    onDone()
-                }
-                .keyboardShortcut(.defaultAction)
-            }
-        }
-        .padding(16)
-        .frame(width: 250)
-        .onChange(of: selection) { _, value in onSave(value) }
-    }
-
-    @State private var selection: [FooterActionKind]
-
-    private func availableKinds(for index: Int) -> [FooterActionKind] {
-        FooterActionKind.allCases.filter { kind in
-            kind != .proxyOverride && (kind == selection[index] || !selection.contains(kind))
-        }
-    }
-
-    private func descriptor(for kind: FooterActionKind) -> FooterActionDescriptor {
-        FooterActionDescriptor.toolingActions(
-            isAllowListActive: false,
-            quickTools: [kind]
-        )[0]
-    }
 }
 
 // MARK: - SessionDurationView

--- a/Rockxy/Views/Toolbar/TrafficCommandBar.swift
+++ b/Rockxy/Views/Toolbar/TrafficCommandBar.swift
@@ -1,0 +1,545 @@
+import SwiftUI
+
+// Renders the traffic quick-action strip that sits above the protocol filter bar.
+
+// MARK: - TrafficCommandKind
+
+enum TrafficCommandKind: String, CaseIterable {
+    case clearSession
+    case jumpToFirstRequest
+    case followLive
+    case jumpToLastRequest
+    case copyAsCURL
+    case togglePin
+    case toggleSave
+}
+
+// MARK: - TrafficCommandDescriptor
+
+/// Value-typed presentation contract for traffic-strip controls and their structured overflow menu.
+/// The main menu remains the keyboard-shortcut owner; this surface mirrors those commands and keeps
+/// their live state and availability close to the request list.
+struct TrafficCommandDescriptor: Identifiable, Equatable {
+    let id: TrafficCommandKind
+    let title: String
+    let systemImage: String
+    let help: String
+    let isActive: Bool
+    let isEnabled: Bool
+
+    static func clearSession(isEnabled: Bool = true) -> Self {
+        .init(
+            id: .clearSession,
+            title: String(localized: "Clear Session"),
+            systemImage: "trash",
+            help: String(localized: "Clear captured requests and logs from this session across all tabs. ⌘K"),
+            isActive: false,
+            isEnabled: isEnabled
+        )
+    }
+
+    static func jumpToFirstRequest(isEnabled: Bool) -> Self {
+        .init(
+            id: .jumpToFirstRequest,
+            title: String(localized: "Jump to First Request"),
+            systemImage: "arrow.up.to.line",
+            help: String(localized: "Jump to the first visible request. ⌘↑"),
+            isActive: false,
+            isEnabled: isEnabled
+        )
+    }
+
+    static func followLive(isActive: Bool) -> Self {
+        .init(
+            id: .followLive,
+            title: String(localized: "Follow Live"),
+            systemImage: "dot.radiowaves.right",
+            help: isActive
+                ? String(localized: "Follow Live is on for this tab. Scroll, select a row, or click again to stop. ⇧⌘L")
+                : String(localized: "Keep the newest request in this tab selected. ⇧⌘L"),
+            isActive: isActive,
+            isEnabled: true
+        )
+    }
+
+    static func jumpToLastRequest(isEnabled: Bool) -> Self {
+        .init(
+            id: .jumpToLastRequest,
+            title: String(localized: "Jump to Last Request"),
+            systemImage: "arrow.down.to.line",
+            help: String(localized: "Jump to the latest visible request without changing Follow Live. ⌘↓"),
+            isActive: false,
+            isEnabled: isEnabled
+        )
+    }
+
+    static func copyAsCURL(isEnabled: Bool) -> Self {
+        .init(
+            id: .copyAsCURL,
+            title: String(localized: "Copy as cURL"),
+            systemImage: "terminal",
+            help: String(localized: "Copy the selected request as a cURL command. ⇧⌘C"),
+            isActive: false,
+            isEnabled: isEnabled
+        )
+    }
+
+    static func togglePin(isPinned: Bool, isEnabled: Bool) -> Self {
+        .init(
+            id: .togglePin,
+            title: isPinned ? String(localized: "Unpin Request") : String(localized: "Pin Request"),
+            systemImage: isPinned ? "pin.fill" : "pin",
+            help: isPinned
+                ? String(localized: "Unpin the selected request from the current session.")
+                : String(localized: "Keep the selected request pinned in the current session."),
+            isActive: isPinned,
+            isEnabled: isEnabled
+        )
+    }
+
+    static func toggleSave(isSaved: Bool, isEnabled: Bool) -> Self {
+        .init(
+            id: .toggleSave,
+            title: isSaved ? String(localized: "Unsave Request") : String(localized: "Save Request"),
+            systemImage: isSaved ? "tray.full.fill" : "tray.and.arrow.down",
+            help: isSaved
+                ? String(localized: "Remove the selected request from the Library.")
+                : String(localized: "Save the selected request to the Library."),
+            isActive: isSaved,
+            isEnabled: isEnabled
+        )
+    }
+}
+
+// MARK: - TrafficRecordingCommandPresentation
+
+/// Presentation for the capture-buffer toggle. Start/Stop remains a window-toolbar lifecycle
+/// control; pausing recording stays in the traffic actions menu to avoid adjacent stop/pause
+/// symbols with overlapping meanings.
+struct TrafficRecordingCommandPresentation: Equatable {
+    let title: String
+    let systemImage: String
+    let help: String
+    let isEnabled: Bool
+
+    static func make(isProxyRunning: Bool, isRecording: Bool) -> Self {
+        .init(
+            title: isRecording ? String(localized: "Pause Recording") : String(localized: "Resume Recording"),
+            systemImage: isRecording ? "pause.fill" : "record.circle",
+            help: isProxyRunning
+                ? (isRecording
+                    ? String(localized: "Pause recording new traffic without stopping the proxy. ⌘P")
+                    : String(localized: "Resume recording new traffic. ⌘P"))
+                : String(localized: "Start the proxy before changing recording. ⌘P"),
+            isEnabled: isProxyRunning
+        )
+    }
+}
+
+// MARK: - TrafficCommandBar
+
+/// A native command strip for immediate traffic work. Session clearing and live-tail state stay
+/// visible; richer request, rule, navigation, session, and export workflows live in one structured
+/// icon menu. Proxy Start/Stop remains in the window toolbar; recording pause lives in overflow
+/// so the two different capture semantics never compete as adjacent transport buttons.
+struct TrafficCommandBar: View {
+    // MARK: Internal
+
+    let coordinator: MainContentCoordinator
+    var onOpenToolWindow: (String) -> Void = { _ in }
+
+    var body: some View {
+        commandRow
+            .padding(.horizontal, Theme.Layout.contentPadding)
+            .padding(.vertical, max(4, (metrics.fontSize - 10) / 3))
+            .background(Color(nsColor: .windowBackgroundColor))
+            .overlay(alignment: .bottom) { Divider() }
+            .fixedSize(horizontal: false, vertical: true)
+            .task { persistResolvedQuickToolsLayoutIfNeeded() }
+    }
+
+    // MARK: Private
+
+    @Environment(\.appUIDisplayMetrics) private var metrics
+    @AppStorage(QuickToolsLayout.storageKey) private var quickToolsLayoutRaw = ""
+    @AppStorage(QuickToolsLayout.legacyFooterStorageKey) private var legacyFooterQuickToolOrder = ""
+    @State private var isCustomizingQuickTools = false
+
+    /// Stable reference to the Allow List singleton so Observation tracks `isActive` inside `body`
+    /// and re-renders the Allow List capsule's active state when the master toggle changes.
+    private let allowListManager = AllowListManager.shared
+
+    private var actions: MainContentCommandActions {
+        MainContentCommandActions(coordinator: coordinator)
+    }
+
+    private var quickToolsLayout: QuickToolsLayout {
+        QuickToolsLayout.resolved(
+            storageRaw: quickToolsLayoutRaw,
+            legacyFooterRaw: legacyFooterQuickToolOrder
+        )
+    }
+
+    private var selectedTransaction: HTTPTransaction? {
+        coordinator.selectedTransaction
+    }
+
+    private var effectiveSelectionCount: Int {
+        max(coordinator.selectedTransactionIDs.count, selectedTransaction == nil ? 0 : 1)
+    }
+
+    private var hasSingleRequestSelection: Bool {
+        TrafficCommandAvailability.canActOnSingleRequest(
+            hasPrimarySelection: selectedTransaction != nil,
+            selectionCount: effectiveSelectionCount
+        )
+    }
+
+    private var canUseHTTPOnlySelection: Bool {
+        guard let selectedTransaction else {
+            return false
+        }
+        return TrafficCommandAvailability.canUseHTTPOnlyRequestAction(
+            hasPrimarySelection: true,
+            selectionCount: effectiveSelectionCount,
+            isWebSocket: selectedTransaction.webSocketConnection != nil,
+            method: selectedTransaction.request.method
+        )
+    }
+
+    private var canClearSession: Bool {
+        TrafficCommandAvailability.canClearSession(
+            transactionCount: coordinator.transactions.count,
+            logCount: coordinator.logEntries.count,
+            hasSessionProvenance: coordinator.sessionProvenance != nil,
+            isClearingSession: coordinator.isClearingSession
+        )
+    }
+
+    private var followLiveBinding: Binding<Bool> {
+        Binding(
+            get: { coordinator.isFollowingLiveTraffic },
+            set: { coordinator.setFollowingLiveTraffic($0) }
+        )
+    }
+
+    private var commandRow: some View {
+        HStack(spacing: 8) {
+            clearSessionButton
+            commandDivider
+            followLiveButton
+            responsiveQuickToolsGroup
+
+            Spacer(minLength: 12)
+            actionsMenu
+        }
+    }
+
+    /// The shared quick-tool capsules for the command bar. Responsive: three capsules when wide,
+    /// two when medium, none when narrow — it never degrades to icon-only controls. Hidden tools
+    /// stay reachable through the Traffic Actions "Quick Tools" submenu.
+    private var responsiveQuickToolsGroup: some View {
+        let descriptors = FooterActionDescriptor.toolingActions(
+            isAllowListActive: allowListManager.isActive,
+            quickTools: quickToolsLayout.commandBar
+        )
+        return ViewThatFits(in: .horizontal) {
+            quickToolsGroup(descriptors)
+            quickToolsGroup(Array(descriptors.prefix(2)))
+            EmptyView()
+        }
+    }
+
+    private var clearSessionButton: some View {
+        let descriptor = TrafficCommandDescriptor.clearSession(isEnabled: canClearSession)
+        return Button {
+            actions.clearSession()
+        } label: {
+            Label(descriptor.title, systemImage: descriptor.systemImage)
+                .font(.system(size: metrics.secondaryFontSize))
+                .lineLimit(1)
+                .fixedSize(horizontal: true, vertical: false)
+        }
+        .buttonStyle(.bordered)
+        .controlSize(.small)
+        .disabled(!descriptor.isEnabled)
+        .help(descriptor.help)
+        .accessibilityLabel(descriptor.title)
+    }
+
+    private var followLiveButton: some View {
+        let descriptor = TrafficCommandDescriptor.followLive(isActive: coordinator.isFollowingLiveTraffic)
+        return Toggle(isOn: followLiveBinding) {
+            Label(descriptor.title, systemImage: descriptor.systemImage)
+                .font(.system(size: metrics.secondaryFontSize))
+                .lineLimit(1)
+                .fixedSize(horizontal: true, vertical: false)
+        }
+        .toggleStyle(.button)
+        .buttonStyle(.bordered)
+        .controlSize(.small)
+        .help(descriptor.help)
+        .accessibilityLabel(descriptor.title)
+        .accessibilityValue(descriptor.isActive ? String(localized: "On") : String(localized: "Off"))
+    }
+
+    private var actionsMenu: some View {
+        let recording = TrafficRecordingCommandPresentation.make(
+            isProxyRunning: coordinator.isProxyRunning,
+            isRecording: coordinator.isRecording
+        )
+        return Menu {
+            Button {
+                actions.toggleRecording()
+            } label: {
+                Label(recording.title, systemImage: recording.systemImage)
+            }
+            .disabled(!recording.isEnabled)
+
+            Divider()
+
+            navigationMenu
+
+            Divider()
+
+            requestMenu
+            createRuleMenu
+
+            Divider()
+
+            quickToolsMenu
+
+            Divider()
+
+            Button(String(localized: "Compose…")) { actions.composeFreshRequest() }
+            sessionMenu
+            exportMenu
+        } label: {
+            Image(systemName: "bolt.circle")
+                .font(.system(size: metrics.controlFontSize, weight: .medium))
+                .foregroundStyle(Color(nsColor: .secondaryLabelColor))
+                .frame(width: metrics.filterBarHeight, height: metrics.filterBarHeight)
+        }
+        .menuStyle(.borderlessButton)
+        .menuIndicator(.hidden)
+        .fixedSize()
+        .help(String(localized: "Traffic, request, rule, session, and export actions"))
+        .accessibilityLabel(String(localized: "Traffic Actions"))
+        .popover(isPresented: $isCustomizingQuickTools, arrowEdge: .bottom) {
+            QuickToolsEditor(
+                layout: quickToolsLayout,
+                onSave: { quickToolsLayoutRaw = $0.encoded },
+                onReset: { quickToolsLayoutRaw = QuickToolsLayout.default.encoded },
+                onDone: { isCustomizingQuickTools = false }
+            )
+        }
+    }
+
+    /// Keeps the command-bar quick tools discoverable when the responsive strip collapses, and
+    /// bridges into the shared customization editor without adding a second ellipsis on top.
+    @ViewBuilder private var quickToolsMenu: some View {
+        Menu(String(localized: "Quick Tools")) {
+            ForEach(
+                FooterActionDescriptor.toolingActions(
+                    isAllowListActive: allowListManager.isActive,
+                    quickTools: quickToolsLayout.commandBar
+                )
+            ) { descriptor in
+                Button {
+                    openQuickTool(descriptor.id)
+                } label: {
+                    Label(descriptor.title, systemImage: descriptor.systemImage)
+                }
+            }
+        }
+        Button(String(localized: "Customize Quick Tools…")) {
+            // A macOS `Menu` tears down its transient window before the next presentation can
+            // begin. Defer the popover state change to the next main-queue turn so the stable
+            // command-bar anchor presents reliably after the menu has closed.
+            DispatchQueue.main.async {
+                isCustomizingQuickTools = true
+            }
+        }
+    }
+
+    @ViewBuilder private var navigationMenu: some View {
+        Button(String(localized: "Jump to First Request")) { actions.selectFirstTransaction() }
+            .disabled(coordinator.filteredTransactions.isEmpty)
+        Button(String(localized: "Jump to Last Request")) { actions.selectLastTransaction() }
+            .disabled(coordinator.filteredTransactions.isEmpty)
+    }
+
+    private var requestMenu: some View {
+        Menu(String(localized: "Selected Request")) {
+            let copy = TrafficCommandDescriptor.copyAsCURL(isEnabled: canUseHTTPOnlySelection)
+            Button(copy.title) { actions.copyAsCURL() }
+                .disabled(!copy.isEnabled)
+
+            let pin = TrafficCommandDescriptor.togglePin(
+                isPinned: selectedTransaction?.isPinned == true,
+                isEnabled: hasSingleRequestSelection
+            )
+            Button(pin.title) {
+                guard let selectedTransaction else {
+                    return
+                }
+                coordinator.togglePin(for: selectedTransaction)
+            }
+
+            let save = TrafficCommandDescriptor.toggleSave(
+                isSaved: selectedTransaction?.isSaved == true,
+                isEnabled: hasSingleRequestSelection
+            )
+            Button(save.title) {
+                guard let selectedTransaction else {
+                    return
+                }
+                coordinator.saveRequest(selectedTransaction)
+            }
+
+            Divider()
+
+            Button(String(localized: "Repeat")) { actions.replayRequest() }
+                .disabled(!canUseHTTPOnlySelection)
+            Button(String(localized: "Edit and Repeat…")) { actions.editAndRepeat() }
+                .disabled(!canUseHTTPOnlySelection)
+
+            Divider()
+
+            Button(String(localized: "Add Note…")) { actions.addComment() }
+            Menu(String(localized: "Highlight")) {
+                ForEach(HighlightColor.allCases, id: \.self) { color in
+                    Button(color.rawValue.capitalized) { actions.setHighlight(color) }
+                }
+                Divider()
+                Button(String(localized: "Remove Highlight")) { actions.setHighlight(nil) }
+            }
+        }
+        .disabled(!hasSingleRequestSelection)
+    }
+
+    private var createRuleMenu: some View {
+        Menu(String(localized: "Create Rule from Request")) {
+            Button(String(localized: "Breakpoint…")) {
+                guard let selectedTransaction else {
+                    return
+                }
+                coordinator.createBreakpointRule(for: selectedTransaction)
+            }
+            Button(String(localized: "Map Local…")) {
+                guard let selectedTransaction else {
+                    return
+                }
+                coordinator.createMapLocalRule(for: selectedTransaction)
+            }
+            Button(String(localized: "Map Remote…")) {
+                guard let selectedTransaction else {
+                    return
+                }
+                coordinator.createMapRemoteRule(for: selectedTransaction)
+            }
+            Button(String(localized: "Network Condition…")) {
+                guard let selectedTransaction else {
+                    return
+                }
+                coordinator.createNetworkConditionsRule(for: selectedTransaction)
+            }
+        }
+        .disabled(!canUseHTTPOnlySelection)
+    }
+
+    private var sessionMenu: some View {
+        Menu(String(localized: "Session")) {
+            Button(String(localized: "Clear Session and Filters")) { actions.clearCaptureAndFilters() }
+                .disabled(!canClearSession)
+            Button(String(localized: "Save Session…")) { actions.saveSession() }
+                .disabled(coordinator.transactions.isEmpty)
+        }
+    }
+
+    private var exportMenu: some View {
+        Menu(String(localized: "Export")) {
+            Button(String(localized: "Export as HAR…")) { actions.exportHAR() }
+                .disabled(coordinator.transactions.isEmpty)
+            Button(String(localized: "Export as OpenAPI YAML…")) { actions.exportOpenAPIYAML() }
+                .disabled(!actions.canExportOpenAPI)
+            Button(String(localized: "Export as OpenAPI HTML…")) { actions.exportOpenAPIHTML() }
+                .disabled(!actions.canExportOpenAPI)
+            Divider()
+            Button(String(localized: "Publish Selected to Gist…")) { actions.publishSelectedToGist() }
+                .disabled(!actions.canPublishGist)
+        }
+    }
+
+    private var commandDivider: some View {
+        Divider()
+            .frame(height: 16)
+            .padding(.horizontal, 4)
+    }
+
+    private func quickToolsRow(_ descriptors: [FooterActionDescriptor]) -> some View {
+        HStack(spacing: 6) {
+            ForEach(descriptors) { descriptor in
+                FooterToolingButton(descriptor: descriptor) {
+                    openQuickTool(descriptor.id)
+                }
+            }
+        }
+        .fixedSize(horizontal: true, vertical: false)
+    }
+
+    private func quickToolsGroup(_ descriptors: [FooterActionDescriptor]) -> some View {
+        HStack(spacing: 8) {
+            commandDivider
+            quickToolsRow(descriptors)
+        }
+        .fixedSize(horizontal: true, vertical: false)
+    }
+
+    private func persistResolvedQuickToolsLayoutIfNeeded() {
+        let normalized = quickToolsLayout.encoded
+        if quickToolsLayoutRaw != normalized {
+            quickToolsLayoutRaw = normalized
+        }
+    }
+
+    private func openQuickTool(_ kind: FooterActionKind) {
+        guard let windowID = kind.toolWindowID else {
+            return
+        }
+        onOpenToolWindow(windowID)
+    }
+}
+
+// MARK: - TrafficCommandAvailability
+
+enum TrafficCommandAvailability {
+    static func canClearSession(
+        transactionCount: Int,
+        logCount: Int,
+        hasSessionProvenance: Bool,
+        isClearingSession: Bool
+    )
+        -> Bool
+    {
+        !isClearingSession && (transactionCount > 0 || logCount > 0 || hasSessionProvenance)
+    }
+
+    static func canActOnSingleRequest(hasPrimarySelection: Bool, selectionCount: Int) -> Bool {
+        hasPrimarySelection && selectionCount == 1
+    }
+
+    static func canUseHTTPOnlyRequestAction(
+        hasPrimarySelection: Bool,
+        selectionCount: Int,
+        isWebSocket: Bool,
+        method: String
+    )
+        -> Bool
+    {
+        canActOnSingleRequest(
+            hasPrimarySelection: hasPrimarySelection,
+            selectionCount: selectionCount
+        ) && !isWebSocket && method.caseInsensitiveCompare("CONNECT") != .orderedSame
+    }
+}

--- a/Rockxy/Views/Toolbar/TrafficQuickTools.swift
+++ b/Rockxy/Views/Toolbar/TrafficQuickTools.swift
@@ -1,0 +1,346 @@
+import SwiftUI
+
+// Shared Quick Tools system: one seven-tool catalog and one persisted layout own both the
+// top `TrafficCommandBar` (3 slots) and the footer `StatusBarView` (4 slots). Both regions render
+// the same `FooterToolingButton` capsule so there is no top-only styling. `proxyOverride` stays a
+// separate dynamic footer control and is never part of this layout.
+
+// MARK: - FooterActionKind + Quick Tools
+
+extension FooterActionKind {
+    /// The seven customizable tools, in canonical order. Excludes `proxyOverride`, which is a
+    /// dynamic footer status control rather than a customizable launcher.
+    static let customizableQuickTools: [FooterActionKind] = allCases.filter { $0 != .proxyOverride }
+
+    /// The tool-window ID opened when this launcher is activated, or `nil` for non-launchers.
+    var toolWindowID: String? {
+        switch self {
+        case .blockList: "blockList"
+        case .allowList: "allowList"
+        case .mapLocal: "mapLocal"
+        case .scripting: "scriptingList"
+        case .mapRemote: "mapRemote"
+        case .breakpoint: "breakpointRules"
+        case .networkConditions: "networkConditions"
+        case .proxyOverride: nil
+        }
+    }
+}
+
+// MARK: - QuickToolsLayout
+
+/// Pure value model for the synchronized 3+4 Quick Tools layout. All seven customizable tools
+/// occur exactly once across the three command-bar slots and four footer slots. Every constructor
+/// path returns a repaired, valid layout so the UI can trust the invariant without extra checks.
+struct QuickToolsLayout: Equatable {
+    // MARK: Lifecycle
+
+    /// Repairs whatever it is given into a valid 3+4 layout. Drops duplicates and `proxyOverride`,
+    /// then backfills any missing tools in canonical order so the invariant always holds.
+    init(commandBar rawCommandBar: [FooterActionKind], footer rawFooter: [FooterActionKind]) {
+        var seen = Set<FooterActionKind>()
+        func cleaned(_ list: [FooterActionKind]) -> [FooterActionKind] {
+            list.filter { $0 != .proxyOverride && seen.insert($0).inserted }
+        }
+
+        let cleanedCommandBar = cleaned(rawCommandBar)
+        let cleanedFooter = cleaned(rawFooter)
+        let missing = FooterActionKind.customizableQuickTools.filter { !seen.contains($0) }
+
+        let pool = cleanedCommandBar + cleanedFooter + missing
+        commandBar = Array(pool.prefix(Self.commandBarSlotCount))
+        footer = Array(pool.dropFirst(Self.commandBarSlotCount).prefix(Self.footerSlotCount))
+    }
+
+    // MARK: Internal
+
+    enum Region: Equatable {
+        case commandBar
+        case footer
+    }
+
+    static let commandBarSlotCount = 3
+    static let footerSlotCount = 4
+    static let storageKey = RockxyIdentity.current.defaultsKey("quickToolsLayout")
+    static let legacyFooterStorageKey = "footerQuickToolOrder"
+
+    /// Approved defaults: Block List, Allow List, Map Remote on top; Breakpoint, Map Local,
+    /// Scripting, Network Conditions in the footer.
+    static let `default` = QuickToolsLayout(
+        commandBar: [.blockList, .allowList, .mapRemote],
+        footer: FooterActionKind.defaultQuickTools
+    )
+
+    private(set) var commandBar: [FooterActionKind]
+    private(set) var footer: [FooterActionKind]
+
+    // MARK: Encoding
+
+    /// Compact `command|footer` storage form, each side comma-separated raw values.
+    var encoded: String {
+        let top = commandBar.map(\.rawValue).joined(separator: ",")
+        let bottom = footer.map(\.rawValue).joined(separator: ",")
+        return "\(top)|\(bottom)"
+    }
+
+    /// Decodes a stored layout string, repairing malformed or duplicate state. Returns `nil` only
+    /// for empty input so callers can fall back to legacy migration.
+    static func decode(_ raw: String) -> QuickToolsLayout? {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            return nil
+        }
+
+        let parts = trimmed.split(separator: "|", maxSplits: 1, omittingEmptySubsequences: false)
+        let commandBar = kinds(from: parts.first.map(String.init) ?? "")
+        let footer = parts.count > 1 ? kinds(from: String(parts[1])) : []
+        return QuickToolsLayout(commandBar: commandBar, footer: footer)
+    }
+
+    /// Resolves the effective layout from the new shared storage value, falling back to a one-time
+    /// read migration of the legacy `footerQuickToolOrder` value when the new key is absent.
+    static func resolved(storageRaw: String, legacyFooterRaw: String) -> QuickToolsLayout {
+        if let decoded = decode(storageRaw) {
+            return decoded
+        }
+        let legacyFooter = kinds(from: legacyFooterRaw)
+        guard !legacyFooter.isEmpty else {
+            return .default
+        }
+        return migrated(fromLegacyFooter: legacyFooter)
+    }
+
+    /// Migration path: keep the four legacy footer selections in the footer and place the
+    /// remaining three tools on the command bar.
+    static func migrated(fromLegacyFooter legacyFooter: [FooterActionKind]) -> QuickToolsLayout {
+        let footer = legacyFooter.filter { $0 != .proxyOverride }
+        let commandBar = FooterActionKind.customizableQuickTools.filter { !footer.contains($0) }
+        return QuickToolsLayout(commandBar: commandBar, footer: footer)
+    }
+
+    // MARK: Mutation
+
+    func tools(in region: Region) -> [FooterActionKind] {
+        region == .commandBar ? commandBar : footer
+    }
+
+    /// Assigns `tool` to the given slot. If `tool` already lives elsewhere, the two slots swap so
+    /// every tool stays assigned exactly once.
+    func assigning(_ tool: FooterActionKind, to region: Region, slot: Int) -> QuickToolsLayout {
+        var updated = self
+        guard updated.slots(for: region).indices.contains(slot) else {
+            return updated
+        }
+
+        let current = updated.slots(for: region)[slot]
+        guard current != tool else {
+            return updated
+        }
+
+        if let location = updated.location(of: tool) {
+            updated.setSlot(location.region, location.slot, to: current)
+        }
+        updated.setSlot(region, slot, to: tool)
+        return updated
+    }
+
+    // MARK: Private
+
+    private static func kinds(from raw: String) -> [FooterActionKind] {
+        raw.split(separator: ",").compactMap {
+            FooterActionKind(rawValue: String($0).trimmingCharacters(in: .whitespacesAndNewlines))
+        }
+    }
+
+    private func slots(for region: Region) -> [FooterActionKind] {
+        region == .commandBar ? commandBar : footer
+    }
+
+    private mutating func setSlot(_ region: Region, _ slot: Int, to tool: FooterActionKind) {
+        if region == .commandBar {
+            commandBar[slot] = tool
+        } else {
+            footer[slot] = tool
+        }
+    }
+
+    private func location(of tool: FooterActionKind) -> (region: Region, slot: Int)? {
+        if let index = commandBar.firstIndex(of: tool) {
+            return (.commandBar, index)
+        }
+        if let index = footer.firstIndex(of: tool) {
+            return (.footer, index)
+        }
+        return nil
+    }
+}
+
+// MARK: - QuickToolsResponsivePolicy
+
+/// Pure policy for how many command-bar capsules stay visible as the center workspace narrows.
+/// The command bar shows the largest fitting count and never degrades to icon-only controls;
+/// hidden tools stay reachable through the Traffic Actions submenu.
+enum QuickToolsResponsivePolicy {
+    /// Candidate visible-capsule counts, largest first: three when wide, two when medium, none
+    /// when narrow.
+    static let candidateCommandBarCounts = [3, 2, 0]
+
+    /// The largest candidate count whose row fits, per the supplied fit predicate.
+    static func visibleCommandBarCount(fitting fits: (Int) -> Bool) -> Int {
+        candidateCommandBarCounts.first(where: fits) ?? 0
+    }
+}
+
+// MARK: - QuickToolsEditor
+
+/// One reusable editor for the shared Quick Tools layout, with Command Bar and Footer sections.
+/// Choosing a tool already assigned elsewhere swaps the two slots; Reset restores approved defaults.
+/// Opened from the footer ellipsis and from the Traffic Actions menu — both write the same key.
+struct QuickToolsEditor: View {
+    // MARK: Lifecycle
+
+    init(
+        layout: QuickToolsLayout,
+        onSave: @escaping (QuickToolsLayout) -> Void,
+        onReset: @escaping () -> Void,
+        onDone: @escaping () -> Void
+    ) {
+        _layout = State(initialValue: layout)
+        self.onSave = onSave
+        self.onReset = onReset
+        self.onDone = onDone
+    }
+
+    // MARK: Internal
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Text(String(localized: "Customize Quick Tools"))
+                .font(.headline)
+
+            section(
+                title: String(localized: "Command Bar"),
+                region: .commandBar,
+                identifierPrefix: "commandBarQuickTools"
+            )
+            section(
+                title: String(localized: "Footer"),
+                region: .footer,
+                identifierPrefix: "footerQuickTools"
+            )
+
+            Divider()
+
+            HStack {
+                Button(String(localized: "Reset Defaults")) {
+                    layout = .default
+                    onReset()
+                }
+                Spacer()
+                Button(String(localized: "Done")) {
+                    onSave(layout)
+                    onDone()
+                }
+                .keyboardShortcut(.defaultAction)
+            }
+        }
+        .padding(16)
+        .frame(width: 288)
+        .onChange(of: layout) { _, value in onSave(value) }
+    }
+
+    // MARK: Private
+
+    @State private var layout: QuickToolsLayout
+
+    private let onSave: (QuickToolsLayout) -> Void
+    private let onReset: () -> Void
+    private let onDone: () -> Void
+
+    private func section(
+        title: String,
+        region: QuickToolsLayout.Region,
+        identifierPrefix: String
+    )
+        -> some View
+    {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(title)
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(.secondary)
+
+            let tools = layout.tools(in: region)
+            Grid(alignment: .leading, horizontalSpacing: 10, verticalSpacing: 8) {
+                ForEach(tools.indices, id: \.self) { index in
+                    GridRow {
+                        Text(String(localized: "Slot \(index + 1)"))
+                            .frame(width: 44, alignment: .leading)
+                        slotMenu(
+                            region: region,
+                            slot: index,
+                            identifier: "\(identifierPrefix).slot\(index + 1)"
+                        )
+                    }
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func slotMenu(
+        region: QuickToolsLayout.Region,
+        slot: Int,
+        identifier: String
+    )
+        -> some View
+    {
+        let current = layout.tools(in: region)[slot]
+        return Menu {
+            ForEach(FooterActionKind.customizableQuickTools, id: \.self) { kind in
+                Button {
+                    layout = layout.assigning(kind, to: region, slot: slot)
+                } label: {
+                    if kind == current {
+                        Label(Self.title(for: kind), systemImage: "checkmark")
+                    } else {
+                        Text(Self.title(for: kind))
+                    }
+                }
+            }
+        } label: {
+            ZStack {
+                RoundedRectangle(cornerRadius: 5, style: .continuous)
+                    .fill(Color(nsColor: .controlBackgroundColor))
+                RoundedRectangle(cornerRadius: 5, style: .continuous)
+                    .stroke(Color(nsColor: .separatorColor), lineWidth: 0.5)
+                HStack(spacing: 8) {
+                    Text(Self.title(for: current))
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                    Spacer(minLength: 8)
+                    Image(systemName: "chevron.down")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+                .padding(.horizontal, 8)
+            }
+            .frame(width: 180, height: 24)
+            .contentShape(Rectangle())
+        }
+        .menuStyle(.button)
+        .buttonStyle(.plain)
+        .menuIndicator(.hidden)
+        .controlSize(.small)
+        .frame(width: 180, height: 24, alignment: .leading)
+        .contentShape(Rectangle())
+        .accessibilityLabel(Self.title(for: current))
+        .accessibilityIdentifier(identifier)
+    }
+
+    private static func title(for kind: FooterActionKind) -> String {
+        FooterActionDescriptor.toolingActions(
+            isAllowListActive: false,
+            quickTools: [kind]
+        ).first?.title ?? kind.rawValue
+    }
+}

--- a/RockxyTests/Breakpoint/BreakpointPayloadSafetyTests.swift
+++ b/RockxyTests/Breakpoint/BreakpointPayloadSafetyTests.swift
@@ -24,6 +24,45 @@ struct BreakpointPayloadSafetyTests {
         #expect(!projection.isEditable)
     }
 
+    @Test("Execute remains available for header edits on a protected body")
+    @MainActor
+    func protectedBodyCanExecute() async throws {
+        let manager = BreakpointManager()
+        let data = BreakpointRequestData(
+            method: "GET",
+            url: "https://api.example.com/data",
+            headers: [],
+            body: "",
+            statusCode: 200,
+            phase: .response,
+            isBodyEditable: false
+        )
+
+        let resultTask = Task { @MainActor in
+            await manager.enqueueAndWait(data)
+        }
+        await Task.yield()
+        let item = try #require(manager.pausedItems.first)
+        manager.resolve(id: item.id, decision: .execute)
+        let result = await resultTask.value
+
+        guard case .execute = result.0 else {
+            Issue.record("Expected protected body to retain the execute decision")
+            return
+        }
+        #expect(!result.1.isBodyEditable)
+    }
+
+    @Test("Protected bodies keep non-body breakpoint controls enabled")
+    func protectedBodyKeepsMetadataControlsEnabled() throws {
+        let editor = try Self.projectFile(named: "Rockxy/Views/Breakpoint/BreakpointEditorView.swift")
+        let window = try Self.projectFile(named: "Rockxy/Views/Breakpoint/BreakpointWindowView.swift")
+
+        #expect(!editor.contains("requestLine(itemId: itemId)\n                    .disabled"))
+        #expect(!editor.contains(".disabled(draftFor(itemId)?.isBodyEditable == false)"))
+        #expect(window.contains("Request-line, status, and header changes can still be applied."))
+    }
+
     @Test("HTTPS origin-form editing preserves encoded delimiters and Unicode")
     func encodedOriginFormRoundTrip() throws {
         let target = "/objects/a%2Fb?token=a%26b%3Fc&label=caf%C3%A9"
@@ -58,5 +97,14 @@ struct BreakpointPayloadSafetyTests {
 
         #expect(updated.url == "/v1/items")
         #expect(updated.fixedHTTPSAuthority == "api.example.com")
+    }
+
+    private static func projectFile(named path: String) throws -> String {
+        let testFile = URL(fileURLWithPath: #filePath)
+        let repoRoot = testFile
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        return try String(contentsOf: repoRoot.appendingPathComponent(path), encoding: .utf8)
     }
 }

--- a/RockxyTests/Core/Detection/AITrafficDetectorTests.swift
+++ b/RockxyTests/Core/Detection/AITrafficDetectorTests.swift
@@ -91,7 +91,7 @@ struct AITrafficDetectorTests {
 
         #expect(!AITrafficDetector.isLikelyAI(transaction: transaction))
         #expect(AITrafficDetector.detect(transaction: transaction) == nil)
-        #expect(!ResponseInspectorTab.availableTabs(hasAIInspection: false).contains(.ai))
+        #expect(!ResponseInspectorTab.availableTabs().contains(.ai))
     }
 
     @Test("AI tab is available only when AI metadata is likely")
@@ -103,7 +103,7 @@ struct AITrafficDetectorTests {
         )
 
         #expect(AITrafficDetector.isLikelyAI(transaction: transaction))
-        #expect(!ResponseInspectorTab.availableTabs(hasAIInspection: true).contains(.ai))
+        #expect(!ResponseInspectorTab.availableTabs().contains(.ai))
         #expect(ProtocolTabKind.availableTabs(for: transaction).contains(.ai))
         #expect(ProtocolTabKind.defaultFor(transaction) == .ai)
     }

--- a/RockxyTests/Core/Plugins/ScriptingRegressionTests.swift
+++ b/RockxyTests/Core/Plugins/ScriptingRegressionTests.swift
@@ -311,15 +311,15 @@ struct ScriptingRegressionTests {
         #expect((mutated.body?.count ?? 0) > 5)
     }
 
-    // MARK: - Finding #4: response-breakpoint preservation when oversize hits
+    // MARK: - Finding #4: response-breakpoint safety when oversize hits
 
-    @Test("Oversize body with breakpoint armed keeps buffering — does NOT flush early")
-    func oversizeBreakpointKeepsBuffering() {
+    @Test("Oversize body suppresses breakpoint and resumes lossless streaming")
+    func oversizeBreakpointResumesStreaming() {
         let decision = ProxyHandlerShared.oversizeRelayDecision(
             deferRelayForScript: true,
             shouldBreakOnResponse: true
         )
-        #expect(decision == .keepBufferingForBreakpoint)
+        #expect(decision == .suppressBreakpointAndResumeStreaming)
     }
 
     @Test("Oversize body without breakpoint flushes buffered prefix and streams the rest")
@@ -340,16 +340,13 @@ struct ScriptingRegressionTests {
         #expect(decision == .alreadyStreaming)
     }
 
-    @Test("Oversize body with breakpoint but no script defer is already streaming (current chunks already relayed)")
+    @Test("Oversize body with breakpoint but no script defer still suppresses the breakpoint")
     func oversizeBreakpointNoDefer() {
-        // shouldBreakOnResponse already suppresses chunk relay independently of
-        // deferRelayForScript, so reaching here means buffering for the breakpoint
-        // is already in place — nothing extra for the truncation branch to do.
         let decision = ProxyHandlerShared.oversizeRelayDecision(
             deferRelayForScript: false,
             shouldBreakOnResponse: true
         )
-        #expect(decision == .alreadyStreaming)
+        #expect(decision == .suppressBreakpointAndResumeStreaming)
     }
 
     // MARK: - Finding #8: master toggle disables runtime hooks

--- a/RockxyTests/Core/ProxyEngine/BreakpointRequestBuilderTests.swift
+++ b/RockxyTests/Core/ProxyEngine/BreakpointRequestBuilderTests.swift
@@ -282,6 +282,40 @@ struct BreakpointRequestBuilderTests {
         #expect(contentLength == "\(result.requestData.body?.count ?? 0)")
     }
 
+    @Test("Non-editable request body is preserved while headers can change")
+    func nonEditableBodyPreserved() {
+        let binary = Data([0x1F, 0x8B, 0x08, 0x00])
+        let originalHead = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/upload")
+        let originalData = HTTPRequestData(
+            method: "POST",
+            url: URL(string: "http://api.example.com/upload")!,
+            httpVersion: "HTTP/1.1",
+            headers: [HTTPHeader(name: "Content-Encoding", value: "gzip")],
+            body: binary
+        )
+        let modified = BreakpointRequestData(
+            method: "POST",
+            url: "http://api.example.com/upload",
+            headers: [
+                EditableHeader(name: "Content-Encoding", value: "gzip"),
+                EditableHeader(name: "X-Debug", value: "true"),
+            ],
+            body: "",
+            statusCode: 200,
+            isBodyEditable: false
+        )
+
+        let result = BreakpointRequestBuilder.build(
+            from: modified,
+            originalHead: originalHead,
+            originalRequestData: originalData
+        )
+
+        #expect(result.requestData.body == binary)
+        #expect(result.requestData.headers.contains { $0.name == "X-Debug" && $0.value == "true" })
+        #expect(result.requestData.headers.first { $0.name == "Content-Length" }?.value == "4")
+    }
+
     @Test("HTTP scheme change to HTTPS is reverted")
     func httpSchemeChangeReverted() {
         let originalHead = HTTPRequestHead(version: .http1_1, method: .GET, uri: "http://example.com/api")

--- a/RockxyTests/Core/ProxyEngine/BreakpointResponseBuilderTests.swift
+++ b/RockxyTests/Core/ProxyEngine/BreakpointResponseBuilderTests.swift
@@ -1,0 +1,80 @@
+import Foundation
+import NIOHTTP1
+@testable import Rockxy
+import Testing
+
+struct BreakpointResponseBuilderTests {
+    @Test("Non-editable response body is preserved while status and headers can change")
+    func nonEditableBodyPreserved() {
+        let binary = Data([0x1F, 0x8B, 0x08, 0x00])
+        var originalHead = HTTPResponseHead(version: .http1_1, status: .ok)
+        originalHead.headers.add(name: "Content-Encoding", value: "gzip")
+        let modified = BreakpointRequestData(
+            method: "GET",
+            url: "https://api.example.com/data",
+            headers: [
+                EditableHeader(name: "Content-Encoding", value: "gzip"),
+                EditableHeader(name: "X-Debug", value: "true"),
+            ],
+            body: "",
+            statusCode: 201,
+            phase: .response,
+            isBodyEditable: false
+        )
+
+        let result = BreakpointResponseBuilder.build(
+            modifiedData: modified,
+            originalHead: originalHead,
+            originalBody: binary
+        )
+
+        #expect(result.head.status == .created)
+        #expect(result.head.headers.first(name: "X-Debug") == "true")
+        #expect(result.head.headers.first(name: "Content-Length") == "4")
+        #expect(result.body == binary)
+    }
+
+    @Test("Editable response body recomputes framing headers")
+    func editableBodyRecomputesFraming() {
+        var originalHead = HTTPResponseHead(version: .http1_1, status: .ok)
+        originalHead.headers.add(name: "Transfer-Encoding", value: "chunked")
+        let modified = BreakpointRequestData(
+            method: "GET",
+            url: "https://api.example.com/data",
+            headers: [EditableHeader(name: "Transfer-Encoding", value: "chunked")],
+            body: "updated",
+            statusCode: 200,
+            phase: .response
+        )
+
+        let result = BreakpointResponseBuilder.build(modifiedData: modified, originalHead: originalHead)
+
+        #expect(result.head.headers.first(name: "Transfer-Encoding") == nil)
+        #expect(result.head.headers.first(name: "Content-Length") == "7")
+        #expect(result.body == Data("updated".utf8))
+    }
+
+    @Test("Clearing editable response body removes stale framing headers")
+    func clearingBodyRemovesFraming() {
+        var originalHead = HTTPResponseHead(version: .http1_1, status: .ok)
+        originalHead.headers.add(name: "Content-Length", value: "10")
+        let modified = BreakpointRequestData(
+            method: "GET",
+            url: "https://api.example.com/data",
+            headers: [
+                EditableHeader(name: "Content-Length", value: "10"),
+                EditableHeader(name: "Transfer-Encoding", value: "chunked"),
+            ],
+            body: "",
+            statusCode: 204,
+            phase: .response
+        )
+
+        let result = BreakpointResponseBuilder.build(modifiedData: modified, originalHead: originalHead)
+
+        #expect(result.head.status == .noContent)
+        #expect(result.head.headers.first(name: "Content-Length") == nil)
+        #expect(result.head.headers.first(name: "Transfer-Encoding") == nil)
+        #expect(result.body == nil)
+    }
+}

--- a/RockxyTests/Core/ProxyEngine/RequestBodyLimitStateTests.swift
+++ b/RockxyTests/Core/ProxyEngine/RequestBodyLimitStateTests.swift
@@ -1,0 +1,23 @@
+@testable import Rockxy
+import Testing
+
+struct RequestBodyLimitStateTests {
+    @Test("Request body overflow latches rejection until reset")
+    func overflowLatchesRejection() {
+        var state = RequestBodyLimitState()
+
+        let acceptedPrefix = state.accept(6, maximum: 10)
+        let acceptedOverflow = state.accept(5, maximum: 10)
+        #expect(acceptedPrefix)
+        #expect(!acceptedOverflow)
+        #expect(state.isRejected)
+        let acceptedAfterRejection = state.accept(1, maximum: 10)
+        #expect(!acceptedAfterRejection)
+
+        state.reset()
+
+        #expect(!state.isRejected)
+        let acceptedAtLimit = state.accept(10, maximum: 10)
+        #expect(acceptedAtLimit)
+    }
+}

--- a/RockxyTests/Core/ProxyEngine/WebSocketFrameHandlerTests.swift
+++ b/RockxyTests/Core/ProxyEngine/WebSocketFrameHandlerTests.swift
@@ -1,0 +1,44 @@
+import NIOCore
+import NIOEmbedded
+import NIOWebSocket
+@testable import Rockxy
+import Testing
+
+struct WebSocketFrameHandlerTests {
+    @Test("Capture limit never interrupts the proxied WebSocket")
+    func captureLimitKeepsRelayActive() throws {
+        let request = TestFixtures.makeRequest(url: "wss://example.com/ws")
+        let connection = WebSocketConnection(upgradeRequest: request)
+        connection.stopCaptureAtLimit()
+        let transaction = HTTPTransaction(
+            request: request,
+            state: .active,
+            webSocketConnection: connection
+        )
+        let peer = EmbeddedChannel()
+        let handler = WebSocketFrameHandler(
+            direction: .received,
+            peerChannel: peer,
+            webSocketConnection: connection,
+            parentTransaction: transaction,
+            onTransactionComplete: { _ in }
+        )
+        let channel = EmbeddedChannel(handler: handler)
+        try peer.connect(to: SocketAddress(ipAddress: "127.0.0.1", port: 8_081)).wait()
+        try channel.connect(to: SocketAddress(ipAddress: "127.0.0.1", port: 8_082)).wait()
+        var payload = channel.allocator.buffer(capacity: 5)
+        payload.writeString("hello")
+
+        try channel.writeInbound(WebSocketFrame(fin: true, opcode: .text, data: payload))
+
+        let forwarded = try #require(try peer.readOutbound(as: WebSocketFrame.self))
+        var forwardedPayload = forwarded.unmaskedData
+        #expect(forwardedPayload.readString(length: 5) == "hello")
+        #expect(channel.isActive)
+        #expect(peer.isActive)
+        #expect(connection.frames.isEmpty)
+
+        _ = try? channel.finish(acceptAlreadyClosed: true)
+        _ = try? peer.finish(acceptAlreadyClosed: true)
+    }
+}

--- a/RockxyTests/Core/RuleEngine/BreakpointManagerTests.swift
+++ b/RockxyTests/Core/RuleEngine/BreakpointManagerTests.swift
@@ -275,8 +275,8 @@ struct BreakpointManagerTests {
         manager.resolveAll(decision: .cancel)
     }
 
-    @Test("execute cannot strip a protected binary payload")
-    func protectedPayloadExecuteFallsBackToOriginal() async throws {
+    @Test("execute preserves a protected binary payload while applying metadata edits")
+    func protectedPayloadExecutePreservesBody() async throws {
         let manager = BreakpointManager()
         var data = BreakpointRequestData(
             method: "POST",
@@ -296,7 +296,7 @@ struct BreakpointManagerTests {
         manager.resolve(id: item.id, decision: .execute)
 
         let result = await task.value
-        #expect(result.0 == .cancel)
+        #expect(result.0 == .execute)
         #expect(result.1.isBodyEditable == false)
     }
 

--- a/RockxyTests/Core/RuleEngine/RuleActionTests.swift
+++ b/RockxyTests/Core/RuleEngine/RuleActionTests.swift
@@ -6,6 +6,14 @@ import Testing
 // Regression tests for `RuleAction` in the core rule engine layer.
 
 struct RuleActionTests {
+    @Test("Only response-capable breakpoints expose a response pre-pass phase")
+    func responseBreakpointPhase() {
+        #expect(RuleAction.breakpoint(phase: .request).responseBreakpointPhase == nil)
+        #expect(RuleAction.breakpoint(phase: .response).responseBreakpointPhase == .response)
+        #expect(RuleAction.breakpoint(phase: .both).responseBreakpointPhase == .both)
+        #expect(RuleAction.block(statusCode: 403).responseBreakpointPhase == nil)
+    }
+
     @Test("Block action returns correct status code")
     func blockAction() async throws {
         let engine = RuleEngine()

--- a/RockxyTests/Keyboard/KeyboardShortcutTests.swift
+++ b/RockxyTests/Keyboard/KeyboardShortcutTests.swift
@@ -59,6 +59,60 @@ struct KeyboardShortcutTests {
         #expect(KeyboardShortcutCatalog.filtered(by: "compare").contains { $0.title == "Basic Compare" })
     }
 
+    @Test("Main capture shortcuts do not collide with Context Dock or Protobuf")
+    func mainCaptureShortcutsDoNotCollide() throws {
+        let app = try Self.projectFile(named: "Rockxy/RockxyApp.swift")
+        let contextDock = try Self.projectFile(named: "Rockxy/Views/Inspector/ContextDockView.swift")
+
+        #expect(Self.occurrences(of: #".keyboardShortcut("u", modifiers: [.command, .option])"#, in: app) == 1)
+        #expect(!contextDock.contains(#".keyboardShortcut("k", modifiers: .command)"#))
+    }
+
+    @Test("Clear does not render in the workspace footer")
+    func clearDoesNotRenderInWorkspaceFooter() throws {
+        let footer = try Self.projectFile(named: "Rockxy/Views/RequestList/StatusBarView.swift")
+        let app = try Self.projectFile(named: "Rockxy/RockxyApp.swift")
+
+        #expect(!footer.contains(#"title: String(localized: "Clear")"#))
+        #expect(!footer.contains("var onClear:"))
+        #expect(app.contains(#"Button(String(localized: "Clear Session"))"#))
+        #expect(app.contains(#".keyboardShortcut("k", modifiers: [.command])"#))
+        #expect(KeyboardShortcutCatalog.allShortcuts.contains {
+            $0.action == "Clear session" && $0.shortcut == "⌘K"
+        })
+    }
+
+    @Test("Traffic command strip reuses menu shortcuts instead of registering duplicates")
+    func trafficCommandStripDoesNotOwnShortcuts() throws {
+        let app = try Self.projectFile(named: "Rockxy/RockxyApp.swift")
+        let commandBar = try Self.projectFile(named: "Rockxy/Views/Toolbar/TrafficCommandBar.swift")
+
+        #expect(!commandBar.contains(".keyboardShortcut"))
+        #expect(Self.occurrences(
+            of: #".keyboardShortcut(.downArrow, modifiers: [.command])"#,
+            in: app
+        ) == 1)
+        #expect(KeyboardShortcutCatalog.allShortcuts.contains {
+            $0.action == "Follow the newest visible request" && $0.shortcut == "⇧⌘L"
+        })
+    }
+
+    @Test("Session and row commands have one truthful owner")
+    func sessionAndContextMenuOwnership() throws {
+        let app = try Self.projectFile(named: "Rockxy/RockxyApp.swift")
+        let actions = try Self.projectFile(named: "Rockxy/Views/Main/MainContentCommandActions.swift")
+        let requestTable = try Self.projectFile(named: "Rockxy/Views/RequestList/RequestTableView.swift")
+
+        // File owns Save Session; Flow owns Clear Session. Neither gets a misleading alias.
+        #expect(Self.occurrences(of: #"Button(String(localized: "Save Session…"))"#, in: app) == 1)
+        #expect(!app.contains(#"Button(String(localized: "Save Requests"))"#))
+        #expect(!app.contains(#"Button(String(localized: "Delete All"))"#))
+        #expect(!actions.contains("func deleteAll()"))
+
+        // Context menus reuse actions but never display or register keyboard shortcuts.
+        #expect(!requestTable.contains("keyEquivalentModifierMask"))
+    }
+
     private static func documentation(named name: String) throws -> String {
         let testFile = URL(fileURLWithPath: #filePath)
         let repoRoot = testFile
@@ -67,6 +121,19 @@ struct KeyboardShortcutTests {
             .deletingLastPathComponent()
         let url = repoRoot.appendingPathComponent("docs").appendingPathComponent(name)
         return try String(contentsOf: url, encoding: .utf8)
+    }
+
+    private static func projectFile(named path: String) throws -> String {
+        let testFile = URL(fileURLWithPath: #filePath)
+        let repoRoot = testFile
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        return try String(contentsOf: repoRoot.appendingPathComponent(path), encoding: .utf8)
+    }
+
+    private static func occurrences(of needle: String, in source: String) -> Int {
+        source.components(separatedBy: needle).count - 1
     }
 
     private static func shortcutIsDocumented(_ shortcut: String, in reference: String) -> Bool {

--- a/RockxyTests/Models/WebSocketConnectionTests.swift
+++ b/RockxyTests/Models/WebSocketConnectionTests.swift
@@ -94,6 +94,24 @@ struct WebSocketConnectionTests {
         #expect(connection.receivedFrames.isEmpty)
     }
 
+    @Test("bounded add rejects empty-frame floods at the count cap")
+    func boundedAddEnforcesFrameCount() {
+        let request = TestFixtures.makeRequest(url: "wss://example.com/ws")
+        let connection = WebSocketConnection(upgradeRequest: request)
+        let frame = WebSocketFrameData(direction: .received, opcode: .ping, payload: Data())
+
+        #expect(connection.addFrame(frame, maximumTotalPayloadSize: 10, maximumFrameCount: 2))
+        #expect(connection.addFrame(frame, maximumTotalPayloadSize: 10, maximumFrameCount: 2))
+        #expect(!connection.addFrame(frame, maximumTotalPayloadSize: 10, maximumFrameCount: 2))
+        #expect(connection.frameCount == 2)
+        #expect(connection.totalPayloadSize == 0)
+        #expect(connection.isCaptureLimitReached)
+
+        let payloadFrame = WebSocketFrameData(direction: .received, opcode: .text, payload: Data([0x01]))
+        #expect(!connection.addFrame(payloadFrame, maximumTotalPayloadSize: 10, maximumFrameCount: 3))
+        #expect(connection.frameCount == 2)
+    }
+
     @Test("upgradeRequest preserved correctly")
     func upgradeRequestPreserved() {
         let request = TestFixtures.makeRequest(url: "wss://example.com/ws/v2")

--- a/RockxyTests/Views/Export/GistPublishConfirmationSheetTests.swift
+++ b/RockxyTests/Views/Export/GistPublishConfirmationSheetTests.swift
@@ -107,6 +107,22 @@ struct GistPublishConfirmationSheetTests {
         #expect(GistPublishCopy.publicWarning.localizedCaseInsensitiveContains("searchable"))
     }
 
+    @Test("Unredacted publishing always requires review")
+    func unredactedPublishingRequiresReview() {
+        #expect(GistPublishConfirmationPolicy.requiresReview(
+            askBeforePublishing: false,
+            redactsSensitiveData: false
+        ))
+        #expect(GistPublishConfirmationPolicy.requiresReview(
+            askBeforePublishing: true,
+            redactsSensitiveData: true
+        ))
+        #expect(!GistPublishConfirmationPolicy.requiresReview(
+            askBeforePublishing: false,
+            redactsSensitiveData: true
+        ))
+    }
+
     // MARK: Source contract
 
     @Test("Sheet keeps a native, scalable, progress-aware publish contract")

--- a/RockxyTests/Views/Inspector/DetachedInspectorStoreTests.swift
+++ b/RockxyTests/Views/Inspector/DetachedInspectorStoreTests.swift
@@ -1,0 +1,136 @@
+import Foundation
+@testable import Rockxy
+import Testing
+
+// Regression tests for the detached Inspector window handoff store and its wiring.
+
+// MARK: - DetachedInspectorStoreTests
+
+@MainActor
+struct DetachedInspectorStoreTests {
+    @Test("Presenting a selection pins the exact transaction reference and highlight context")
+    func presentPinsExactReferenceAndContext() {
+        let store = DetachedInspectorStore.shared
+        let transaction = TestFixtures.makeTransaction(method: "GET", url: "https://api.example.com/pin")
+        let context = InspectorHighlightContext(literalTerms: ["token"], regexPatterns: ["[0-9]+"])
+
+        store.present(transaction: transaction, highlightContext: context)
+
+        #expect(store.requestedSelection?.transaction === transaction)
+        #expect(store.requestedSelection?.highlightContext == context)
+    }
+
+    @Test("Each present bumps the version monotonically")
+    func presentIncrementsVersion() {
+        let store = DetachedInspectorStore.shared
+        let previousVersion = store.version
+
+        store.present(
+            transaction: TestFixtures.makeTransaction(url: "https://api.example.com/v1"),
+            highlightContext: .empty
+        )
+
+        #expect(store.version == previousVersion &+ 1)
+    }
+
+    @Test("Re-presenting retargets the window to a new transaction and bumps the version again")
+    func presentRetargetsSelection() {
+        let store = DetachedInspectorStore.shared
+        let first = TestFixtures.makeTransaction(method: "GET", url: "https://api.example.com/first")
+        let second = TestFixtures.makeTransaction(method: "POST", url: "https://api.example.com/second")
+
+        store.present(transaction: first, highlightContext: .empty)
+        let afterFirst = store.version
+        #expect(store.requestedSelection?.transaction === first)
+
+        store.present(transaction: second, highlightContext: .empty)
+
+        #expect(store.requestedSelection?.transaction === second)
+        #expect(store.version == afterFirst &+ 1)
+    }
+
+    @Test("Dismissing releases only the matching retained selection")
+    func dismissReleasesOnlyMatchingSelection() throws {
+        let store = DetachedInspectorStore.shared
+        let transaction = TestFixtures.makeTransaction(url: "https://api.example.com/retained")
+        store.present(transaction: transaction, highlightContext: .empty)
+        let selectionID = try #require(store.requestedSelection?.id)
+
+        store.dismiss(selectionID: UUID())
+        #expect(store.requestedSelection?.transaction === transaction)
+
+        store.dismiss(selectionID: selectionID)
+        #expect(store.requestedSelection == nil)
+    }
+}
+
+// MARK: - DetachedInspectorWiringTests
+
+/// Source contract locking the detached Inspector window id, the pop-out affordance, and
+/// the non-recursive detached window rendering. Actual SwiftUI window presentation is not
+/// exercised here — these assertions read source to keep the handoff wiring aligned.
+struct DetachedInspectorWiringTests {
+    // MARK: Internal
+
+    @Test("The pop-out affordance is restrained, labeled, and only shown when a callback is supplied")
+    func urlBarPopOutButtonIsGatedAndLabeled() throws {
+        let urlBar = try readProjectFile("Rockxy/Views/Inspector/InspectorURLBar.swift")
+
+        #expect(urlBar.contains("var onOpenDetachedInspector: (() -> Void)?"))
+        #expect(urlBar.contains("if let onOpenDetachedInspector {"))
+        #expect(urlBar.contains("Image(systemName: \"macwindow.on.rectangle\")"))
+        #expect(urlBar.contains(".help(String(localized: \"Open Inspector in New Window\"))"))
+        #expect(urlBar.contains(".accessibilityLabel(String(localized: \"Open Inspector in New Window\"))"))
+    }
+
+    @Test("The main panel opens the detached window only in its single-selection branch")
+    func panelWiresDetachedHandoff() throws {
+        let panel = try readProjectFile("Rockxy/Views/Inspector/InspectorPanelView.swift")
+
+        #expect(panel.contains("onOpenDetachedInspector:"))
+        #expect(panel.contains("DetachedInspectorStore.shared.present("))
+        #expect(panel.contains("openWindow(id: \"detachedInspector\")"))
+    }
+
+    @Test("The app declares one detached Inspector window scene bound to that id")
+    func appDeclaresDetachedInspectorWindow() throws {
+        let app = try readProjectFile("Rockxy/RockxyApp.swift")
+
+        #expect(app.contains("id: \"detachedInspector\""))
+        #expect(app.contains("DetachedInspectorWindowView(coordinator:"))
+    }
+
+    @Test("The detached window renders the URL bar without re-offering the pop-out affordance")
+    func detachedWindowDoesNotRecurse() throws {
+        let window = try readProjectFile("Rockxy/Views/Inspector/DetachedInspectorWindowView.swift")
+
+        #expect(window.contains("InspectorURLBar("))
+        #expect(!window.contains("onOpenDetachedInspector"))
+        #expect(window.contains("onOpenToolWindow: { id in openWindow(id: id) }"))
+        #expect(window.contains("previewTabStore: coordinator.previewTabStore"))
+        #expect(window.contains("@State private var selection: DetachedInspectorSelection?"))
+    }
+
+    // MARK: Private
+
+    private enum ResolveError: Error {
+        case rootNotFound
+    }
+
+    private func readProjectFile(_ relativePath: String) throws -> String {
+        let root = try resolveProjectRoot()
+        return try String(contentsOf: root.appendingPathComponent(relativePath), encoding: .utf8)
+    }
+
+    private func resolveProjectRoot() throws -> URL {
+        var url = URL(fileURLWithPath: #filePath)
+        while url.lastPathComponent != "RockxyTests", url.path != "/" {
+            url.deleteLastPathComponent()
+        }
+        guard url.lastPathComponent == "RockxyTests" else {
+            throw ResolveError.rootNotFound
+        }
+        url.deleteLastPathComponent()
+        return url
+    }
+}

--- a/RockxyTests/Views/Main/FilteringTests.swift
+++ b/RockxyTests/Views/Main/FilteringTests.swift
@@ -806,6 +806,72 @@ struct FilteringTests {
         #expect(coordinator.filteredTransactions.count == 2)
     }
 
+    @Test("clear capture and filters resets visibility lenses in every workspace")
+    func clearCaptureAndFiltersResetsEveryWorkspaceVisibilityLens() async {
+        let coordinator = MainContentCoordinator()
+        let firstWorkspace = coordinator.activeWorkspace
+        let secondWorkspace = coordinator.workspaceStore.createWorkspace(title: "Filtered")
+        let focusSet = FocusSet(name: "API", domain: "example.com")
+
+        for workspace in [firstWorkspace, secondWorkspace] {
+            workspace.filterCriteria.searchText = "api"
+            workspace.filterCriteria.sidebarScope = .saved
+            workspace.sidebarSelection = .allSaved
+            workspace.isFilterBarVisible = true
+            workspace.filterRules = [
+                FilterRule(isEnabled: true, field: .url, filterOperator: .contains, value: "api"),
+            ]
+            workspace.activeTrafficSignal = .errors
+            workspace.focusSets = [focusSet]
+            workspace.activeFocusSetID = focusSet.id
+            workspace.mutedTrafficSources = [.host("noise.example.com")]
+        }
+
+        await coordinator.clearCaptureAndFilters()
+
+        for workspace in [firstWorkspace, secondWorkspace] {
+            #expect(workspace.filterCriteria.isEmpty)
+            #expect(workspace.filterCriteria.sidebarScope == .allTraffic)
+            #expect(workspace.sidebarSelection == nil)
+            #expect(!workspace.isFilterBarVisible)
+            #expect(workspace.filterRules.count == 1)
+            #expect(workspace.filterRules[0].value.isEmpty)
+            #expect(workspace.activeTrafficSignal == nil)
+            #expect(workspace.activeFocusSetID == nil)
+            #expect(workspace.mutedTrafficSources.isEmpty)
+            #expect(workspace.focusSets == [focusSet])
+        }
+
+        let fresh = TestFixtures.makeTransaction(url: "https://fresh.example.net/new")
+        coordinator.processBatch([fresh], generation: coordinator.sessionGeneration)
+
+        #expect(firstWorkspace.filteredTransactions.map(\.id) == [fresh.id])
+        #expect(secondWorkspace.filteredTransactions.map(\.id) == [fresh.id])
+    }
+
+    @Test("Editing an active Focus Set refreshes every workspace that uses it")
+    func editingFocusSetRefreshesOtherWorkspaces() {
+        let coordinator = MainContentCoordinator()
+        let api = TestFixtures.makeTransaction(url: "https://api.example.com/data")
+        let web = TestFixtures.makeTransaction(url: "https://www.example.com/home")
+        coordinator.transactions = [api, web]
+        coordinator.recomputeFilteredTransactions()
+
+        let second = coordinator.workspaceStore.createWorkspace(title: "Second")
+        coordinator.recomputeFilteredTransactions(for: second)
+
+        var focusSet = FocusSet(name: "Target", domain: "api.example.com")
+        coordinator.saveFocusSet(focusSet)
+        second.activeFocusSetID = focusSet.id
+        coordinator.recomputeFilteredTransactions(for: second)
+        #expect(second.filteredTransactions.map(\.id) == [api.id])
+
+        focusSet.domain = "www.example.com"
+        coordinator.saveFocusSet(focusSet)
+
+        #expect(second.filteredTransactions.map(\.id) == [web.id])
+    }
+
     // MARK: Private
 
     // MARK: - Setup

--- a/RockxyTests/Views/Main/FooterActionDescriptorTests.swift
+++ b/RockxyTests/Views/Main/FooterActionDescriptorTests.swift
@@ -2,6 +2,8 @@ import Foundation
 @testable import Rockxy
 import Testing
 
+// MARK: - FooterActionDescriptorTests
+
 struct FooterActionDescriptorTests {
     @Test("Footer tooling action order is stable")
     func toolingActionOrder() {
@@ -95,6 +97,160 @@ struct FooterActionDescriptorTests {
         let actions = FooterActionDescriptor.toolingActions(isAllowListActive: false)
 
         #expect(FooterActionKind.defaultQuickTools == actions.map(\.id))
+    }
+
+    @Test("Each customizable tool maps to its approved tool-window ID")
+    func toolWindowIDMapping() {
+        #expect(FooterActionKind.blockList.toolWindowID == "blockList")
+        #expect(FooterActionKind.allowList.toolWindowID == "allowList")
+        #expect(FooterActionKind.mapRemote.toolWindowID == "mapRemote")
+        #expect(FooterActionKind.mapLocal.toolWindowID == "mapLocal")
+        #expect(FooterActionKind.scripting.toolWindowID == "scriptingList")
+        #expect(FooterActionKind.breakpoint.toolWindowID == "breakpointRules")
+        #expect(FooterActionKind.networkConditions.toolWindowID == "networkConditions")
+        #expect(FooterActionKind.proxyOverride.toolWindowID == nil)
+    }
+}
+
+// MARK: - QuickToolsLayoutTests
+
+struct QuickToolsLayoutTests {
+    @Test("Approved defaults place three tools on top and four in the footer")
+    func approvedDefaults() {
+        let layout = QuickToolsLayout.default
+
+        #expect(layout.commandBar == [.blockList, .allowList, .mapRemote])
+        #expect(layout.footer == [.breakpoint, .mapLocal, .scripting, .networkConditions])
+    }
+
+    @Test("All seven customizable tools occur exactly once across both regions")
+    func sevenUniqueAssignments() {
+        let layout = QuickToolsLayout.default
+        let combined = layout.commandBar + layout.footer
+
+        #expect(combined.count == 7)
+        #expect(Set(combined) == Set(FooterActionKind.customizableQuickTools))
+        #expect(!combined.contains(.proxyOverride))
+        #expect(layout.commandBar.count == QuickToolsLayout.commandBarSlotCount)
+        #expect(layout.footer.count == QuickToolsLayout.footerSlotCount)
+    }
+
+    @Test("Encode/decode round trips a valid layout")
+    func encodeDecodeRoundTrip() {
+        let layout = QuickToolsLayout(
+            commandBar: [.scripting, .breakpoint, .networkConditions],
+            footer: [.blockList, .allowList, .mapRemote, .mapLocal]
+        )
+
+        let decoded = QuickToolsLayout.decode(layout.encoded)
+
+        #expect(decoded == layout)
+    }
+
+    @Test("Empty storage decodes to nil so callers fall back to migration")
+    func emptyStorageDecodesNil() {
+        #expect(QuickToolsLayout.decode("") == nil)
+        #expect(QuickToolsLayout.decode("   ") == nil)
+    }
+
+    @Test("Persistence decoding tolerates whitespace around tool IDs")
+    func persistenceWhitespaceRepair() throws {
+        let decoded = try #require(QuickToolsLayout.decode(
+            " blockList, allowList,mapRemote | breakpoint,mapLocal,scripting,networkConditions "
+        ))
+
+        #expect(decoded == .default)
+    }
+
+    @Test("Malformed and duplicate persistence repairs to a valid unique layout")
+    func malformedRepair() throws {
+        // Duplicates, an unknown token, proxyOverride, and a missing footer side.
+        let repaired = try #require(
+            QuickToolsLayout.decode("blockList,blockList,proxyOverride,bogus|allowList,allowList")
+        )
+
+        let combined = repaired.commandBar + repaired.footer
+        #expect(repaired.commandBar.count == 3)
+        #expect(repaired.footer.count == 4)
+        #expect(Set(combined) == Set(FooterActionKind.customizableQuickTools))
+        #expect(!combined.contains(.proxyOverride))
+        // Cleaned survivors keep their leading position before backfill.
+        #expect(repaired.commandBar.first == .blockList)
+    }
+
+    @Test("Legacy footer order migrates its four tools to the footer and the rest on top")
+    func legacyFooterMigration() {
+        let legacy = "breakpoint,mapLocal,scripting,networkConditions"
+        let layout = QuickToolsLayout.resolved(storageRaw: "", legacyFooterRaw: legacy)
+
+        #expect(layout.footer == [.breakpoint, .mapLocal, .scripting, .networkConditions])
+        #expect(Set(layout.commandBar) == [.blockList, .allowList, .mapRemote])
+    }
+
+    @Test("A customized legacy footer migration preserves its exact four selections")
+    func legacyFooterMigrationPreservesSelection() {
+        let legacy = "allowList,scripting,mapRemote,breakpoint"
+        let layout = QuickToolsLayout.resolved(storageRaw: "", legacyFooterRaw: legacy)
+
+        #expect(layout.footer == [.allowList, .scripting, .mapRemote, .breakpoint])
+        #expect(Set(layout.commandBar) == [.blockList, .mapLocal, .networkConditions])
+    }
+
+    @Test("New storage value wins over the legacy footer key")
+    func newStorageWinsOverLegacy() {
+        let stored = QuickToolsLayout(
+            commandBar: [.mapLocal, .scripting, .networkConditions],
+            footer: [.blockList, .allowList, .mapRemote, .breakpoint]
+        )
+        let layout = QuickToolsLayout.resolved(
+            storageRaw: stored.encoded,
+            legacyFooterRaw: "breakpoint,mapLocal,scripting,networkConditions"
+        )
+
+        #expect(layout == stored)
+    }
+
+    @Test("Assigning a tool already in the other region swaps the two slots")
+    func crossRegionSwap() {
+        let layout = QuickToolsLayout.default
+        // mapLocal currently lives in footer slot 1; move it to command-bar slot 0.
+        let swapped = layout.assigning(.mapLocal, to: .commandBar, slot: 0)
+
+        #expect(swapped.commandBar[0] == .mapLocal)
+        // The displaced command-bar tool (blockList) lands where mapLocal used to sit.
+        #expect(swapped.footer[1] == .blockList)
+        // Invariant preserved.
+        let combined = swapped.commandBar + swapped.footer
+        #expect(Set(combined) == Set(FooterActionKind.customizableQuickTools))
+        #expect(combined.count == 7)
+    }
+
+    @Test("Assigning within the same region swaps intra-region slots")
+    func intraRegionSwap() {
+        let layout = QuickToolsLayout.default
+        // allowList is command-bar slot 1; assign it to slot 0 (blockList).
+        let swapped = layout.assigning(.allowList, to: .commandBar, slot: 0)
+
+        #expect(swapped.commandBar[0] == .allowList)
+        #expect(swapped.commandBar[1] == .blockList)
+        #expect(swapped.footer == layout.footer)
+    }
+
+    @Test("Assigning a tool to the slot it already occupies is a no-op")
+    func idempotentAssignment() {
+        let layout = QuickToolsLayout.default
+        #expect(layout.assigning(.blockList, to: .commandBar, slot: 0) == layout)
+    }
+
+    @Test("Responsive policy collapses three to two to zero, never icon-only")
+    func responsivePolicy() {
+        #expect(QuickToolsResponsivePolicy.candidateCommandBarCounts == [3, 2, 0])
+
+        #expect(QuickToolsResponsivePolicy.visibleCommandBarCount { $0 <= 3 } == 3)
+        #expect(QuickToolsResponsivePolicy.visibleCommandBarCount { $0 <= 2 } == 2)
+        #expect(QuickToolsResponsivePolicy.visibleCommandBarCount { $0 == 0 } == 0)
+        // No candidate produces one visible capsule — it never falls to a single icon.
+        #expect(!QuickToolsResponsivePolicy.candidateCommandBarCounts.contains(1))
     }
 }
 
@@ -251,6 +407,8 @@ struct FooterMutationIndicatorBuilderTests {
     }
 }
 
+// MARK: - ProxyOverrideCommandActionsTests
+
 struct ProxyOverrideCommandActionsTests {
     @Test("system proxy override command is enabled only while proxy is running")
     @MainActor
@@ -263,6 +421,34 @@ struct ProxyOverrideCommandActionsTests {
 
         coordinator.isProxyRunning = true
         #expect(actions.canToggleSystemProxyOverride)
+    }
+
+    @Test("recording command is enabled only while proxy is running")
+    @MainActor
+    func toggleRecordingCommandAvailability() {
+        let coordinator = MainContentCoordinator()
+        let actions = MainContentCommandActions(coordinator: coordinator)
+
+        #expect(actions.canToggleRecording == false)
+
+        coordinator.isProxyRunning = true
+        #expect(actions.canToggleRecording)
+    }
+
+    @Test("first and last navigation are available without an existing selection")
+    @MainActor
+    func firstAndLastNavigationAvailability() {
+        let coordinator = MainContentCoordinator()
+        let actions = MainContentCommandActions(coordinator: coordinator)
+
+        #expect(actions.hasSelectedTransaction == false)
+        #expect(actions.hasVisibleTransactions == false)
+
+        coordinator.transactions = [TestFixtures.makeTransaction()]
+        coordinator.recomputeFilteredTransactions()
+
+        #expect(actions.hasSelectedTransaction == false)
+        #expect(actions.hasVisibleTransactions)
     }
 
     @Test("OpenAPI export command requires eligible HTTP traffic")

--- a/RockxyTests/Views/Main/HistoryRetentionTests.swift
+++ b/RockxyTests/Views/Main/HistoryRetentionTests.swift
@@ -309,6 +309,22 @@ struct HistoryRetentionTests {
         #expect(coordinator.cachedSessionStore == nil)
     }
 
+    @Test("Evicting error rows recomputes the footer error count")
+    @MainActor
+    func evictionRecomputesErrorCount() {
+        let coordinator = MainContentCoordinator()
+        let error = TestFixtures.makeTransaction(statusCode: 503)
+        let success = TestFixtures.makeTransaction(statusCode: 200)
+        coordinator.transactions = [error, success]
+        coordinator.recomputeErrorCount()
+        #expect(coordinator.errorCount == 1)
+
+        coordinator.evictOldestTransactions(count: 1)
+
+        #expect(coordinator.transactions.map(\.id) == [success.id])
+        #expect(coordinator.errorCount == 0)
+    }
+
     @Test("reportAcceptedCount triggers eviction sized to the exact overflow")
     @MainActor
     func reportAcceptedCountTriggersEviction() async {

--- a/RockxyTests/Views/Main/ProxyDisplayStateTests.swift
+++ b/RockxyTests/Views/Main/ProxyDisplayStateTests.swift
@@ -40,6 +40,21 @@ struct ProxyDisplayStateTests {
         #expect(coordinator.proxyDisplayState == .paused)
     }
 
+    @Test("Recording cannot be toggled while the proxy is stopped")
+    func recordingToggleRequiresRunningProxy() {
+        let coordinator = MainContentCoordinator()
+        coordinator.isRecording = true
+
+        coordinator.toggleRecording()
+
+        #expect(coordinator.isRecording)
+
+        coordinator.isProxyRunning = true
+        coordinator.toggleRecording()
+
+        #expect(!coordinator.isRecording)
+    }
+
     @Test("Coordinator reports stopped after failed start clears startup state")
     func stoppedAfterFailedStart() {
         let coordinator = MainContentCoordinator()

--- a/RockxyTests/Views/Main/TrafficCommandBarTests.swift
+++ b/RockxyTests/Views/Main/TrafficCommandBarTests.swift
@@ -1,0 +1,222 @@
+import Foundation
+@testable import Rockxy
+import Testing
+
+struct TrafficCommandDescriptorTests {
+    @Test("Clear Session descriptor exposes ⌘K and never toggles")
+    func clearSessionContract() {
+        let descriptor = TrafficCommandDescriptor.clearSession(isEnabled: false)
+
+        #expect(descriptor.id == .clearSession)
+        #expect(descriptor.title == "Clear Session")
+        #expect(descriptor.systemImage == "trash")
+        #expect(descriptor.help.contains("⌘K"))
+        #expect(descriptor.help.localizedCaseInsensitiveContains("all tabs"))
+        #expect(descriptor.isActive == false)
+        #expect(!descriptor.isEnabled)
+    }
+
+    @Test("Clear availability follows global session content, never active filters")
+    func clearSessionAvailability() {
+        #expect(!TrafficCommandAvailability.canClearSession(
+            transactionCount: 0,
+            logCount: 0,
+            hasSessionProvenance: false,
+            isClearingSession: false
+        ))
+        #expect(TrafficCommandAvailability.canClearSession(
+            transactionCount: 1,
+            logCount: 0,
+            hasSessionProvenance: false,
+            isClearingSession: false
+        ))
+        #expect(TrafficCommandAvailability.canClearSession(
+            transactionCount: 0,
+            logCount: 1,
+            hasSessionProvenance: false,
+            isClearingSession: false
+        ))
+        #expect(TrafficCommandAvailability.canClearSession(
+            transactionCount: 0,
+            logCount: 0,
+            hasSessionProvenance: true,
+            isClearingSession: false
+        ))
+        #expect(!TrafficCommandAvailability.canClearSession(
+            transactionCount: 1,
+            logCount: 1,
+            hasSessionProvenance: true,
+            isClearingSession: true
+        ))
+    }
+
+    @Test("Follow Live descriptor reflects the per-workspace live-tail state")
+    func followLiveActiveState() {
+        let off = TrafficCommandDescriptor.followLive(isActive: false)
+        let on = TrafficCommandDescriptor.followLive(isActive: true)
+
+        #expect(off.id == .followLive)
+        #expect(off.systemImage == "dot.radiowaves.right")
+        #expect(off.isActive == false)
+
+        #expect(on.isActive)
+        #expect(on.isEnabled)
+        #expect(on.help != off.help)
+    }
+
+    @Test("Both Follow Live states surface the ⇧⌘L shortcut")
+    func followLiveShortcutHint() {
+        for isActive in [false, true] {
+            #expect(TrafficCommandDescriptor.followLive(isActive: isActive).help.contains("⇧⌘L"))
+        }
+    }
+
+    @Test("Jump to Last Request reuses the View command without owning a second shortcut")
+    func jumpToLastRequestContract() {
+        let descriptor = TrafficCommandDescriptor.jumpToLastRequest(isEnabled: false)
+
+        #expect(descriptor.id == .jumpToLastRequest)
+        #expect(descriptor.title == "Jump to Last Request")
+        #expect(descriptor.systemImage == "arrow.down.to.line")
+        #expect(descriptor.help.contains("⌘↓"))
+        #expect(descriptor.help.localizedCaseInsensitiveContains("without changing Follow Live"))
+        #expect(!descriptor.isEnabled)
+    }
+
+    @Test("Recording stays an overflow action with explicit stopped, recording, and paused states")
+    func recordingOverflowContract() {
+        let stopped = TrafficRecordingCommandPresentation.make(isProxyRunning: false, isRecording: true)
+        let recording = TrafficRecordingCommandPresentation.make(isProxyRunning: true, isRecording: true)
+        let paused = TrafficRecordingCommandPresentation.make(isProxyRunning: true, isRecording: false)
+
+        #expect(!stopped.isEnabled)
+        #expect(recording.title == "Pause Recording")
+        #expect(recording.systemImage == "pause.fill")
+        #expect(paused.title == "Resume Recording")
+        #expect(paused.systemImage == "record.circle")
+        #expect([stopped, recording, paused].allSatisfy { $0.help.contains("⌘P") })
+    }
+
+    @Test("Request actions expose distinct local state without inventing shortcuts")
+    func requestActionContracts() {
+        let copy = TrafficCommandDescriptor.copyAsCURL(isEnabled: true)
+        let pin = TrafficCommandDescriptor.togglePin(isPinned: true, isEnabled: true)
+        let save = TrafficCommandDescriptor.toggleSave(isSaved: true, isEnabled: true)
+
+        #expect(copy.systemImage == "terminal")
+        #expect(copy.help.contains("⇧⌘C"))
+        #expect(pin.title == "Unpin Request")
+        #expect(pin.systemImage == "pin.fill")
+        #expect(pin.isActive)
+        #expect(save.title == "Unsave Request")
+        #expect(save.systemImage == "tray.full.fill")
+        #expect(save.isActive)
+    }
+
+    @Test("Command strip action families complement filtering and footer tool launchers")
+    func ownershipMatrix() {
+        let descriptors = [
+            TrafficCommandDescriptor.clearSession(),
+            TrafficCommandDescriptor.jumpToFirstRequest(isEnabled: true),
+            TrafficCommandDescriptor.followLive(isActive: false),
+            TrafficCommandDescriptor.jumpToLastRequest(isEnabled: true),
+            TrafficCommandDescriptor.copyAsCURL(isEnabled: true),
+            TrafficCommandDescriptor.togglePin(isPinned: false, isEnabled: true),
+            TrafficCommandDescriptor.toggleSave(isSaved: false, isEnabled: true),
+        ]
+
+        #expect(descriptors.map(\.id) == TrafficCommandKind.allCases)
+        #expect(descriptors.allSatisfy { !$0.systemImage.isEmpty })
+        // Search and protocol filtering keep their own rows; the command strip never masquerades
+        // as a second filter surface.
+        #expect(descriptors.allSatisfy { !$0.help.localizedCaseInsensitiveContains("filter") })
+    }
+
+    @Test("Single-request actions fail closed for no selection and multi-selection")
+    func singleRequestAvailability() {
+        #expect(!TrafficCommandAvailability.canActOnSingleRequest(
+            hasPrimarySelection: false,
+            selectionCount: 0
+        ))
+        #expect(TrafficCommandAvailability.canActOnSingleRequest(
+            hasPrimarySelection: true,
+            selectionCount: 1
+        ))
+        #expect(!TrafficCommandAvailability.canActOnSingleRequest(
+            hasPrimarySelection: true,
+            selectionCount: 2
+        ))
+    }
+
+    @Test("Protocol-sensitive request bridges reject WebSocket and CONNECT source rows")
+    func ruleAndReplayAvailability() {
+        #expect(TrafficCommandAvailability.canUseHTTPOnlyRequestAction(
+            hasPrimarySelection: true,
+            selectionCount: 1,
+            isWebSocket: false,
+            method: "GET"
+        ))
+        #expect(!TrafficCommandAvailability.canUseHTTPOnlyRequestAction(
+            hasPrimarySelection: true,
+            selectionCount: 1,
+            isWebSocket: true,
+            method: "GET"
+        ))
+        #expect(!TrafficCommandAvailability.canUseHTTPOnlyRequestAction(
+            hasPrimarySelection: true,
+            selectionCount: 1,
+            isWebSocket: false,
+            method: "connect"
+        ))
+        #expect(!TrafficCommandAvailability.canUseHTTPOnlyRequestAction(
+            hasPrimarySelection: true,
+            selectionCount: 2,
+            isWebSocket: false,
+            method: "GET"
+        ))
+    }
+
+    @Test("Footer cannot regain Clear Session or Follow Live ownership")
+    func footerOwnershipIsolation() {
+        let footerActionIDs = Set(FooterActionKind.allCases.map(\.rawValue))
+
+        #expect(footerActionIDs.isDisjoint(with: ["clearSession", "followLive"]))
+    }
+
+    @Test("Command-bar quick tools default to Block List, Allow List, Map Remote")
+    func commandBarQuickToolDefaults() {
+        #expect(QuickToolsLayout.default.commandBar == [.blockList, .allowList, .mapRemote])
+    }
+
+    @Test("Shared quick-tools layout never claims Clear Session or Follow Live ownership")
+    func quickToolsIsolationFromSessionAndLive() {
+        let layout = QuickToolsLayout.default
+        let toolIDs = Set((layout.commandBar + layout.footer).map(\.rawValue))
+
+        #expect(toolIDs.isDisjoint(with: ["clearSession", "followLive"]))
+        // Recording stays in the overflow menu — it is not a quick tool.
+        #expect(!toolIDs.contains("proxyOverride"))
+    }
+
+    @Test("One-shot jump selects the newest visible request without changing Follow Live")
+    @MainActor
+    func jumpDoesNotChangeFollowLive() {
+        let coordinator = MainContentCoordinator()
+        let hidden = TestFixtures.makeTransaction(url: "https://hidden.example.com/first")
+        let visible = TestFixtures.makeTransaction(url: "https://visible.example.com/latest")
+        coordinator.transactions = [hidden, visible]
+        coordinator.filterCriteria.sidebarDomain = "visible.example.com"
+        coordinator.recomputeFilteredTransactions()
+
+        coordinator.selectLastFilteredTransaction()
+
+        #expect(coordinator.selectedTransaction?.id == visible.id)
+        #expect(!coordinator.isFollowingLiveTraffic)
+
+        coordinator.setFollowingLiveTraffic(true)
+        coordinator.selectLastFilteredTransaction()
+
+        #expect(coordinator.selectedTransaction?.id == visible.id)
+        #expect(coordinator.isFollowingLiveTraffic)
+    }
+}

--- a/RockxyTests/Views/RequestList/RequestTableRefreshTests.swift
+++ b/RockxyTests/Views/RequestList/RequestTableRefreshTests.swift
@@ -76,6 +76,52 @@ struct RequestTableRefreshTests {
         #expect(coordinator.filteredRows.map(\.id) == previousIDs + [appended.id])
     }
 
+    @Test("Row derivation builds selection indexes in displayed order")
+    func rowDerivationBuildsSelectionIndexes() {
+        let coordinator = MainContentCoordinator()
+        let beta = TestFixtures.makeTransaction(url: "https://beta.example.com/2")
+        let alpha = TestFixtures.makeTransaction(url: "https://alpha.example.com/1")
+        coordinator.transactions = [beta, alpha]
+        coordinator.activeSortDescriptors = [NSSortDescriptor(key: "url", ascending: true)]
+
+        coordinator.recomputeFilteredTransactions()
+
+        #expect(coordinator.activeWorkspace.trafficSelectionIndex[alpha.id]?.rowIndex == 0)
+        #expect(coordinator.activeWorkspace.trafficSelectionIndex[beta.id]?.rowIndex == 1)
+        #expect(coordinator.activeWorkspace.trafficSelectionIndex[alpha.id]?.transaction === alpha)
+        #expect(coordinator.activeWorkspace.trafficSelectionIndex[beta.id]?.transaction === beta)
+    }
+
+    @Test("Append-only derivation extends selection indexes without rebuilding selection state")
+    func appendExtendsSelectionIndexes() {
+        let coordinator = MainContentCoordinator()
+        let first = TestFixtures.makeTransaction(url: "https://alpha.example.com/1")
+        coordinator.transactions = [first]
+        coordinator.recomputeFilteredTransactions()
+
+        let appended = TestFixtures.makeTransaction(url: "https://beta.example.com/2")
+        coordinator.transactions.append(appended)
+        coordinator.appendFilteredTransactions([appended])
+
+        #expect(coordinator.activeWorkspace.trafficSelectionIndex[first.id]?.rowIndex == 0)
+        #expect(coordinator.activeWorkspace.trafficSelectionIndex[appended.id]?.rowIndex == 1)
+        #expect(coordinator.activeWorkspace.trafficSelectionIndex[appended.id]?.transaction === appended)
+    }
+
+    @Test("Table selection resolves its primary transaction from workspace indexes")
+    func tableSelectionUsesWorkspaceIndexes() {
+        let coordinator = MainContentCoordinator()
+        let first = TestFixtures.makeTransaction(url: "https://alpha.example.com/1")
+        let second = TestFixtures.makeTransaction(url: "https://beta.example.com/2")
+        coordinator.transactions = [first, second]
+        coordinator.recomputeFilteredTransactions()
+
+        coordinator.selectTransactions([first.id, second.id], primaryID: second.id)
+
+        #expect(coordinator.selectedTransactionIDs == [first.id, second.id])
+        #expect(coordinator.selectedTransaction === second)
+    }
+
     @Test("Sort active + append: token changes")
     func sortActiveAppend() {
         let coordinator = MainContentCoordinator()

--- a/RockxyTests/Views/RequestList/RequestTableRefreshTests.swift
+++ b/RockxyTests/Views/RequestList/RequestTableRefreshTests.swift
@@ -320,6 +320,39 @@ struct RequestTableRefreshTests {
         #expect(coordinator.filteredRows.first?.id == t2.id)
     }
 
+    @Test("Keyboard delete removes the complete multi-selection")
+    func deleteMultiSelection() {
+        let coordinator = MainContentCoordinator()
+        let t1 = TestFixtures.makeTransaction()
+        let t2 = TestFixtures.makeTransaction()
+        let t3 = TestFixtures.makeTransaction()
+        coordinator.transactions = [t1, t2, t3]
+        coordinator.recomputeFilteredTransactions()
+        coordinator.selectedTransactionIDs = [t1.id, t2.id]
+        coordinator.selectTransaction(t1)
+
+        coordinator.deleteSelectedTransaction()
+
+        #expect(coordinator.transactions.map(\.id) == [t3.id])
+        #expect(coordinator.filteredRows.map(\.id) == [t3.id])
+        #expect(coordinator.selectedTransactionIDs.isEmpty)
+        #expect(coordinator.selectedTransaction == nil)
+    }
+
+    @Test("Deleting error rows recomputes the footer error count")
+    func deletingErrorsRecomputesErrorCount() {
+        let coordinator = MainContentCoordinator()
+        let error = TestFixtures.makeTransaction(statusCode: 500)
+        let success = TestFixtures.makeTransaction(statusCode: 200)
+        coordinator.transactions = [error, success]
+        coordinator.recomputeErrorCount()
+        #expect(coordinator.errorCount == 1)
+
+        coordinator.deleteTransactions([error])
+
+        #expect(coordinator.errorCount == 0)
+    }
+
     @Test("Keyboard delete works for persisted-only rows")
     func deletePersistedOnlyRow() {
         let coordinator = MainContentCoordinator()

--- a/RockxyTests/Views/RequestList/RequestTableSelectionScrollTests.swift
+++ b/RockxyTests/Views/RequestList/RequestTableSelectionScrollTests.swift
@@ -228,6 +228,35 @@ struct RequestTableSelectionScrollTests {
         #expect(scrollView.contentView.bounds.origin.y == preservedOrigin.y)
     }
 
+    @Test("Stale selection indexes are ignored before reaching NSTableView")
+    func staleSelectionIndexIsIgnored() {
+        var selectedIDs = Set<UUID>()
+        let transaction = TestFixtures.makeTransaction()
+        let row = RequestListRow(from: transaction, sslState: .insecure)
+        let parent = RequestTableView(
+            workspaceID: UUID(),
+            rows: [row],
+            refreshToken: 1,
+            isAppendOnly: false,
+            selectionIndex: [
+                transaction.id: TrafficSelectionIndexEntry(
+                    transaction: transaction,
+                    rowIndex: 10
+                ),
+            ],
+            selectedIDs: Binding(
+                get: { selectedIDs },
+                set: { selectedIDs = $0 }
+            )
+        )
+        let coordinator = RequestTableView.Coordinator(parent: parent)
+        let tableView = makeTableView(rowCount: 1, coordinator: coordinator)
+
+        coordinator.syncSelection(to: [transaction.id], in: tableView)
+
+        #expect(tableView.selectedRowIndexes.isEmpty)
+    }
+
     @Test("Only user-initiated scrolling yields Follow Live")
     func userInitiatedScrollingYieldsFollowLive() async {
         var selectedIDs = Set<UUID>()

--- a/RockxyTests/Views/ToolWindowReadabilityTests.swift
+++ b/RockxyTests/Views/ToolWindowReadabilityTests.swift
@@ -1129,7 +1129,8 @@ struct ToolWindowReadabilityTests {
         #expect(editorSource.contains("syncRawMessageFromDraft(itemId: selectedItemId, force: true)"))
         #expect(source.contains("item.editableDraft.isBodyEditable"))
         #expect(editorSource.contains(#"String(localized: "Original payload protected")"#))
-        #expect(editorSource.contains("draft.isBodyEditable"))
+        #expect(editorSource.contains("draftFor(itemId)?.isBodyEditable == false"))
+        #expect(editorSource.contains("canApplySelectedChanges = true"))
     }
 
     @Test("HTTPS decryption and full proxy bypass keep distinct native workflows")

--- a/docs/keyboard-shortcuts.md
+++ b/docs/keyboard-shortcuts.md
@@ -22,10 +22,11 @@ Rockxy follows the same shortcut pattern across the main capture window, rule ed
 
 | Shortcut | Action |
 |---|---|
-| `⌘K` | Clear capture |
-| `⇧⌘K` | Clear capture and filters |
+| `⌘K` | Clear session |
+| `⇧⌘K` | Clear session and filters |
 | `⌘P` | Pause or resume capture |
 | `⌘L` | Focus the search bar |
+| `⇧⌘L` | Follow the newest visible request in the active workspace tab |
 | `⌘↑` / `⌘↓` | Jump to the first or last captured row |
 | `↑` / `↓` | Move row selection |
 | `⌘E` | Edit and Repeat the selected request |

--- a/docs/traffic-command-bar-qa.md
+++ b/docs/traffic-command-bar-qa.md
@@ -1,0 +1,34 @@
+# Traffic Command Bar QA
+
+## Result
+
+The traffic command bar passed focused visual and interaction QA. No actionable
+P0, P1, or P2 issue remains.
+
+## Visual Quality
+
+- Native system typography remains readable without clipping at compact window widths.
+- The command bar sits directly above the protocol and search controls, preserving the workspace hierarchy.
+- Native bordered controls, window background colors, and dividers match the existing Rockxy interface.
+- `Clear Session` and `Follow Live` use standard SF Symbols and native control states.
+- Footer tools remain in place and the command bar leaves flexible space for future actions.
+
+## Interaction Coverage
+
+- Accessibility exposes `Clear Session` with its Command-K shortcut help.
+- Accessibility exposes `Follow Live` with its Shift-Command-L shortcut help.
+- Clicking `Follow Live` updates the same state used by its menu command.
+- Shift-Command-L toggles live following without duplicating state ownership.
+- Command-K clears the current session without starting capture.
+- The command bar remains stable while capture is stopped and the session is empty.
+
+## Implementation Decisions
+
+- Commands without an executable workflow are intentionally omitted.
+- `Follow Live` uses a native toggle button so macOS owns hover, focus, pressed,
+  and selected rendering.
+
+## Follow-up
+
+- P3: Repeat the visual pass with a populated session and the largest supported
+  accessibility text size during a broader release QA cycle.


### PR DESCRIPTION
## Summary

- Bound retained request, response, and WebSocket payloads while preserving relay behavior and protected breakpoint bodies.
- Complete the traffic command workflow for clearing sessions, following live traffic, request actions, synchronized Quick Tools, filters, selection, and export review.
- Add an independent transaction inspector window for flexible request and response inspection.
- Remove full-history scans from transaction selection and defer inspector-only work until it is required.
- Skip macOS app builds for release-metadata-only workflow changes while preserving full validation for source changes.
- Add focused regression coverage and document the completed traffic command bar QA pass.

## Why

Large and continuously updating capture sessions must remain responsive without allowing retained payloads or repeated main-thread scans to degrade the workspace. Inspection and command workflows also need predictable native behavior across dense traffic, protected payloads, and independent detail windows.

## Impact

- Capture memory growth is bounded across HTTP, HTTPS, breakpoint, and WebSocket paths without interrupting upstream relay traffic.
- Protected binary bodies remain byte-safe while request-line, status, and header edits can still be applied.
- Traffic commands share one coordinator-owned state path and preserve filters, selection, retention counters, and export intent.
- Request selection resolves through indexed row state, avoiding repeated linear scans before the inspector appears.
- Request and response details can be opened in a separate resizable window without changing the active workspace selection.
- Metadata-only release updates can use the lightweight validation path; source changes retain lint, test, and universal-build coverage.

## Related issues

Refs #9
Refs #10
Refs #14
Refs #16
Refs #180

## Validation

- `swiftlint lint --strict`
- Focused request-list, inspector routing, detached inspector, breakpoint safety, WebSocket, and proxy limit tests
- Focused breakpoint manager, payload safety, and tool-window readability suites
- Full macOS test suite attempted serially; the branch-related suites pass. `RootCADownloadServerLifecycleTests` remains intermittently order-sensitive outside this diff, and passes when run isolated with parallel testing disabled.
- Debug app build through the test workflow
