### PR TITLE
fix(ci): validate mixed release metadata changes

### DIFF
--- a/.github/tools/classify_ci_changes.py
+++ b/.github/tools/classify_ci_changes.py
@@ -8,12 +8,12 @@ from pathlib import PurePosixPath
 from typing import Iterable
 
 
-LIGHTWEIGHT_FILES = {
-    "LICENSE",
+RELEASE_METADATA_FILES = {
     "appcast.xml",
     "releases/catalog.json",
     "releases/latest.json",
 }
+LIGHTWEIGHT_FILES = {"LICENSE", *RELEASE_METADATA_FILES}
 DOCUMENTATION_SUFFIXES = {".md", ".mdx"}
 DOCUMENTATION_DIRECTORIES = {"docs", "legal"}
 
@@ -37,6 +37,11 @@ def is_lightweight_only(paths: Iterable[str]) -> bool:
     return all(is_lightweight_path(path) for path in paths)
 
 
+def release_metadata_changed(paths: Iterable[str]) -> bool:
+    """Return whether repository release metadata is part of the change."""
+    return any(path in RELEASE_METADATA_FILES for path in paths)
+
+
 def paths_from_null_delimited(payload: bytes) -> list[str]:
     """Decode the null-delimited output produced by ``git diff -z``."""
     return [
@@ -48,7 +53,11 @@ def paths_from_null_delimited(payload: bytes) -> list[str]:
 
 def main() -> None:
     paths = paths_from_null_delimited(sys.stdin.buffer.read())
-    print("true" if is_lightweight_only(paths) else "false")
+    print(f"lightweight-only={'true' if is_lightweight_only(paths) else 'false'}")
+    print(
+        "release-metadata-changed="
+        f"{'true' if release_metadata_changed(paths) else 'false'}"
+    )
 
 
 if __name__ == "__main__":

--- a/.github/tools/tests/test_classify_ci_changes.py
+++ b/.github/tools/tests/test_classify_ci_changes.py
@@ -38,9 +38,11 @@ class CIChangeClassifierTests(unittest.TestCase):
         ]
 
         self.assertTrue(classifier.is_lightweight_only(paths))
+        self.assertTrue(classifier.release_metadata_changed(paths))
 
     def test_empty_history_only_diff_uses_lightweight_ci(self):
         self.assertTrue(classifier.is_lightweight_only([]))
+        self.assertFalse(classifier.release_metadata_changed([]))
 
     def test_source_change_requires_full_ci(self):
         self.assertFalse(
@@ -53,6 +55,12 @@ class CIChangeClassifierTests(unittest.TestCase):
                 ["README.md", "RockxyTests/Core/ProxyEngine/ProxyServerTests.swift"]
             )
         )
+
+    def test_mixed_source_and_release_metadata_still_requires_validation(self):
+        paths = ["Rockxy/RockxyApp.swift", "releases/latest.json"]
+
+        self.assertFalse(classifier.is_lightweight_only(paths))
+        self.assertTrue(classifier.release_metadata_changed(paths))
 
     def test_workflow_change_requires_full_ci(self):
         self.assertFalse(

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       lightweight-only: ${{ steps.classify.outputs.lightweight-only }}
+      release-metadata-changed: ${{ steps.classify.outputs.release-metadata-changed }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # immutable commit
         with:
@@ -46,17 +47,18 @@ jobs:
           BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
         run: |
-          lightweight_only=false
           if { [ "$EVENT_NAME" = "pull_request" ] || [ "$EVENT_NAME" = "push" ]; } &&
              [ -n "$BASE_SHA" ] && [ -n "$HEAD_SHA" ] &&
              [ "$BASE_SHA" != "0000000000000000000000000000000000000000" ]; then
-            lightweight_only="$(
-              git diff --name-only --no-renames -z "$BASE_SHA" "$HEAD_SHA" |
-                python3 .github/tools/classify_ci_changes.py
-            )"
+            git diff --name-only --no-renames -z "$BASE_SHA" "$HEAD_SHA" |
+              python3 .github/tools/classify_ci_changes.py |
+              tee -a "$GITHUB_OUTPUT"
+          else
+            {
+              echo "lightweight-only=false"
+              echo "release-metadata-changed=false"
+            } | tee -a "$GITHUB_OUTPUT"
           fi
-          echo "lightweight-only=$lightweight_only" >> "$GITHUB_OUTPUT"
-          echo "lightweight-only: $lightweight_only"
 
   lint:
     name: SwiftLint
@@ -78,7 +80,7 @@ jobs:
         if: needs.changes.outputs.lightweight-only != 'true'
         run: swiftlint lint --strict
       - name: Validate release metadata
-        if: needs.changes.outputs.lightweight-only == 'true'
+        if: needs.changes.outputs.release-metadata-changed == 'true'
         run: python3 releases/validate_metadata.py
 
   test:
@@ -327,6 +329,3 @@ jobs:
           verify_helper_resources_in_app "build/arm64/Build/Products/Release/Rockxy.app" "arm64 app bundle"
           verify_helper_resources_in_app "build/x86_64/Build/Products/Release/Rockxy.app" "x86_64 app bundle"
           verify_helper_resources_in_app "artifacts/Rockxy.app" "universal app bundle"
-      - name: Validate release metadata without rebuilding application binaries
-        if: needs.changes.outputs.lightweight-only == 'true'
-        run: python3 releases/validate_metadata.py


### PR DESCRIPTION
## Summary

- Track release metadata changes independently from the lightweight CI decision.
- Run the repository metadata validator for mixed source and release metadata updates.
- Keep documentation-only changes on the lightweight runner path.

## Why

A mixed change must receive the full application checks and still validate the actual release metadata files. Unit tests for the validator do not validate the checked-in metadata by themselves.

## Impact

This closes the mixed-change validation gap without restoring application builds for documentation-only updates.

## Related work

Refs #270

## Validation

- `python3 -m unittest discover -s .github/tools/tests -p 'test_*.py'` (41 tests)
- `python3 -m unittest discover -s releases/tests -p 'test_*.py'` (4 tests)
- `python3 releases/validate_metadata.py`
- Parsed `.github/workflows/build.yml` successfully with Ruby YAML
- Verified docs-only input returns `lightweight-only=true` and `release-metadata-changed=false`
- Verified mixed Swift/release input returns `lightweight-only=false` and `release-metadata-changed=true`
- `git diff --check`
