### PR TITLE
ci: use lightweight checks for documentation changes

### DIFF
--- a/.github/tools/classify_ci_changes.py
+++ b/.github/tools/classify_ci_changes.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Classify whether a change can use Rockxy's lightweight CI path."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import PurePosixPath
+from typing import Iterable
+
+
+LIGHTWEIGHT_FILES = {
+    "LICENSE",
+    "appcast.xml",
+    "releases/catalog.json",
+    "releases/latest.json",
+}
+DOCUMENTATION_SUFFIXES = {".md", ".mdx"}
+DOCUMENTATION_DIRECTORIES = {"docs", "legal"}
+
+
+def is_lightweight_path(path: str) -> bool:
+    """Return whether *path* cannot affect application behavior or CI execution."""
+    normalized = PurePosixPath(path)
+    if path in LIGHTWEIGHT_FILES:
+        return True
+    if normalized.suffix.lower() in DOCUMENTATION_SUFFIXES:
+        return True
+    return bool(normalized.parts) and normalized.parts[0] in DOCUMENTATION_DIRECTORIES
+
+
+def is_lightweight_only(paths: Iterable[str]) -> bool:
+    """Return true when every changed path is documentation or release metadata.
+
+    An empty diff is safe for the lightweight path. This occurs for history-only
+    merges whose resulting tree is unchanged.
+    """
+    return all(is_lightweight_path(path) for path in paths)
+
+
+def paths_from_null_delimited(payload: bytes) -> list[str]:
+    """Decode the null-delimited output produced by ``git diff -z``."""
+    return [
+        path.decode("utf-8", errors="surrogateescape")
+        for path in payload.split(b"\0")
+        if path
+    ]
+
+
+def main() -> None:
+    paths = paths_from_null_delimited(sys.stdin.buffer.read())
+    print("true" if is_lightweight_only(paths) else "false")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/tools/tests/test_classify_ci_changes.py
+++ b/.github/tools/tests/test_classify_ci_changes.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Regression tests for the Build & Validate change classifier."""
+
+from __future__ import annotations
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "classify_ci_changes.py"
+SPEC = importlib.util.spec_from_file_location("classify_ci_changes", MODULE_PATH)
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError("unable to load CI change classifier")
+classifier = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(classifier)
+
+
+class CIChangeClassifierTests(unittest.TestCase):
+    def test_readmes_and_documentation_use_lightweight_ci(self):
+        paths = [
+            "README.md",
+            "README.vi.md",
+            "docs/getting-started/first-capture.mdx",
+            "docs/images/WelcomeRockxy.png",
+            "CONTRIBUTING.md",
+            "legal/BINARY-EULA-v1.0.md",
+        ]
+
+        self.assertTrue(classifier.is_lightweight_only(paths))
+
+    def test_release_metadata_uses_lightweight_ci(self):
+        paths = [
+            "CHANGELOG.md",
+            "appcast.xml",
+            "releases/catalog.json",
+            "releases/latest.json",
+        ]
+
+        self.assertTrue(classifier.is_lightweight_only(paths))
+
+    def test_empty_history_only_diff_uses_lightweight_ci(self):
+        self.assertTrue(classifier.is_lightweight_only([]))
+
+    def test_source_change_requires_full_ci(self):
+        self.assertFalse(
+            classifier.is_lightweight_only(["Rockxy/Core/ProxyEngine/ProxyServer.swift"])
+        )
+
+    def test_mixed_documentation_and_source_requires_full_ci(self):
+        self.assertFalse(
+            classifier.is_lightweight_only(
+                ["README.md", "RockxyTests/Core/ProxyEngine/ProxyServerTests.swift"]
+            )
+        )
+
+    def test_workflow_change_requires_full_ci(self):
+        self.assertFalse(
+            classifier.is_lightweight_only([".github/workflows/build.yml"])
+        )
+
+    def test_null_delimited_paths_preserve_spaces(self):
+        self.assertEqual(
+            classifier.paths_from_null_delimited(
+                b"docs/Release Notes.mdx\0README.md\0"
+            ),
+            ["docs/Release Notes.mdx", "README.md"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,69 +33,65 @@ jobs:
     name: Classify changes
     runs-on: ubuntu-latest
     outputs:
-      metadata-only: ${{ steps.classify.outputs.metadata-only }}
+      lightweight-only: ${{ steps.classify.outputs.lightweight-only }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # immutable commit
         with:
           fetch-depth: 0
           persist-credentials: false
       - id: classify
-        name: Detect release-metadata-only changes
+        name: Detect lightweight-only changes
         env:
           EVENT_NAME: ${{ github.event_name }}
           BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
         run: |
-          metadata_only=false
+          lightweight_only=false
           if { [ "$EVENT_NAME" = "pull_request" ] || [ "$EVENT_NAME" = "push" ]; } &&
              [ -n "$BASE_SHA" ] && [ -n "$HEAD_SHA" ] &&
              [ "$BASE_SHA" != "0000000000000000000000000000000000000000" ]; then
-            changed_files="$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")"
-            if [ -n "$changed_files" ]; then
-              metadata_only=true
-              while IFS= read -r path; do
-                case "$path" in
-                  CHANGELOG.md|docs/changelog.mdx|appcast.xml|releases/latest.json|releases/catalog.json|README.md|README.*.md) ;;
-                  *) metadata_only=false; break ;;
-                esac
-              done <<<"$changed_files"
-            fi
+            lightweight_only="$(
+              git diff --name-only --no-renames -z "$BASE_SHA" "$HEAD_SHA" |
+                python3 .github/tools/classify_ci_changes.py
+            )"
           fi
-          echo "metadata-only=$metadata_only" >> "$GITHUB_OUTPUT"
-          echo "metadata-only: $metadata_only"
+          echo "lightweight-only=$lightweight_only" >> "$GITHUB_OUTPUT"
+          echo "lightweight-only: $lightweight_only"
 
   lint:
     name: SwiftLint
     needs: changes
-    runs-on: "${{ needs.changes.outputs.metadata-only == 'true' && 'ubuntu-latest' || 'macos-15' }}"
+    runs-on: "${{ needs.changes.outputs.lightweight-only == 'true' && 'ubuntu-latest' || 'macos-15' }}"
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # immutable commit
         with:
           persist-credentials: false
       - name: Install SwiftLint
-        if: needs.changes.outputs.metadata-only != 'true'
+        if: needs.changes.outputs.lightweight-only != 'true'
         run: brew install swiftlint
+      - name: Test CI change policy
+        run: python3 .github/tools/tests/test_classify_ci_changes.py
       - name: Test release metadata policy
         run: python3 -m unittest discover -s releases/tests -p 'test_*.py'
       - name: Lint
-        if: needs.changes.outputs.metadata-only != 'true'
+        if: needs.changes.outputs.lightweight-only != 'true'
         run: swiftlint lint --strict
       - name: Validate release metadata
-        if: needs.changes.outputs.metadata-only == 'true'
+        if: needs.changes.outputs.lightweight-only == 'true'
         run: python3 releases/validate_metadata.py
 
   test:
     name: Test
     needs: changes
-    runs-on: "${{ needs.changes.outputs.metadata-only == 'true' && 'ubuntu-latest' || 'macos-15' }}"
+    runs-on: "${{ needs.changes.outputs.lightweight-only == 'true' && 'ubuntu-latest' || 'macos-15' }}"
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # immutable commit
         with:
           persist-credentials: false
       - name: Prepare CI developer config
-        if: needs.changes.outputs.metadata-only != 'true'
+        if: needs.changes.outputs.lightweight-only != 'true'
         run: |
           cat > Configuration/Developer.xcconfig <<'EOF'
           #include "LocalDev.xcconfig"
@@ -105,7 +101,7 @@ jobs:
           DEVELOPMENT_TEAM =
           EOF
       - name: Select Xcode
-        if: needs.changes.outputs.metadata-only != 'true'
+        if: needs.changes.outputs.lightweight-only != 'true'
         run: |
           for candidate in \
             /Applications/Xcode_16.4.app \
@@ -124,7 +120,7 @@ jobs:
           ls -1 /Applications | grep '^Xcode' || true
           exit 1
       - name: Run tests
-        if: needs.changes.outputs.metadata-only != 'true'
+        if: needs.changes.outputs.lightweight-only != 'true'
         run: |
           mkdir -p build/test-results
           xcodebuild -project Rockxy.xcodeproj \
@@ -141,20 +137,20 @@ jobs:
             PROVISIONING_PROFILE_SPECIFIER="" \
             test
       - name: Run release metadata tests
-        if: needs.changes.outputs.metadata-only == 'true'
+        if: needs.changes.outputs.lightweight-only == 'true'
         run: python3 -m unittest discover -s releases/tests -p 'test_*.py'
 
   build-universal:
     name: Build (Universal)
     needs: changes
-    runs-on: "${{ needs.changes.outputs.metadata-only == 'true' && 'ubuntu-latest' || 'macos-15' }}"
+    runs-on: "${{ needs.changes.outputs.lightweight-only == 'true' && 'ubuntu-latest' || 'macos-15' }}"
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # immutable commit
         with:
           persist-credentials: false
       - name: Prepare CI developer config
-        if: needs.changes.outputs.metadata-only != 'true'
+        if: needs.changes.outputs.lightweight-only != 'true'
         run: |
           cat > Configuration/Developer.xcconfig <<'EOF'
           #include "LocalDev.xcconfig"
@@ -164,7 +160,7 @@ jobs:
           DEVELOPMENT_TEAM =
           EOF
       - name: Select Xcode
-        if: needs.changes.outputs.metadata-only != 'true'
+        if: needs.changes.outputs.lightweight-only != 'true'
         run: |
           for candidate in \
             /Applications/Xcode_16.4.app \
@@ -183,7 +179,7 @@ jobs:
           ls -1 /Applications | grep '^Xcode' || true
           exit 1
       - name: Build arm64
-        if: needs.changes.outputs.metadata-only != 'true'
+        if: needs.changes.outputs.lightweight-only != 'true'
         run: |
           xcodebuild -project Rockxy.xcodeproj \
             -scheme Rockxy \
@@ -199,7 +195,7 @@ jobs:
             PROVISIONING_PROFILE_SPECIFIER="" \
             build
       - name: Build x86_64
-        if: needs.changes.outputs.metadata-only != 'true'
+        if: needs.changes.outputs.lightweight-only != 'true'
         run: |
           xcodebuild -project Rockxy.xcodeproj \
             -scheme Rockxy \
@@ -215,7 +211,7 @@ jobs:
             PROVISIONING_PROFILE_SPECIFIER="" \
             build
       - name: Create universal binary
-        if: needs.changes.outputs.metadata-only != 'true'
+        if: needs.changes.outputs.lightweight-only != 'true'
         run: |
           helper_plist_name_from_app() {
             /usr/libexec/PlistBuddy -c 'Print :RockxyHelperPlistName' "$1/Contents/Info.plist"
@@ -275,7 +271,7 @@ jobs:
 
           cd artifacts && zip -r "$ARTIFACT_BASENAME-universal.zip" "$APP_NAME.app"
       - name: Verify bundled helper resources
-        if: needs.changes.outputs.metadata-only != 'true'
+        if: needs.changes.outputs.lightweight-only != 'true'
         run: |
           verify_helper_resources_in_app() {
             local app_path="$1"
@@ -332,5 +328,5 @@ jobs:
           verify_helper_resources_in_app "build/x86_64/Build/Products/Release/Rockxy.app" "x86_64 app bundle"
           verify_helper_resources_in_app "artifacts/Rockxy.app" "universal app bundle"
       - name: Validate release metadata without rebuilding application binaries
-        if: needs.changes.outputs.metadata-only == 'true'
+        if: needs.changes.outputs.lightweight-only == 'true'
         run: python3 releases/validate_metadata.py


### PR DESCRIPTION
## Summary

- Expand CI change classification to cover README, documentation, legal documents, release metadata, and history-only merges.
- Move the classification policy into a focused Python helper with regression coverage.
- Preserve the full macOS lint, test, and universal-build path for source, test, tooling, workflow, and mixed changes.

## Why

Documentation-only updates should not consume macOS test and universal-build runners when they cannot affect application behavior. History synchronization with an unchanged resulting tree should also avoid an unnecessary full build.

## Impact

Lightweight changes retain the existing required check names but execute only inexpensive validation on Ubuntu. Any application-impacting or unrecognized path fails safe to the full CI path. Workflow changes themselves continue to receive full validation.

## Related issues

No directly related repository issue was found.

## Validation

- `python3 -m unittest discover -s .github/tools/tests -p 'test_*.py'` (40 tests)
- `python3 -m unittest discover -s releases/tests -p 'test_*.py'` (4 tests)
- `python3 releases/validate_metadata.py`
- Parsed `.github/workflows/build.yml` successfully with Ruby YAML
- Verified README/docs-only input selects lightweight CI
- Verified mixed README and Swift source input selects full CI
- `git diff --check origin/main...HEAD`
