### PR TITLE
fix(traffic): preserve reveal consumption by workspace

### DIFF
--- a/Rockxy/Views/RequestList/RequestTableView.swift
+++ b/Rockxy/Views/RequestList/RequestTableView.swift
@@ -462,8 +462,7 @@ extension RequestTableView {
         private var pendingContextSelectionIDs: Set<UUID>?
         private var pendingContextPrimaryID: UUID?
         private var userScrollObserver: NSObjectProtocol?
-        private var lastAppliedRevealWorkspaceID: UUID?
-        private var lastAppliedRevealGeneration: Int?
+        private var lastAppliedRevealGenerationByWorkspace: [UUID: Int] = [:]
 
         /// Guard flag to prevent feedback loops: when we programmatically update NSTableView
         /// selection from SwiftUI state, we suppress the delegate callback that would
@@ -1276,8 +1275,7 @@ extension RequestTableView {
             in tableView: NSTableView
         ) {
             guard let request,
-                  lastAppliedRevealWorkspaceID != workspaceID
-                    || lastAppliedRevealGeneration != request.generation,
+                  request.generation > (lastAppliedRevealGenerationByWorkspace[workspaceID] ?? 0),
                   let rowIndex = parent.selectionIndex[request.transactionID]?.rowIndex,
                   rows.indices.contains(rowIndex),
                   rows[rowIndex].id == request.transactionID else
@@ -1286,8 +1284,7 @@ extension RequestTableView {
             }
 
             tableView.scrollRowToVisible(rowIndex)
-            lastAppliedRevealWorkspaceID = workspaceID
-            lastAppliedRevealGeneration = request.generation
+            lastAppliedRevealGenerationByWorkspace[workspaceID] = request.generation
         }
 
         func contextSelectionIDs(

--- a/RockxyTests/Views/RequestList/TrafficBoundaryNavigationTests.swift
+++ b/RockxyTests/Views/RequestList/TrafficBoundaryNavigationTests.swift
@@ -74,6 +74,48 @@ struct TrafficBoundaryNavigationTests {
         #expect(scrollView.contentView.bounds.origin.y > 0)
     }
 
+    @Test("Jump reveal remains consumed after switching away from and back to a workspace")
+    func jumpRevealConsumptionPersistsAcrossWorkspaceSwitches() {
+        let firstWorkspaceID = UUID()
+        let secondWorkspaceID = UUID()
+        let transactions = TestFixtures.makeBulkTransactions(count: 100)
+        let rows = transactions.map { RequestListRow(from: $0, sslState: .insecure) }
+        let target = transactions[99]
+        let selectionIndex = [
+            target.id: TrafficSelectionIndexEntry(transaction: target, rowIndex: 99)
+        ]
+        var selectedIDs: Set<UUID> = [target.id]
+        let parent = RequestTableView(
+            workspaceID: firstWorkspaceID,
+            rows: rows,
+            refreshToken: 0,
+            isAppendOnly: false,
+            selectionIndex: selectionIndex,
+            selectedIDs: Binding(
+                get: { selectedIDs },
+                set: { selectedIDs = $0 }
+            )
+        )
+        let coordinator = RequestTableView.Coordinator(parent: parent)
+        coordinator.rows = rows
+        let tableView = makeTableView(rowCount: rows.count, coordinator: coordinator)
+        let scrollView = makeScrollView(documentView: tableView)
+        let request = TrafficRevealRequest(transactionID: target.id, generation: 1)
+
+        coordinator.syncRevealRequest(request, workspaceID: firstWorkspaceID, in: tableView)
+        #expect(scrollView.contentView.bounds.origin.y > 0)
+
+        scrollView.contentView.scroll(to: .zero)
+        scrollView.reflectScrolledClipView(scrollView.contentView)
+        coordinator.syncRevealRequest(request, workspaceID: secondWorkspaceID, in: tableView)
+        #expect(scrollView.contentView.bounds.origin.y > 0)
+
+        scrollView.contentView.scroll(to: .zero)
+        scrollView.reflectScrolledClipView(scrollView.contentView)
+        coordinator.syncRevealRequest(request, workspaceID: firstWorkspaceID, in: tableView)
+        #expect(scrollView.contentView.bounds.origin.y == 0)
+    }
+
     // MARK: Private
 
     private func makeScrollView(documentView: NSTableView) -> NSScrollView {


### PR DESCRIPTION
## Summary

- track consumed traffic-reveal generations independently for each workspace
- prevent an unchanged reveal request from scrolling again after an A → B → A workspace switch
- preserve fresh-generation reveals for repeated navigation commands

## Validation

- `swiftlint lint --strict`
- `xcodebuild -project Rockxy.xcodeproj -scheme Rockxy -destination platform=macOS -only-testing:RockxyTests/TrafficBoundaryNavigationTests test`

## Related work

Refs #14

Addresses the unresolved one-shot reveal review thread on #273.