### PR TITLE
docs(readme): add Trendshift repository badge

### DIFF
--- a/README.ar.md
+++ b/README.ar.md
@@ -51,6 +51,10 @@
 </p>
 
 <p align="center">
+  <a href="https://trendshift.io/repositories/26380?utm_source=trendshift-badge&amp;utm_medium=badge&amp;utm_campaign=badge-trendshift-26380" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/trendshift/repositories/26380/daily?language=Swift" alt="RockxyApp/Rockxy | Trendshift" width="250" height="55" /></a>
+</p>
+
+<p align="center">
   <a href="https://youtu.be/RvkQuwUjBaQ" title="Watch the Rockxy demo on YouTube">
     <img src="docs/images/Rockxy-Demo-Preview.png" alt="Rockxy running on macOS" width="800" />
   </a>

--- a/README.bn.md
+++ b/README.bn.md
@@ -49,6 +49,10 @@
 </p>
 
 <p align="center">
+  <a href="https://trendshift.io/repositories/26380?utm_source=trendshift-badge&amp;utm_medium=badge&amp;utm_campaign=badge-trendshift-26380" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/trendshift/repositories/26380/daily?language=Swift" alt="RockxyApp/Rockxy | Trendshift" width="250" height="55" /></a>
+</p>
+
+<p align="center">
   <a href="https://youtu.be/RvkQuwUjBaQ" title="Watch the Rockxy demo on YouTube">
     <img src="docs/images/Rockxy-Demo-Preview.png" alt="Rockxy running on macOS" width="800" />
   </a>

--- a/README.de.md
+++ b/README.de.md
@@ -49,6 +49,10 @@
 </p>
 
 <p align="center">
+  <a href="https://trendshift.io/repositories/26380?utm_source=trendshift-badge&amp;utm_medium=badge&amp;utm_campaign=badge-trendshift-26380" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/trendshift/repositories/26380/daily?language=Swift" alt="RockxyApp/Rockxy | Trendshift" width="250" height="55" /></a>
+</p>
+
+<p align="center">
   <a href="https://youtu.be/RvkQuwUjBaQ" title="Watch the Rockxy demo on YouTube">
     <img src="docs/images/Rockxy-Demo-Preview.png" alt="Rockxy auf macOS" width="800" />
   </a>

--- a/README.es.md
+++ b/README.es.md
@@ -49,6 +49,10 @@
 </p>
 
 <p align="center">
+  <a href="https://trendshift.io/repositories/26380?utm_source=trendshift-badge&amp;utm_medium=badge&amp;utm_campaign=badge-trendshift-26380" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/trendshift/repositories/26380/daily?language=Swift" alt="RockxyApp/Rockxy | Trendshift" width="250" height="55" /></a>
+</p>
+
+<p align="center">
   <a href="https://youtu.be/RvkQuwUjBaQ" title="Watch the Rockxy demo on YouTube">
     <img src="docs/images/Rockxy-Demo-Preview.png" alt="Rockxy ejecutándose en macOS" width="800" />
   </a>

--- a/README.fa.md
+++ b/README.fa.md
@@ -51,6 +51,10 @@
 </p>
 
 <p align="center">
+  <a href="https://trendshift.io/repositories/26380?utm_source=trendshift-badge&amp;utm_medium=badge&amp;utm_campaign=badge-trendshift-26380" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/trendshift/repositories/26380/daily?language=Swift" alt="RockxyApp/Rockxy | Trendshift" width="250" height="55" /></a>
+</p>
+
+<p align="center">
   <a href="https://youtu.be/RvkQuwUjBaQ" title="Watch the Rockxy demo on YouTube">
     <img src="docs/images/Rockxy-Demo-Preview.png" alt="Rockxy running on macOS" width="800" />
   </a>

--- a/README.fr.md
+++ b/README.fr.md
@@ -49,6 +49,10 @@
 </p>
 
 <p align="center">
+  <a href="https://trendshift.io/repositories/26380?utm_source=trendshift-badge&amp;utm_medium=badge&amp;utm_campaign=badge-trendshift-26380" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/trendshift/repositories/26380/daily?language=Swift" alt="RockxyApp/Rockxy | Trendshift" width="250" height="55" /></a>
+</p>
+
+<p align="center">
   <a href="https://youtu.be/RvkQuwUjBaQ" title="Watch the Rockxy demo on YouTube">
     <img src="docs/images/Rockxy-Demo-Preview.png" alt="Rockxy en cours d'ex&eacute;cution sur macOS" width="800" />
   </a>

--- a/README.it.md
+++ b/README.it.md
@@ -49,6 +49,10 @@
 </p>
 
 <p align="center">
+  <a href="https://trendshift.io/repositories/26380?utm_source=trendshift-badge&amp;utm_medium=badge&amp;utm_campaign=badge-trendshift-26380" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/trendshift/repositories/26380/daily?language=Swift" alt="RockxyApp/Rockxy | Trendshift" width="250" height="55" /></a>
+</p>
+
+<p align="center">
   <a href="https://youtu.be/RvkQuwUjBaQ" title="Watch the Rockxy demo on YouTube">
     <img src="docs/images/Rockxy-Demo-Preview.png" alt="Rockxy running on macOS" width="800" />
   </a>

--- a/README.ja.md
+++ b/README.ja.md
@@ -49,6 +49,10 @@
 </p>
 
 <p align="center">
+  <a href="https://trendshift.io/repositories/26380?utm_source=trendshift-badge&amp;utm_medium=badge&amp;utm_campaign=badge-trendshift-26380" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/trendshift/repositories/26380/daily?language=Swift" alt="RockxyApp/Rockxy | Trendshift" width="250" height="55" /></a>
+</p>
+
+<p align="center">
   <a href="https://youtu.be/RvkQuwUjBaQ" title="Watch the Rockxy demo on YouTube">
     <img src="docs/images/Rockxy-Demo-Preview.png" alt="macOS で動作中の Rockxy" width="800" />
   </a>

--- a/README.ka.md
+++ b/README.ka.md
@@ -49,6 +49,10 @@
 </p>
 
 <p align="center">
+  <a href="https://trendshift.io/repositories/26380?utm_source=trendshift-badge&amp;utm_medium=badge&amp;utm_campaign=badge-trendshift-26380" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/trendshift/repositories/26380/daily?language=Swift" alt="RockxyApp/Rockxy | Trendshift" width="250" height="55" /></a>
+</p>
+
+<p align="center">
   <a href="https://youtu.be/RvkQuwUjBaQ" title="Watch the Rockxy demo on YouTube">
     <img src="docs/images/Rockxy-Demo-Preview.png" alt="Rockxy running on macOS" width="800" />
   </a>

--- a/README.ko.md
+++ b/README.ko.md
@@ -49,6 +49,10 @@
 </p>
 
 <p align="center">
+  <a href="https://trendshift.io/repositories/26380?utm_source=trendshift-badge&amp;utm_medium=badge&amp;utm_campaign=badge-trendshift-26380" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/trendshift/repositories/26380/daily?language=Swift" alt="RockxyApp/Rockxy | Trendshift" width="250" height="55" /></a>
+</p>
+
+<p align="center">
   <a href="https://youtu.be/RvkQuwUjBaQ" title="Watch the Rockxy demo on YouTube">
     <img src="docs/images/Rockxy-Demo-Preview.png" alt="macOS에서 실행 중인 Rockxy" width="800" />
   </a>

--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@
   <a href="https://opencollective.com/rockxy/donate"><img src="https://img.shields.io/badge/Open%20Collective-support%20Rockxy-7FADF2?logo=opencollective&logoColor=white" alt="Support Rockxy on Open Collective" /></a>
 </p>
 
+<p align="center">
+  <a href="https://trendshift.io/repositories/26380?utm_source=trendshift-badge&amp;utm_medium=badge&amp;utm_campaign=badge-trendshift-26380" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/trendshift/repositories/26380/daily?language=Swift" alt="RockxyApp/Rockxy | Trendshift" width="250" height="55" /></a>
+</p>
+
 > [!IMPORTANT]
 > This repository contains the public Rockxy Community source edition under
 > AGPL-3.0-or-later. Builds made solely from this repository are AGPL builds.

--- a/README.nl.md
+++ b/README.nl.md
@@ -49,6 +49,10 @@
 </p>
 
 <p align="center">
+  <a href="https://trendshift.io/repositories/26380?utm_source=trendshift-badge&amp;utm_medium=badge&amp;utm_campaign=badge-trendshift-26380" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/trendshift/repositories/26380/daily?language=Swift" alt="RockxyApp/Rockxy | Trendshift" width="250" height="55" /></a>
+</p>
+
+<p align="center">
   <a href="https://youtu.be/RvkQuwUjBaQ" title="Watch the Rockxy demo on YouTube">
     <img src="docs/images/Rockxy-Demo-Preview.png" alt="Rockxy running on macOS" width="800" />
   </a>

--- a/README.pl.md
+++ b/README.pl.md
@@ -49,6 +49,10 @@
 </p>
 
 <p align="center">
+  <a href="https://trendshift.io/repositories/26380?utm_source=trendshift-badge&amp;utm_medium=badge&amp;utm_campaign=badge-trendshift-26380" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/trendshift/repositories/26380/daily?language=Swift" alt="RockxyApp/Rockxy | Trendshift" width="250" height="55" /></a>
+</p>
+
+<p align="center">
   <a href="https://youtu.be/RvkQuwUjBaQ" title="Watch the Rockxy demo on YouTube">
     <img src="docs/images/Rockxy-Demo-Preview.png" alt="Rockxy running on macOS" width="800" />
   </a>

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -49,6 +49,10 @@
 </p>
 
 <p align="center">
+  <a href="https://trendshift.io/repositories/26380?utm_source=trendshift-badge&amp;utm_medium=badge&amp;utm_campaign=badge-trendshift-26380" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/trendshift/repositories/26380/daily?language=Swift" alt="RockxyApp/Rockxy | Trendshift" width="250" height="55" /></a>
+</p>
+
+<p align="center">
   <a href="https://youtu.be/RvkQuwUjBaQ" title="Watch the Rockxy demo on YouTube">
     <img src="docs/images/Rockxy-Demo-Preview.png" alt="Rockxy rodando no macOS" width="800" />
   </a>

--- a/README.ro.md
+++ b/README.ro.md
@@ -49,6 +49,10 @@
 </p>
 
 <p align="center">
+  <a href="https://trendshift.io/repositories/26380?utm_source=trendshift-badge&amp;utm_medium=badge&amp;utm_campaign=badge-trendshift-26380" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/trendshift/repositories/26380/daily?language=Swift" alt="RockxyApp/Rockxy | Trendshift" width="250" height="55" /></a>
+</p>
+
+<p align="center">
   <a href="https://youtu.be/RvkQuwUjBaQ" title="Watch the Rockxy demo on YouTube">
     <img src="docs/images/Rockxy-Demo-Preview.png" alt="Rockxy running on macOS" width="800" />
   </a>

--- a/README.ru.md
+++ b/README.ru.md
@@ -49,6 +49,10 @@
 </p>
 
 <p align="center">
+  <a href="https://trendshift.io/repositories/26380?utm_source=trendshift-badge&amp;utm_medium=badge&amp;utm_campaign=badge-trendshift-26380" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/trendshift/repositories/26380/daily?language=Swift" alt="RockxyApp/Rockxy | Trendshift" width="250" height="55" /></a>
+</p>
+
+<p align="center">
   <a href="https://youtu.be/RvkQuwUjBaQ" title="Watch the Rockxy demo on YouTube">
     <img src="docs/images/Rockxy-Demo-Preview.png" alt="Rockxy running on macOS" width="800" />
   </a>

--- a/README.tr.md
+++ b/README.tr.md
@@ -49,6 +49,10 @@
 </p>
 
 <p align="center">
+  <a href="https://trendshift.io/repositories/26380?utm_source=trendshift-badge&amp;utm_medium=badge&amp;utm_campaign=badge-trendshift-26380" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/trendshift/repositories/26380/daily?language=Swift" alt="RockxyApp/Rockxy | Trendshift" width="250" height="55" /></a>
+</p>
+
+<p align="center">
   <a href="https://youtu.be/RvkQuwUjBaQ" title="Watch the Rockxy demo on YouTube">
     <img src="docs/images/Rockxy-Demo-Preview.png" alt="Rockxy running on macOS" width="800" />
   </a>

--- a/README.uk.md
+++ b/README.uk.md
@@ -49,6 +49,10 @@
 </p>
 
 <p align="center">
+  <a href="https://trendshift.io/repositories/26380?utm_source=trendshift-badge&amp;utm_medium=badge&amp;utm_campaign=badge-trendshift-26380" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/trendshift/repositories/26380/daily?language=Swift" alt="RockxyApp/Rockxy | Trendshift" width="250" height="55" /></a>
+</p>
+
+<p align="center">
   <a href="https://youtu.be/RvkQuwUjBaQ" title="Watch the Rockxy demo on YouTube">
     <img src="docs/images/Rockxy-Demo-Preview.png" alt="Rockxy running on macOS" width="800" />
   </a>

--- a/README.vi.md
+++ b/README.vi.md
@@ -49,6 +49,10 @@
 </p>
 
 <p align="center">
+  <a href="https://trendshift.io/repositories/26380?utm_source=trendshift-badge&amp;utm_medium=badge&amp;utm_campaign=badge-trendshift-26380" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/trendshift/repositories/26380/daily?language=Swift" alt="RockxyApp/Rockxy | Trendshift" width="250" height="55" /></a>
+</p>
+
+<p align="center">
   <a href="https://youtu.be/RvkQuwUjBaQ" title="Watch the Rockxy demo on YouTube">
     <img src="docs/images/Rockxy-Demo-Preview.png" alt="Rockxy chạy trên macOS" width="800" />
   </a>

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -49,6 +49,10 @@
 </p>
 
 <p align="center">
+  <a href="https://trendshift.io/repositories/26380?utm_source=trendshift-badge&amp;utm_medium=badge&amp;utm_campaign=badge-trendshift-26380" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/trendshift/repositories/26380/daily?language=Swift" alt="RockxyApp/Rockxy | Trendshift" width="250" height="55" /></a>
+</p>
+
+<p align="center">
   <a href="https://youtu.be/RvkQuwUjBaQ" title="Watch the Rockxy demo on YouTube">
     <img src="docs/images/Rockxy-Demo-Preview.png" alt="Rockxy running on macOS" width="800" />
   </a>

--- a/README.zh.md
+++ b/README.zh.md
@@ -49,6 +49,10 @@
 </p>
 
 <p align="center">
+  <a href="https://trendshift.io/repositories/26380?utm_source=trendshift-badge&amp;utm_medium=badge&amp;utm_campaign=badge-trendshift-26380" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/trendshift/repositories/26380/daily?language=Swift" alt="RockxyApp/Rockxy | Trendshift" width="250" height="55" /></a>
+</p>
+
+<p align="center">
   <a href="https://youtu.be/RvkQuwUjBaQ" title="Watch the Rockxy demo on YouTube">
     <img src="docs/images/Rockxy-Demo-Preview.png" alt="Rockxy 在 macOS 上运行" width="800" />
   </a>


### PR DESCRIPTION
## Summary

- Add the Rockxy Trendshift repository badge to the primary README.
- Keep badge placement consistent across all 20 localized README variants.

## Why

The repository header should expose its current Trendshift ranking consistently for readers in every supported language.

## Impact

This documentation-only change adds one centered badge below the existing shield row. It does not affect the application, build configuration, dependencies, release metadata, or user traffic.

## Validation

- Confirmed all 21 README variants contain exactly one Trendshift badge.
- Confirmed the repository landing URL returns HTTP 200.
- Confirmed the badge endpoint returns HTTP 200 with SVG content.
- git diff --check
- swiftlint lint --strict