### PR TITLE
release: promote local project management and isolated traffic tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Added local Projects with Project-scoped traffic history, durable Traffic Tab layouts and filters, and configuration-only `.rockxyproject` import and export.
 - Added nearby iPhone transfers as a dedicated iOS workspace so the current Mac traffic remains available.
 - Kept the nearby-transfer receiver discoverable while Rockxy is running, even when macOS restores the app without a main window.
 - Added AI traffic inspection for recognized model API traffic, including provider/model hints, streaming state, usage fields when present, tool-call summaries, retrieval hints, and warnings for unavailable fields.

--- a/README.md
+++ b/README.md
@@ -275,13 +275,13 @@ Save sessions, import/export HAR for cross-tool handoff, copy any request as cUR
 
 `.rockxysession` · `HAR Import / Export` · `Copy as cURL` · `Copy as JSON` · `Raw HTTP` · `Secret Redaction` · `Token Sanitize` · `Privacy-Safe Share`
 
-### Multi-Tab Workspaces
+### Projects & Traffic Tabs
 
 <img src="docs/images/features/DemoMultipleTabWorkingSpace.png" alt="Rockxy multi-tab workspaces showing independently filtered views of the same live capture" width="820" />
 
-Keep independent investigation views side-by-side on the same live capture — one tab for staging traffic, one for production, and one for an iOS device flow. Each tab has its own filters, sorting, selection, sidebar scope, and inspector state while sharing the proxy and captured transactions.
+Group work into local Projects — one Project for checkout, another for authentication, each with tabs for errors, devices, or environments. New requests are assigned to the active Project when they begin; switching back restores that Project's in-memory traffic and durable tab setup.
 
-`Shared Live Capture` · `Per-Tab Filters & Sort` · `Per-Tab Inspector` · `Compare Environments` · `Mac & iOS Together` · `Detach & Rename`
+`3 Local Projects` · `Project-Scoped Traffic` · `Durable Tab Filters` · `Per-Tab Inspector` · `Config Import / Export` · `No Captured Bodies in Catalog`
 
 ### JavaScript Scripting
 

--- a/Rockxy/AppDelegate.swift
+++ b/Rockxy/AppDelegate.swift
@@ -91,6 +91,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSUserInterfaceValidat
 
         Self.logger.info("Rockxy terminating — cleaning up system proxy")
         Task {
+            await RockxyWorkspaceWindowManager.shared.flushProjectStateForTermination()
             Self.logger.info("Quit: starting proxy restore")
             do {
                 try await SystemProxyManager.shared.disableSystemProxy()

--- a/Rockxy/ContentView.swift
+++ b/Rockxy/ContentView.swift
@@ -58,6 +58,16 @@ struct ContentView: View {
         } workspace: {
             ZStack(alignment: .bottom) {
                 VStack(spacing: 0) {
+                    if let warning = coordinator.projectPersistenceWarningMessage {
+                        SystemProxyWarningBanner(
+                            message: warning,
+                            primaryActionTitle: String(localized: "Repair Projects…"),
+                            onPrimaryAction: {
+                                coordinator.isProjectRecoveryPresented = true
+                            }
+                        )
+                    }
+
                     if let warning = coordinator.systemProxyWarning {
                         SystemProxyWarningBanner(
                             message: warning.message,
@@ -128,6 +138,12 @@ struct ContentView: View {
             // contention between the app's loadInitialRules and test suites.
             guard managesLifecycle, !ProcessInfo.processInfo.isTestHost else {
                 return
+            }
+            await coordinator.hydrateProjectsOnLaunch()
+            if case .failed = coordinator.projectStore.loadState {
+                coordinator.isProjectRecoveryPresented = true
+            } else {
+                RockxyWorkspaceWindowManager.shared.projectDidChange(coordinator: coordinator)
             }
             coordinator.readiness.startObserving()
             coordinator.setupRulesObserver()
@@ -207,6 +223,39 @@ struct ContentView: View {
                 },
                 onCancel: { coordinator.gistPublishContext = nil }
             )
+        }
+        .sheet(item: Binding(
+            get: {
+                coordinator.isProjectManagerPresented ? nil : coordinator.projectNameEditorContext
+            },
+            set: { coordinator.projectNameEditorContext = $0 }
+        )) { context in
+            ProjectNameEditorSheet(context: context, coordinator: coordinator)
+        }
+        .sheet(isPresented: $coordinator.isProjectManagerPresented) {
+            ProjectManagerSheet(coordinator: coordinator)
+        }
+        .sheet(isPresented: $coordinator.isProjectRecoveryPresented) {
+            ProjectRecoverySheet(coordinator: coordinator)
+        }
+        .alert(
+            String(localized: "Project Operation Failed"),
+            isPresented: Binding(
+                get: { coordinator.lastProjectOperationError != nil },
+                set: {
+                    if !$0 {
+                        coordinator.lastProjectOperationError = nil
+                    }
+                }
+            )
+        ) {
+            Button(String(localized: "OK")) {
+                coordinator.lastProjectOperationError = nil
+            }
+        } message: {
+            if let message = coordinator.projectOperationErrorMessage {
+                Text(message)
+            }
         }
         .appUIDisplayMetrics(displayMetrics)
     }

--- a/Rockxy/Core/BabylonCapture/BabylonCaptureReceiver.swift
+++ b/Rockxy/Core/BabylonCapture/BabylonCaptureReceiver.swift
@@ -398,7 +398,7 @@ final class BabylonCaptureReceiver: @unchecked Sendable {
         )
         state.identity = identity
         Task { @MainActor [weak coordinator] in
-            coordinator?.registerBabylonCapture(identity: identity)
+            await coordinator?.registerBabylonCapture(identity: identity)
         }
     }
 

--- a/Rockxy/Core/Plugins/ScriptMultiArgBridge.swift
+++ b/Rockxy/Core/Plugins/ScriptMultiArgBridge.swift
@@ -144,7 +144,8 @@ enum ScriptMultiArgBridge {
             httpVersion: original.httpVersion,
             headers: newHeaders,
             body: newBody,
-            contentType: ContentTypeDetector.detect(headers: newHeaders, body: newBody)
+            contentType: ContentTypeDetector.detect(headers: newHeaders, body: newBody),
+            captureContext: original.captureContext
         )
     }
 

--- a/Rockxy/Core/Plugins/ScriptRequestContext.swift
+++ b/Rockxy/Core/Plugins/ScriptRequestContext.swift
@@ -207,7 +207,8 @@ struct ScriptRequestContext {
             httpVersion: request.httpVersion,
             headers: newHeaders,
             body: newBody,
-            contentType: request.contentType
+            contentType: request.contentType,
+            captureContext: request.captureContext
         )
     }
 

--- a/Rockxy/Core/ProxyEngine/BreakpointRequestBuilder.swift
+++ b/Rockxy/Core/ProxyEngine/BreakpointRequestBuilder.swift
@@ -133,7 +133,8 @@ enum BreakpointRequestBuilder {
             httpVersion: originalRequestData.httpVersion,
             headers: resolvedHeaders,
             body: body,
-            contentType: originalRequestData.contentType
+            contentType: originalRequestData.contentType,
+            captureContext: originalRequestData.captureContext
         )
 
         return Result(head: head, requestData: requestData)

--- a/Rockxy/Core/ProxyEngine/HTTPProxyHandler.swift
+++ b/Rockxy/Core/ProxyEngine/HTTPProxyHandler.swift
@@ -34,6 +34,7 @@ final class HTTPProxyHandler: ChannelInboundHandler, RemovableChannelHandler, @u
         connectionLimiter: ConnectionLimiter,
         customCertificateManager: CustomCertificateManager = .shared,
         upstreamProxySnapshotProvider: @escaping @Sendable () -> UpstreamProxyResolvedConfiguration? = { nil },
+        captureContextProvider: @escaping @Sendable () -> TrafficCaptureContext? = { nil },
         onTransactionComplete: @escaping @Sendable (HTTPTransaction) -> Void,
         onBreakpointHit: (@Sendable (BreakpointRequestData) async -> (BreakpointDecision, BreakpointRequestData))? = nil
     ) {
@@ -43,6 +44,7 @@ final class HTTPProxyHandler: ChannelInboundHandler, RemovableChannelHandler, @u
         self.connectionLimiter = connectionLimiter
         self.customCertificateManager = customCertificateManager
         self.upstreamProxySnapshotProvider = upstreamProxySnapshotProvider
+        self.captureContextProvider = captureContextProvider
         self.onTransactionComplete = onTransactionComplete
         self.onBreakpointHit = onBreakpointHit
     }
@@ -62,6 +64,7 @@ final class HTTPProxyHandler: ChannelInboundHandler, RemovableChannelHandler, @u
             requestHead = head
             requestBody = context.channel.allocator.buffer(capacity: 0)
             requestStartTime = .now()
+            requestCaptureContext = captureContextProvider()
             requestBodyLimitState.reset()
             if clientSourcePort == nil, let port = context.channel.remoteAddress?.port {
                 clientSourcePort = UInt16(port)
@@ -75,6 +78,7 @@ final class HTTPProxyHandler: ChannelInboundHandler, RemovableChannelHandler, @u
                 sendErrorResponse(context: context, status: 413, requestData: buildRequestData(from: head))
                 requestHead = nil
                 requestBody = nil
+                requestCaptureContext = nil
                 return
             }
             requestBody?.writeImmutableBuffer(buffer)
@@ -86,6 +90,7 @@ final class HTTPProxyHandler: ChannelInboundHandler, RemovableChannelHandler, @u
             processRequest(context: context, head: head)
             requestHead = nil
             requestBody = nil
+            requestCaptureContext = nil
         }
     }
 
@@ -107,6 +112,7 @@ final class HTTPProxyHandler: ChannelInboundHandler, RemovableChannelHandler, @u
     private let connectionLimiter: ConnectionLimiter
     private let customCertificateManager: CustomCertificateManager
     private let upstreamProxySnapshotProvider: @Sendable () -> UpstreamProxyResolvedConfiguration?
+    private let captureContextProvider: @Sendable () -> TrafficCaptureContext?
     private let onTransactionComplete: @Sendable (HTTPTransaction) -> Void
     private let onBreakpointHit: (@Sendable (BreakpointRequestData) async -> (
         BreakpointDecision,
@@ -118,6 +124,7 @@ final class HTTPProxyHandler: ChannelInboundHandler, RemovableChannelHandler, @u
     private var requestHead: HTTPRequestHead?
     private var requestBody: ByteBuffer?
     private var requestStartTime: DispatchTime?
+    private var requestCaptureContext: TrafficCaptureContext?
     private var clientSourcePort: UInt16?
     private var requestBodyLimitState = RequestBodyLimitState()
 
@@ -194,7 +201,11 @@ final class HTTPProxyHandler: ChannelInboundHandler, RemovableChannelHandler, @u
                         break
                     }
                 }
-                self.handleConnect(context: context, head: head)
+                self.handleConnect(
+                    context: context,
+                    head: head,
+                    requestData: requestData
+                )
                 return
             }
 
@@ -307,7 +318,8 @@ final class HTTPProxyHandler: ChannelInboundHandler, RemovableChannelHandler, @u
             httpVersion: "\(head.version.major).\(head.version.minor)",
             headers: headers,
             body: body,
-            contentType: contentType
+            contentType: contentType,
+            captureContext: requestCaptureContext
         )
     }
 
@@ -588,11 +600,12 @@ extension HTTPProxyHandler {
     /// TLS termination with a per-host certificate.
     nonisolated func handleConnect(
         context: ChannelHandlerContext,
-        head: HTTPRequestHead
+        head: HTTPRequestHead,
+        requestData: HTTPRequestData
     ) {
         guard let parsed = try? HostPortParser.parse(head.uri) else {
             proxyHandlerLogger.warning("SECURITY: Malformed CONNECT URI")
-            sendErrorResponse(context: context, status: 400, requestData: buildRequestData(from: head))
+            sendErrorResponse(context: context, status: 400, requestData: requestData)
             return
         }
         let host = parsed.host
@@ -619,6 +632,8 @@ extension HTTPProxyHandler {
                 bypassProxyManager: .shared,
                 customCertificateManager: self.customCertificateManager,
                 upstreamProxySnapshotProvider: self.upstreamProxySnapshotProvider,
+                captureContextProvider: self.captureContextProvider,
+                tunnelCaptureContext: requestData.captureContext,
                 clientSourcePort: self.clientSourcePort,
                 onTransactionComplete: self.onTransactionComplete,
                 onBreakpointHit: self.onBreakpointHit

--- a/Rockxy/Core/ProxyEngine/HTTPSProxyRelayHandler.swift
+++ b/Rockxy/Core/ProxyEngine/HTTPSProxyRelayHandler.swift
@@ -29,6 +29,7 @@ final class HTTPSProxyRelayHandler: ChannelInboundHandler, @unchecked Sendable {
         connectionLimiter: ConnectionLimiter,
         customCertificateManager: CustomCertificateManager = .shared,
         upstreamProxySnapshotProvider: @escaping @Sendable () -> UpstreamProxyResolvedConfiguration? = { nil },
+        captureContextProvider: @escaping @Sendable () -> TrafficCaptureContext? = { nil },
         clientSourcePort: UInt16? = nil,
         onTransactionComplete: @escaping @Sendable (HTTPTransaction) -> Void,
         onBreakpointHit: (@Sendable (BreakpointRequestData) async -> (BreakpointDecision, BreakpointRequestData))? = nil
@@ -40,6 +41,7 @@ final class HTTPSProxyRelayHandler: ChannelInboundHandler, @unchecked Sendable {
         self.connectionLimiter = connectionLimiter
         self.customCertificateManager = customCertificateManager
         self.upstreamProxySnapshotProvider = upstreamProxySnapshotProvider
+        self.captureContextProvider = captureContextProvider
         self.clientSourcePort = clientSourcePort
         self.onTransactionComplete = onTransactionComplete
         self.onBreakpointHit = onBreakpointHit
@@ -70,6 +72,7 @@ final class HTTPSProxyRelayHandler: ChannelInboundHandler, @unchecked Sendable {
             requestHead = head
             requestBody = context.channel.allocator.buffer(capacity: 0)
             requestStartTime = .now()
+            requestCaptureContext = captureContextProvider()
             requestBodyLimitState.reset()
 
         case let .body(buffer):
@@ -85,6 +88,7 @@ final class HTTPSProxyRelayHandler: ChannelInboundHandler, @unchecked Sendable {
                 )
                 requestHead = nil
                 requestBody = nil
+                requestCaptureContext = nil
                 return
             }
             requestBody?.writeImmutableBuffer(buffer)
@@ -96,6 +100,7 @@ final class HTTPSProxyRelayHandler: ChannelInboundHandler, @unchecked Sendable {
             forwardHTTPSRequest(context: context, head: head)
             requestHead = nil
             requestBody = nil
+            requestCaptureContext = nil
         }
     }
 
@@ -117,6 +122,7 @@ final class HTTPSProxyRelayHandler: ChannelInboundHandler, @unchecked Sendable {
     private let connectionLimiter: ConnectionLimiter
     private let customCertificateManager: CustomCertificateManager
     private let upstreamProxySnapshotProvider: @Sendable () -> UpstreamProxyResolvedConfiguration?
+    private let captureContextProvider: @Sendable () -> TrafficCaptureContext?
     private let clientSourcePort: UInt16?
     private let onTransactionComplete: @Sendable (HTTPTransaction) -> Void
     private let onBreakpointHit: (@Sendable (BreakpointRequestData) async -> (
@@ -129,6 +135,7 @@ final class HTTPSProxyRelayHandler: ChannelInboundHandler, @unchecked Sendable {
     private var requestHead: HTTPRequestHead?
     private var requestBody: ByteBuffer?
     private var requestStartTime: DispatchTime?
+    private var requestCaptureContext: TrafficCaptureContext?
     private var requestBodyLimitState = RequestBodyLimitState()
 
     nonisolated private func makeTransactionCallback(
@@ -275,10 +282,10 @@ final class HTTPSProxyRelayHandler: ChannelInboundHandler, @unchecked Sendable {
     nonisolated private func buildRequestData(from head: HTTPRequestHead) -> HTTPRequestData {
         let headers = head.headers.map { HTTPHeader(name: $0.name, value: $0.value) }
         let body: Data? = if let buffer = requestBody, buffer.readableBytes > 0,
-                            let bytes = buffer.getBytes(
-                                at: buffer.readerIndex,
-                                length: buffer.readableBytes
-                            )
+                             let bytes = buffer.getBytes(
+                                 at: buffer.readerIndex,
+                                 length: buffer.readableBytes
+                             )
         {
             Data(bytes)
         } else {
@@ -294,7 +301,8 @@ final class HTTPSProxyRelayHandler: ChannelInboundHandler, @unchecked Sendable {
             httpVersion: "\(head.version.major).\(head.version.minor)",
             headers: headers,
             body: body,
-            contentType: ContentTypeDetector.detect(headers: headers, body: body)
+            contentType: ContentTypeDetector.detect(headers: headers, body: body),
+            captureContext: requestCaptureContext
         )
     }
 

--- a/Rockxy/Core/ProxyEngine/ProxyHandlerShared.swift
+++ b/Rockxy/Core/ProxyEngine/ProxyHandlerShared.swift
@@ -119,11 +119,10 @@ enum ProxyHandlerShared {
         let components = URLComponents(url: requestData.url, resolvingAgainstBaseURL: false)
         let encodedPath = components?.percentEncodedPath ?? requestData.url.path
         let path = encodedPath.isEmpty ? "/" : encodedPath
-        let uri: String
-        if let query = components?.percentEncodedQuery, !query.isEmpty {
-            uri = "\(path)?\(query)"
+        let uri: String = if let query = components?.percentEncodedQuery, !query.isEmpty {
+            "\(path)?\(query)"
         } else {
-            uri = path
+            path
         }
 
         var headers = HTTPHeaders(requestData.headers.map { ($0.name, $0.value) })
@@ -194,12 +193,15 @@ enum ProxyHandlerShared {
         var modifiedHead = originalHead
         modifiedHead.uri = uri
 
-        let hostHeaderValue: String
-        if configuration.preserveHostHeader {
-            hostHeaderValue = originalHead.headers.first(name: "Host")
-                ?? hostHeader(host: originalURL.host() ?? fallbackHost, port: originalURL.port ?? fallbackPort, scheme: originalScheme)
+        let hostHeaderValue: String = if configuration.preserveHostHeader {
+            originalHead.headers.first(name: "Host")
+                ?? hostHeader(
+                    host: originalURL.host() ?? fallbackHost,
+                    port: originalURL.port ?? fallbackPort,
+                    scheme: originalScheme
+                )
         } else {
-            hostHeaderValue = hostHeader(host: upstreamHost, port: upstreamPort, scheme: scheme)
+            hostHeader(host: upstreamHost, port: upstreamPort, scheme: scheme)
         }
         modifiedHead.headers.replaceOrAdd(name: "Host", value: NetworkValidator.sanitizeHeaderValue(hostHeaderValue))
 
@@ -218,7 +220,8 @@ enum ProxyHandlerShared {
             httpVersion: requestData.httpVersion,
             headers: modifiedHead.headers.map { HTTPHeader(name: $0.name, value: $0.value) },
             body: requestData.body,
-            contentType: requestData.contentType
+            contentType: requestData.contentType,
+            captureContext: requestData.captureContext
         )
 
         return MapRemoteRewrite(
@@ -304,7 +307,8 @@ enum ProxyHandlerShared {
 
     private static func defaultPort(for scheme: String) -> Int {
         switch scheme.lowercased() {
-        case "https", "wss":
+        case "https",
+             "wss":
             443
         default:
             80

--- a/Rockxy/Core/ProxyEngine/ProxyServer.swift
+++ b/Rockxy/Core/ProxyEngine/ProxyServer.swift
@@ -92,6 +92,7 @@ actor ProxyServer {
         ruleEngine: RuleEngine = RuleEngine(),
         scriptPluginManager: ScriptPluginManager? = nil,
         upstreamProxySnapshotProvider: @escaping @Sendable () -> UpstreamProxyResolvedConfiguration? = { nil },
+        captureContextProvider: @escaping @Sendable () -> TrafficCaptureContext? = { nil },
         onTransactionComplete: @escaping @Sendable (HTTPTransaction) -> Void = { _ in },
         onBreakpointHit: (@Sendable (BreakpointRequestData) async -> (BreakpointDecision, BreakpointRequestData))? = nil
     ) {
@@ -100,6 +101,7 @@ actor ProxyServer {
         self.ruleEngine = ruleEngine
         self.scriptPluginManager = scriptPluginManager
         self.upstreamProxySnapshotProvider = upstreamProxySnapshotProvider
+        self.captureContextProvider = captureContextProvider
         self.onTransactionComplete = onTransactionComplete
         self.onBreakpointHit = onBreakpointHit
     }
@@ -124,6 +126,7 @@ actor ProxyServer {
         let scriptMgr = scriptPluginManager
         let limiter = connectionLimiter
         let callback = onTransactionComplete
+        let captureProvider = captureContextProvider
         let breakpointHit = onBreakpointHit
         refreshUpstreamProxySnapshot()
         let upstreamProxyProvider: @Sendable () -> UpstreamProxyResolvedConfiguration? = {
@@ -159,6 +162,7 @@ actor ProxyServer {
                         scriptPluginManager: scriptMgr,
                         connectionLimiter: limiter,
                         upstreamProxySnapshotProvider: upstreamProxyProvider,
+                        captureContextProvider: captureProvider,
                         onTransactionComplete: callback,
                         onBreakpointHit: breakpointHit
                     )
@@ -226,6 +230,7 @@ actor ProxyServer {
     private let ruleEngine: RuleEngine
     private let scriptPluginManager: ScriptPluginManager?
     private let upstreamProxySnapshotProvider: @Sendable () -> UpstreamProxyResolvedConfiguration?
+    private let captureContextProvider: @Sendable () -> TrafficCaptureContext?
     private let connectionLimiter = ConnectionLimiter()
     private let onTransactionComplete: @Sendable (HTTPTransaction) -> Void
     private let onBreakpointHit: (@Sendable (BreakpointRequestData) async -> (

--- a/Rockxy/Core/ProxyEngine/TLSInterceptHandler.swift
+++ b/Rockxy/Core/ProxyEngine/TLSInterceptHandler.swift
@@ -99,6 +99,8 @@ final class TLSInterceptHandler: ChannelInboundHandler, RemovableChannelHandler,
         bypassProxyManager: BypassProxyManager = .shared,
         customCertificateManager: CustomCertificateManager = .shared,
         upstreamProxySnapshotProvider: @escaping @Sendable () -> UpstreamProxyResolvedConfiguration? = { nil },
+        captureContextProvider: @escaping @Sendable () -> TrafficCaptureContext? = { nil },
+        tunnelCaptureContext: TrafficCaptureContext? = nil,
         clientSourcePort: UInt16? = nil,
         onTransactionComplete: @escaping @Sendable (HTTPTransaction) -> Void,
         onBreakpointHit: (@Sendable (BreakpointRequestData) async -> (BreakpointDecision, BreakpointRequestData))? = nil
@@ -113,6 +115,8 @@ final class TLSInterceptHandler: ChannelInboundHandler, RemovableChannelHandler,
         self.bypassProxyManager = bypassProxyManager
         self.customCertificateManager = customCertificateManager
         self.upstreamProxySnapshotProvider = upstreamProxySnapshotProvider
+        self.captureContextProvider = captureContextProvider
+        self.tunnelCaptureContext = tunnelCaptureContext
         self.clientSourcePort = clientSourcePort
         self.onTransactionComplete = onTransactionComplete
         self.onBreakpointHit = onBreakpointHit
@@ -142,7 +146,8 @@ final class TLSInterceptHandler: ChannelInboundHandler, RemovableChannelHandler,
         state: TransactionState,
         sourcePort: UInt16?,
         measuredDuration: TimeInterval? = nil,
-        isTLSFailure: Bool = false
+        isTLSFailure: Bool = false,
+        captureContext: TrafficCaptureContext? = nil
     )
         -> HTTPTransaction
     {
@@ -167,7 +172,8 @@ final class TLSInterceptHandler: ChannelInboundHandler, RemovableChannelHandler,
                 state: state,
                 sourcePort: sourcePort,
                 measuredDuration: measuredDuration,
-                isTLSFailure: isTLSFailure
+                isTLSFailure: isTLSFailure,
+                captureContext: captureContext
             )
         }
         let requestData = HTTPRequestData(
@@ -176,7 +182,8 @@ final class TLSInterceptHandler: ChannelInboundHandler, RemovableChannelHandler,
             httpVersion: "1.1",
             headers: [],
             body: nil,
-            contentType: nil
+            contentType: nil,
+            captureContext: captureContext
         )
         let transaction = HTTPTransaction(
             request: requestData,
@@ -236,6 +243,28 @@ final class TLSInterceptHandler: ChannelInboundHandler, RemovableChannelHandler,
         return config
     }
 
+    nonisolated static func initialTunnelMode(
+        host: String,
+        sslProxyingManager: SSLProxyingManager,
+        bypassProxyManager: BypassProxyManager
+    )
+        -> InitialTunnelMode
+    {
+        if bypassProxyManager.isHostBypassed(host) {
+            return .rawTunnel(.bypassProxyList)
+        }
+
+        if !sslProxyingManager.shouldIntercept(host) {
+            return .rawTunnel(.noSSLProxyingRule)
+        }
+
+        if sslProxyingManager.isAutoPassthrough(host) {
+            return .rawTunnel(.autoPassthrough)
+        }
+
+        return .intercept
+    }
+
     nonisolated func handlerAdded(context: ChannelHandlerContext) {
         setupTLSPipeline(context: context)
     }
@@ -261,6 +290,8 @@ final class TLSInterceptHandler: ChannelInboundHandler, RemovableChannelHandler,
     private let bypassProxyManager: BypassProxyManager
     private let customCertificateManager: CustomCertificateManager
     private let upstreamProxySnapshotProvider: @Sendable () -> UpstreamProxyResolvedConfiguration?
+    private let captureContextProvider: @Sendable () -> TrafficCaptureContext?
+    private let tunnelCaptureContext: TrafficCaptureContext?
     private let clientSourcePort: UInt16?
     private let onTransactionComplete: @Sendable (HTTPTransaction) -> Void
     private let onBreakpointHit: (@Sendable (BreakpointRequestData) async -> (
@@ -346,26 +377,6 @@ final class TLSInterceptHandler: ChannelInboundHandler, RemovableChannelHandler,
         }
     }
 
-    nonisolated static func initialTunnelMode(
-        host: String,
-        sslProxyingManager: SSLProxyingManager,
-        bypassProxyManager: BypassProxyManager
-    ) -> InitialTunnelMode {
-        if bypassProxyManager.isHostBypassed(host) {
-            return .rawTunnel(.bypassProxyList)
-        }
-
-        if !sslProxyingManager.shouldIntercept(host) {
-            return .rawTunnel(.noSSLProxyingRule)
-        }
-
-        if sslProxyingManager.isAutoPassthrough(host) {
-            return .rawTunnel(.autoPassthrough)
-        }
-
-        return .intercept
-    }
-
     nonisolated private func installTLSHandlers(
         context: ChannelHandlerContext,
         identity: CustomTLSIdentity,
@@ -395,6 +406,8 @@ final class TLSInterceptHandler: ChannelInboundHandler, RemovableChannelHandler,
                 sslProxyingManager: self.sslProxyingManager,
                 customCertificateManager: self.customCertificateManager,
                 upstreamProxySnapshotProvider: self.upstreamProxySnapshotProvider,
+                captureContextProvider: self.captureContextProvider,
+                tunnelCaptureContext: self.tunnelCaptureContext,
                 clientSourcePort: self.clientSourcePort,
                 onTransactionComplete: callback,
                 onBreakpointHit: breakpointHit
@@ -493,7 +506,8 @@ final class TLSInterceptHandler: ChannelInboundHandler, RemovableChannelHandler,
                             statusMessage: "Connection Established",
                             state: .completed,
                             sourcePort: self.clientSourcePort,
-                            measuredDuration: self.tunnelElapsedDuration()
+                            measuredDuration: self.tunnelElapsedDuration(),
+                            captureContext: self.tunnelCaptureContext
                         )
                     )
                 } onFailure: { error in
@@ -537,6 +551,8 @@ final class PostHandshakeHandler: ChannelInboundHandler, RemovableChannelHandler
         sslProxyingManager: SSLProxyingManager,
         customCertificateManager: CustomCertificateManager = .shared,
         upstreamProxySnapshotProvider: @escaping @Sendable () -> UpstreamProxyResolvedConfiguration? = { nil },
+        captureContextProvider: @escaping @Sendable () -> TrafficCaptureContext? = { nil },
+        tunnelCaptureContext: TrafficCaptureContext? = nil,
         clientSourcePort: UInt16? = nil,
         onTransactionComplete: @escaping @Sendable (HTTPTransaction) -> Void,
         onBreakpointHit: (@Sendable (BreakpointRequestData) async -> (BreakpointDecision, BreakpointRequestData))? = nil
@@ -549,6 +565,8 @@ final class PostHandshakeHandler: ChannelInboundHandler, RemovableChannelHandler
         self.sslProxyingManager = sslProxyingManager
         self.customCertificateManager = customCertificateManager
         self.upstreamProxySnapshotProvider = upstreamProxySnapshotProvider
+        self.captureContextProvider = captureContextProvider
+        self.tunnelCaptureContext = tunnelCaptureContext
         self.clientSourcePort = clientSourcePort
         self.onTransactionComplete = onTransactionComplete
         self.onBreakpointHit = onBreakpointHit
@@ -574,6 +592,7 @@ final class PostHandshakeHandler: ChannelInboundHandler, RemovableChannelHandler
                 connectionLimiter: connectionLimiter,
                 customCertificateManager: customCertificateManager,
                 upstreamProxySnapshotProvider: upstreamProxySnapshotProvider,
+                captureContextProvider: captureContextProvider,
                 clientSourcePort: clientSourcePort,
                 onTransactionComplete: onTransactionComplete,
                 onBreakpointHit: onBreakpointHit
@@ -640,7 +659,8 @@ final class PostHandshakeHandler: ChannelInboundHandler, RemovableChannelHandler
                 state: .failed,
                 sourcePort: clientSourcePort,
                 measuredDuration: tunnelElapsedDuration(),
-                isTLSFailure: true
+                isTLSFailure: true,
+                captureContext: tunnelCaptureContext
             )
         )
 
@@ -655,7 +675,8 @@ final class PostHandshakeHandler: ChannelInboundHandler, RemovableChannelHandler
             statusMessage: "Connection Established",
             state: .completed,
             sourcePort: clientSourcePort,
-            measuredDuration: tunnelElapsedDuration()
+            measuredDuration: tunnelElapsedDuration(),
+            captureContext: tunnelCaptureContext
         )
     }
 
@@ -675,6 +696,8 @@ final class PostHandshakeHandler: ChannelInboundHandler, RemovableChannelHandler
     private let sslProxyingManager: SSLProxyingManager
     private let customCertificateManager: CustomCertificateManager
     private let upstreamProxySnapshotProvider: @Sendable () -> UpstreamProxyResolvedConfiguration?
+    private let captureContextProvider: @Sendable () -> TrafficCaptureContext?
+    private let tunnelCaptureContext: TrafficCaptureContext?
     private let clientSourcePort: UInt16?
     private let onTransactionComplete: @Sendable (HTTPTransaction) -> Void
     private let onBreakpointHit: (@Sendable (BreakpointRequestData) async -> (

--- a/Rockxy/Core/Services/RockxyNearbyTransferProtocol.swift
+++ b/Rockxy/Core/Services/RockxyNearbyTransferProtocol.swift
@@ -57,6 +57,7 @@ enum RockxyNearbyTransferError: LocalizedError {
     case transferTooLarge
     case emptyTransfer
     case invalidTransaction
+    case projectCatalogUnavailable
 
     // MARK: Internal
 
@@ -80,6 +81,8 @@ enum RockxyNearbyTransferError: LocalizedError {
             "The transferred session contains no requests."
         case .invalidTransaction:
             "The transferred session contains an invalid request."
+        case .projectCatalogUnavailable:
+            "Projects could not be loaded, so Rockxy did not import the transferred session."
         }
     }
 }

--- a/Rockxy/Core/Storage/PortableProjectDocument.swift
+++ b/Rockxy/Core/Storage/PortableProjectDocument.swift
@@ -1,0 +1,226 @@
+import Darwin
+import Foundation
+import os
+
+// Config-only file codec for the portable `.rockxyproject` document. This layer
+// only encodes/decodes and validates bytes: it never presents UI, mutates the
+// live ``ProjectStore``, or orchestrates import/merge. Reads fail closed on a
+// symlink, non-regular node, oversized data, corrupt JSON, an unsupported format
+// version, or any structurally invalid document — mirroring the fail-closed and
+// atomic-write posture of ``ProjectCatalogRepository``.
+
+// MARK: - PortableProjectDocumentError
+
+enum PortableProjectDocumentError: Error, Equatable {
+    case fileMissing
+    case symbolicLink
+    case notRegularFile
+    case fileTooLarge(bytes: Int)
+    case encodedDocumentTooLarge(bytes: Int)
+    case corruptData
+    case unsupportedFormatVersion(found: Int)
+    case invalid(PortableProjectError)
+}
+
+// MARK: - PortableProjectDocument
+
+enum PortableProjectDocument {
+    // MARK: Internal
+
+    /// Proposed public file extension for a portable Project configuration.
+    static let fileExtension = "rockxyproject"
+
+    /// Maximum encoded/pre-read document size (1 MiB). A config-only document never
+    /// carries traffic, so this bounds both hostile input and accidental bloat.
+    static let maxDocumentByteSize = Int(ImportSizePolicy.maxProjectConfigFileSize)
+
+    /// Encodes a ``Project``'s portable, allowlisted configuration to JSON bytes.
+    static func encode(_ project: Project) throws -> Data {
+        try encode(PortableProject(exporting: project))
+    }
+
+    /// Encodes an already-built portable document to JSON bytes, enforcing the size cap.
+    static func encode(_ portable: PortableProject) throws -> Data {
+        let data = try encoder.encode(portable)
+        guard data.count <= maxDocumentByteSize else {
+            throw PortableProjectDocumentError.encodedDocumentTooLarge(bytes: data.count)
+        }
+        return data
+    }
+
+    /// Atomically writes a Project's portable configuration to `url`. The sibling
+    /// temporary file is created as `0600` before any content is written, then
+    /// renamed over the destination so a symlink is replaced rather than followed.
+    static func write(
+        _ project: Project,
+        to url: URL,
+        fileManager: FileManager = .default,
+        beforePublishing: ((URL) throws -> Void)? = nil
+    )
+        throws
+    {
+        let data = try encode(project)
+        let temporaryURL = url
+            .deletingLastPathComponent()
+            .appendingPathComponent(".\(UUID().uuidString).rockxyproject.tmp")
+        var descriptor: Int32? = try openForPrivateWrite(temporaryURL)
+        guard let openDescriptor = descriptor else {
+            throw POSIXError(.EIO)
+        }
+        var didPublish = false
+        defer {
+            if let descriptor {
+                Darwin.close(descriptor)
+            }
+            if !didPublish {
+                try? fileManager.removeItem(at: temporaryURL)
+            }
+        }
+
+        try writeAll(data, to: openDescriptor)
+        guard Darwin.fsync(openDescriptor) == 0 else {
+            throw currentPOSIXError()
+        }
+        guard Darwin.close(openDescriptor) == 0 else {
+            descriptor = nil
+            throw currentPOSIXError()
+        }
+        descriptor = nil
+
+        try beforePublishing?(temporaryURL)
+        guard Darwin.rename(temporaryURL.path, url.path) == 0 else {
+            throw currentPOSIXError()
+        }
+        didPublish = true
+        try fileManager.setAttributes([.posixPermissions: 0o600], ofItemAtPath: url.path)
+        Self.logger.info("Exported portable project configuration")
+    }
+
+    /// Reads and fully validates a portable document from `url`, returning the
+    /// decoded DTO only after every fail-closed check passes. Never follows a
+    /// symlink and never reads a non-regular or oversized node.
+    static func read(
+        from url: URL,
+        fileManager _: FileManager = .default,
+        afterOpening: (() throws -> Void)? = nil
+    )
+        throws -> PortableProject
+    {
+        let data = try readBoundedRegularFile(from: url, afterOpening: afterOpening)
+
+        let portable: PortableProject
+        do {
+            portable = try decoder.decode(PortableProject.self, from: data)
+        } catch {
+            throw PortableProjectDocumentError.corruptData
+        }
+
+        guard portable.formatVersion == PortableProject.currentFormatVersion else {
+            throw PortableProjectDocumentError.unsupportedFormatVersion(found: portable.formatVersion)
+        }
+        do {
+            try portable.validate()
+        } catch let error as PortableProjectError {
+            throw PortableProjectDocumentError.invalid(error)
+        }
+        return portable
+    }
+
+    // MARK: Private
+
+    private static let logger = Logger(
+        subsystem: RockxyIdentity.current.logSubsystem,
+        category: "PortableProjectDocument"
+    )
+
+    private static let encoder: JSONEncoder = {
+        let configured = JSONEncoder()
+        configured.outputFormatting = [.sortedKeys]
+        return configured
+    }()
+
+    private static let decoder = JSONDecoder()
+
+    private static func openForPrivateWrite(_ url: URL) throws -> Int32 {
+        let descriptor = Darwin.open(
+            url.path,
+            O_WRONLY | O_CREAT | O_EXCL | O_CLOEXEC,
+            S_IRUSR | S_IWUSR
+        )
+        guard descriptor >= 0 else {
+            throw currentPOSIXError()
+        }
+        return descriptor
+    }
+
+    private static func writeAll(_ data: Data, to descriptor: Int32) throws {
+        try data.withUnsafeBytes { bytes in
+            guard let baseAddress = bytes.baseAddress else {
+                return
+            }
+            var offset = 0
+            while offset < bytes.count {
+                let written = Darwin.write(
+                    descriptor,
+                    baseAddress.advanced(by: offset),
+                    bytes.count - offset
+                )
+                if written < 0, errno == EINTR {
+                    continue
+                }
+                guard written > 0 else {
+                    throw currentPOSIXError()
+                }
+                offset += written
+            }
+        }
+    }
+
+    /// Opens once with no-follow semantics, validates that descriptor, and bounds
+    /// the read itself. The optional hook is a deterministic regression-test seam
+    /// for replacing the pathname after the descriptor is already secured.
+    private static func readBoundedRegularFile(
+        from url: URL,
+        afterOpening: (() throws -> Void)?
+    )
+        throws -> Data
+    {
+        let descriptor = Darwin.open(url.path, O_RDONLY | O_NOFOLLOW | O_CLOEXEC)
+        guard descriptor >= 0 else {
+            switch errno {
+            case ENOENT:
+                throw PortableProjectDocumentError.fileMissing
+            case ELOOP:
+                throw PortableProjectDocumentError.symbolicLink
+            default:
+                throw currentPOSIXError()
+            }
+        }
+        defer { Darwin.close(descriptor) }
+
+        var metadata = stat()
+        guard Darwin.fstat(descriptor, &metadata) == 0 else {
+            throw currentPOSIXError()
+        }
+        guard (metadata.st_mode & S_IFMT) == S_IFREG else {
+            throw PortableProjectDocumentError.notRegularFile
+        }
+        guard metadata.st_size >= 0,
+              metadata.st_size <= off_t(maxDocumentByteSize) else
+        {
+            throw PortableProjectDocumentError.fileTooLarge(bytes: Int(metadata.st_size))
+        }
+
+        try afterOpening?()
+        let handle = FileHandle(fileDescriptor: descriptor, closeOnDealloc: false)
+        let data = try handle.read(upToCount: maxDocumentByteSize + 1) ?? Data()
+        guard data.count <= maxDocumentByteSize else {
+            throw PortableProjectDocumentError.fileTooLarge(bytes: data.count)
+        }
+        return data
+    }
+
+    private static func currentPOSIXError() -> POSIXError {
+        POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+    }
+}

--- a/Rockxy/Core/Storage/ProjectCatalogRepository.swift
+++ b/Rockxy/Core/Storage/ProjectCatalogRepository.swift
@@ -1,0 +1,313 @@
+import Foundation
+import os
+
+// MARK: - ProjectCatalogPersisting
+
+/// Injection seam for Project catalog persistence. ``ProjectStore`` depends on
+/// this protocol so tests can substitute an in-memory or faulting double and do
+/// no real Application Support I/O.
+protocol ProjectCatalogPersisting: Sendable {
+    /// Loads the persisted catalog. A genuinely missing catalog is created and
+    /// persisted immediately so its identifiers are stable across launches. Throws
+    /// (without writing) for any invalid existing file.
+    func load() async throws -> ProjectCatalog
+    /// Atomically persists the catalog. Throws ``ProjectCatalogRepositoryError``
+    /// for oversized encodings, a stale revision, or an invalid on-disk file that
+    /// must not be overwritten.
+    func save(_ catalog: ProjectCatalog) async throws
+    /// Deliberate recovery entry point: replaces the on-disk catalog with a fresh
+    /// default, preserving the prior regular file as a bounded recovery backup
+    /// where safely possible. Only ever called after the user chooses to reset.
+    func reset() async throws -> ProjectCatalog
+}
+
+// MARK: - ProjectCatalogRepositoryError
+
+enum ProjectCatalogRepositoryError: Error, Equatable {
+    case fileTooLarge(bytes: Int)
+    case encodedCatalogTooLarge(bytes: Int)
+    case notRegularFile
+    case symbolicLink
+    case directorySymbolicLink
+    case notDirectory
+    case unsupportedSchemaVersion(found: Int)
+    case corruptData
+    case validation(ProjectCatalogValidationError)
+    case staleRevision(attempted: UInt64, current: UInt64)
+}
+
+// MARK: - ProjectCatalogRepository
+
+/// Actor-backed versioned JSON storage for the Project catalog.
+///
+/// The path is constant (`projects/catalog.json`); user input never becomes a
+/// path component. Reads are bounded and fail closed on a symlinked or
+/// non-directory container, or a symlink, non-regular, oversized, corrupt,
+/// newer-schema, or structurally invalid catalog file, and never overwrite such a
+/// file. A genuinely missing catalog is created and persisted so its UUIDs are
+/// stable. Writes go through a sibling temporary file with an atomic replacement,
+/// `0600` file / `0700` directory permissions, and a monotonic revision guard —
+/// seeded from disk before the first write — so a stale or out-of-order write
+/// cannot clobber a newer or invalid catalog.
+actor ProjectCatalogRepository: ProjectCatalogPersisting {
+    // MARK: Lifecycle
+
+    init(
+        directoryURL: URL = RockxyIdentity.current.appSupportPath("projects"),
+        fileManager: FileManager = .default,
+        now: @escaping @Sendable () -> Date = { Date() }
+    ) {
+        self.directoryURL = directoryURL
+        self.fileManager = fileManager
+        self.now = now
+        fileURL = directoryURL.appendingPathComponent(Self.catalogFileName, isDirectory: false)
+        recoveryBackupURL = directoryURL.appendingPathComponent(Self.recoveryBackupFileName, isDirectory: false)
+    }
+
+    // MARK: Internal
+
+    /// Maximum encoded/pre-read catalog size (2 MiB).
+    static let maxCatalogByteSize = 2_097_152
+
+    static let catalogFileName = "catalog.json"
+
+    /// Fixed-name copy of the previous regular file kept by ``reset()`` so a manual
+    /// recovery can inspect what was replaced. Bounded and never a symlink target.
+    static let recoveryBackupFileName = "catalog.recovery.json"
+
+    nonisolated let directoryURL: URL
+    nonisolated let fileURL: URL
+
+    func load() throws -> ProjectCatalog {
+        if let existing = try readValidatedCatalog() {
+            seedRevisionBaseline(with: existing.revision)
+            return existing
+        }
+        // Genuinely missing: create and persist immediately so the identifiers are
+        // stable across launches rather than regenerated until the first mutation.
+        try prepareDirectory()
+        let fresh = ProjectCatalog.makeDefault(now: now())
+        lastPersistedRevision = 0
+        try writeCatalogAtomically(fresh)
+        return fresh
+    }
+
+    func save(_ catalog: ProjectCatalog) throws {
+        // Revalidate the current regular file before every write. This protects not
+        // only save-before-load, but also a catalog replaced or corrupted by another
+        // process after this repository instance loaded it.
+        try refreshRevisionBaselineFromDisk()
+
+        guard catalog.revision > lastPersistedRevision else {
+            throw ProjectCatalogRepositoryError.staleRevision(
+                attempted: catalog.revision,
+                current: lastPersistedRevision
+            )
+        }
+        do {
+            try catalog.validate()
+        } catch let error as ProjectCatalogValidationError {
+            throw ProjectCatalogRepositoryError.validation(error)
+        }
+
+        try writeCatalogAtomically(catalog)
+        Self.logger.info("Persisted project catalog revision \(catalog.revision)")
+    }
+
+    func reset() throws -> ProjectCatalog {
+        try prepareDirectory()
+        try backUpExistingFileForRecovery()
+        let fresh = ProjectCatalog.makeDefault(now: now())
+        lastPersistedRevision = 0
+        try writeCatalogAtomically(fresh)
+        Self.logger.info("Reset project catalog to a fresh default")
+        return fresh
+    }
+
+    // MARK: Private
+
+    private static let logger = Logger(
+        subsystem: RockxyIdentity.current.logSubsystem,
+        category: "ProjectCatalogRepository"
+    )
+
+    private let fileManager: FileManager
+    private let now: @Sendable () -> Date
+    private let recoveryBackupURL: URL
+
+    /// Highest revision known to be on disk; guards against stale async writes.
+    private var lastPersistedRevision: UInt64 = 0
+
+    private let encoder: JSONEncoder = {
+        let configured = JSONEncoder()
+        configured.outputFormatting = [.sortedKeys]
+        return configured
+    }()
+
+    private let decoder = JSONDecoder()
+
+    /// Returns the validated on-disk catalog, or `nil` when the file is genuinely
+    /// missing. Throws (without mutating) for any invalid existing node, so callers
+    /// never overwrite a file they could not fully validate.
+    private func readValidatedCatalog() throws -> ProjectCatalog? {
+        try validateDirectoryIfPresent()
+
+        guard let type = fileType(at: fileURL) else {
+            return nil
+        }
+        guard type != .typeSymbolicLink else {
+            throw ProjectCatalogRepositoryError.symbolicLink
+        }
+        guard type == .typeRegular else {
+            throw ProjectCatalogRepositoryError.notRegularFile
+        }
+
+        let attributes = try fileManager.attributesOfItem(atPath: fileURL.path)
+        if let size = attributes[.size] as? Int, size > Self.maxCatalogByteSize {
+            throw ProjectCatalogRepositoryError.fileTooLarge(bytes: size)
+        }
+
+        let data = try Data(contentsOf: fileURL)
+        guard data.count <= Self.maxCatalogByteSize else {
+            throw ProjectCatalogRepositoryError.fileTooLarge(bytes: data.count)
+        }
+
+        let catalog: ProjectCatalog
+        do {
+            catalog = try decoder.decode(ProjectCatalog.self, from: data)
+        } catch {
+            throw ProjectCatalogRepositoryError.corruptData
+        }
+
+        guard catalog.schemaVersion == ProjectCatalog.currentSchemaVersion else {
+            throw ProjectCatalogRepositoryError.unsupportedSchemaVersion(found: catalog.schemaVersion)
+        }
+        do {
+            try catalog.validate()
+        } catch let error as ProjectCatalogValidationError {
+            throw ProjectCatalogRepositoryError.validation(error)
+        }
+        return catalog
+    }
+
+    private func seedRevisionBaseline(with revision: UInt64) {
+        lastPersistedRevision = max(lastPersistedRevision, revision)
+    }
+
+    private func refreshRevisionBaselineFromDisk() throws {
+        if let existing = try readValidatedCatalog() {
+            lastPersistedRevision = max(lastPersistedRevision, existing.revision)
+        }
+    }
+
+    /// Encodes, bounds, and atomically replaces the catalog file, enforcing final
+    /// `0700` directory and `0600` file permissions. Permission failures surface
+    /// rather than being ignored. Advances ``lastPersistedRevision`` on success.
+    private func writeCatalogAtomically(_ catalog: ProjectCatalog) throws {
+        let data = try encoder.encode(catalog)
+        guard data.count <= Self.maxCatalogByteSize else {
+            throw ProjectCatalogRepositoryError.encodedCatalogTooLarge(bytes: data.count)
+        }
+
+        try prepareDirectory()
+        try assertExistingFileSafeToReplace()
+
+        let tempURL = directoryURL.appendingPathComponent(
+            ".\(UUID().uuidString).catalog.tmp",
+            isDirectory: false
+        )
+        do {
+            try data.write(to: tempURL, options: .atomic)
+            try fileManager.setAttributes([.posixPermissions: 0o600], ofItemAtPath: tempURL.path)
+
+            if fileType(at: fileURL) != nil {
+                _ = try fileManager.replaceItemAt(fileURL, withItemAt: tempURL)
+            } else {
+                try fileManager.moveItem(at: tempURL, to: fileURL)
+            }
+            try fileManager.setAttributes([.posixPermissions: 0o600], ofItemAtPath: fileURL.path)
+        } catch {
+            try? fileManager.removeItem(at: tempURL)
+            throw error
+        }
+
+        lastPersistedRevision = catalog.revision
+    }
+
+    /// Rejects a symlinked or non-directory container before use.
+    private func validateDirectoryIfPresent() throws {
+        guard let type = fileType(at: directoryURL) else {
+            return
+        }
+        guard type != .typeSymbolicLink else {
+            throw ProjectCatalogRepositoryError.directorySymbolicLink
+        }
+        guard type == .typeDirectory else {
+            throw ProjectCatalogRepositoryError.notDirectory
+        }
+    }
+
+    /// Validates the container, creating it with `0700` when absent, and always
+    /// enforces final `0700` permissions on the leaf directory.
+    private func prepareDirectory() throws {
+        try validateDirectoryIfPresent()
+        if fileType(at: directoryURL) == nil {
+            try fileManager.createDirectory(
+                at: directoryURL,
+                withIntermediateDirectories: true,
+                attributes: [.posixPermissions: 0o700]
+            )
+        }
+        try fileManager.setAttributes([.posixPermissions: 0o700], ofItemAtPath: directoryURL.path)
+    }
+
+    private func assertExistingFileSafeToReplace() throws {
+        guard let type = fileType(at: fileURL) else {
+            return
+        }
+        guard type != .typeSymbolicLink else {
+            throw ProjectCatalogRepositoryError.symbolicLink
+        }
+        guard type == .typeRegular else {
+            throw ProjectCatalogRepositoryError.notRegularFile
+        }
+    }
+
+    /// Preserves the previous regular catalog file as a fixed-name recovery backup
+    /// when it is safe and bounded; never follows a symlink and discards any
+    /// non-regular or oversized node instead of preserving it.
+    private func backUpExistingFileForRecovery() throws {
+        guard let type = fileType(at: fileURL) else {
+            return
+        }
+        if let recoveryType = fileType(at: recoveryBackupURL) {
+            guard recoveryType == .typeRegular || recoveryType == .typeSymbolicLink else {
+                throw ProjectCatalogRepositoryError.notRegularFile
+            }
+            try fileManager.removeItem(at: recoveryBackupURL)
+        }
+        if type == .typeSymbolicLink {
+            // Explicit reset may remove the link itself, but never follows it.
+            try fileManager.removeItem(at: fileURL)
+            return
+        }
+        guard type == .typeRegular else {
+            throw ProjectCatalogRepositoryError.notRegularFile
+        }
+        let attributes = try fileManager.attributesOfItem(atPath: fileURL.path)
+        if let size = attributes[.size] as? Int, size > Self.maxCatalogByteSize {
+            throw ProjectCatalogRepositoryError.fileTooLarge(bytes: size)
+        }
+        try fileManager.moveItem(at: fileURL, to: recoveryBackupURL)
+        try fileManager.setAttributes([.posixPermissions: 0o600], ofItemAtPath: recoveryBackupURL.path)
+    }
+
+    /// The node type at `url` using `lstat` semantics (a symlink reports itself),
+    /// or `nil` when nothing exists there.
+    private func fileType(at url: URL) -> FileAttributeType? {
+        guard let attributes = try? fileManager.attributesOfItem(atPath: url.path) else {
+            return nil
+        }
+        return attributes[.type] as? FileAttributeType
+    }
+}

--- a/Rockxy/Core/TrafficCapture/TrafficCaptureContext.swift
+++ b/Rockxy/Core/TrafficCapture/TrafficCaptureContext.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+// MARK: - TrafficCaptureContext
+
+/// Immutable logical ownership captured when a request begins.
+///
+/// The proxy listener remains app-wide, but every completed transaction is routed
+/// back to the Project and capture session that owned its request start. The
+/// generation changes when that session is cleared, so late completions from the
+/// cleared generation cannot reappear in the new history.
+struct TrafficCaptureContext: Equatable, Hashable, Sendable {
+    let projectID: UUID
+    let sessionID: UUID
+    let generation: UInt64
+}
+
+// MARK: - TrafficCaptureContextStore
+
+/// Lock-backed bridge between main-actor Project selection and SwiftNIO event-loop
+/// threads. NIO handlers take a synchronous snapshot; they never reach into UI or
+/// actor-isolated state while a request is being decoded.
+final class TrafficCaptureContextStore: @unchecked Sendable {
+    // MARK: Lifecycle
+
+    init(_ context: TrafficCaptureContext? = nil) {
+        currentContext = context
+    }
+
+    // MARK: Internal
+
+    func snapshot() -> TrafficCaptureContext? {
+        lock.lock()
+        defer { lock.unlock() }
+        return currentContext
+    }
+
+    func update(_ context: TrafficCaptureContext?) {
+        lock.lock()
+        currentContext = context
+        lock.unlock()
+    }
+
+    // MARK: Private
+
+    private let lock = NSLock()
+    private var currentContext: TrafficCaptureContext?
+}

--- a/Rockxy/Core/TrafficCapture/TrafficSessionManager.swift
+++ b/Rockxy/Core/TrafficCapture/TrafficSessionManager.swift
@@ -91,13 +91,23 @@ actor TrafficSessionManager {
     /// can align its own generation tag with the actor's. Use this for production session
     /// rollovers where the callback must run before the new generation is observed.
     func beginNewSession() async -> UInt {
+        let rollover = await beginNewSessionPreservingPending()
+        return rollover.generation
+    }
+
+    /// Atomically advances the global delivery generation while returning the
+    /// pending transactions that had already completed. Project-scoped clear uses
+    /// this to retain only explicitly routed transactions owned by other Projects;
+    /// unowned and active-Project pending work is still discarded.
+    func beginNewSessionPreservingPending() async -> (generation: UInt, pending: [HTTPTransaction]) {
+        let pending = pendingUpdates
         pendingUpdates.removeAll()
         totalBuffered = 0
         generation &+= 1
         if let onBeginNewSession {
             await onBeginNewSession(generation)
         }
-        return generation
+        return (generation, pending)
     }
 
     func reportAcceptedCount(_ count: Int, generation: UInt) {

--- a/Rockxy/Core/Utilities/ImportSizePolicy.swift
+++ b/Rockxy/Core/Utilities/ImportSizePolicy.swift
@@ -13,6 +13,11 @@ enum ImportSizePolicy {
     static let maxHARFileSize: UInt64 = 100 * 1_024 * 1_024 // 100 MB
     static let maxSessionFileSize: UInt64 = 200 * 1_024 * 1_024 // 200 MB
 
+    /// Portable Project configuration files carry only view intent (names, filter
+    /// and layout preferences) — never captured traffic — so a tight 1 MiB cap is
+    /// ample and bounds hostile/corrupt allocation on import.
+    static let maxProjectConfigFileSize: UInt64 = 1 * 1_024 * 1_024 // 1 MiB
+
     static func validateFileSize(at url: URL, maxSize: UInt64) -> Result<Void, ImportSizeError> {
         do {
             let attributes = try FileManager.default.attributesOfItem(atPath: url.path)

--- a/Rockxy/Info.plist
+++ b/Rockxy/Info.plist
@@ -24,6 +24,28 @@
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>UTExportedTypeDeclarations</key>
+	<array>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.json</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>Rockxy Project Configuration</string>
+			<key>UTTypeIdentifier</key>
+			<string>$(ROCKXY_SHARED_UTTYPE_PREFIX).project</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>rockxyproject</string>
+				</array>
+				<key>public.mime-type</key>
+				<string>application/vnd.rockxy.project+json</string>
+			</dict>
+		</dict>
+	</array>
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>NSHumanReadableCopyright</key>

--- a/Rockxy/Models/Network/HTTPRequestData.swift
+++ b/Rockxy/Models/Network/HTTPRequestData.swift
@@ -15,6 +15,27 @@ struct HTTPRequestData: Sendable {
     var headers: [HTTPHeader]
     var body: Data?
     var contentType: ContentType?
+    /// Logical Project/session ownership captured at request start. It is runtime
+    /// routing metadata and is deliberately excluded from HAR/session serializers.
+    let captureContext: TrafficCaptureContext?
+
+    init(
+        method: String,
+        url: URL,
+        httpVersion: String,
+        headers: [HTTPHeader],
+        body: Data? = nil,
+        contentType: ContentType? = nil,
+        captureContext: TrafficCaptureContext? = nil
+    ) {
+        self.method = method
+        self.url = url
+        self.httpVersion = httpVersion
+        self.headers = headers
+        self.body = body
+        self.contentType = contentType
+        self.captureContext = captureContext
+    }
 
     var host: String {
         url.host() ?? ""

--- a/Rockxy/Models/Network/HTTPTransaction.swift
+++ b/Rockxy/Models/Network/HTTPTransaction.swift
@@ -36,6 +36,7 @@ final class HTTPTransaction: Identifiable, @unchecked Sendable {
         self.graphQLInfo = graphQLInfo
         self.web3RPCInfo = web3RPCInfo
         self.x402Info = x402Info
+        captureContext = request.captureContext
     }
 
     // MARK: Internal
@@ -64,6 +65,10 @@ final class HTTPTransaction: Identifiable, @unchecked Sendable {
     var matchedRuleActionSummary: String?
     var matchedRulePattern: String?
 
+    /// Runtime-only ownership. Portable session files intentionally omit this so
+    /// an imported capture is assigned to the destination Project chosen by the user.
+    private(set) var captureContext: TrafficCaptureContext?
+
     /// Request-list ordering metadata. Tracks the order this transaction was received by
     /// the coordinator, independent of `timestamp`. Used only for the request-list "row #"
     /// column sort. Must not be used by export, persistence, inspector, or replay.
@@ -84,6 +89,15 @@ final class HTTPTransaction: Identifiable, @unchecked Sendable {
         matchedRuleName = rule.name
         matchedRuleActionSummary = rule.action.matchedRuleActionSummary
         matchedRulePattern = rule.matchCondition.urlPattern
+    }
+
+    /// Assigns ownership to locally-created/imported transactions while preserving
+    /// a proxy-captured request's immutable request-start route.
+    func assignCaptureContextIfMissing(_ context: TrafficCaptureContext) {
+        guard captureContext == nil else {
+            return
+        }
+        captureContext = context
     }
 }
 

--- a/Rockxy/Models/Projects/PortableProject.swift
+++ b/Rockxy/Models/Projects/PortableProject.swift
@@ -1,0 +1,303 @@
+import Foundation
+
+// Portable, config-only Project transfer DTO for the `.rockxyproject` format.
+//
+// This is a deliberately *external* contract, distinct from the internal on-disk
+// ``ProjectCatalog`` document: it carries only a Project name plus explicitly
+// allowlisted traffic-tab filter/layout intent. It is default-deny — it has no
+// field for captured transactions, bodies, headers, cookies, logs, credential
+// stores, local file paths, scripts, project/tab UUIDs, or machine-local focus-set
+// IDs. User-authored filter text is intentionally portable and may itself be
+// sensitive, so the export UI warns users to review it before sharing. Importing
+// regenerates fresh identifiers and drops machine-local focus references.
+
+// MARK: - PortableProjectError
+
+/// Rejection reasons for a decoded portable Project. All fail closed.
+enum PortableProjectError: Error, Equatable {
+    case unsupportedFormatVersion(found: Int)
+    case nameInvalid(ProjectNameNormalizationError)
+    case tabCountOutOfRange(count: Int)
+    case activeTabIndexOutOfRange(index: Int)
+    case tabCapacityExceededAfterDefaultInsertion(required: Int, limit: Int)
+    case tabInvalid(ProjectSnapshotValidationError)
+}
+
+// MARK: - PortableFilterRule
+
+/// Portable form of a single advanced filter row. Unlike ``FilterRuleSnapshot``
+/// it deliberately carries no `id`: portable files never encode UUIDs, and a
+/// fresh identifier is minted when the row is materialized on import.
+struct PortableFilterRule: Codable, Equatable {
+    // MARK: Lifecycle
+
+    init(
+        isEnabled: Bool = true,
+        connectorRawValue: String = FilterLogicConnector.and.rawValue,
+        fieldRawValue: String = FilterField.url.rawValue,
+        operatorRawValue: String = FilterOperator.contains.rawValue,
+        value: String = ""
+    ) {
+        self.isEnabled = isEnabled
+        self.connectorRawValue = connectorRawValue
+        self.fieldRawValue = fieldRawValue
+        self.operatorRawValue = operatorRawValue
+        self.value = value
+    }
+
+    init(_ snapshot: FilterRuleSnapshot) {
+        isEnabled = snapshot.isEnabled
+        connectorRawValue = snapshot.connectorRawValue
+        fieldRawValue = snapshot.fieldRawValue
+        operatorRawValue = snapshot.operatorRawValue
+        value = snapshot.value.boundedToGraphemes(ProjectStructuralLimits.maxFilterStringGraphemes)
+    }
+
+    // MARK: Internal
+
+    var isEnabled: Bool
+    var connectorRawValue: String
+    var fieldRawValue: String
+    var operatorRawValue: String
+    var value: String
+
+    /// Materializes a durable snapshot row with a freshly minted identifier.
+    func makeSnapshot() -> FilterRuleSnapshot {
+        FilterRuleSnapshot(
+            id: UUID(),
+            isEnabled: isEnabled,
+            connectorRawValue: connectorRawValue,
+            fieldRawValue: fieldRawValue,
+            operatorRawValue: operatorRawValue,
+            value: value
+        )
+    }
+
+    func validate() throws {
+        guard value.count <= ProjectStructuralLimits.maxFilterStringGraphemes else {
+            throw ProjectSnapshotValidationError.stringTooLong(field: "portableFilterRule.value")
+        }
+    }
+}
+
+// MARK: - PortableProjectTab
+
+/// Portable, allowlisted view intent of a single traffic tab.
+///
+/// Every field here is an explicit copy from ``ProjectTabSnapshot``. The tab `id`
+/// and `activeFocusSetID` are intentionally omitted so they cannot leave the
+/// machine; importing mints a fresh tab identifier and leaves the focus reference
+/// nil until the user re-selects one locally.
+struct PortableProjectTab: Codable, Equatable {
+    // MARK: Lifecycle
+
+    init(
+        title: String,
+        isClosable: Bool,
+        filter: FilterCriteriaSnapshot = .empty,
+        advancedFilterRows: [PortableFilterRule] = [],
+        isFilterBarVisible: Bool = false,
+        mainTabRawValue: String = MainTab.traffic.rawValue,
+        inspectorLayoutRawValue: String = InspectorLayoutCoding.hidden,
+        isContextDockVisible: Bool = false,
+        contextDockTabRawValue: String = ContextDockTabCoding.details,
+        focusNavigatorModeRawValue: String = FocusNavigatorMode.browse.rawValue,
+        activeTrafficSignalRawValue: String? = nil,
+        mutedTrafficSources: [MutedTrafficSourceSnapshot] = []
+    ) {
+        self.title = title
+        self.isClosable = isClosable
+        self.filter = filter
+        self.advancedFilterRows = advancedFilterRows
+        self.isFilterBarVisible = isFilterBarVisible
+        self.mainTabRawValue = mainTabRawValue
+        self.inspectorLayoutRawValue = inspectorLayoutRawValue
+        self.isContextDockVisible = isContextDockVisible
+        self.contextDockTabRawValue = contextDockTabRawValue
+        self.focusNavigatorModeRawValue = focusNavigatorModeRawValue
+        self.activeTrafficSignalRawValue = activeTrafficSignalRawValue
+        self.mutedTrafficSources = mutedTrafficSources
+    }
+
+    /// Copies the portable, allowlisted subset of a durable tab snapshot, dropping
+    /// its identifier and machine-local focus-set reference.
+    init(_ snapshot: ProjectTabSnapshot) {
+        title = snapshot.title
+        isClosable = snapshot.isClosable
+        filter = snapshot.filter
+        advancedFilterRows = snapshot.advancedFilterRows.map { PortableFilterRule($0) }
+        isFilterBarVisible = snapshot.isFilterBarVisible
+        mainTabRawValue = snapshot.mainTabRawValue
+        inspectorLayoutRawValue = snapshot.inspectorLayoutRawValue
+        isContextDockVisible = snapshot.isContextDockVisible
+        contextDockTabRawValue = snapshot.contextDockTabRawValue
+        focusNavigatorModeRawValue = snapshot.focusNavigatorModeRawValue
+        activeTrafficSignalRawValue = snapshot.activeTrafficSignalRawValue
+        mutedTrafficSources = snapshot.mutedTrafficSources
+    }
+
+    // MARK: Internal
+
+    var title: String
+    var isClosable: Bool
+    var filter: FilterCriteriaSnapshot
+    var advancedFilterRows: [PortableFilterRule]
+    var isFilterBarVisible: Bool
+    var mainTabRawValue: String
+    var inspectorLayoutRawValue: String
+    var isContextDockVisible: Bool
+    var contextDockTabRawValue: String
+    var focusNavigatorModeRawValue: String
+    var activeTrafficSignalRawValue: String?
+    var mutedTrafficSources: [MutedTrafficSourceSnapshot]
+
+    /// Materializes a durable tab snapshot with a fresh identifier, a canonical
+    /// title, freshly identified filter rows, and no focus-set reference.
+    func makeTabSnapshot() -> ProjectTabSnapshot {
+        ProjectTabSnapshot(
+            id: UUID(),
+            title: (try? ProjectNormalization.normalizedDisplayName(title)) ?? title,
+            isClosable: isClosable,
+            filter: filter,
+            advancedFilterRows: advancedFilterRows.map { $0.makeSnapshot() },
+            isFilterBarVisible: isFilterBarVisible,
+            mainTabRawValue: mainTabRawValue,
+            inspectorLayoutRawValue: inspectorLayoutRawValue,
+            isContextDockVisible: isContextDockVisible,
+            contextDockTabRawValue: contextDockTabRawValue,
+            focusNavigatorModeRawValue: focusNavigatorModeRawValue,
+            activeTrafficSignalRawValue: activeTrafficSignalRawValue,
+            activeFocusSetID: nil,
+            mutedTrafficSources: mutedTrafficSources
+        )
+    }
+
+    /// Validates decoded bounds. The title need only be *normalizable* (imports may
+    /// arrive in a non-canonical Unicode form); ``makeTabSnapshot()`` canonicalizes
+    /// it. Filter strings and collections are bounded exactly as the durable form.
+    func validate() throws {
+        do {
+            _ = try ProjectNormalization.normalizedDisplayName(title)
+        } catch let error as ProjectNameNormalizationError {
+            throw ProjectSnapshotValidationError.titleInvalid(error)
+        }
+        guard advancedFilterRows.count <= ProjectStructuralLimits.maxAdvancedFilterRows else {
+            throw ProjectSnapshotValidationError.collectionTooLarge(field: "portableTab.advancedFilterRows")
+        }
+        guard mutedTrafficSources.count <= ProjectStructuralLimits.maxMutedTrafficSources else {
+            throw ProjectSnapshotValidationError.collectionTooLarge(field: "portableTab.mutedTrafficSources")
+        }
+        try filter.validate()
+        for row in advancedFilterRows {
+            try row.validate()
+        }
+        for source in mutedTrafficSources {
+            try source.validate()
+        }
+    }
+}
+
+// MARK: - PortableProject
+
+/// Versioned, config-only portable Project document (`.rockxyproject`).
+///
+/// `formatVersion` is the *external* transfer contract version and is deliberately
+/// independent of ``ProjectCatalog/currentSchemaVersion`` (the internal on-disk
+/// document). The active tab is referenced by ``activeTabIndex`` rather than a
+/// persisted UUID so no identifier crosses the machine boundary.
+struct PortableProject: Codable, Equatable {
+    // MARK: Lifecycle
+
+    init(
+        formatVersion: Int = PortableProject.currentFormatVersion,
+        name: String,
+        activeTabIndex: Int,
+        tabs: [PortableProjectTab]
+    ) {
+        self.formatVersion = formatVersion
+        self.name = name
+        self.activeTabIndex = activeTabIndex
+        self.tabs = tabs
+    }
+
+    /// Captures the portable, allowlisted subset of a durable ``Project``. Traffic,
+    /// identifiers, and focus-set references are never copied.
+    init(exporting project: Project) {
+        formatVersion = Self.currentFormatVersion
+        name = project.name
+        activeTabIndex = project.tabs.firstIndex { $0.id == project.activeTabID } ?? 0
+        tabs = project.tabs.map { PortableProjectTab($0) }
+    }
+
+    // MARK: Internal
+
+    /// External transfer-format version. Independent of the internal catalog schema.
+    static let currentFormatVersion = 1
+
+    var formatVersion: Int
+    var name: String
+    var activeTabIndex: Int
+    var tabs: [PortableProjectTab]
+
+    /// Materializes a valid, live ``Project`` with freshly minted identifiers.
+    ///
+    /// The name/titles are canonicalized, every tab receives a new UUID, filter
+    /// rows are re-identified, focus-set references are dropped, and the tab
+    /// invariants (a guaranteed non-closable default, unique IDs, capacity) are
+    /// re-established through ``Project/normalizedTabs(_:activeTabID:maxTabs:)``.
+    func makeProject(
+        id: UUID = UUID(),
+        now: Date,
+        maxTabs: Int = ProjectStructuralLimits.tabCountRange.upperBound
+    )
+        throws -> Project
+    {
+        let snapshots = tabs.map { $0.makeTabSnapshot() }
+        let requiredCount = snapshots.count + (snapshots.contains { !$0.isClosable } ? 0 : 1)
+        guard requiredCount <= maxTabs else {
+            throw PortableProjectError.tabCapacityExceededAfterDefaultInsertion(
+                required: requiredCount,
+                limit: maxTabs
+            )
+        }
+        let desiredActiveTabID = snapshots.indices.contains(activeTabIndex)
+            ? snapshots[activeTabIndex].id
+            : (snapshots.first?.id ?? UUID())
+        let normalized = Project.normalizedTabs(snapshots, activeTabID: desiredActiveTabID, maxTabs: maxTabs)
+        return Project(
+            id: id,
+            name: (try? ProjectNormalization.normalizedDisplayName(name)) ?? name,
+            createdAt: now,
+            updatedAt: now,
+            activeTabID: normalized.activeTabID,
+            tabs: normalized.tabs
+        )
+    }
+
+    /// Validates every decoded bound and fails closed on an unsupported version,
+    /// an unnormalizable name, an out-of-range tab count or active index, or any
+    /// invalid tab. Unknown JSON keys are ignored by the decoder before this runs.
+    func validate() throws {
+        guard formatVersion == Self.currentFormatVersion else {
+            throw PortableProjectError.unsupportedFormatVersion(found: formatVersion)
+        }
+        do {
+            _ = try ProjectNormalization.normalizedDisplayName(name)
+        } catch let error as ProjectNameNormalizationError {
+            throw PortableProjectError.nameInvalid(error)
+        }
+        guard ProjectStructuralLimits.tabCountRange.contains(tabs.count) else {
+            throw PortableProjectError.tabCountOutOfRange(count: tabs.count)
+        }
+        guard tabs.indices.contains(activeTabIndex) else {
+            throw PortableProjectError.activeTabIndexOutOfRange(index: activeTabIndex)
+        }
+        for tab in tabs {
+            do {
+                try tab.validate()
+            } catch let error as ProjectSnapshotValidationError {
+                throw PortableProjectError.tabInvalid(error)
+            }
+        }
+    }
+}

--- a/Rockxy/Models/Projects/ProjectCatalog.swift
+++ b/Rockxy/Models/Projects/ProjectCatalog.swift
@@ -1,0 +1,213 @@
+import Foundation
+
+// MARK: - ProjectCatalogValidationError
+
+/// Structural rejection reasons for a decoded or mutated catalog. These are
+/// integrity failures (fail closed), not user-facing capacity messaging.
+enum ProjectCatalogValidationError: Error, Equatable {
+    case projectCountOutOfRange(count: Int)
+    case duplicateProjectID(UUID)
+    case duplicateProjectName(foldedKey: String)
+    case projectNameInvalid(ProjectNameNormalizationError)
+    case unresolvedActiveProjectID
+    case tabCountOutOfRange(projectID: UUID, count: Int)
+    case duplicateTabID(UUID)
+    case missingNonClosableTab(projectID: UUID)
+    case unresolvedActiveTabID(projectID: UUID)
+    case tabSnapshotInvalid(ProjectSnapshotValidationError)
+}
+
+// MARK: - Project
+
+/// A durable, local Project: a stable identity plus the serializable configuration
+/// of its traffic tabs. Runtime capture is logically routed by this identity but is
+/// not embedded in the bounded catalog; rules, secrets, favorites, and focus-set
+/// definitions remain app-level libraries or references.
+struct Project: Codable, Equatable, Identifiable {
+    // MARK: Lifecycle
+
+    init(
+        id: UUID = UUID(),
+        name: String,
+        createdAt: Date,
+        updatedAt: Date,
+        activeTabID: UUID,
+        tabs: [ProjectTabSnapshot]
+    ) {
+        self.id = id
+        self.name = name
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+        self.activeTabID = activeTabID
+        self.tabs = tabs
+    }
+
+    // MARK: Internal
+
+    let id: UUID
+    var name: String
+    var createdAt: Date
+    var updatedAt: Date
+    var activeTabID: UUID
+    var tabs: [ProjectTabSnapshot]
+
+    /// Builds a valid Project with a single guaranteed non-closable default tab.
+    static func makeDefault(
+        id: UUID = UUID(),
+        name: String,
+        createdAt: Date,
+        updatedAt: Date
+    )
+        -> Project
+    {
+        let tab = ProjectTabSnapshot.makeDefaultAllTraffic()
+        return Project(
+            id: id,
+            name: name,
+            createdAt: createdAt,
+            updatedAt: updatedAt,
+            activeTabID: tab.id,
+            tabs: [tab]
+        )
+    }
+
+    /// Guarantees the tab invariants for an arbitrary snapshot list, returning the
+    /// repaired tabs and a valid active ID.
+    static func normalizedTabs(
+        _ snapshots: [ProjectTabSnapshot],
+        activeTabID desiredActiveTabID: UUID,
+        maxTabs: Int
+    )
+        -> (tabs: [ProjectTabSnapshot], activeTabID: UUID)
+    {
+        let capacity = max(maxTabs, ProjectStructuralLimits.tabCountRange.lowerBound)
+        var tabs = snapshots
+
+        // Drop duplicate IDs, preserving first occurrence.
+        var seen = Set<UUID>()
+        tabs = tabs.filter { seen.insert($0.id).inserted }
+
+        if tabs.isEmpty {
+            tabs = [ProjectTabSnapshot.makeDefaultAllTraffic()]
+        } else if !tabs.contains(where: { !$0.isClosable }) {
+            tabs.insert(ProjectTabSnapshot.makeDefaultAllTraffic(), at: 0)
+        }
+
+        if tabs.count > capacity {
+            let defaultIndex = tabs.firstIndex { !$0.isClosable } ?? 0
+            let keeper = tabs.remove(at: defaultIndex)
+            tabs = [keeper] + tabs.prefix(capacity - 1)
+        }
+
+        let activeTabID = tabs.contains { $0.id == desiredActiveTabID }
+            ? desiredActiveTabID
+            : tabs[0].id
+        return (tabs, activeTabID)
+    }
+
+    func validate() throws {
+        do {
+            try ProjectNormalization.requireCanonical(name)
+        } catch let error as ProjectNameNormalizationError {
+            throw ProjectCatalogValidationError.projectNameInvalid(error)
+        }
+
+        guard ProjectStructuralLimits.tabCountRange.contains(tabs.count) else {
+            throw ProjectCatalogValidationError.tabCountOutOfRange(projectID: id, count: tabs.count)
+        }
+
+        var seen = Set<UUID>()
+        for tab in tabs {
+            guard seen.insert(tab.id).inserted else {
+                throw ProjectCatalogValidationError.duplicateTabID(tab.id)
+            }
+            do {
+                try tab.validate()
+            } catch let error as ProjectSnapshotValidationError {
+                throw ProjectCatalogValidationError.tabSnapshotInvalid(error)
+            }
+        }
+
+        guard tabs.contains(where: { !$0.isClosable }) else {
+            throw ProjectCatalogValidationError.missingNonClosableTab(projectID: id)
+        }
+        guard tabs.contains(where: { $0.id == activeTabID }) else {
+            throw ProjectCatalogValidationError.unresolvedActiveTabID(projectID: id)
+        }
+    }
+}
+
+// MARK: - ProjectCatalog
+
+/// The versioned root persisted document. Owns 1...N Projects, the active Project
+/// reference, a schema version, and a monotonic revision that lets the repository
+/// reject stale out-of-order writes.
+struct ProjectCatalog: Codable, Equatable {
+    // MARK: Lifecycle
+
+    init(
+        schemaVersion: Int = ProjectCatalog.currentSchemaVersion,
+        revision: UInt64 = 1,
+        activeProjectID: UUID,
+        projects: [Project]
+    ) {
+        self.schemaVersion = schemaVersion
+        self.revision = revision
+        self.activeProjectID = activeProjectID
+        self.projects = projects
+    }
+
+    // MARK: Internal
+
+    static let currentSchemaVersion = 1
+
+    var schemaVersion: Int
+    var revision: UInt64
+    var activeProjectID: UUID
+    var projects: [Project]
+
+    var activeProject: Project? {
+        projects.first { $0.id == activeProjectID }
+    }
+
+    /// A valid one-Project catalog used for a missing file or a fresh install.
+    static func makeDefault(
+        name: String = ProjectStructuralLimits.defaultProjectName,
+        now: Date
+    )
+        -> ProjectCatalog
+    {
+        let project = Project.makeDefault(name: name, createdAt: now, updatedAt: now)
+        return ProjectCatalog(
+            schemaVersion: currentSchemaVersion,
+            revision: 1,
+            activeProjectID: project.id,
+            projects: [project]
+        )
+    }
+
+    /// Validates every structural invariant. Does not check the schema version:
+    /// that is the repository's decode-time concern.
+    func validate() throws {
+        guard ProjectStructuralLimits.projectCountRange.contains(projects.count) else {
+            throw ProjectCatalogValidationError.projectCountOutOfRange(count: projects.count)
+        }
+
+        var seenIDs = Set<UUID>()
+        var seenNameKeys = Set<String>()
+        for project in projects {
+            guard seenIDs.insert(project.id).inserted else {
+                throw ProjectCatalogValidationError.duplicateProjectID(project.id)
+            }
+            try project.validate()
+            let key = ProjectNormalization.foldedKey(for: project.name)
+            guard seenNameKeys.insert(key).inserted else {
+                throw ProjectCatalogValidationError.duplicateProjectName(foldedKey: key)
+            }
+        }
+
+        guard projects.contains(where: { $0.id == activeProjectID }) else {
+            throw ProjectCatalogValidationError.unresolvedActiveProjectID
+        }
+    }
+}

--- a/Rockxy/Models/Projects/ProjectNormalization.swift
+++ b/Rockxy/Models/Projects/ProjectNormalization.swift
@@ -1,0 +1,114 @@
+import Foundation
+
+// MARK: - ProjectNameNormalizationError
+
+/// Deterministic rejection reasons for a Project name or tab title.
+enum ProjectNameNormalizationError: Error, Equatable {
+    /// The value was empty after trimming and normalization.
+    case empty
+    /// The value contained a control, or unsafe invisible/directional formatting,
+    /// character after normalization (e.g. U+202E RLO, U+200B ZWSP, U+00AD soft
+    /// hyphen). Legitimate joining controls (U+200C ZWNJ, U+200D ZWJ) are allowed.
+    case containsControlCharacters
+    /// The value exceeded ``ProjectStructuralLimits/nameGraphemeRange``.
+    case tooLong(graphemeCount: Int)
+    /// The stored value was not already in canonical form: it differs from its own
+    /// ``ProjectNormalization/normalizedDisplayName(_:)``. Persisted names/titles
+    /// must be stored canonically so folded uniqueness is well defined.
+    case notCanonical
+}
+
+// MARK: - ProjectNormalization
+
+/// Deterministic normalization and folding for Project names and tab titles.
+///
+/// The same rules apply to both so persisted display text is stable across
+/// launches and platforms: trim surrounding whitespace/newlines, apply canonical
+/// Unicode composition, reject control and unsafe formatting characters, and
+/// bound the grapheme count.
+/// Uniqueness compares the *folded* key so visually identical names that differ
+/// only by case or diacritics collide deterministically.
+enum ProjectNormalization {
+    // MARK: Internal
+
+    /// Returns the canonical display form of a name/title, or throws a
+    /// deterministic reason it is invalid. Canonical means: canonical Unicode
+    /// composition, surrounding whitespace trimmed, no control or unsafe
+    /// invisible/directional formatting characters (joining controls U+200C/U+200D
+    /// are preserved), and a bounded grapheme count. Applying this twice is
+    /// idempotent — that fixed point is exactly what ``requireCanonical(_:)``
+    /// enforces on stored values.
+    static func normalizedDisplayName(_ raw: String) throws -> String {
+        // Canonical composition first, then trim, so composed/decomposed forms of
+        // a surrounding-whitespace character are handled identically.
+        let normalized = raw
+            .precomposedStringWithCanonicalMapping
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard !normalized.isEmpty else {
+            throw ProjectNameNormalizationError.empty
+        }
+
+        if normalized.unicodeScalars.contains(where: isDisallowedScalar) {
+            throw ProjectNameNormalizationError.containsControlCharacters
+        }
+
+        let graphemeCount = normalized.count
+        guard ProjectStructuralLimits.nameGraphemeRange.contains(graphemeCount) else {
+            throw ProjectNameNormalizationError.tooLong(graphemeCount: graphemeCount)
+        }
+
+        return normalized
+    }
+
+    /// Throws unless `value` is already in canonical form (equal to its own
+    /// ``normalizedDisplayName(_:)``). Used by structural validation to reject a
+    /// stored name/title that was never canonicalized, so folded uniqueness always
+    /// compares canonical values.
+    static func requireCanonical(_ value: String) throws {
+        let canonical = try normalizedDisplayName(value)
+        guard canonical.unicodeScalars.elementsEqual(value.unicodeScalars) else {
+            throw ProjectNameNormalizationError.notCanonical
+        }
+    }
+
+    /// Returns the deterministic uniqueness key for an already-normalized name.
+    /// Folding is case- and diacritic-insensitive under a fixed POSIX locale so
+    /// the result does not vary with the host's current locale.
+    static func foldedKey(for normalizedName: String) -> String {
+        normalizedName.folding(
+            options: [.caseInsensitive, .diacriticInsensitive, .widthInsensitive],
+            locale: Locale(identifier: "en_US_POSIX")
+        )
+    }
+
+    /// Convenience: normalize then fold, used when comparing raw user input to
+    /// existing normalized names.
+    static func foldedKey(forRawName raw: String) throws -> String {
+        try foldedKey(for: normalizedDisplayName(raw))
+    }
+
+    // MARK: Private
+
+    /// Zero-width joiners that are legitimate in emoji sequences (e.g. the family
+    /// emoji) and joining scripts, so they must survive normalization even though
+    /// they share the `.format` general category with spoofing scalars.
+    private static let allowedFormatScalars: Set<Unicode.Scalar> = [
+        "\u{200C}", // ZERO WIDTH NON-JOINER
+        "\u{200D}", // ZERO WIDTH JOINER
+    ]
+
+    /// Rejects control characters and unsafe invisible/directional formatting used
+    /// for spoofing (e.g. U+202E RLO, U+200B ZWSP, U+00AD soft hyphen) while
+    /// preserving the joining controls in ``allowedFormatScalars``.
+    private static func isDisallowedScalar(_ scalar: Unicode.Scalar) -> Bool {
+        switch scalar.properties.generalCategory {
+        case .control:
+            true
+        case .format:
+            !allowedFormatScalars.contains(scalar)
+        default:
+            false
+        }
+    }
+}

--- a/Rockxy/Models/Projects/ProjectStore.swift
+++ b/Rockxy/Models/Projects/ProjectStore.swift
@@ -1,0 +1,551 @@
+import Foundation
+import os
+
+// MARK: - ProjectMutationError
+
+/// User-actionable rejection reasons for a Project mutation.
+enum ProjectMutationError: Error, Equatable {
+    case nameInvalid(ProjectNameNormalizationError)
+    case duplicateName
+    case capacityReached(limit: Int)
+    case tabCapacityReached(limit: Int)
+    case projectNotFound
+    case cannotDeleteFinalProject
+    /// A capture clear is crossing an actor boundary. Active-Project transitions
+    /// are serialized until it completes so observable state cannot change owner.
+    case captureClearInProgress
+    /// The store has no confirmed catalog to mutate yet (never loaded, still
+    /// loading, or a load failed). Mutations are refused so a failed load cannot
+    /// overwrite the invalid on-disk catalog. See ``ProjectLoadState``.
+    case storeNotReady
+    /// The monotonic revision counter is exhausted. The catalog is left unchanged
+    /// rather than wrapping and silently reordering behind a persisted revision.
+    case revisionExhausted
+    /// A supplied tab snapshot set was corrupt or noncanonical; the active
+    /// Project's tabs are left unchanged.
+    case invalidTabSnapshot(ProjectCatalogValidationError)
+    /// A reconciled set of Project entities violated a structural invariant; the
+    /// catalog is left unchanged rather than persisting an invalid state.
+    case reconciledProjectsInvalid(ProjectCatalogValidationError)
+    /// A reconciliation was attempted against a stale local revision (the catalog
+    /// advanced since the candidate was built, e.g. because a live tab edit was
+    /// flushed just before the apply). The catalog is left unchanged so the caller
+    /// can rebuild against the current state and retry. This is a purely in-process
+    /// compare-and-swap guard, never external sync metadata.
+    case staleRevision(expected: UInt64, actual: UInt64)
+}
+
+// MARK: - ProjectPersistenceStatus
+
+/// Explicit, observable persistence state for the current catalog.
+enum ProjectPersistenceStatus: Equatable {
+    case idle
+    case saving
+    case saved
+    case failed(String)
+}
+
+// MARK: - ProjectLoadState
+
+/// Explicit load lifecycle for a repository-backed store. Mutations are only
+/// permitted in ``ready``; every other state fails closed so an unconfirmed or
+/// failed load can never overwrite the on-disk catalog. An in-memory store (no
+/// repository) is ``ready`` from construction.
+enum ProjectLoadState: Equatable {
+    case idle
+    case loading
+    case ready
+    case failed(String)
+}
+
+// MARK: - ProjectStore
+
+/// In-memory owner of the Project catalog. Enforces names, capacity, and every
+/// structural invariant at each mutation, models an explicit load lifecycle,
+/// exposes persistence/load failure state, and delegates durable storage to an
+/// injectable repository.
+///
+/// A `nil` repository keeps the store fully in-memory and immediately mutable, so
+/// test hosts perform no Application Support I/O unless they inject a repository.
+@MainActor @Observable
+final class ProjectStore {
+    // MARK: Lifecycle
+
+    init(
+        policy: any AppPolicy = DefaultAppPolicy(),
+        repository: ProjectCatalogPersisting? = nil,
+        catalog: ProjectCatalog? = nil,
+        now: @escaping () -> Date = { Date() }
+    ) {
+        self.repository = repository
+        self.now = now
+        maxProjects = Self.clamp(policy.maxProjects, into: ProjectStructuralLimits.projectCountRange)
+        maxTabsPerProject = Self.clamp(policy.maxWorkspaceTabs, into: ProjectStructuralLimits.tabCountRange)
+        self.catalog = catalog ?? ProjectCatalog.makeDefault(now: now())
+        // With a repository the in-memory default is provisional until a load
+        // confirms (or an explicit reset replaces) it; without one it is durable.
+        loadState = repository == nil ? .ready : .idle
+    }
+
+    // MARK: Internal
+
+    /// Effective Project *creation* capacity: ``AppPolicy/maxProjects`` clamped
+    /// into the structural range. This gates new/imported Projects only; it never
+    /// truncates or rejects existing state and can be refreshed at runtime via
+    /// ``refreshCapacity(with:)``.
+    private(set) var maxProjects: Int
+    /// Effective per-Project tab *creation* capacity: ``AppPolicy/maxWorkspaceTabs``
+    /// clamped. Gates imported tab counts only; hydrated tabs are retained up to
+    /// the structural upper bound regardless of this value.
+    private(set) var maxTabsPerProject: Int
+
+    private(set) var catalog: ProjectCatalog
+    private(set) var loadState: ProjectLoadState
+    private(set) var persistenceStatus: ProjectPersistenceStatus = .idle
+    private(set) var loadFailureMessage: String?
+
+    var projects: [Project] {
+        catalog.projects
+    }
+
+    var activeProjectID: UUID {
+        catalog.activeProjectID
+    }
+
+    var activeProject: Project {
+        catalog.activeProject ?? catalog.projects[0]
+    }
+
+    /// Whether ordinary mutations are currently permitted.
+    var isMutable: Bool {
+        loadState == .ready
+    }
+
+    var canCreateProject: Bool {
+        isMutable && catalog.projects.count < maxProjects
+    }
+
+    /// Loads the persisted catalog, replacing the provisional in-memory default on
+    /// success. The loaded catalog is defensively re-validated for structural
+    /// integrity even when a repository was injected, but a catalog that merely
+    /// exceeds this build's product *creation* capacity is accepted and remains
+    /// mutable for non-creation actions — capacity gates new work, not retention.
+    /// On a structural (or I/O) failure the safe default is retained, the reason is
+    /// exposed via ``loadFailureMessage``, ``loadState`` becomes
+    /// ``ProjectLoadState/failed(_:)``, and no mutation or save touches the file.
+    func loadPersistedCatalog() async {
+        guard let repository else {
+            return
+        }
+        guard loadState != .loading else {
+            return
+        }
+        loadState = .loading
+        do {
+            let loaded = try await repository.load()
+            try loaded.validate()
+            catalog = loaded
+            loadFailureMessage = nil
+            loadState = .ready
+        } catch {
+            loadFailureMessage = String(describing: error)
+            loadState = .failed(String(describing: error))
+        }
+    }
+
+    /// Re-clamps the effective Project/tab *creation* capacity from a refreshed
+    /// policy without touching retained state. Existing Projects and tabs are never
+    /// deleted, truncated, or hidden by a capacity change; only future create,
+    /// import, and duplicate actions observe the new bound. No revision is bumped
+    /// and no save is triggered, because durable catalog contents are unchanged.
+    func refreshCapacity(with policy: any AppPolicy) {
+        maxProjects = Self.clamp(policy.maxProjects, into: ProjectStructuralLimits.projectCountRange)
+        maxTabsPerProject = Self.clamp(policy.maxWorkspaceTabs, into: ProjectStructuralLimits.tabCountRange)
+    }
+
+    /// Retries a previously failed (or not-yet-attempted) load. Safe to call from
+    /// a recovery affordance after ``loadState`` reports failure.
+    func retryLoad() async {
+        await loadPersistedCatalog()
+    }
+
+    /// Explicit, caller-initiated reset/recovery. Replaces the on-disk catalog with
+    /// a fresh default (preserving the prior file as a bounded recovery backup where
+    /// safely possible) and returns the store to a mutable state. Intended to sit
+    /// behind a deliberate confirmation UI, never on an ordinary code path.
+    func resetToDefaultCatalog() async {
+        guard let repository else {
+            catalog = ProjectCatalog.makeDefault(now: now())
+            loadFailureMessage = nil
+            loadState = .ready
+            return
+        }
+        do {
+            catalog = try await repository.reset()
+            loadFailureMessage = nil
+            loadState = .ready
+            persistenceStatus = .saved
+        } catch {
+            loadFailureMessage = String(describing: error)
+            loadState = .failed(String(describing: error))
+        }
+    }
+
+    @discardableResult
+    func createProject(name: String) throws -> Project {
+        try ensureMutable()
+        guard catalog.projects.count < maxProjects else {
+            throw ProjectMutationError.capacityReached(limit: maxProjects)
+        }
+        let normalized = try normalized(name)
+        guard !nameCollides(with: normalized, excluding: nil) else {
+            throw ProjectMutationError.duplicateName
+        }
+        guard let revision = nextRevision() else {
+            throw ProjectMutationError.revisionExhausted
+        }
+        let timestamp = now()
+        let project = Project.makeDefault(name: normalized, createdAt: timestamp, updatedAt: timestamp)
+        catalog.projects.append(project)
+        catalog.activeProjectID = project.id
+        catalog.revision = revision
+        persist()
+        return project
+    }
+
+    /// Activates an existing Project. Throws rather than silently no-op'ing so a
+    /// store-not-ready, unknown-ID, or revision-exhausted selection can never look
+    /// successful to the coordinator/UI. Re-selecting the active Project is a
+    /// deliberate no-op that neither throws nor bumps the revision.
+    func selectProject(id: UUID) throws {
+        try ensureMutable()
+        guard id != catalog.activeProjectID else {
+            return
+        }
+        guard catalog.projects.contains(where: { $0.id == id }) else {
+            throw ProjectMutationError.projectNotFound
+        }
+        guard let revision = nextRevision() else {
+            throw ProjectMutationError.revisionExhausted
+        }
+        catalog.activeProjectID = id
+        catalog.revision = revision
+        persist()
+    }
+
+    func renameProject(id: UUID, to newName: String) throws {
+        try ensureMutable()
+        guard let index = catalog.projects.firstIndex(where: { $0.id == id }) else {
+            throw ProjectMutationError.projectNotFound
+        }
+        let normalized = try normalized(newName)
+        guard !nameCollides(with: normalized, excluding: id) else {
+            throw ProjectMutationError.duplicateName
+        }
+        guard catalog.projects[index].name != normalized else {
+            return
+        }
+        guard let revision = nextRevision() else {
+            throw ProjectMutationError.revisionExhausted
+        }
+        catalog.projects[index].name = normalized
+        catalog.projects[index].updatedAt = now()
+        catalog.revision = revision
+        persist()
+    }
+
+    /// Imports a validated, config-only portable document as a new Project. IDs
+    /// are always regenerated by the DTO, name conflicts are resolved without
+    /// overwriting, and the catalog changes in one revision-bumped commit.
+    @discardableResult
+    func importProject(_ portable: PortableProject) throws -> Project {
+        try ensureMutable()
+        guard catalog.projects.count < maxProjects else {
+            throw ProjectMutationError.capacityReached(limit: maxProjects)
+        }
+        try portable.validate()
+        guard portable.tabs.count <= maxTabsPerProject else {
+            throw ProjectMutationError.tabCapacityReached(limit: maxTabsPerProject)
+        }
+        guard let revision = nextRevision() else {
+            throw ProjectMutationError.revisionExhausted
+        }
+
+        let timestamp = now()
+        let materialized: Project
+        do {
+            materialized = try portable.makeProject(now: timestamp, maxTabs: maxTabsPerProject)
+        } catch PortableProjectError.tabCapacityExceededAfterDefaultInsertion {
+            throw ProjectMutationError.tabCapacityReached(limit: maxTabsPerProject)
+        }
+        var project = materialized
+        project.name = uniqueImportedName(for: project.name)
+        do {
+            try project.validate()
+            var candidate = catalog
+            candidate.projects.append(project)
+            candidate.activeProjectID = project.id
+            candidate.revision = revision
+            try candidate.validate()
+            catalog = candidate
+        } catch let error as ProjectCatalogValidationError {
+            throw ProjectMutationError.invalidTabSnapshot(error)
+        }
+        persist()
+        return project
+    }
+
+    func deleteProject(id: UUID) throws {
+        try ensureMutable()
+        guard catalog.projects.count > 1 else {
+            throw ProjectMutationError.cannotDeleteFinalProject
+        }
+        guard let index = catalog.projects.firstIndex(where: { $0.id == id }) else {
+            throw ProjectMutationError.projectNotFound
+        }
+        guard let revision = nextRevision() else {
+            throw ProjectMutationError.revisionExhausted
+        }
+        if id == catalog.activeProjectID {
+            // Deterministically activate the following Project, else the previous.
+            let adjacentIndex = index + 1 < catalog.projects.count ? index + 1 : index - 1
+            catalog.activeProjectID = catalog.projects[adjacentIndex].id
+        }
+        catalog.projects.remove(at: index)
+        catalog.revision = revision
+        persist()
+    }
+
+    /// Reorders Projects to `orderedIDs`, tolerating missing/extra IDs (unlisted
+    /// Projects keep their relative order at the tail). Throws for a not-ready store
+    /// or an exhausted revision; an empty list or a request that reproduces the
+    /// current order is a no-op that neither throws nor bumps the revision.
+    func reorderProjects(_ orderedIDs: [UUID]) throws {
+        try ensureMutable()
+        guard !orderedIDs.isEmpty else {
+            return
+        }
+        var remaining = catalog.projects
+        var reordered: [Project] = []
+        reordered.reserveCapacity(remaining.count)
+        for id in orderedIDs {
+            guard let index = remaining.firstIndex(where: { $0.id == id }) else {
+                continue
+            }
+            reordered.append(remaining.remove(at: index))
+        }
+        reordered.append(contentsOf: remaining)
+        guard reordered.count == catalog.projects.count,
+              reordered.map(\.id) != catalog.projects.map(\.id) else
+        {
+            return
+        }
+        guard let revision = nextRevision() else {
+            throw ProjectMutationError.revisionExhausted
+        }
+        catalog.projects = reordered
+        catalog.revision = revision
+        persist()
+    }
+
+    /// Replaces the active Project's tab configuration with a captured snapshot.
+    ///
+    /// Titles are canonicalized deliberately and the result is validated *before*
+    /// any mutation: a corrupt or noncanonical snapshot (a title that cannot be
+    /// canonicalized, or an oversized filter) is rejected with the active Project's
+    /// tabs left untouched. Capacity is defensively clamped to the structural upper
+    /// bound — never the lower product creation limit — so hydrated tabs retained
+    /// above that limit persist intact; a snapshot reproducing the current tabs is
+    /// a no-op.
+    func updateActiveProjectTabs(_ snapshots: [ProjectTabSnapshot], activeTabID: UUID) throws {
+        try ensureMutable()
+        guard let index = catalog.projects.firstIndex(where: { $0.id == catalog.activeProjectID }) else {
+            throw ProjectMutationError.projectNotFound
+        }
+
+        var canonicalSnapshots: [ProjectTabSnapshot] = []
+        canonicalSnapshots.reserveCapacity(snapshots.count)
+        for var snapshot in snapshots {
+            do {
+                snapshot.title = try ProjectNormalization.normalizedDisplayName(snapshot.title)
+            } catch let error as ProjectNameNormalizationError {
+                throw ProjectMutationError.invalidTabSnapshot(.tabSnapshotInvalid(.titleInvalid(error)))
+            }
+            canonicalSnapshots.append(snapshot)
+        }
+
+        // Never trust a caller's capacity, but clamp to the structural upper bound
+        // rather than the product creation limit so hydrated tabs above the current
+        // creation capacity are retained rather than silently truncated on autosave.
+        let capacity = ProjectStructuralLimits.tabCountRange.upperBound
+        let (normalizedTabs, resolvedActiveTabID) = Project.normalizedTabs(
+            canonicalSnapshots,
+            activeTabID: activeTabID,
+            maxTabs: capacity
+        )
+
+        let current = catalog.projects[index]
+        var candidate = current
+        candidate.tabs = normalizedTabs
+        candidate.activeTabID = resolvedActiveTabID
+        do {
+            try candidate.validate()
+        } catch let error as ProjectCatalogValidationError {
+            throw ProjectMutationError.invalidTabSnapshot(error)
+        }
+
+        // No-op when the tab set and active tab are unchanged (ignoring timestamps).
+        guard normalizedTabs != current.tabs || resolvedActiveTabID != current.activeTabID else {
+            return
+        }
+        guard let revision = nextRevision() else {
+            throw ProjectMutationError.revisionExhausted
+        }
+        candidate.updatedAt = now()
+        catalog.projects[index] = candidate
+        catalog.revision = revision
+        persist()
+    }
+
+    /// Applies an externally reconciled set of Project entities as the new catalog
+    /// contents, guarded by an in-process compare-and-swap on the local revision.
+    /// This is the single local seam a future reconciliation adapter uses; it accepts
+    /// reconciled *entities only* and never an external revision token — the catalog's
+    /// revision stays a local monotonic persistence/CAS guard.
+    ///
+    /// `expectedRevision` is the caller's last-observed local revision. If the catalog
+    /// has advanced past it (for example because a live tab edit was flushed just
+    /// before this call) the reconciliation is rejected atomically with
+    /// ``ProjectMutationError/staleRevision(expected:actual:)`` and the catalog is left
+    /// untouched, so a newer local edit is never overwritten and the caller can
+    /// rebuild and retry.
+    ///
+    /// The current local active Project is preserved when it still exists in the
+    /// reconciled set; otherwise the first reconciled Project (a deterministic
+    /// choice from the supplied order) becomes active. Structural invariants are
+    /// validated *before* any mutation, so invalid input throws
+    /// ``ProjectMutationError/reconciledProjectsInvalid(_:)`` with the catalog
+    /// untouched. A reconciled set identical to the current contents is an accepted
+    /// no-op that returns `false` without bumping the local revision or persisting;
+    /// an applied change returns `true`.
+    @discardableResult
+    func reconcile(projects: [Project], expectedRevision: UInt64) throws -> Bool {
+        try ensureMutable()
+        guard expectedRevision == catalog.revision else {
+            throw ProjectMutationError.staleRevision(expected: expectedRevision, actual: catalog.revision)
+        }
+
+        let preservesActive = projects.contains { $0.id == catalog.activeProjectID }
+        let resolvedActiveID = preservesActive
+            ? catalog.activeProjectID
+            : (projects.first?.id ?? catalog.activeProjectID)
+
+        var candidate = catalog
+        candidate.projects = projects
+        candidate.activeProjectID = resolvedActiveID
+
+        guard candidate.projects != catalog.projects || candidate.activeProjectID != catalog.activeProjectID else {
+            return false
+        }
+
+        do {
+            try candidate.validate()
+        } catch let error as ProjectCatalogValidationError {
+            throw ProjectMutationError.reconciledProjectsInvalid(error)
+        }
+        guard let revision = nextRevision() else {
+            throw ProjectMutationError.revisionExhausted
+        }
+        candidate.revision = revision
+        catalog = candidate
+        persist()
+        return true
+    }
+
+    func waitForPendingPersistence() async {
+        await persistenceTask?.value
+    }
+
+    // MARK: Private
+
+    private static let logger = Logger(
+        subsystem: RockxyIdentity.current.logSubsystem,
+        category: "ProjectStore"
+    )
+
+    @ObservationIgnored private var persistenceTask: Task<Void, Never>?
+
+    private let repository: ProjectCatalogPersisting?
+    private let now: () -> Date
+
+    private static func clamp(_ value: Int, into range: ClosedRange<Int>) -> Int {
+        min(max(value, range.lowerBound), range.upperBound)
+    }
+
+    private func ensureMutable() throws {
+        guard isMutable else {
+            throw ProjectMutationError.storeNotReady
+        }
+    }
+
+    /// The revision the next mutation would persist, or `nil` when the monotonic
+    /// counter is exhausted (so the caller can fail without wrapping).
+    private func nextRevision() -> UInt64? {
+        catalog.revision == UInt64.max ? nil : catalog.revision + 1
+    }
+
+    private func normalized(_ raw: String) throws -> String {
+        do {
+            return try ProjectNormalization.normalizedDisplayName(raw)
+        } catch let error as ProjectNameNormalizationError {
+            throw ProjectMutationError.nameInvalid(error)
+        }
+    }
+
+    private func nameCollides(with normalizedName: String, excluding id: UUID?) -> Bool {
+        let key = ProjectNormalization.foldedKey(for: normalizedName)
+        return catalog.projects.contains {
+            $0.id != id && ProjectNormalization.foldedKey(for: $0.name) == key
+        }
+    }
+
+    private func uniqueImportedName(for normalizedName: String) -> String {
+        guard nameCollides(with: normalizedName, excluding: nil) else {
+            return normalizedName
+        }
+        var ordinal = 1
+        while true {
+            let suffix = ordinal == 1 ? " (Imported)" : " (Imported \(ordinal))"
+            let maxBaseCount = max(1, ProjectStructuralLimits.nameGraphemeRange.upperBound - suffix.count)
+            let candidate = normalizedName.boundedToGraphemes(maxBaseCount) + suffix
+            if !nameCollides(with: candidate, excluding: nil) {
+                return candidate
+            }
+            ordinal += 1
+        }
+    }
+
+    private func persist() {
+        guard let repository else {
+            return
+        }
+        let snapshot = catalog
+        persistenceStatus = .saving
+        persistenceTask = Task { @MainActor in
+            do {
+                try await repository.save(snapshot)
+                if catalog.revision == snapshot.revision {
+                    persistenceStatus = .saved
+                }
+            } catch {
+                guard catalog.revision == snapshot.revision else {
+                    // A later in-memory snapshot superseded this write and owns the
+                    // observable persistence status.
+                    return
+                }
+                persistenceStatus = .failed(String(describing: error))
+                Self.logger.error("Project catalog persistence failed: \(String(describing: error))")
+            }
+        }
+    }
+}

--- a/Rockxy/Models/Projects/ProjectStructuralLimits.swift
+++ b/Rockxy/Models/Projects/ProjectStructuralLimits.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+// MARK: - ProjectStructuralLimits
+
+/// Structural safety bounds for the persisted Project catalog.
+///
+/// These are storage-integrity limits, not product entitlement logic: they cap
+/// allocation and reject hostile or corrupt input regardless of edition. Product
+/// capacity (how many Projects a build offers) lives in ``AppPolicy/maxProjects``
+/// and is clamped into ``projectCountRange`` before use.
+enum ProjectStructuralLimits {
+    /// Public default number of Projects offered by ``DefaultAppPolicy``.
+    static let defaultProjectCapacity = 3
+
+    /// Hard structural range for the number of Projects in a catalog.
+    static let projectCountRange = 1 ... 128
+
+    /// Hard structural range for the number of traffic tabs in a Project.
+    /// The effective per-Project tab capacity is ``AppPolicy/maxWorkspaceTabs``
+    /// clamped into this range.
+    static let tabCountRange = 1 ... 32
+
+    /// Allowed grapheme-cluster count for a normalized Project name or tab title.
+    static let nameGraphemeRange = 1 ... 80
+
+    /// Maximum grapheme length of any single persisted filter string.
+    static let maxFilterStringGraphemes = 512
+
+    /// Maximum element count of any persisted filter collection.
+    static let maxFilterCollectionCount = 64
+
+    /// Maximum number of persisted advanced filter rows per tab.
+    static let maxAdvancedFilterRows = 64
+
+    /// Maximum number of persisted muted-traffic-source references per tab.
+    static let maxMutedTrafficSources = 128
+
+    /// Default Project name used when creating a fresh catalog.
+    static let defaultProjectName = "My Project"
+
+    /// Title of the guaranteed non-closable default tab.
+    static let defaultTabTitle = "All Traffic"
+}

--- a/Rockxy/Models/Projects/ProjectTabSnapshot+WorkspaceState.swift
+++ b/Rockxy/Models/Projects/ProjectTabSnapshot+WorkspaceState.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+// Explicit, bounded conversion between a live ``WorkspaceState`` traffic tab and
+// its durable ``ProjectTabSnapshot``. Kept separate from the DTO so the snapshot
+// value type stays free of `@MainActor` UI dependencies, and separate from
+// ``WorkspaceState`` so that type never gains `Codable`/persistence coupling.
+
+@MainActor
+extension ProjectTabSnapshot {
+    /// Captures the durable configuration of a single live traffic tab.
+    init(capturing workspace: WorkspaceState) {
+        self.init(
+            id: workspace.id,
+            title: workspace.title.boundedToGraphemes(ProjectStructuralLimits.nameGraphemeRange.upperBound),
+            isClosable: workspace.isClosable,
+            filter: FilterCriteriaSnapshot(workspace.filterCriteria),
+            advancedFilterRows: workspace.filterRules
+                .prefix(ProjectStructuralLimits.maxAdvancedFilterRows)
+                .map { FilterRuleSnapshot($0) },
+            isFilterBarVisible: workspace.isFilterBarVisible,
+            mainTabRawValue: workspace.activeMainTab.rawValue,
+            inspectorLayoutRawValue: InspectorLayoutCoding.rawValue(for: workspace.inspectorLayout),
+            isContextDockVisible: workspace.isContextDockVisible,
+            contextDockTabRawValue: ContextDockTabCoding.rawValue(for: workspace.contextDockTab),
+            focusNavigatorModeRawValue: workspace.focusNavigatorMode.rawValue,
+            activeTrafficSignalRawValue: workspace.activeTrafficSignal?.rawValue,
+            activeFocusSetID: workspace.activeFocusSetID,
+            mutedTrafficSources: workspace.mutedTrafficSources
+                .map { MutedTrafficSourceSnapshot($0) }
+                .sorted { $0.value < $1.value }
+                .boundedCount(ProjectStructuralLimits.maxMutedTrafficSources)
+        )
+    }
+
+    /// Rebuilds a live traffic tab from this snapshot. Only durable view intent is
+    /// restored; captured traffic and derived indexes are recomputed elsewhere and
+    /// app-global focus-set definitions are loaded by ``WorkspaceState`` itself.
+    func hydrateWorkspaceState() -> WorkspaceState {
+        let resolvedFilter = filter.resolved
+        let state = WorkspaceState(
+            id: id,
+            title: title,
+            isClosable: isClosable,
+            initialFilter: resolvedFilter,
+            inspectorLayout: InspectorLayoutCoding.layout(for: inspectorLayoutRawValue),
+            isContextDockVisible: isContextDockVisible,
+            allowsAutomaticInspectorReveal: true
+        )
+        state.activeMainTab = MainTab(rawValue: mainTabRawValue) ?? .traffic
+        state.contextDockTab = ContextDockTabCoding.tab(for: contextDockTabRawValue)
+        state.focusNavigatorMode = FocusNavigatorMode(rawValue: focusNavigatorModeRawValue) ?? .browse
+        state.activeTrafficSignal = activeTrafficSignalRawValue.flatMap { TrafficSignal(rawValue: $0) }
+        state.activeFocusSetID = activeFocusSetID
+        state.mutedTrafficSources = Set(mutedTrafficSources.compactMap(\.resolved))
+        state.filterRules = advancedFilterRows.isEmpty
+            ? [FilterRule()]
+            : advancedFilterRows.map(\.resolved)
+        state.isFilterBarVisible = isFilterBarVisible
+        return state
+    }
+}

--- a/Rockxy/Models/Projects/ProjectTabSnapshot.swift
+++ b/Rockxy/Models/Projects/ProjectTabSnapshot.swift
@@ -1,0 +1,418 @@
+import Foundation
+
+// MARK: - ProjectSnapshotValidationError
+
+/// Rejection reasons for a decoded snapshot that exceeds structural bounds.
+enum ProjectSnapshotValidationError: Error, Equatable {
+    case titleInvalid(ProjectNameNormalizationError)
+    case stringTooLong(field: String)
+    case collectionTooLarge(field: String)
+}
+
+// MARK: - MutedTrafficSourceSnapshot
+
+/// Durable, resilient reference to a muted traffic source. The live
+/// ``MutedTrafficSource`` is a non-`Codable` UI enum; this DTO stores its kind
+/// as a stable raw string so unknown future kinds decode without throwing.
+struct MutedTrafficSourceSnapshot: Codable, Equatable, Hashable {
+    enum Kind: String, Codable {
+        case host
+        case pathPrefix
+    }
+
+    var kindRawValue: String
+    var value: String
+
+    /// Resolves to a live source, dropping unknown kinds.
+    var resolved: MutedTrafficSource? {
+        switch Kind(rawValue: kindRawValue) {
+        case .host: .host(value)
+        case .pathPrefix: .pathPrefix(value)
+        case nil: nil
+        }
+    }
+
+    init(kindRawValue: String, value: String) {
+        self.kindRawValue = kindRawValue
+        self.value = value
+    }
+
+    init(_ source: MutedTrafficSource) {
+        switch source {
+        case let .host(value):
+            kindRawValue = Kind.host.rawValue
+            self.value = value.boundedToGraphemes(ProjectStructuralLimits.maxFilterStringGraphemes)
+        case let .pathPrefix(value):
+            kindRawValue = Kind.pathPrefix.rawValue
+            self.value = value.boundedToGraphemes(ProjectStructuralLimits.maxFilterStringGraphemes)
+        }
+    }
+
+    func validate() throws {
+        guard value.count <= ProjectStructuralLimits.maxFilterStringGraphemes else {
+            throw ProjectSnapshotValidationError.stringTooLong(field: "mutedTrafficSource.value")
+        }
+    }
+}
+
+// MARK: - FilterRuleSnapshot
+
+/// Durable form of a single advanced filter row. Field/operator are stored as
+/// raw strings and resolved with safe fallbacks so persisted rows survive enum
+/// evolution instead of failing to decode.
+struct FilterRuleSnapshot: Codable, Equatable {
+    var id: UUID
+    var isEnabled: Bool
+    var connectorRawValue: String
+    var fieldRawValue: String
+    var operatorRawValue: String
+    var value: String
+
+    init(
+        id: UUID = UUID(),
+        isEnabled: Bool = true,
+        connectorRawValue: String = FilterLogicConnector.and.rawValue,
+        fieldRawValue: String = FilterField.url.rawValue,
+        operatorRawValue: String = FilterOperator.contains.rawValue,
+        value: String = ""
+    ) {
+        self.id = id
+        self.isEnabled = isEnabled
+        self.connectorRawValue = connectorRawValue
+        self.fieldRawValue = fieldRawValue
+        self.operatorRawValue = operatorRawValue
+        self.value = value
+    }
+
+    init(_ rule: FilterRule) {
+        id = rule.id
+        isEnabled = rule.isEnabled
+        connectorRawValue = rule.connector.rawValue
+        fieldRawValue = rule.field.rawValue
+        operatorRawValue = rule.filterOperator.rawValue
+        value = rule.value.boundedToGraphemes(ProjectStructuralLimits.maxFilterStringGraphemes)
+    }
+
+    var resolved: FilterRule {
+        FilterRule(
+            id: id,
+            isEnabled: isEnabled,
+            connector: FilterLogicConnector(rawValue: connectorRawValue) ?? .and,
+            field: FilterField(rawValue: fieldRawValue) ?? .url,
+            filterOperator: FilterOperator(rawValue: operatorRawValue) ?? .contains,
+            value: value
+        )
+    }
+
+    func validate() throws {
+        guard value.count <= ProjectStructuralLimits.maxFilterStringGraphemes else {
+            throw ProjectSnapshotValidationError.stringTooLong(field: "filterRule.value")
+        }
+    }
+}
+
+// MARK: - FilterCriteriaSnapshot
+
+/// Bounded, durable subset of ``FilterCriteria``. Excludes `exactTransactionID`
+/// because it points into live captured traffic that the catalog never persists.
+/// Enum-valued fields are stored as raw strings/ints and resolved with fallbacks.
+struct FilterCriteriaSnapshot: Codable, Equatable {
+    var searchText: String
+    var methods: [String]
+    var statusCodes: [Int]
+    var contentTypeRawValues: [String]
+    var domains: [String]
+    var logLevelRawValues: [Int]
+    var protocolFilterRawValues: [String]
+    var searchFieldRawValue: String
+    var isSearchEnabled: Bool
+    var sidebarDomain: String?
+    var sidebarPathPrefix: String?
+    var sidebarApp: String?
+    var sidebarScopeRawValue: String
+
+    static let empty = FilterCriteriaSnapshot(FilterCriteria.empty)
+
+    init(
+        searchText: String = "",
+        methods: [String] = [],
+        statusCodes: [Int] = [],
+        contentTypeRawValues: [String] = [],
+        domains: [String] = [],
+        logLevelRawValues: [Int] = [],
+        protocolFilterRawValues: [String] = [],
+        searchFieldRawValue: String = FilterField.url.rawValue,
+        isSearchEnabled: Bool = true,
+        sidebarDomain: String? = nil,
+        sidebarPathPrefix: String? = nil,
+        sidebarApp: String? = nil,
+        sidebarScopeRawValue: String = SidebarScopeCoding.allTraffic
+    ) {
+        self.searchText = searchText
+        self.methods = methods
+        self.statusCodes = statusCodes
+        self.contentTypeRawValues = contentTypeRawValues
+        self.domains = domains
+        self.logLevelRawValues = logLevelRawValues
+        self.protocolFilterRawValues = protocolFilterRawValues
+        self.searchFieldRawValue = searchFieldRawValue
+        self.isSearchEnabled = isSearchEnabled
+        self.sidebarDomain = sidebarDomain
+        self.sidebarPathPrefix = sidebarPathPrefix
+        self.sidebarApp = sidebarApp
+        self.sidebarScopeRawValue = sidebarScopeRawValue
+    }
+
+    init(_ criteria: FilterCriteria) {
+        let maxString = ProjectStructuralLimits.maxFilterStringGraphemes
+        let maxCount = ProjectStructuralLimits.maxFilterCollectionCount
+
+        searchText = criteria.searchText.boundedToGraphemes(maxString)
+        methods = criteria.methods
+            .filter { $0.count <= maxString }
+            .sorted()
+            .boundedCount(maxCount)
+        statusCodes = criteria.statusCodes.sorted().boundedCount(maxCount)
+        contentTypeRawValues = criteria.contentTypes
+            .map(\.rawValue)
+            .sorted()
+            .boundedCount(maxCount)
+        domains = criteria.domains
+            .filter { $0.count <= maxString }
+            .sorted()
+            .boundedCount(maxCount)
+        logLevelRawValues = criteria.logLevels
+            .map(\.rawValue)
+            .sorted()
+            .boundedCount(maxCount)
+        protocolFilterRawValues = criteria.activeProtocolFilters
+            .map(\.rawValue)
+            .sorted()
+            .boundedCount(maxCount)
+        searchFieldRawValue = criteria.searchField.rawValue
+        isSearchEnabled = criteria.isSearchEnabled
+        sidebarDomain = criteria.sidebarDomain?.boundedToGraphemes(maxString)
+        sidebarPathPrefix = criteria.sidebarPathPrefix?.boundedToGraphemes(maxString)
+        sidebarApp = criteria.sidebarApp?.boundedToGraphemes(maxString)
+        sidebarScopeRawValue = SidebarScopeCoding.rawValue(for: criteria.sidebarScope)
+    }
+
+    var resolved: FilterCriteria {
+        var criteria = FilterCriteria()
+        criteria.searchText = searchText
+        criteria.methods = Set(methods)
+        criteria.statusCodes = Set(statusCodes)
+        criteria.contentTypes = Set(contentTypeRawValues.compactMap { ContentType(rawValue: $0) })
+        criteria.domains = Set(domains)
+        criteria.logLevels = Set(logLevelRawValues.compactMap { LogLevel(rawValue: $0) })
+        criteria.activeProtocolFilters = Set(protocolFilterRawValues.compactMap { ProtocolFilter(rawValue: $0) })
+        criteria.searchField = FilterField(rawValue: searchFieldRawValue) ?? .url
+        criteria.isSearchEnabled = isSearchEnabled
+        criteria.sidebarDomain = sidebarDomain
+        criteria.sidebarPathPrefix = sidebarPathPrefix
+        criteria.sidebarApp = sidebarApp
+        criteria.sidebarScope = SidebarScopeCoding.scope(for: sidebarScopeRawValue)
+        // exactTransactionID is deliberately not restored: it references live traffic.
+        return criteria
+    }
+
+    func validate() throws {
+        func checkString(_ value: String, _ field: String) throws {
+            guard value.count <= ProjectStructuralLimits.maxFilterStringGraphemes else {
+                throw ProjectSnapshotValidationError.stringTooLong(field: field)
+            }
+        }
+        func checkCount(_ count: Int, _ field: String) throws {
+            guard count <= ProjectStructuralLimits.maxFilterCollectionCount else {
+                throw ProjectSnapshotValidationError.collectionTooLarge(field: field)
+            }
+        }
+
+        try checkString(searchText, "filter.searchText")
+        try checkCount(methods.count, "filter.methods")
+        try checkCount(statusCodes.count, "filter.statusCodes")
+        try checkCount(contentTypeRawValues.count, "filter.contentTypes")
+        try checkCount(domains.count, "filter.domains")
+        try checkCount(logLevelRawValues.count, "filter.logLevels")
+        try checkCount(protocolFilterRawValues.count, "filter.protocolFilters")
+        for method in methods { try checkString(method, "filter.method") }
+        for domain in domains { try checkString(domain, "filter.domain") }
+        if let sidebarDomain { try checkString(sidebarDomain, "filter.sidebarDomain") }
+        if let sidebarPathPrefix { try checkString(sidebarPathPrefix, "filter.sidebarPathPrefix") }
+        if let sidebarApp { try checkString(sidebarApp, "filter.sidebarApp") }
+    }
+}
+
+// MARK: - SidebarScopeCoding
+
+/// Stable string coding for ``SidebarScope`` (which is `Codable` but not
+/// `RawRepresentable`), with a safe fallback for unknown values.
+enum SidebarScopeCoding {
+    static let allTraffic = "allTraffic"
+
+    static func rawValue(for scope: SidebarScope) -> String {
+        switch scope {
+        case .allTraffic: "allTraffic"
+        case .saved: "saved"
+        case .pinned: "pinned"
+        case .notes: "notes"
+        }
+    }
+
+    static func scope(for rawValue: String) -> SidebarScope {
+        switch rawValue {
+        case "saved": .saved
+        case "pinned": .pinned
+        case "notes": .notes
+        default: .allTraffic
+        }
+    }
+}
+
+// MARK: - ProjectTabSnapshot
+
+/// Durable, bounded snapshot of a single traffic tab's serializable view intent.
+///
+/// Captures only durable configuration from ``WorkspaceState`` and deliberately
+/// excludes transactions, rows, selections, sort descriptors, sidebar derived
+/// indexes, logs, assistant messages/review payloads/tasks, and captured
+/// headers/bodies. Enum-valued presentation preferences are stored as stable
+/// raw strings and resolved with safe fallbacks.
+struct ProjectTabSnapshot: Codable, Equatable, Identifiable {
+    let id: UUID
+    var title: String
+    var isClosable: Bool
+    var filter: FilterCriteriaSnapshot
+    var advancedFilterRows: [FilterRuleSnapshot]
+    var isFilterBarVisible: Bool
+    var mainTabRawValue: String
+    var inspectorLayoutRawValue: String
+    var isContextDockVisible: Bool
+    var contextDockTabRawValue: String
+    var focusNavigatorModeRawValue: String
+    var activeTrafficSignalRawValue: String?
+    var activeFocusSetID: UUID?
+    var mutedTrafficSources: [MutedTrafficSourceSnapshot]
+
+    // MARK: Lifecycle
+
+    init(
+        id: UUID = UUID(),
+        title: String,
+        isClosable: Bool,
+        filter: FilterCriteriaSnapshot = .empty,
+        advancedFilterRows: [FilterRuleSnapshot] = [FilterRuleSnapshot()],
+        isFilterBarVisible: Bool = false,
+        mainTabRawValue: String = MainTab.traffic.rawValue,
+        inspectorLayoutRawValue: String = InspectorLayoutCoding.hidden,
+        isContextDockVisible: Bool = false,
+        contextDockTabRawValue: String = ContextDockTabCoding.details,
+        focusNavigatorModeRawValue: String = FocusNavigatorMode.browse.rawValue,
+        activeTrafficSignalRawValue: String? = nil,
+        activeFocusSetID: UUID? = nil,
+        mutedTrafficSources: [MutedTrafficSourceSnapshot] = []
+    ) {
+        self.id = id
+        self.title = title
+        self.isClosable = isClosable
+        self.filter = filter
+        self.advancedFilterRows = advancedFilterRows
+        self.isFilterBarVisible = isFilterBarVisible
+        self.mainTabRawValue = mainTabRawValue
+        self.inspectorLayoutRawValue = inspectorLayoutRawValue
+        self.isContextDockVisible = isContextDockVisible
+        self.contextDockTabRawValue = contextDockTabRawValue
+        self.focusNavigatorModeRawValue = focusNavigatorModeRawValue
+        self.activeTrafficSignalRawValue = activeTrafficSignalRawValue
+        self.activeFocusSetID = activeFocusSetID
+        self.mutedTrafficSources = mutedTrafficSources
+    }
+
+    // MARK: Internal
+
+    /// The guaranteed non-closable default tab every Project must contain.
+    static func makeDefaultAllTraffic(
+        id: UUID = UUID(),
+        title: String = ProjectStructuralLimits.defaultTabTitle
+    ) -> ProjectTabSnapshot {
+        ProjectTabSnapshot(id: id, title: title, isClosable: false)
+    }
+
+    /// Validates decoded bounds. The title is normalized (1...80 graphemes,
+    /// no control characters); filter strings/collections are bounded.
+    func validate() throws {
+        do {
+            try ProjectNormalization.requireCanonical(title)
+        } catch let error as ProjectNameNormalizationError {
+            throw ProjectSnapshotValidationError.titleInvalid(error)
+        }
+        guard advancedFilterRows.count <= ProjectStructuralLimits.maxAdvancedFilterRows else {
+            throw ProjectSnapshotValidationError.collectionTooLarge(field: "tab.advancedFilterRows")
+        }
+        guard mutedTrafficSources.count <= ProjectStructuralLimits.maxMutedTrafficSources else {
+            throw ProjectSnapshotValidationError.collectionTooLarge(field: "tab.mutedTrafficSources")
+        }
+        try filter.validate()
+        for row in advancedFilterRows { try row.validate() }
+        for source in mutedTrafficSources { try source.validate() }
+    }
+}
+
+// MARK: - InspectorLayoutCoding
+
+/// Stable string coding for the non-`RawRepresentable` ``InspectorLayout`` enum.
+enum InspectorLayoutCoding {
+    static let hidden = "hidden"
+    static let bottom = "bottom"
+
+    static func rawValue(for layout: InspectorLayout) -> String {
+        switch layout {
+        case .hidden: hidden
+        case .bottom: bottom
+        }
+    }
+
+    static func layout(for rawValue: String) -> InspectorLayout {
+        rawValue == bottom ? .bottom : .hidden
+    }
+}
+
+// MARK: - ContextDockTabCoding
+
+/// Stable string coding for the non-`RawRepresentable` ``ContextDockTab`` enum.
+enum ContextDockTabCoding {
+    static let details = "details"
+    static let aiAssistant = "aiAssistant"
+
+    static func rawValue(for tab: ContextDockTab) -> String {
+        switch tab {
+        case .details: details
+        case .aiAssistant: aiAssistant
+        }
+    }
+
+    static func tab(for rawValue: String) -> ContextDockTab {
+        rawValue == aiAssistant ? .aiAssistant : .details
+    }
+}
+
+// MARK: - String + bounds
+
+extension String {
+    /// Returns a copy limited to `maxGraphemes` grapheme clusters.
+    func boundedToGraphemes(_ maxGraphemes: Int) -> String {
+        guard count > maxGraphemes else {
+            return self
+        }
+        return String(prefix(maxGraphemes))
+    }
+}
+
+// MARK: - Array + bounds
+
+extension Array {
+    /// Returns a copy limited to `maxCount` elements.
+    func boundedCount(_ maxCount: Int) -> [Element] {
+        count > maxCount ? Array(prefix(maxCount)) : self
+    }
+}

--- a/Rockxy/Models/Settings/AppPolicy.swift
+++ b/Rockxy/Models/Settings/AppPolicy.swift
@@ -9,9 +9,12 @@ import Foundation
 /// engines stay reusable and edition-neutral.
 protocol AppPolicy: Sendable {
     var maxWorkspaceTabs: Int { get }
+    var maxProjects: Int { get }
     var maxDomainFavorites: Int { get }
     var maxActiveRulesPerTool: Int { get }
     var maxEnabledScripts: Int { get }
+    /// Maximum in-memory traffic history retained independently by each Project.
+    /// The overall bound is this value multiplied by the bounded Project capacity.
     var maxLiveHistoryEntries: Int { get }
     var upstreamProxyAllowsSOCKS5: Bool { get }
     var upstreamProxyAllowsAuthentication: Bool { get }
@@ -21,6 +24,13 @@ protocol AppPolicy: Sendable {
 }
 
 extension AppPolicy {
+    /// Public default project capacity. Clamped to the repository's structural
+    /// range (``ProjectStructuralLimits/projectCountRange``) by ``ProjectStore``.
+    /// Capacity is product policy; structural safety limits are not.
+    var maxProjects: Int {
+        ProjectStructuralLimits.defaultProjectCapacity
+    }
+
     var upstreamProxyAllowsSOCKS5: Bool {
         false
     }
@@ -48,6 +58,7 @@ extension AppPolicy {
 /// and represent the baseline experience.
 struct DefaultAppPolicy: AppPolicy {
     let maxWorkspaceTabs = 8
+    let maxProjects = 3
     let maxDomainFavorites = 5
     let maxActiveRulesPerTool = 10
     let maxEnabledScripts = 10

--- a/Rockxy/Models/Settings/RockxyUTType.swift
+++ b/Rockxy/Models/Settings/RockxyUTType.swift
@@ -3,6 +3,12 @@ import UniformTypeIdentifiers
 // Declares the Uniform Type Identifiers for Rockxy session and HAR files.
 
 extension UTType {
+    /// Portable, configuration-only Project document (`.rockxyproject`).
+    static let rockxyProject = UTType(
+        exportedAs: RockxyIdentity.current.projectUTTypeIdentifier,
+        conformingTo: .json
+    )
+
     /// Native Rockxy session file format (`.rockxysession`).
     /// Conforms to `public.json` since the underlying format is JSON.
     static let rockxySession = UTType(

--- a/Rockxy/Models/UI/WorkspaceStore.swift
+++ b/Rockxy/Models/UI/WorkspaceStore.swift
@@ -11,7 +11,7 @@ final class WorkspaceStore {
         maxWorkspaces: Int = 8,
         layoutPreferences: WorkspaceLayoutPreferences = WorkspaceLayoutPreferences()
     ) {
-        self.maxWorkspaces = max(maxWorkspaces, 1)
+        self.maxWorkspaces = Self.clampCreationCapacity(maxWorkspaces)
         self.layoutPreferences = layoutPreferences
         let defaultWorkspace = Self.makeWorkspace(
             title: String(localized: "All Traffic"),
@@ -25,7 +25,10 @@ final class WorkspaceStore {
 
     // MARK: Internal
 
-    let maxWorkspaces: Int
+    /// Effective tab *creation* capacity. Gates new/duplicated tabs only; it never
+    /// truncates hydrated tabs, which are retained up to the structural upper bound.
+    /// Refreshable at runtime via ``refreshCapacity(maxWorkspaces:)``.
+    private(set) var maxWorkspaces: Int
 
     var workspaces: [WorkspaceState]
     var activeWorkspaceID: UUID
@@ -40,6 +43,15 @@ final class WorkspaceStore {
 
     var canCreateWorkspace: Bool {
         workspaces.count < maxWorkspaces
+    }
+
+    /// Re-sets the effective tab *creation* capacity at runtime. Existing tabs are
+    /// never closed or truncated by a lower limit; only future create/duplicate
+    /// actions observe the new bound. Clamped into the structural tab range so a
+    /// bad or expanded policy can never authorize creating more live tabs than the
+    /// structural upper bound (which snapshot persistence would later truncate).
+    func refreshCapacity(maxWorkspaces newValue: Int) {
+        maxWorkspaces = Self.clampCreationCapacity(newValue)
     }
 
     @discardableResult
@@ -192,6 +204,58 @@ final class WorkspaceStore {
         workspace.title = newTitle
     }
 
+    // MARK: Project snapshot seams
+
+    /// Captures the durable, bounded configuration of the current traffic tabs.
+    /// Live transactions, rows, selections, sort descriptors, sidebar indexes,
+    /// logs, and assistant state are intentionally excluded.
+    func captureTabSnapshots() -> [ProjectTabSnapshot] {
+        workspaces.map { ProjectTabSnapshot(capturing: $0) }
+    }
+
+    /// Replaces all traffic tabs with hydrated snapshots for a Project switch.
+    /// Always restores at least one non-closable default tab and a valid active
+    /// ID, even if given an empty or malformed set. Hydration retains up to the
+    /// structural tab upper bound — not the lower creation limit — so a Project
+    /// carrying more tabs than the current creation capacity is restored intact.
+    func applyTabSnapshots(_ snapshots: [ProjectTabSnapshot], activeTabID: UUID) {
+        var hydrated = snapshots.map { $0.hydrateWorkspaceState() }
+
+        if hydrated.isEmpty {
+            hydrated = [Self.makeWorkspace(
+                title: String(localized: "All Traffic"),
+                isClosable: false,
+                filter: .empty,
+                layoutPreferences: layoutPreferences
+            )]
+        } else if !hydrated.contains(where: { !$0.isClosable }) {
+            hydrated.insert(
+                Self.makeWorkspace(
+                    title: String(localized: "All Traffic"),
+                    isClosable: false,
+                    filter: .empty,
+                    layoutPreferences: layoutPreferences
+                ),
+                at: 0
+            )
+        }
+
+        let retentionCap = ProjectStructuralLimits.tabCountRange.upperBound
+        if hydrated.count > retentionCap {
+            // Bound only by the structural upper limit: keep the non-closable
+            // default and the earliest tabs. The creation limit never truncates
+            // retained tabs here.
+            let defaultIndex = hydrated.firstIndex { !$0.isClosable } ?? 0
+            let keeper = hydrated.remove(at: defaultIndex)
+            hydrated = [keeper] + hydrated.prefix(retentionCap - 1)
+        }
+
+        workspaces = hydrated
+        activeWorkspaceID = hydrated.contains { $0.id == activeTabID }
+            ? activeTabID
+            : hydrated[0].id
+    }
+
     func rememberBottomInspectorVisibility(_ isVisible: Bool) {
         layoutPreferences.rememberBottomInspectorVisibility(isVisible)
     }
@@ -203,14 +267,26 @@ final class WorkspaceStore {
     // MARK: Private
 
     private static let logger = Logger(subsystem: RockxyIdentity.current.logSubsystem, category: "WorkspaceStore")
+
     private let layoutPreferences: WorkspaceLayoutPreferences
+
+    /// Clamps a requested tab creation capacity into the structural tab range
+    /// (`ProjectStructuralLimits.tabCountRange`). Both the lower and upper bound are
+    /// enforced: at least one tab is always creatable, and never more than the
+    /// structural upper bound that durable snapshots retain.
+    private static func clampCreationCapacity(_ value: Int) -> Int {
+        let range = ProjectStructuralLimits.tabCountRange
+        return min(max(value, range.lowerBound), range.upperBound)
+    }
 
     private static func makeWorkspace(
         title: String,
         isClosable: Bool,
         filter: FilterCriteria,
         layoutPreferences: WorkspaceLayoutPreferences
-    ) -> WorkspaceState {
+    )
+        -> WorkspaceState
+    {
         let preferredBottomVisibility = layoutPreferences.preferredBottomInspectorVisibility
         return WorkspaceState(
             title: title,

--- a/Rockxy/RockxyApp.swift
+++ b/Rockxy/RockxyApp.swift
@@ -23,7 +23,10 @@ struct RockxyApp: App {
 
     @MainActor
     init() {
-        let coordinator = MainContentCoordinator()
+        let projectRepository: ProjectCatalogPersisting? = RockxyIdentity.isRunningTests
+            ? nil
+            : ProjectCatalogRepository()
+        let coordinator = MainContentCoordinator(projectCatalogRepository: projectRepository)
         _mainCoordinator = State(initialValue: coordinator)
 
         // Nearby transfer belongs to the app lifecycle, not the main-window
@@ -439,9 +442,13 @@ private struct DetachedInspectorWindowScene: Scene {
 /// Certificate identities are managed in a focused utility window with
 /// predictable geometry rather than restoring a stale, oversized workspace.
 private struct CustomCertificatesWindowScene: Scene {
+    // MARK: Internal
+
     var body: some Scene {
         customCertificatesWindow
     }
+
+    // MARK: Private
 
     private var customCertificatesWindow: some Scene {
         let base = Window(String(localized: "Custom Certificates"), id: "customCertificates") {
@@ -706,6 +713,7 @@ struct RockxyMenuCommands: Commands {
         appMenu
         fileMenu
         editMenu
+        projectMenu
         viewMenu
         flowMenu
         toolsMenu
@@ -838,6 +846,59 @@ struct RockxyMenuCommands: Commands {
                 actions?.focusSearchField()
             }
             .keyboardShortcut("f", modifiers: [.command])
+        }
+    }
+
+    private var projectMenu: some Commands {
+        CommandMenu(String(localized: "Project")) {
+            Button(String(localized: "New Project…")) {
+                actions?.newProject()
+            }
+            .keyboardShortcut("n", modifiers: [.command, .shift])
+            .disabled(actions?.canCreateProject != true)
+
+            Button(String(localized: "Rename Project…")) {
+                actions?.renameActiveProject()
+            }
+            .disabled(actions?.canEditProjects != true)
+
+            Button(String(localized: "Manage Projects…")) {
+                actions?.manageProjects()
+            }
+
+            Divider()
+
+            Button(String(localized: "Export Project Configuration…")) {
+                actions?.exportProjectConfiguration()
+            }
+            .disabled(actions?.canEditProjects != true)
+
+            Button(String(localized: "Import Project Configuration…")) {
+                actions?.importProjectConfiguration()
+            }
+            .disabled(actions?.canCreateProject != true)
+
+            Divider()
+
+            ForEach(actions?.projects ?? []) { project in
+                Button {
+                    actions?.switchProject(id: project.id)
+                } label: {
+                    if project.id == actions?.activeProjectID {
+                        Label(project.name, systemImage: "checkmark")
+                    } else {
+                        Text(project.name)
+                    }
+                }
+                .disabled(actions?.canEditProjects != true)
+            }
+
+            if actions?.projectsNeedRecovery == true {
+                Divider()
+                Button(String(localized: "Repair Projects…")) {
+                    actions?.showProjectRecovery()
+                }
+            }
         }
     }
 

--- a/Rockxy/Views/Common/NativeWorkspaceWindowChrome.swift
+++ b/Rockxy/Views/Common/NativeWorkspaceWindowChrome.swift
@@ -74,6 +74,9 @@ final class NativeWorkspaceToolbar: NSObject, NSToolbarDelegate {
     static let proxyStatusIdentifier = NSToolbarItem.Identifier(
         "\(RockxyIdentity.current.logSubsystem).toolbar.proxyStatus"
     )
+    static let projectSelectorIdentifier = NSToolbarItem.Identifier(
+        "\(RockxyIdentity.current.logSubsystem).toolbar.projectSelector"
+    )
     static let actionGroupIdentifier = NSToolbarItem.Identifier(
         "\(RockxyIdentity.current.logSubsystem).toolbar.actions"
     )
@@ -111,6 +114,7 @@ final class NativeWorkspaceToolbar: NSObject, NSToolbarDelegate {
             .flexibleSpace,
             Self.sidebarToggleIdentifier,
             Self.sidebarTrackingSeparatorIdentifier,
+            Self.projectSelectorIdentifier,
             .flexibleSpace,
             Self.proxyStatusIdentifier,
             .flexibleSpace,
@@ -138,6 +142,15 @@ final class NativeWorkspaceToolbar: NSObject, NSToolbarDelegate {
                 splitView: splitViewController.splitView,
                 dividerIndex: 0
             )
+        case Self.projectSelectorIdentifier:
+            let item = hostingItem(
+                identifier: itemIdentifier,
+                rootView: AnyView(ProjectToolbarSelectorView(coordinator: coordinator))
+            )
+            item.label = String(localized: "Project")
+            item.paletteLabel = item.label
+            item.visibilityPriority = .high
+            return item
         case Self.proxyStatusIdentifier:
             return hostingItem(
                 identifier: itemIdentifier,

--- a/Rockxy/Views/Main/Extensions/MainContentCoordinator+BabylonCapture.swift
+++ b/Rockxy/Views/Main/Extensions/MainContentCoordinator+BabylonCapture.swift
@@ -1,4 +1,5 @@
 import Foundation
+import os
 
 extension MainContentCoordinator {
     func configureBabylonCaptureIntake() {
@@ -21,17 +22,28 @@ extension MainContentCoordinator {
                 }
             }
             let settings = AppSettingsStorage.load()
-            await manager.setMaxBufferSize(min(settings.maxBufferSize, policy.maxLiveHistoryEntries))
+            let effectiveBufferSize = min(settings.maxBufferSize, policy.maxLiveHistoryEntries)
+            liveHistoryLimit = max(1, effectiveBufferSize)
+            await manager.setMaxBufferSize(effectiveBufferSize)
             await manager.setProxyPort(activeProxyPort)
             await manager.startBatchTimer()
         }
     }
 
     func receiveBabylonTransaction(_ transaction: HTTPTransaction) async {
+        guard await ensureProjectCatalogReadyForDataIntake() else {
+            Self.logger.error("Dropped Babylon traffic because the Project catalog is unavailable")
+            return
+        }
+        transaction.assignCaptureContextIfMissing(activeCaptureContext)
         await sessionManager.addTransaction(transaction)
     }
 
-    func registerBabylonCapture(identity: BabylonCaptureIdentity) {
+    func registerBabylonCapture(identity: BabylonCaptureIdentity) async {
+        guard await ensureProjectCatalogReadyForDataIntake() else {
+            Self.logger.error("Skipped Babylon workspace because the Project catalog is unavailable")
+            return
+        }
         guard BabylonCaptureWorkspaceRegistry.shared.register(identity) else {
             return
         }

--- a/Rockxy/Views/Main/Extensions/MainContentCoordinator+Eviction.swift
+++ b/Rockxy/Views/Main/Extensions/MainContentCoordinator+Eviction.swift
@@ -14,6 +14,7 @@ extension MainContentCoordinator {
         let removedIDs = Set(transactions.prefix(removeCount).map(\.id))
 
         transactions.removeFirst(removeCount)
+        transactionsByProjectID[projectStore.activeProjectID] = transactions
         rebuildObservedDomainsByApp()
         recomputeErrorCount()
         evictFromAllWorkspaces(removedIDs: removedIDs)

--- a/Rockxy/Views/Main/Extensions/MainContentCoordinator+Import.swift
+++ b/Rockxy/Views/Main/Extensions/MainContentCoordinator+Import.swift
@@ -158,13 +158,21 @@ extension MainContentCoordinator {
             let importedTransactions = try importer.importData(data)
 
             await clearSession()
+            let captureContext = activeCaptureContext
 
             for transaction in importedTransactions {
+                transaction.assignCaptureContextIfMissing(captureContext)
                 transaction.sequenceNumber = nextSequenceNumber
                 nextSequenceNumber += 1
                 transactions.append(transaction)
                 updateDomainTree(for: transaction)
                 updateAppNodes(for: transaction)
+            }
+            transactionsByProjectID[projectStore.activeProjectID] = transactions
+            nextSequenceNumberByProjectID[projectStore.activeProjectID] = nextSequenceNumber
+            let overflow = max(0, transactions.count - liveHistoryLimit)
+            if overflow > 0 {
+                evictOldestTransactions(count: overflow)
             }
             rebuildObservedDomainsByApp()
             recomputeFilteredTransactions()
@@ -177,6 +185,7 @@ extension MainContentCoordinator {
                 logEntryCount: 0,
                 importedAt: Date()
             )
+            sessionProvenanceByProjectID[projectStore.activeProjectID] = sessionProvenance
 
             activeToast = ToastMessage(
                 style: .success,
@@ -199,20 +208,33 @@ extension MainContentCoordinator {
             let session = try SessionSerializer.deserialize(from: data)
 
             await clearSession()
+            let captureContext = activeCaptureContext
 
             for codableTransaction in session.transactions {
                 let transaction = codableTransaction.toLiveModel()
+                transaction.assignCaptureContextIfMissing(captureContext)
                 transaction.sequenceNumber = nextSequenceNumber
                 nextSequenceNumber += 1
                 transactions.append(transaction)
                 updateDomainTree(for: transaction)
                 updateAppNodes(for: transaction)
             }
+            transactionsByProjectID[projectStore.activeProjectID] = transactions
+            nextSequenceNumberByProjectID[projectStore.activeProjectID] = nextSequenceNumber
+            let overflow = max(0, transactions.count - liveHistoryLimit)
+            if overflow > 0 {
+                evictOldestTransactions(count: overflow)
+            }
             rebuildObservedDomainsByApp()
 
             if let codableLogEntries = session.logEntries {
                 logEntries = codableLogEntries.map { $0.toLiveModel() }
             }
+            let maxLogs = AppSettingsStorage.load().maxLogBufferSize
+            if logEntries.count > maxLogs {
+                logEntries.removeFirst(logEntries.count - maxLogs)
+            }
+            logEntriesByProjectID[projectStore.activeProjectID] = logEntries
 
             recomputeFilteredTransactions()
             headerColumnStore.updateDiscoveredHeaders(from: transactions)
@@ -224,6 +246,7 @@ extension MainContentCoordinator {
                 logEntryCount: session.logEntries?.count ?? 0,
                 importedAt: Date()
             )
+            sessionProvenanceByProjectID[projectStore.activeProjectID] = sessionProvenance
 
             activeToast = ToastMessage(
                 style: .success,

--- a/Rockxy/Views/Main/Extensions/MainContentCoordinator+Logs.swift
+++ b/Rockxy/Views/Main/Extensions/MainContentCoordinator+Logs.swift
@@ -13,13 +13,15 @@ extension MainContentCoordinator {
 
     func startLogCapture() {
         Self.logger.info("Starting log capture")
+        let contextStore = captureContextStore
         Task {
             await logEngine.setOnLogEntry { [weak self] entry in
                 guard let self else {
                     return
                 }
+                let captureContext = contextStore.snapshot()
                 Task { @MainActor in
-                    self.addLogEntry(entry)
+                    self.addLogEntry(entry, captureContext: captureContext)
                 }
             }
 
@@ -38,26 +40,57 @@ extension MainContentCoordinator {
     // MARK: - Log Entry Processing
 
     func addLogEntry(_ entry: LogEntry) {
+        addLogEntry(entry, captureContext: activeCaptureContext)
+    }
+
+    /// Routes and correlates a log using the Project ownership captured when the
+    /// log engine delivered it, not whichever Project is active after the main-
+    /// actor hop. Stale, deleted, or cleared Project generations fail closed.
+    func addLogEntry(_ entry: LogEntry, captureContext: TrafficCaptureContext?) {
         guard isRecording else {
+            return
+        }
+        guard let captureContext,
+              captureContext.sessionID == captureContext.projectID,
+              projectStore.projects.contains(where: { $0.id == captureContext.projectID }),
+              captureContext.generation
+                == captureGenerationByProjectID[captureContext.projectID, default: 0] else
+        {
+            Self.logger.debug("Dropped log entry with stale or unknown Project ownership")
             return
         }
 
         var mutableEntry = entry
         let settings = AppSettingsStorage.load()
+        let projectID = captureContext.projectID
+        let projectTransactions = if projectID == projectStore.activeProjectID {
+            transactions
+        } else {
+            transactionsByProjectID[projectID] ?? []
+        }
+        var projectLogs = if projectID == projectStore.activeProjectID {
+            logEntries
+        } else {
+            logEntriesByProjectID[projectID] ?? []
+        }
 
         if let correlatedId = LogCorrelator.correlate(
             logEntry: entry,
-            with: transactions
+            with: projectTransactions
         ) {
             mutableEntry.correlatedTransactionId = correlatedId
         }
 
-        logEntries.append(mutableEntry)
+        projectLogs.append(mutableEntry)
 
-        if logEntries.count > settings.maxLogBufferSize {
-            let excess = logEntries.count - settings.maxLogBufferSize
-            logEntries.removeFirst(excess)
+        if projectLogs.count > settings.maxLogBufferSize {
+            let excess = projectLogs.count - settings.maxLogBufferSize
+            projectLogs.removeFirst(excess)
             Self.logger.debug("Evicted \(excess) oldest log entries")
+        }
+        logEntriesByProjectID[projectID] = projectLogs
+        if projectID == projectStore.activeProjectID {
+            logEntries = projectLogs
         }
     }
 }

--- a/Rockxy/Views/Main/Extensions/MainContentCoordinator+NearbyTransfer.swift
+++ b/Rockxy/Views/Main/Extensions/MainContentCoordinator+NearbyTransfer.swift
@@ -7,6 +7,9 @@ extension MainContentCoordinator {
     )
         async throws
     {
+        guard await ensureProjectCatalogReadyForDataIntake() else {
+            throw RockxyNearbyTransferError.projectCatalogUnavailable
+        }
         let importedTransactions = try session.transactions.map(Self.makeNearbyTransaction)
         guard !importedTransactions.isEmpty else {
             throw RockxyNearbyTransferError.emptyTransfer
@@ -21,13 +24,21 @@ extension MainContentCoordinator {
             activeWorkspace
         }
 
+        let captureContext = activeCaptureContext
         for transaction in importedTransactions {
+            transaction.assignCaptureContextIfMissing(captureContext)
             transaction.sequenceNumber = nextSequenceNumber
             nextSequenceNumber += 1
             transactions.append(transaction)
             updateDomainGroupingIndex(for: transaction, in: destinationWorkspace)
             updateAppNodes(for: transaction, in: destinationWorkspace)
         }
+        let overflow = max(0, transactions.count - liveHistoryLimit)
+        if overflow > 0 {
+            evictOldestTransactions(count: overflow)
+        }
+        transactionsByProjectID[projectStore.activeProjectID] = transactions
+        nextSequenceNumberByProjectID[projectStore.activeProjectID] = nextSequenceNumber
         refreshDomainTree(for: destinationWorkspace)
         destinationWorkspace.filteredTransactions = importedTransactions.filter { !$0.isTLSFailure }
         destinationWorkspace.lastDeriveWasAppendOnly = false
@@ -43,6 +54,7 @@ extension MainContentCoordinator {
             logEntryCount: 0,
             importedAt: Date()
         )
+        sessionProvenanceByProjectID[projectStore.activeProjectID] = sessionProvenance
         activeToast = ToastMessage(
             style: .success,
             text: String(localized: "Added \(importedTransactions.count) iOS requests from \(safeDeviceName)")

--- a/Rockxy/Views/Main/Extensions/MainContentCoordinator+ProjectPresentation.swift
+++ b/Rockxy/Views/Main/Extensions/MainContentCoordinator+ProjectPresentation.swift
@@ -1,0 +1,107 @@
+import Foundation
+
+// MARK: - MainContentCoordinator + Project Presentation
+
+extension MainContentCoordinator {
+    func presentNewProjectEditor() {
+        guard projectStore.isMutable else {
+            lastProjectOperationError = .storeNotReady
+            return
+        }
+        guard projectStore.canCreateProject else {
+            lastProjectOperationError = .capacityReached(limit: projectStore.maxProjects)
+            return
+        }
+        projectNameEditorContext = ProjectNameEditorContext(
+            mode: .create,
+            initialName: nextUntakenProjectName()
+        )
+    }
+
+    func presentRenameProjectEditor(id: UUID) {
+        guard let project = projectStore.projects.first(where: { $0.id == id }) else {
+            lastProjectOperationError = .projectNotFound
+            return
+        }
+        projectNameEditorContext = ProjectNameEditorContext(
+            mode: .rename(project.id),
+            initialName: project.name
+        )
+    }
+
+    func requestProjectDeletion(_ project: Project) {
+        projectDeletionRequest = ProjectDeletionRequest(
+            projectID: project.id,
+            projectName: project.name
+        )
+    }
+
+    var projectOperationErrorMessage: String? {
+        guard let error = lastProjectOperationError else {
+            return nil
+        }
+        return switch error {
+        case let .nameInvalid(reason):
+            switch reason {
+            case .empty:
+                String(localized: "Enter a Project name.")
+            case .containsControlCharacters:
+                String(localized: "Project names cannot contain control characters.")
+            case let .tooLong(count):
+                String(localized: "Project names are limited to 80 characters (received \(count)).")
+            case .notCanonical:
+                String(localized: "The Project name is not in canonical Unicode form.")
+            }
+        case .duplicateName:
+            String(localized: "A Project with this name already exists.")
+        case let .capacityReached(limit):
+            String(localized: "This build supports up to \(limit) Projects.")
+        case let .tabCapacityReached(limit):
+            String(localized: "A Project can contain up to \(limit) Traffic Tabs in this build.")
+        case .projectNotFound:
+            String(localized: "The selected Project no longer exists.")
+        case .cannotDeleteFinalProject:
+            String(localized: "Rockxy must keep at least one Project.")
+        case .captureClearInProgress:
+            String(localized: "Wait for the active Project capture to finish clearing, then try again.")
+        case .storeNotReady:
+            String(localized: "Projects are not ready. Retry loading the catalog first.")
+        case .revisionExhausted:
+            String(localized: "The Project catalog revision limit was reached.")
+        case .invalidTabSnapshot:
+            String(
+                localized: "A Traffic Tab contains an invalid name or filter configuration. Rename or simplify that tab, then try again."
+            )
+        case .reconciledProjectsInvalid:
+            String(localized: "The reconciled Projects were structurally invalid and were not applied.")
+        case .staleRevision:
+            String(localized: "Projects changed since this update was prepared. Try again.")
+        }
+    }
+
+    var projectPersistenceWarningMessage: String? {
+        guard case .failed = projectStore.loadState else {
+            return nil
+        }
+        return String(
+            localized: "Projects could not be loaded. Traffic Tab and filter changes will not be saved until Projects are repaired."
+        )
+    }
+
+    private func nextUntakenProjectName() -> String {
+        let base = String(localized: "New Project")
+        let used = Set(projectStore.projects.map {
+            ProjectNormalization.foldedKey(for: $0.name)
+        })
+        if !used.contains(ProjectNormalization.foldedKey(for: base)) {
+            return base
+        }
+        for number in 2 ... projectStore.maxProjects + 1 {
+            let candidate = "\(base) \(number)"
+            if !used.contains(ProjectNormalization.foldedKey(for: candidate)) {
+                return candidate
+            }
+        }
+        return base
+    }
+}

--- a/Rockxy/Views/Main/Extensions/MainContentCoordinator+ProjectTransfer.swift
+++ b/Rockxy/Views/Main/Extensions/MainContentCoordinator+ProjectTransfer.swift
@@ -1,0 +1,149 @@
+import AppKit
+import Foundation
+import os
+import UniformTypeIdentifiers
+
+// MARK: - MainContentCoordinator + Project Transfer
+
+/// Native import/export orchestration for the public config-only
+/// `.rockxyproject` format. Import is always non-destructive: it previews the
+/// categories, creates a new Project, and never replaces existing capture data.
+extension MainContentCoordinator {
+    @discardableResult
+    func exportActiveProjectConfiguration() -> Bool {
+        exportProjectConfiguration(id: projectStore.activeProjectID)
+    }
+
+    /// Exports the Project selected by a management surface. Only the active
+    /// Project needs a pre-export workspace flush; inactive Projects already hold
+    /// their last durable Traffic Tab snapshot in the catalog.
+    @discardableResult
+    func exportProjectConfiguration(id: UUID) -> Bool {
+        guard projectStore.isMutable,
+              let project = projectStore.projects.first(where: { $0.id == id }) else
+        {
+            return false
+        }
+        if id == projectStore.activeProjectID, !flushProjectTabSnapshot() {
+            return false
+        }
+
+        let panel = NSSavePanel()
+        panel.allowedContentTypes = [.rockxyProject]
+        panel.canCreateDirectories = true
+        panel.nameFieldStringValue = "\(safeProjectFileStem(project.name)).rockxyproject"
+        panel
+            .message =
+            String(
+                localized: "Exports tabs, filters, and layout only. Captured traffic is excluded. Filter text may be sensitive; review it before sharing."
+            )
+        guard panel.runModal() == .OK, let url = panel.url else {
+            return false
+        }
+
+        do {
+            // Resolve again after the modal panel returns. Project lifecycle
+            // actions are synchronous on the main actor, but this keeps the
+            // selected identity authoritative if a future presentation changes.
+            guard let currentProject = projectStore.projects.first(where: { $0.id == id }) else {
+                return false
+            }
+            try PortableProjectDocument.write(currentProject, to: url)
+            activeToast = ToastMessage(
+                style: .success,
+                text: String(localized: "Exported Project configuration")
+            )
+            return true
+        } catch {
+            presentProjectTransferError(
+                title: String(localized: "Project Export Failed"),
+                error: error
+            )
+            return false
+        }
+    }
+
+    @discardableResult
+    func importProjectConfiguration() -> Bool {
+        guard !isClearingSession else {
+            lastProjectOperationError = .captureClearInProgress
+            return false
+        }
+        guard projectStore.canCreateProject else {
+            lastProjectOperationError = .capacityReached(limit: projectStore.maxProjects)
+            return false
+        }
+
+        let panel = NSOpenPanel()
+        panel.allowedContentTypes = [.rockxyProject, .json]
+        panel.allowsMultipleSelection = false
+        panel.canChooseDirectories = false
+        panel.message = String(localized: "Choose a configuration-only .rockxyproject file")
+        guard panel.runModal() == .OK, let url = panel.url else {
+            return false
+        }
+
+        do {
+            let portable = try PortableProjectDocument.read(from: url)
+            guard confirmPortableProjectImport(portable, fileName: url.lastPathComponent) else {
+                return false
+            }
+            guard !isClearingSession else {
+                lastProjectOperationError = .captureClearInProgress
+                return false
+            }
+            cacheActiveProjectCaptureState()
+            guard flushProjectTabSnapshot() else {
+                return false
+            }
+            _ = try projectStore.importProject(portable)
+            activateCurrentProject()
+            lastProjectOperationError = nil
+            activeToast = ToastMessage(
+                style: .success,
+                text: String(localized: "Imported \(portable.name) as a new Project")
+            )
+            return true
+        } catch let error as ProjectMutationError {
+            lastProjectOperationError = error
+            presentProjectTransferError(title: String(localized: "Project Import Failed"), error: error)
+            return false
+        } catch {
+            presentProjectTransferError(title: String(localized: "Project Import Failed"), error: error)
+            return false
+        }
+    }
+
+    // MARK: Private
+
+    private func confirmPortableProjectImport(_ portable: PortableProject, fileName: String) -> Bool {
+        let alert = NSAlert()
+        alert.messageText = String(localized: "Import \(portable.name) as a New Project?")
+        alert.informativeText = String(
+            localized: "\(fileName) contains \(portable.tabs.count) traffic tab(s), user-authored filter text, host/path patterns, and layout preferences. It contains no captured traffic, bodies, headers, cookies, scripts, or local file paths. Filter text may be sensitive. Existing Projects will not be replaced."
+        )
+        alert.alertStyle = .informational
+        alert.addButton(withTitle: String(localized: "Import"))
+        alert.addButton(withTitle: String(localized: "Cancel"))
+        return alert.runModal() == .alertFirstButtonReturn
+    }
+
+    private func safeProjectFileStem(_ name: String) -> String {
+        let invalid = CharacterSet(charactersIn: "/:")
+        let components = name.components(separatedBy: invalid).filter { !$0.isEmpty }
+        let stem = components.joined(separator: "-").trimmingCharacters(in: .whitespacesAndNewlines)
+        return stem.isEmpty ? "Rockxy-Project" : stem
+    }
+
+    private func presentProjectTransferError(title: String, error: Error) {
+        Self.logger.error("Project transfer failed: \(String(describing: error))")
+        let alert = NSAlert()
+        alert.messageText = title
+        alert
+            .informativeText =
+            String(localized: "The Project configuration could not be processed safely. \(String(describing: error))")
+        alert.alertStyle = .warning
+        alert.addButton(withTitle: String(localized: "OK"))
+        alert.runModal()
+    }
+}

--- a/Rockxy/Views/Main/Extensions/MainContentCoordinator+Projects.swift
+++ b/Rockxy/Views/Main/Extensions/MainContentCoordinator+Projects.swift
@@ -1,0 +1,528 @@
+import Foundation
+import Observation
+
+// MARK: - ProjectObservationTarget
+
+private final class ProjectObservationTarget: @unchecked Sendable {
+    // MARK: Lifecycle
+
+    init(_ coordinator: MainContentCoordinator) {
+        self.coordinator = coordinator
+    }
+
+    // MARK: Internal
+
+    weak var coordinator: MainContentCoordinator?
+}
+
+// Extends `MainContentCoordinator` with non-visual Project orchestration: startup
+// hydration, Project lifecycle (switch/create/delete/rename/reorder), and
+// Observation-driven debounced autosave of durable traffic-tab configuration.
+//
+// This layer owns only orchestration. It never presents UI. Durable Project
+// persistence contains only `ProjectTabSnapshot` view intent, while runtime capture
+// histories and logs are isolated in bounded in-memory Project buckets. User
+// messaging and sheets are owned by the app layer.
+
+// MARK: - MainContentCoordinator + Projects
+
+extension MainContentCoordinator {
+    // MARK: - Startup Hydration
+
+    /// Loads the persisted catalog exactly once, coalescing concurrent callers. On a
+    /// ready load it applies the active Project's tabs and capture history to the
+    /// workspace store and arms debounced autosave. On a failed load it retains
+    /// the current safe workspaces, performs no writes, and leaves the store's
+    /// failure observable (`projectStore.loadState` / `loadFailureMessage`).
+    func hydrateProjectsOnLaunch() async {
+        if let existing = projectHydrationTask {
+            await existing.value
+            return
+        }
+        guard !hasHydratedProjects else {
+            return
+        }
+        let task = Task { @MainActor [weak self] in
+            guard let self else {
+                return
+            }
+            await self.performProjectHydration()
+        }
+        projectHydrationTask = task
+        await task.value
+        // Clear only after a failed attempt so an explicit retry can re-run; a
+        // successful hydration is guarded by `hasHydratedProjects`.
+        if !hasHydratedProjects {
+            projectHydrationTask = nil
+        }
+    }
+
+    /// Ensures app-lifecycle data producers never bind traffic or workspaces to
+    /// the provisional default Project that exists before catalog hydration.
+    /// External intake fails closed when the persisted catalog cannot be loaded.
+    func ensureProjectCatalogReadyForDataIntake() async -> Bool {
+        // A receiver may deliver many frames while recovery UI is open. Do not
+        // turn each frame into another disk retry after a known load failure;
+        // only the explicit Retry action should leave this state.
+        if case .failed = projectStore.loadState {
+            return false
+        }
+        await hydrateProjectsOnLaunch()
+        return hasHydratedProjects && projectStore.loadState == .ready
+    }
+
+    // MARK: - Project Switching
+
+    /// Persists the outgoing Project's tabs and runtime capture projection, activates
+    /// `id`, then restores that Project's tabs/history without stopping the app-wide
+    /// proxy listener. The target is validated before any outgoing
+    /// mutation; on failure the current UI/workspaces and active Project stay
+    /// coherent. Re-selecting the active Project is a successful no-op.
+    @discardableResult
+    func switchToProject(id: UUID) -> Bool {
+        guard !isClearingSession else {
+            lastProjectOperationError = .captureClearInProgress
+            return false
+        }
+        guard projectStore.isMutable else {
+            lastProjectOperationError = .storeNotReady
+            return false
+        }
+        guard id != projectStore.activeProjectID else {
+            lastProjectOperationError = nil
+            return true
+        }
+        // Validate the target before mutating the outgoing Project.
+        guard projectStore.projects.contains(where: { $0.id == id }) else {
+            lastProjectOperationError = .projectNotFound
+            return false
+        }
+        cacheActiveProjectCaptureState()
+        guard flushProjectTabSnapshot() else {
+            return false
+        }
+        do {
+            try projectStore.selectProject(id: id)
+        } catch let error as ProjectMutationError {
+            lastProjectOperationError = error
+            return false
+        } catch {
+            return false
+        }
+        activateCurrentProject()
+        lastProjectOperationError = nil
+        return true
+    }
+
+    // MARK: - Reconciliation
+
+    /// Edition-neutral local reconciliation seam. Applies an externally reconciled
+    /// set of Project entities while keeping the coordinator's workspace tabs,
+    /// capture-routing context, and per-Project runtime buckets coherent.
+    ///
+    /// `expectedRevision` is the caller's last-observed local catalog revision. The
+    /// active Project's live tab configuration is flushed first (so an unsaved edit
+    /// is preserved rather than lost), then the store performs an in-process
+    /// compare-and-swap against `expectedRevision`. If the flush advanced the
+    /// revision the candidate is now stale and is rejected for caller retry — the
+    /// flushed edit is never overwritten. Runtime buckets are cleared only for
+    /// removed Project IDs. The workspace/capture context is refreshed only when the
+    /// active Project identity or its tab configuration actually changed, so an
+    /// inactive-only reconciliation leaves the current live workspace untouched.
+    /// Runtime capture for a surviving active Project is preserved across a refresh.
+    /// Returns whether the catalog changed; failures surface via
+    /// `lastProjectOperationError`.
+    @discardableResult
+    func reconcileProjects(_ projects: [Project], expectedRevision: UInt64) -> Bool {
+        guard !isClearingSession else {
+            lastProjectOperationError = .captureClearInProgress
+            return false
+        }
+        guard projectStore.isMutable else {
+            lastProjectOperationError = .storeNotReady
+            return false
+        }
+
+        let previousProjectIDs = Set(projectStore.projects.map(\.id))
+        cacheActiveProjectCaptureState()
+        guard flushProjectTabSnapshot() else {
+            return false
+        }
+        let previousActive = projectStore.activeProject
+
+        let changed: Bool
+        do {
+            changed = try projectStore.reconcile(projects: projects, expectedRevision: expectedRevision)
+        } catch let error as ProjectMutationError {
+            lastProjectOperationError = error
+            return false
+        } catch {
+            return false
+        }
+
+        let removedProjectIDs = previousProjectIDs.subtracting(projectStore.projects.map(\.id))
+        for projectID in removedProjectIDs {
+            transactionsByProjectID.removeValue(forKey: projectID)
+            logEntriesByProjectID.removeValue(forKey: projectID)
+            sessionProvenanceByProjectID.removeValue(forKey: projectID)
+            captureGenerationByProjectID.removeValue(forKey: projectID)
+            nextSequenceNumberByProjectID.removeValue(forKey: projectID)
+        }
+
+        let newActive = projectStore.activeProject
+        let activeIdentityChanged = newActive.id != previousActive.id
+        let activeTabConfigurationChanged = newActive.activeTabID != previousActive.activeTabID
+            || newActive.tabs != previousActive.tabs
+        if activeIdentityChanged || activeTabConfigurationChanged {
+            activateCurrentProject()
+        }
+
+        lastProjectOperationError = nil
+        return changed
+    }
+
+    // MARK: - Capacity Refresh
+
+    /// Re-clamps the Project and workspace-tab *creation* capacities from a refreshed
+    /// policy without deleting or truncating any retained Project or tab. Only future
+    /// create/import/duplicate actions observe the new bounds; existing over-limit
+    /// state is preserved intact.
+    func refreshProjectCreationCapacity(with policy: any AppPolicy) {
+        projectStore.refreshCapacity(with: policy)
+        workspaceStore.refreshCapacity(maxWorkspaces: policy.maxWorkspaceTabs)
+    }
+
+    // MARK: - Project Lifecycle
+
+    /// Persists the outgoing snapshot, creates and activates a new Project, then
+    /// applies its default tab set and rebuilds. Returns `nil` (with
+    /// `lastProjectOperationError` set) on rejection, leaving current state intact.
+    @discardableResult
+    func createProject(named name: String) -> Project? {
+        guard !isClearingSession else {
+            lastProjectOperationError = .captureClearInProgress
+            return nil
+        }
+        guard projectStore.isMutable else {
+            lastProjectOperationError = .storeNotReady
+            return nil
+        }
+        cacheActiveProjectCaptureState()
+        guard flushProjectTabSnapshot() else {
+            return nil
+        }
+        do {
+            let project = try projectStore.createProject(name: name)
+            activateCurrentProject()
+            lastProjectOperationError = nil
+            return project
+        } catch let error as ProjectMutationError {
+            lastProjectOperationError = error
+            return nil
+        } catch {
+            return nil
+        }
+    }
+
+    /// Deletes a Project. Deleting the active Project applies and rebuilds the
+    /// deterministically selected adjacent Project; deleting an inactive Project
+    /// preserves the current tabs (only the active Project's durable edits are first
+    /// flushed so they are not lost).
+    @discardableResult
+    func deleteProject(id: UUID) -> Bool {
+        guard !isClearingSession else {
+            lastProjectOperationError = .captureClearInProgress
+            return false
+        }
+        guard projectStore.isMutable else {
+            lastProjectOperationError = .storeNotReady
+            return false
+        }
+        let deletingActive = id == projectStore.activeProjectID
+        let deletedProjectID = id
+        if deletingActive {
+            cacheActiveProjectCaptureState()
+        }
+        if !deletingActive {
+            // Preserve the current active Project's edits; its tabs are untouched.
+            guard flushProjectTabSnapshot() else {
+                return false
+            }
+        }
+        do {
+            try projectStore.deleteProject(id: id)
+        } catch let error as ProjectMutationError {
+            lastProjectOperationError = error
+            return false
+        } catch {
+            return false
+        }
+        if deletingActive {
+            activateCurrentProject()
+        }
+        transactionsByProjectID.removeValue(forKey: deletedProjectID)
+        logEntriesByProjectID.removeValue(forKey: deletedProjectID)
+        sessionProvenanceByProjectID.removeValue(forKey: deletedProjectID)
+        captureGenerationByProjectID.removeValue(forKey: deletedProjectID)
+        nextSequenceNumberByProjectID.removeValue(forKey: deletedProjectID)
+        lastProjectOperationError = nil
+        return true
+    }
+
+    /// Renames a Project. Never swaps tabs.
+    @discardableResult
+    func renameProject(id: UUID, to name: String) -> Bool {
+        guard projectStore.isMutable else {
+            lastProjectOperationError = .storeNotReady
+            return false
+        }
+        do {
+            try projectStore.renameProject(id: id, to: name)
+            lastProjectOperationError = nil
+            return true
+        } catch let error as ProjectMutationError {
+            lastProjectOperationError = error
+            return false
+        } catch {
+            return false
+        }
+    }
+
+    /// Reorders Projects. Never swaps tabs.
+    @discardableResult
+    func reorderProjects(_ orderedIDs: [UUID]) -> Bool {
+        guard projectStore.isMutable else {
+            lastProjectOperationError = .storeNotReady
+            return false
+        }
+        do {
+            try projectStore.reorderProjects(orderedIDs)
+            lastProjectOperationError = nil
+            return true
+        } catch let error as ProjectMutationError {
+            lastProjectOperationError = error
+            return false
+        } catch {
+            return false
+        }
+    }
+
+    // MARK: - Explicit Flush
+
+    /// Captures the active Project's traffic-tab configuration and persists it
+    /// through the store. Intended both for the debounced autosave and as an
+    /// explicit pre-transition flush the app can call before a known window change.
+    /// A snapshot that reproduces the stored tabs is a no-op (no revision bump).
+    /// Returns whether the store accepted the snapshot.
+    @discardableResult
+    func flushProjectTabSnapshot() -> Bool {
+        guard projectStore.isMutable else {
+            return false
+        }
+        let snapshots = workspaceStore.captureTabSnapshots()
+        let activeTabID = workspaceStore.activeWorkspaceID
+        do {
+            try projectStore.updateActiveProjectTabs(snapshots, activeTabID: activeTabID)
+            lastProjectOperationError = nil
+            return true
+        } catch let error as ProjectMutationError {
+            lastProjectOperationError = error
+            return false
+        } catch {
+            return false
+        }
+    }
+
+    func flushProjectStateForTermination() async {
+        projectTabAutosaveTask?.cancel()
+        projectTabAutosaveTask = nil
+        _ = flushProjectTabSnapshot()
+        await projectStore.waitForPendingPersistence()
+    }
+
+    // MARK: - Autosave (Observation-driven)
+
+    /// Arms Observation-driven autosave once the store is hydrated. Idempotent.
+    func beginProjectTabObservation() {
+        guard hasHydratedProjects, !isObservingProjectTabs else {
+            return
+        }
+        isObservingProjectTabs = true
+        armProjectTabObservation()
+    }
+
+    /// Schedules a single debounced autosave, cancelling any in-flight one so rapid
+    /// edits coalesce into one write. Never accumulates tasks.
+    func scheduleProjectTabAutosave() {
+        projectTabAutosaveTask?.cancel()
+        projectTabAutosaveTask = Task { @MainActor [weak self] in
+            guard let self else {
+                return
+            }
+            do {
+                try await Task.sleep(for: self.projectTabAutosaveDebounce)
+            } catch {
+                // Cancelled by a newer change: coalesced into the later save.
+                return
+            }
+            guard !Task.isCancelled else {
+                return
+            }
+            self.flushProjectTabSnapshot()
+            self.projectTabAutosaveTask = nil
+        }
+    }
+
+    // MARK: - Private
+
+    private func performProjectHydration() async {
+        await projectStore.loadPersistedCatalog()
+        guard projectStore.loadState == .ready else {
+            // Failed load: keep current workspaces, write nothing, do not arm autosave.
+            return
+        }
+        seedActiveProjectCaptureStateIfNeeded()
+        activateCurrentProject()
+        hasHydratedProjects = true
+        beginProjectTabObservation()
+    }
+
+    /// Applies the active Project's tabs and isolated capture history to the
+    /// workspace store, then cancels
+    /// workspace-scoped assistant work orphaned by the tab replacement. All mutation
+    /// runs with autosave suppressed.
+    func activateCurrentProject() {
+        let project = projectStore.activeProject
+        cancelWorkspaceScopedAssistantWork()
+        restoreActiveProjectCaptureState()
+        refreshCaptureContextSnapshot()
+        withProjectSnapshotApplication {
+            workspaceStore.applyTabSnapshots(project.tabs, activeTabID: project.activeTabID)
+            rebuildAllWorkspacesForCaptureReplacement()
+        }
+    }
+
+    /// Recomputes each workspace's sidebar indexes and filtered rows from only the
+    /// active Project's runtime capture projection.
+    func rebuildAllWorkspacesForCaptureReplacement() {
+        for workspace in workspaceStore.workspaces {
+            rebuildSidebarIndexes(for: workspace)
+            recomputeFilteredTransactions(for: workspace)
+        }
+        TrafficDomainSnapshot.shared.update(appNodes: appNodes, domainTree: domainTree)
+    }
+
+    // MARK: - Capture Routing
+
+    /// Stable session identity for the current single-session Project slice. A
+    /// distinct `sessionID` remains in the routing contract so adding archived or
+    /// named sessions later does not change proxy ownership semantics.
+    var activeCaptureContext: TrafficCaptureContext {
+        let projectID = projectStore.activeProjectID
+        return TrafficCaptureContext(
+            projectID: projectID,
+            sessionID: projectID,
+            generation: captureGenerationByProjectID[projectID, default: 0]
+        )
+    }
+
+    func refreshCaptureContextSnapshot() {
+        captureContextStore.update(activeCaptureContext)
+    }
+
+    func cacheActiveProjectCaptureState() {
+        let projectID = projectStore.activeProjectID
+        transactionsByProjectID[projectID] = transactions
+        nextSequenceNumberByProjectID[projectID] = nextSequenceNumber
+        logEntriesByProjectID[projectID] = logEntries
+        if let sessionProvenance {
+            sessionProvenanceByProjectID[projectID] = sessionProvenance
+        } else {
+            sessionProvenanceByProjectID.removeValue(forKey: projectID)
+        }
+    }
+
+    func seedActiveProjectCaptureStateIfNeeded() {
+        let projectID = projectStore.activeProjectID
+        if transactionsByProjectID[projectID] == nil, !transactions.isEmpty {
+            let context = activeCaptureContext
+            for transaction in transactions {
+                transaction.assignCaptureContextIfMissing(context)
+            }
+            transactionsByProjectID[projectID] = transactions
+            nextSequenceNumberByProjectID[projectID] = nextSequenceNumber
+        }
+        if logEntriesByProjectID[projectID] == nil, !logEntries.isEmpty {
+            logEntriesByProjectID[projectID] = logEntries
+        }
+        if sessionProvenanceByProjectID[projectID] == nil, let sessionProvenance {
+            sessionProvenanceByProjectID[projectID] = sessionProvenance
+        }
+    }
+
+    private func restoreActiveProjectCaptureState() {
+        let projectID = projectStore.activeProjectID
+        transactions = transactionsByProjectID[projectID] ?? []
+        logEntries = logEntriesByProjectID[projectID] ?? []
+        sessionProvenance = sessionProvenanceByProjectID[projectID]
+        nextSequenceNumber = (transactions.map(\.sequenceNumber).max() ?? -1) + 1
+        nextSequenceNumberByProjectID[projectID] = nextSequenceNumber
+        recomputeErrorCount()
+        resetTrafficMetrics()
+        recordTrafficMetrics(for: transactions)
+        rebuildObservedDomainsByApp()
+        debugAssistantTransactionsByHost.removeAll()
+        debugAssistantIndexedTransactionIDs.removeAll()
+        debugAssistantIndexedLiveCount = 0
+        debugAssistantTrafficIndexGeneration &+= 1
+        appendToDebugAssistantTrafficIndex(transactions)
+        headerColumnStore.updateDiscoveredHeaders(from: transactions)
+    }
+
+    private func cancelWorkspaceScopedAssistantWork() {
+        for workspaceID in Array(debugAssistantTasks.keys) {
+            cancelDebugAssistantTask(for: workspaceID)
+        }
+    }
+
+    private func withProjectSnapshotApplication(_ body: () -> Void) {
+        let previous = isApplyingProjectSnapshot
+        isApplyingProjectSnapshot = true
+        defer { isApplyingProjectSnapshot = previous }
+        body()
+    }
+
+    /// Registers Observation dependencies on the durable tab seams and re-arms after
+    /// each change. Autosave scheduling is skipped while a snapshot is being applied;
+    /// a stray post-application save is additionally a store no-op because
+    /// `updateActiveProjectTabs` rejects an unchanged tab set.
+    private func armProjectTabObservation() {
+        let target = ProjectObservationTarget(self)
+        withObservationTracking {
+            trackDurableTabConfiguration()
+        } onChange: {
+            Task { @MainActor in
+                guard let coordinator = target.coordinator,
+                      coordinator.isObservingProjectTabs else
+                {
+                    return
+                }
+                coordinator.armProjectTabObservation()
+                guard !coordinator.isApplyingProjectSnapshot else {
+                    return
+                }
+                coordinator.scheduleProjectTabAutosave()
+            }
+        }
+    }
+
+    /// Touches exactly the durable configuration captured into `ProjectTabSnapshot`
+    /// so Observation tracks those properties and nothing more. Building the
+    /// snapshots is the single source of truth for which seams are durable.
+    private func trackDurableTabConfiguration() {
+        _ = workspaceStore.activeWorkspaceID
+        for workspace in workspaceStore.workspaces {
+            _ = ProjectTabSnapshot(capturing: workspace)
+        }
+    }
+}

--- a/Rockxy/Views/Main/Extensions/MainContentCoordinator+ProxyControl.swift
+++ b/Rockxy/Views/Main/Extensions/MainContentCoordinator+ProxyControl.swift
@@ -24,6 +24,13 @@ extension MainContentCoordinator {
                 isProxyStarting = false
             }
 
+            guard await ensureProjectCatalogReadyForDataIntake() else {
+                proxyError = String(
+                    localized: "Projects could not be loaded. Repair Projects before starting capture."
+                )
+                return
+            }
+
             let settings = AppSettingsStorage.load()
             do {
                 try await certificateManager.ensureRootCA()
@@ -256,44 +263,76 @@ extension MainContentCoordinator {
         // Mark the rollover intent synchronously so batches delivered while the
         // main actor is suspended can be classified deterministically.
         let targetGeneration = sessionGeneration &+ 1
+        let activeProjectID = projectStore.activeProjectID
+        captureGenerationByProjectID[activeProjectID, default: 0] &+= 1
+        refreshCaptureContextSnapshot()
         isClearingSession = true
+        clearingProjectID = activeProjectID
         clearingTargetGeneration = targetGeneration
         deferredSessionBatches.removeAll()
 
         // Advance the actor-side generation first so any traffic arriving while
         // the main actor is suspended joins the new session instead of being
         // stamped with an old generation.
-        let resolvedGeneration = await sessionManager.beginNewSession()
+        let rollover = await sessionManager.beginNewSessionPreservingPending()
+        let resolvedGeneration = rollover.generation
 
         // Validate that this clear is still the authoritative in-flight clear
         // after the suspension. A different generation here would mean state
         // has been reset out from under us; abandon the rest of the clear.
         guard clearingTargetGeneration == targetGeneration else {
+            clearingProjectID = nil
+            clearingTargetGeneration = nil
+            deferredSessionBatches.removeAll()
+            isClearingSession = false
             return
         }
         sessionGeneration = resolvedGeneration
 
-        transactions.removeAll()
-        rebuildObservedDomainsByApp()
-        logEntries.removeAll()
-        errorCount = 0
-        sessionProvenance = nil
-        importPreview = nil
-        exportScopeContext = nil
-        activeToast = nil
-        clearAllWorkspaces()
-        resetTrafficMetrics()
+        // Defer everything that had completed before the rollover. Per-Project
+        // ownership and generations are the authoritative stale check after clear:
+        // old target-Project work is dropped, unchanged inactive-Project work is
+        // retained, and newly stamped target-Project work is accepted.
+        if !rollover.pending.isEmpty {
+            deferredSessionBatches.append(
+                .init(transactions: rollover.pending, generation: resolvedGeneration)
+            )
+        }
 
-        // Advance nextSequenceNumber past highest assigned to any remaining persisted favorite
-        if persistedFavorites.isEmpty {
-            nextSequenceNumber = 0
+        transactionsByProjectID[activeProjectID] = []
+        nextSequenceNumberByProjectID[activeProjectID] = 0
+        logEntriesByProjectID[activeProjectID] = []
+        sessionProvenanceByProjectID.removeValue(forKey: activeProjectID)
+
+        // Normal UI paths serialize Project transitions while clearing. Keep this
+        // identity check as a second line of defense so a future direct store
+        // mutation cannot clear another Project's active projection.
+        if projectStore.activeProjectID == activeProjectID {
+            transactions.removeAll()
+            rebuildObservedDomainsByApp()
+            logEntries.removeAll()
+            errorCount = 0
+            sessionProvenance = nil
+            importPreview = nil
+            exportScopeContext = nil
+            activeToast = nil
+            clearAllWorkspaces()
+            resetTrafficMetrics()
+
+            // Advance nextSequenceNumber past highest assigned to any remaining persisted favorite
+            if persistedFavorites.isEmpty {
+                nextSequenceNumber = 0
+            } else {
+                let maxSeq = persistedFavorites.map(\.sequenceNumber).max() ?? 0
+                nextSequenceNumber = maxSeq + 1
+            }
         } else {
-            let maxSeq = persistedFavorites.map(\.sequenceNumber).max() ?? 0
-            nextSequenceNumber = maxSeq + 1
+            Self.logger.error("Active Project changed during clear; protected the new projection")
         }
 
         let deferredBatches = deferredSessionBatches
         deferredSessionBatches.removeAll()
+        clearingProjectID = nil
         clearingTargetGeneration = nil
         isClearingSession = false
 
@@ -329,6 +368,7 @@ extension MainContentCoordinator {
         )
 
         let bpManager = breakpointManager
+        refreshCaptureContextSnapshot()
         // Ensure scripts are loaded before the proxy starts accepting connections,
         // so the first captured request sees the same script state as every later one.
         // After the first call this is a fast no-op.
@@ -340,6 +380,9 @@ extension MainContentCoordinator {
             ruleEngine: RuleEngine.shared,
             scriptPluginManager: PluginManager.shared.scriptManager,
             upstreamProxySnapshotProvider: upstreamProxySnapshotProvider,
+            captureContextProvider: { [captureContextStore] in
+                captureContextStore.snapshot()
+            },
             onTransactionComplete: { transaction in
                 Task {
                     await manager.addTransaction(transaction)
@@ -367,6 +410,7 @@ extension MainContentCoordinator {
             }
         }
         let effectiveBufferSize = min(settings.maxBufferSize, policy.maxLiveHistoryEntries)
+        liveHistoryLimit = max(1, effectiveBufferSize)
         await sessionManager.setMaxBufferSize(effectiveBufferSize)
         await sessionManager.setProxyPort(resolvedPort)
         await sessionManager.startBatchTimer()
@@ -378,18 +422,19 @@ extension MainContentCoordinator {
 
     func processBatch(_ batch: [HTTPTransaction], generation: UInt) {
         if isClearingSession {
-            guard generation == clearingTargetGeneration else {
-                Self.logger.debug("Batch of \(batch.count) dropped — stale clear-session generation")
+            guard let targetGeneration = clearingTargetGeneration else {
+                Self.logger.error("Dropped batch because clear state had no target generation")
                 return
             }
 
-            deferredSessionBatches.append(.init(transactions: batch, generation: generation))
+            // Restamp only the batch-delivery generation. Immutable per-Project
+            // ownership still decides which transactions survive after the clear.
+            deferredSessionBatches.append(.init(transactions: batch, generation: targetGeneration))
             return
         }
 
-        guard generation == sessionGeneration else {
-            Self.logger.debug("Batch of \(batch.count) dropped — stale session generation")
-            return
+        if generation != sessionGeneration {
+            Self.logger.debug("Evaluating an older delivery batch by its Project ownership")
         }
         guard isRecording else {
             Self.logger.debug("Batch of \(batch.count) dropped — recording paused")
@@ -407,39 +452,76 @@ extension MainContentCoordinator {
             return
         }
 
-        // Report only accepted transactions back to the actor for buffer accounting.
-        // This ensures paused/filtered batches do not consume the live-history budget.
-        // The generation tag prevents stale reports from a pre-clear batch affecting
-        // post-clear accounting.
-        let acceptedCount = filteredBatch.count
-        Task { await sessionManager.reportAcceptedCount(acceptedCount, generation: generation) }
-
-        recordTrafficMetrics(for: filteredBatch)
-
-        Self.logger
-            .info(
-                "Processing batch of \(filteredBatch.count) transactions (total: \(self.transactions.count + filteredBatch.count))"
-            )
+        // Tests, startup restoration, and bounded local integrations may seed the
+        // active projection directly before the first routed proxy batch. Adopt
+        // that history once so the first completion appends instead of replacing it.
+        seedActiveProjectCaptureStateIfNeeded()
+        let knownProjectIDs = Set(projectStore.projects.map(\.id))
+        var routedBatches: [UUID: [HTTPTransaction]] = [:]
 
         for transaction in filteredBatch {
-            transaction.sequenceNumber = nextSequenceNumber
-            nextSequenceNumber += 1
-            transactions.append(transaction)
-
-            if let statusCode = transaction.response?.statusCode, statusCode >= 400 {
-                errorCount += 1
+            guard let context = transaction.captureContext else {
+                Self.logger.error("Dropped transaction without request-start Project ownership")
+                continue
             }
+            guard knownProjectIDs.contains(context.projectID),
+                  context.sessionID == context.projectID,
+                  context.generation == captureGenerationByProjectID[context.projectID, default: 0] else
+            {
+                Self.logger.debug("Dropped transaction with stale or unknown Project capture route")
+                continue
+            }
+            routedBatches[context.projectID, default: []].append(transaction)
         }
-        appendToDebugAssistantTrafficIndex(filteredBatch)
-        appendObservedDomainsByApp(from: filteredBatch)
 
-        updateAllWorkspaces(with: filteredBatch)
-        followLatestVisibleTransaction(from: filteredBatch)
+        for (projectID, projectBatch) in routedBatches {
+            var history = transactionsByProjectID[projectID] ?? []
+            var sequence = nextSequenceNumberByProjectID[projectID]
+                ?? ((history.map(\.sequenceNumber).max() ?? -1) + 1)
+            for transaction in projectBatch {
+                transaction.sequenceNumber = sequence
+                sequence += 1
+                history.append(transaction)
+            }
+            nextSequenceNumberByProjectID[projectID] = sequence
 
-        headerColumnStore.updateDiscoveredHeaders(fromBatch: filteredBatch)
+            let overflow = max(0, history.count - liveHistoryLimit)
+            if overflow > 0 {
+                history.removeFirst(overflow)
+            }
+            transactionsByProjectID[projectID] = history
+
+            guard projectID == projectStore.activeProjectID else {
+                Self.logger.debug("Routed \(projectBatch.count) late transaction(s) to an inactive Project")
+                continue
+            }
+
+            transactions = history
+            nextSequenceNumber = sequence
+            if overflow > 0 {
+                rebuildObservedDomainsByApp()
+                debugAssistantTransactionsByHost.removeAll()
+                debugAssistantIndexedTransactionIDs.removeAll()
+                debugAssistantIndexedLiveCount = 0
+                debugAssistantTrafficIndexGeneration &+= 1
+                appendToDebugAssistantTrafficIndex(history)
+                rebuildAllWorkspacesForCaptureReplacement()
+            } else {
+                updateAllWorkspaces(with: projectBatch)
+                appendToDebugAssistantTrafficIndex(projectBatch)
+                appendObservedDomainsByApp(from: projectBatch)
+            }
+
+            recordTrafficMetrics(for: projectBatch)
+            recomputeErrorCount()
+            followLatestVisibleTransaction(from: projectBatch)
+            headerColumnStore.updateDiscoveredHeaders(fromBatch: projectBatch)
+        }
     }
 
     func handleClientAppEnrichment(_ enrichedTransactions: [HTTPTransaction]) {
+        let activeIDs = Set(transactions.map(\.id))
+        let enrichedTransactions = enrichedTransactions.filter { activeIDs.contains($0.id) }
         guard !enrichedTransactions.isEmpty else {
             return
         }
@@ -516,7 +598,7 @@ extension MainContentCoordinator {
     private func workspaceUsesClientDependentOrderingOrFiltering(_ workspace: WorkspaceState) -> Bool {
         if workspace.filterCriteria.sidebarApp != nil
             || workspace.filterCriteria.isSearchEnabled
-                && workspace.filterCriteria.searchField == .clientApp
+            && workspace.filterCriteria.searchField == .clientApp
             || workspace.activeSortDescriptors.contains(where: { $0.key == "client" })
             || workspace.activeFocusSet != nil
             || !workspace.mutedTrafficSources.isEmpty

--- a/Rockxy/Views/Main/MainContentCommandActions.swift
+++ b/Rockxy/Views/Main/MainContentCommandActions.swift
@@ -76,6 +76,35 @@ struct MainContentCommandActions {
         coordinator.workspaceStore.workspaces.contains { $0.id == coordinator.workspaceStore.activeWorkspaceID }
     }
 
+    var projects: [Project] {
+        coordinator.projectStore.projects
+    }
+
+    var activeProjectID: UUID {
+        coordinator.projectStore.activeProjectID
+    }
+
+    var canCreateProject: Bool {
+        coordinator.projectStore.canCreateProject && !coordinator.isClearingSession
+    }
+
+    var canEditProjects: Bool {
+        coordinator.projectStore.isMutable && !coordinator.isClearingSession
+    }
+
+    var projectsNeedRecovery: Bool {
+        if case .failed = coordinator.projectStore.loadState {
+            return true
+        }
+        return false
+    }
+
+    // MARK: - View
+
+    var isFollowingLiveTraffic: Bool {
+        coordinator.isFollowingLiveTraffic
+    }
+
     func startProxy() {
         coordinator.startProxy()
     }
@@ -172,18 +201,12 @@ struct MainContentCommandActions {
         coordinator.setHighlight(color, for: transaction)
     }
 
-    // MARK: - View
-
-    var isFollowingLiveTraffic: Bool {
-        coordinator.isFollowingLiveTraffic
-    }
-
     func setFollowingLiveTraffic(_ isEnabled: Bool) {
         coordinator.setFollowingLiveTraffic(isEnabled)
     }
 
     func toggleSourceList() {
-        withAnimation(.smooth(duration: 0.18)) {
+        _ = withAnimation(.smooth(duration: 0.18)) {
             NSApp.keyWindow?.firstResponder?.tryToPerform(
                 #selector(NSSplitViewController.toggleSidebar(_:)),
                 with: nil
@@ -280,6 +303,42 @@ struct MainContentCommandActions {
 
     func nextWorkspaceTab() {
         RockxyWorkspaceWindowManager.shared.selectNextWorkspaceTab(coordinator: coordinator)
+    }
+
+    // MARK: - Projects
+
+    func newProject() {
+        coordinator.presentNewProjectEditor()
+    }
+
+    func renameActiveProject() {
+        coordinator.presentRenameProjectEditor(id: coordinator.projectStore.activeProjectID)
+    }
+
+    func manageProjects() {
+        coordinator.isProjectManagerPresented = true
+    }
+
+    func showProjectRecovery() {
+        coordinator.isProjectRecoveryPresented = true
+    }
+
+    func exportProjectConfiguration() {
+        _ = coordinator.exportActiveProjectConfiguration()
+    }
+
+    func importProjectConfiguration() {
+        guard coordinator.importProjectConfiguration() else {
+            return
+        }
+        RockxyWorkspaceWindowManager.shared.projectDidChange(coordinator: coordinator)
+    }
+
+    func switchProject(id: UUID) {
+        guard coordinator.switchToProject(id: id) else {
+            return
+        }
+        RockxyWorkspaceWindowManager.shared.projectDidChange(coordinator: coordinator)
     }
 }
 

--- a/Rockxy/Views/Main/MainContentCoordinator.swift
+++ b/Rockxy/Views/Main/MainContentCoordinator.swift
@@ -134,7 +134,9 @@ final class MainContentCoordinator {
         assistantRuntime: any AssistantProviderRuntimeProtocol = AssistantProviderRuntime.shared,
         assistantSettingsProvider: @escaping @MainActor () -> AppSettings = {
             AppSettingsManager.shared.settings
-        }
+        },
+        projectCatalogRepository: ProjectCatalogPersisting? = nil,
+        projectTabAutosaveDebounce: Duration = .milliseconds(500)
     ) {
         self.policy = policy
         self.assistantRuntime = assistantRuntime
@@ -143,12 +145,21 @@ final class MainContentCoordinator {
             maxWorkspaces: policy.maxWorkspaceTabs,
             layoutPreferences: workspaceLayoutPreferences
         )
+        // A `nil` repository keeps the Project store fully in-memory (and immediately
+        // ready) so tests and previews do no Application Support I/O; the app injects
+        // the concrete repository later. The store shares this coordinator's policy.
+        self.projectStore = ProjectStore(policy: policy, repository: projectCatalogRepository)
+        self.projectTabAutosaveDebounce = projectTabAutosaveDebounce
+        self.liveHistoryLimit = policy.maxLiveHistoryEntries
+        refreshCaptureContextSnapshot()
     }
 
     deinit {
         for handle in debugAssistantTasks.values {
             handle.task.cancel()
         }
+        projectTabAutosaveTask?.cancel()
+        projectHydrationTask?.cancel()
         if let rulesObserver {
             NotificationCenter.default.removeObserver(rulesObserver)
         }
@@ -225,7 +236,9 @@ final class MainContentCoordinator {
     var activeProxyPort = AppSettingsManager.shared.settings.proxyPort
     var isRecording = true
     var sessionGeneration: UInt = 0
+    var liveHistoryLimit: Int
     var isClearingSession = false
+    var clearingProjectID: UUID?
     var clearingTargetGeneration: UInt?
     var deferredSessionBatches: [DeferredBatch] = []
     var proxyError: String?
@@ -283,6 +296,50 @@ final class MainContentCoordinator {
     var previewTabStore = PreviewTabStore()
     var headerColumnStore = HeaderColumnStore()
     var filterPresetStore = FilterPresetStore()
+
+    // MARK: - Projects
+
+    /// Durable owner of the Project → traffic-tab configuration. Non-visual
+    /// orchestration lives in `MainContentCoordinator+Projects`; user messaging and
+    /// sheets are owned by the app layer.
+    let projectStore: ProjectStore
+
+    /// Thread-safe request-start routing snapshot consumed by SwiftNIO handlers.
+    let captureContextStore = TrafficCaptureContextStore()
+
+    /// In-memory capture histories are isolated per Project while `transactions`
+    /// remains the active Project's observable UI projection.
+    @ObservationIgnored var transactionsByProjectID: [UUID: [HTTPTransaction]] = [:]
+    @ObservationIgnored var logEntriesByProjectID: [UUID: [LogEntry]] = [:]
+    @ObservationIgnored var sessionProvenanceByProjectID: [UUID: SessionProvenance] = [:]
+    @ObservationIgnored var captureGenerationByProjectID: [UUID: UInt64] = [:]
+    @ObservationIgnored var nextSequenceNumberByProjectID: [UUID: Int] = [:]
+
+    /// The last non-fatal Project operation error, exposed for the app layer to
+    /// surface. Reset on the next successful operation. Not a presentation state.
+    var lastProjectOperationError: ProjectMutationError?
+
+    var projectNameEditorContext: ProjectNameEditorContext?
+    var projectDeletionRequest: ProjectDeletionRequest?
+    var isProjectManagerPresented = false
+    var isProjectRecoveryPresented = false
+
+    /// Debounce window that coalesces rapid traffic-tab edits into a single durable
+    /// autosave. Injectable so tests can shorten it.
+    @ObservationIgnored let projectTabAutosaveDebounce: Duration
+    /// The single in-flight debounced autosave, replaced/cancelled on each change so
+    /// the coordinator never accumulates unbounded persistence tasks.
+    @ObservationIgnored var projectTabAutosaveTask: Task<Void, Never>?
+    /// Coalesces concurrent startup hydration attempts so the catalog loads once.
+    @ObservationIgnored var projectHydrationTask: Task<Void, Never>?
+    /// True once the active Project's tabs have been applied to the workspace store.
+    @ObservationIgnored var hasHydratedProjects = false
+    /// True while Observation-driven autosave is armed (only after a ready load).
+    @ObservationIgnored var isObservingProjectTabs = false
+    /// Suppresses autosave scheduling while a Project snapshot is being applied to
+    /// the workspace store, so hydration/switches never write back through the same
+    /// observation seam mid-application.
+    @ObservationIgnored var isApplyingProjectSnapshot = false
 
     // MARK: - UI State — Import/Export
 

--- a/Rockxy/Views/Main/WorkspaceWindowManager.swift
+++ b/Rockxy/Views/Main/WorkspaceWindowManager.swift
@@ -50,6 +50,7 @@ final class RockxyWorkspaceWindowManager: NSObject {
 
     func registerPrimaryWindow(_ window: NSWindow, coordinator: MainContentCoordinator) {
         self.coordinator = coordinator
+        terminationCoordinator = coordinator
         primaryWindow = window
         configure(window)
         installObserversIfNeeded(for: window)
@@ -127,7 +128,17 @@ final class RockxyWorkspaceWindowManager: NSObject {
     }
 
     func updateWindowTitles(coordinator: MainContentCoordinator) {
-        primaryWindow?.title = coordinator.workspaceStore.activeWorkspace.title
+        primaryWindow?.title = coordinator.projectStore.activeProject.name
+    }
+
+    func projectDidChange(coordinator: MainContentCoordinator) {
+        self.coordinator = coordinator
+        updateTabAccessory(forceVisible: coordinator.workspaceStore.workspaces.count > 1)
+        updateWindowTitles(coordinator: coordinator)
+    }
+
+    func flushProjectStateForTermination() async {
+        await terminationCoordinator?.flushProjectStateForTermination()
     }
 
     func beginRenameForActiveWorkspace(coordinator: MainContentCoordinator) {
@@ -158,6 +169,9 @@ final class RockxyWorkspaceWindowManager: NSObject {
     private static let logger = Logger(subsystem: RockxyIdentity.current.logSubsystem, category: "WorkspaceTabs")
 
     private weak var coordinator: MainContentCoordinator?
+    /// Survives primary-window closure so AppDelegate can still force the final
+    /// debounced Project snapshot to disk while the app remains running.
+    private weak var terminationCoordinator: MainContentCoordinator?
     private(set) weak var primaryWindow: NSWindow?
     private var accessoryControllers: [ObjectIdentifier: WorkspaceTabBarAccessoryController] = [:]
     private var observersByWindow: [ObjectIdentifier: [NSObjectProtocol]] = [:]
@@ -295,10 +309,11 @@ final class RockxyWorkspaceWindowManager: NSObject {
 
     fileprivate func renameWorkspace(_ workspaceID: UUID, to title: String) {
         guard let coordinator,
-              coordinator.workspaceStore.workspaces.contains(where: { $0.id == workspaceID }) else {
+              coordinator.workspaceStore.workspaces.contains(where: { $0.id == workspaceID }),
+              let normalizedTitle = try? ProjectNormalization.normalizedDisplayName(title) else {
             return
         }
-        coordinator.workspaceStore.renameWorkspace(id: workspaceID, to: title)
+        coordinator.workspaceStore.renameWorkspace(id: workspaceID, to: normalizedTitle)
         updateTabAccessory(forceVisible: coordinator.workspaceStore.workspaces.count > 1)
         updateWindowTitles(coordinator: coordinator)
     }

--- a/Rockxy/Views/Projects/ProjectPresentation.swift
+++ b/Rockxy/Views/Projects/ProjectPresentation.swift
@@ -1,0 +1,776 @@
+import AppKit
+import SwiftUI
+
+// MARK: - Project Presentation Models
+
+struct ProjectNameEditorContext: Identifiable, Equatable {
+    enum Mode: Equatable {
+        case create
+        case rename(UUID)
+    }
+
+    let id = UUID()
+    let mode: Mode
+    let initialName: String
+
+    var title: String {
+        switch mode {
+        case .create:
+            String(localized: "New Project")
+        case .rename:
+            String(localized: "Rename Project")
+        }
+    }
+
+    var actionTitle: String {
+        switch mode {
+        case .create:
+            String(localized: "Create")
+        case .rename:
+            String(localized: "Rename")
+        }
+    }
+}
+
+struct ProjectDeletionRequest: Identifiable, Equatable {
+    let projectID: UUID
+    let projectName: String
+
+    var id: UUID { projectID }
+}
+
+// MARK: - ProjectToolbarSelectorView
+
+enum ProjectToolbarSelectorMetrics {
+    static let minimumWidth: CGFloat = 104
+    static let maximumWidth: CGFloat = 240
+    static let nonTextWidth: CGFloat = 48
+
+    static func preferredWidth(
+        for projectName: String,
+        font: NSFont = .systemFont(ofSize: NSFont.systemFontSize)
+    )
+        -> CGFloat
+    {
+        let textWidth = ceil(
+            (projectName as NSString).size(withAttributes: [.font: font]).width
+        )
+        return min(maximumWidth, max(minimumWidth, textWidth + nonTextWidth))
+    }
+}
+
+struct ProjectToolbarSelectorView: View {
+    @Bindable var coordinator: MainContentCoordinator
+
+    var body: some View {
+        Menu {
+            ForEach(coordinator.projectStore.projects) { project in
+                Button {
+                    guard coordinator.switchToProject(id: project.id) else {
+                        return
+                    }
+                    RockxyWorkspaceWindowManager.shared.projectDidChange(coordinator: coordinator)
+                } label: {
+                    if project.id == coordinator.projectStore.activeProjectID {
+                        Label(project.name, systemImage: "checkmark")
+                    } else {
+                        Text(project.name)
+                    }
+                }
+                .disabled(!canTransitionProjects)
+            }
+
+            Divider()
+
+            Button(String(localized: "New Project…")) {
+                coordinator.presentNewProjectEditor()
+            }
+            .keyboardShortcut("n", modifiers: [.command, .shift])
+            .disabled(!canCreateProject)
+
+            Button(String(localized: "Rename Project…")) {
+                coordinator.presentRenameProjectEditor(id: coordinator.projectStore.activeProjectID)
+            }
+            .disabled(!canTransitionProjects)
+
+            Button(String(localized: "Manage Projects…")) {
+                coordinator.isProjectManagerPresented = true
+            }
+
+            if case .failed = coordinator.projectStore.loadState {
+                Divider()
+                Button(String(localized: "Repair Projects…")) {
+                    coordinator.isProjectRecoveryPresented = true
+                }
+            }
+        } label: {
+            HStack(spacing: 6) {
+                Image(systemName: projectStatusSymbol)
+                    .foregroundStyle(projectStatusColor)
+                Text(coordinator.projectStore.activeProject.name)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+                    .layoutPriority(1)
+                Image(systemName: "chevron.down")
+                    .font(.caption2.weight(.semibold))
+                    .foregroundStyle(.secondary)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .contentShape(.rect)
+        }
+        .menuIndicator(.hidden)
+        .menuStyle(.borderlessButton)
+        .frame(width: preferredWidth, alignment: .leading)
+        .fixedSize(horizontal: true, vertical: false)
+        .help(String(localized: "Active Project: \(coordinator.projectStore.activeProject.name)"))
+        .accessibilityLabel(String(localized: "Active Project"))
+        .accessibilityValue(coordinator.projectStore.activeProject.name)
+    }
+
+    private var preferredWidth: CGFloat {
+        ProjectToolbarSelectorMetrics.preferredWidth(
+            for: coordinator.projectStore.activeProject.name
+        )
+    }
+
+    private var canCreateProject: Bool {
+        coordinator.projectStore.canCreateProject && !coordinator.isClearingSession
+    }
+
+    private var canTransitionProjects: Bool {
+        coordinator.projectStore.isMutable && !coordinator.isClearingSession
+    }
+
+    private var projectStatusSymbol: String {
+        switch coordinator.projectStore.loadState {
+        case .failed:
+            "folder.badge.questionmark"
+        case .loading:
+            "folder"
+        case .idle, .ready:
+            "folder.fill"
+        }
+    }
+
+    private var projectStatusColor: Color {
+        if case .failed = coordinator.projectStore.loadState {
+            return .orange
+        }
+        return .accentColor
+    }
+}
+
+// MARK: - ProjectNameEditorSheet
+
+struct ProjectNameEditorSheet: View {
+    init(context: ProjectNameEditorContext, coordinator: MainContentCoordinator) {
+        self.context = context
+        self.coordinator = coordinator
+        _name = State(initialValue: context.initialName)
+    }
+
+    let context: ProjectNameEditorContext
+    let coordinator: MainContentCoordinator
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack(spacing: 12) {
+                Image(systemName: "folder.fill")
+                    .font(.title2)
+                    .foregroundStyle(Color.accentColor)
+                    .frame(width: 30)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(context.title)
+                        .font(.headline)
+                    Text(String(localized: "Projects keep Traffic Tab layouts and filters together."))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+            }
+            .padding(18)
+
+            Divider()
+
+            VStack(alignment: .leading, spacing: 7) {
+                Text(String(localized: "Project Name"))
+                    .font(.subheadline.weight(.medium))
+                TextField(String(localized: "For example: Checkout API"), text: $name)
+                    .textFieldStyle(.roundedBorder)
+                Text(validationMessage ?? String(localized: "1–80 characters. Names must be unique."))
+                    .font(.caption)
+                    .foregroundStyle(validationMessage == nil ? Color.secondary : Color.orange)
+            }
+            .padding(18)
+
+            Divider()
+
+            HStack {
+                Spacer()
+                Button(String(localized: "Cancel"), role: .cancel) {
+                    dismiss()
+                }
+                .keyboardShortcut(.cancelAction)
+                Button(context.actionTitle) {
+                    submit()
+                }
+                .keyboardShortcut(.defaultAction)
+                .disabled(validationMessage != nil)
+            }
+            .padding(.horizontal, 18)
+            .frame(height: 52)
+        }
+        .frame(width: 460)
+    }
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var name: String
+
+    private var normalizedName: String? {
+        try? ProjectNormalization.normalizedDisplayName(name)
+    }
+
+    private var validationMessage: String? {
+        guard let normalizedName else {
+            return String(localized: "Enter a name without control characters.")
+        }
+        let key = ProjectNormalization.foldedKey(for: normalizedName)
+        let excludedID: UUID? = switch context.mode {
+        case .create: nil
+        case let .rename(id): id
+        }
+        if coordinator.projectStore.projects.contains(where: {
+            $0.id != excludedID && ProjectNormalization.foldedKey(for: $0.name) == key
+        }) {
+            return String(localized: "A Project with this name already exists.")
+        }
+        return nil
+    }
+
+    private func submit() {
+        guard let normalizedName else {
+            return
+        }
+        let succeeded: Bool = switch context.mode {
+        case .create:
+            coordinator.createProject(named: normalizedName) != nil
+        case let .rename(id):
+            coordinator.renameProject(id: id, to: normalizedName)
+        }
+        guard succeeded else {
+            return
+        }
+        RockxyWorkspaceWindowManager.shared.projectDidChange(coordinator: coordinator)
+        dismiss()
+    }
+}
+
+// MARK: - ProjectManagerSheet
+
+struct ProjectManagerSheet: View {
+    init(coordinator: MainContentCoordinator) {
+        self.coordinator = coordinator
+        _selection = State(initialValue: coordinator.projectStore.activeProjectID)
+    }
+
+    let coordinator: MainContentCoordinator
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HSplitView {
+                projectSidebar
+                    .frame(minWidth: 230, idealWidth: 250, maxWidth: 300)
+                detail
+                    .frame(minWidth: 430, maxWidth: .infinity, maxHeight: .infinity)
+            }
+            Divider()
+            actionBar
+        }
+        .font(toolMetrics.font())
+        .frame(
+            minWidth: max(720, toolMetrics.bodyFontSize * 20 + 460),
+            idealWidth: max(780, toolMetrics.bodyFontSize * 22 + 494),
+            minHeight: max(500, toolMetrics.bodyFontSize * 14 + 318),
+            idealHeight: max(540, toolMetrics.bodyFontSize * 16 + 340)
+        )
+        .confirmationDialog(
+            String(localized: "Delete Project?"),
+            isPresented: deleteConfirmation,
+            titleVisibility: .visible,
+            presenting: coordinator.projectDeletionRequest
+        ) { request in
+            Button(String(localized: "Delete \(request.projectName)"), role: .destructive) {
+                delete(request)
+            }
+            Button(String(localized: "Cancel"), role: .cancel) {}
+        } message: { _ in
+            Text(
+                String(localized: "This removes the Project, its in-memory traffic history, and its saved Traffic Tab configuration.")
+                    + " "
+                    + String(localized: "Manually saved session files, rules, and favorites are not deleted.")
+            )
+        }
+        .sheet(item: Binding(
+            get: { coordinator.projectNameEditorContext },
+            set: { coordinator.projectNameEditorContext = $0 }
+        )) { context in
+            ProjectNameEditorSheet(context: context, coordinator: coordinator)
+        }
+        .onChange(of: coordinator.projectStore.activeProjectID) { _, activeProjectID in
+            selection = activeProjectID
+        }
+    }
+
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.appUIDisplayMetrics) private var appMetrics
+    @State private var selection: UUID?
+
+    private var selectedProject: Project? {
+        coordinator.projectStore.projects.first { $0.id == selection }
+    }
+
+    private var toolMetrics: ToolWindowDisplayMetrics {
+        ToolWindowDisplayMetrics(appMetrics: appMetrics)
+    }
+
+    private var canCreateProject: Bool {
+        coordinator.projectStore.canCreateProject && !coordinator.isClearingSession
+    }
+
+    private var canTransitionProjects: Bool {
+        coordinator.projectStore.isMutable && !coordinator.isClearingSession
+    }
+
+    private var canExportSelectedProject: Bool {
+        canTransitionProjects && selectedProject != nil
+    }
+
+    private var projectSidebar: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            VStack(alignment: .leading, spacing: 3) {
+                Text(String(localized: "Projects"))
+                    .font(.system(size: max(15, toolMetrics.bodyFontSize + 2), weight: .semibold))
+                Text(String(localized: "Organize Project-scoped traffic and durable Traffic Tab layouts."))
+                    .font(toolMetrics.secondaryFont())
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            .padding(.horizontal, toolMetrics.contentHorizontalPadding)
+            .padding(.top, toolMetrics.headerTopPadding)
+            .padding(.bottom, toolMetrics.headerBottomPadding)
+
+            Divider()
+
+            List(selection: $selection) {
+                ForEach(coordinator.projectStore.projects) { project in
+                    HStack(spacing: 8) {
+                        Image(systemName: project.id == coordinator.projectStore.activeProjectID
+                            ? "folder.fill"
+                            : "folder")
+                            .foregroundStyle(selection == project.id ? Color.primary : Color.secondary)
+                            .frame(width: 16)
+                        VStack(alignment: .leading, spacing: 1) {
+                            Text(project.name)
+                                .lineLimit(1)
+                                .truncationMode(.middle)
+                            Text(trafficTabCountText(project.tabs.count))
+                                .font(toolMetrics.metadataFont())
+                                .foregroundStyle(.secondary)
+                        }
+                        Spacer(minLength: 4)
+                        if project.id == coordinator.projectStore.activeProjectID {
+                            Image(systemName: "checkmark.circle.fill")
+                                .font(.system(size: toolMetrics.smallIconFontSize))
+                                .foregroundStyle(selection == project.id ? Color.primary : Color.accentColor)
+                                .help(String(localized: "Active Project"))
+                                .accessibilityLabel(String(localized: "Active Project"))
+                        }
+                    }
+                    .tag(project.id)
+                    .padding(.vertical, 2)
+                    .accessibilityElement(children: .combine)
+                    .accessibilityLabel(project.name)
+                    .accessibilityValue(projectAccessibilityValue(project))
+                }
+            }
+            .listStyle(.sidebar)
+
+            Divider()
+
+            HStack(spacing: toolMetrics.controlSpacing) {
+                addRemoveControl
+
+                Spacer()
+
+                Text("\(coordinator.projectStore.projects.count)/\(coordinator.projectStore.maxProjects)")
+                    .font(toolMetrics.metadataFont(monospaced: true))
+                    .foregroundStyle(.secondary)
+                    .accessibilityLabel(String(localized: "Project capacity"))
+                    .accessibilityValue(
+                        String(
+                            localized:
+                            "\(coordinator.projectStore.projects.count) of \(coordinator.projectStore.maxProjects) Projects"
+                        )
+                    )
+            }
+            .padding(.horizontal, toolMetrics.contentHorizontalPadding)
+            .padding(.vertical, toolMetrics.footerTopPadding)
+        }
+        .background(Color(nsColor: .windowBackgroundColor))
+    }
+
+    @ViewBuilder
+    private var detail: some View {
+        if let project = selectedProject {
+            VStack(alignment: .leading, spacing: 0) {
+                HStack(alignment: .center, spacing: toolMetrics.controlSpacing) {
+                    VStack(alignment: .leading, spacing: 3) {
+                        Text(project.name)
+                            .font(.system(size: max(15, toolMetrics.bodyFontSize + 2), weight: .semibold))
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                        Text(project.id == coordinator.projectStore.activeProjectID
+                            ? String(localized: "Active Project")
+                            : String(localized: "Local Project"))
+                            .font(toolMetrics.secondaryFont())
+                            .foregroundStyle(.secondary)
+                    }
+                    Spacer()
+                    if project.id != coordinator.projectStore.activeProjectID {
+                        Button(String(localized: "Open Project")) {
+                            open(project)
+                        }
+                        .disabled(!canTransitionProjects)
+                    }
+                    Button(String(localized: "Rename…")) {
+                        coordinator.presentRenameProjectEditor(id: project.id)
+                    }
+                    .disabled(!canTransitionProjects)
+                }
+                .padding(.horizontal, toolMetrics.contentHorizontalPadding)
+                .padding(.vertical, toolMetrics.headerBottomPadding)
+
+                Divider()
+
+                VStack(alignment: .leading, spacing: toolMetrics.controlSpacing) {
+                    HStack {
+                        Text(String(localized: "Traffic Tabs"))
+                            .font(toolMetrics.font(weight: .medium))
+                        Spacer()
+                        Text(trafficTabCountText(project.tabs.count))
+                            .font(toolMetrics.metadataFont(monospaced: true))
+                            .foregroundStyle(.secondary)
+                    }
+
+                    List {
+                        ForEach(project.tabs) { tab in
+                            HStack(spacing: toolMetrics.controlSpacing) {
+                                Image(systemName: tab.isClosable ? "rectangle" : "rectangle.fill")
+                                    .foregroundStyle(.secondary)
+                                    .frame(width: 16)
+                                Text(tab.title)
+                                    .lineLimit(1)
+                                    .truncationMode(.middle)
+                                Spacer()
+                                if tab.id == project.activeTabID {
+                                    Label(String(localized: "Current"), systemImage: "checkmark")
+                                        .font(toolMetrics.metadataFont())
+                                        .foregroundStyle(.secondary)
+                                }
+                            }
+                            .frame(minHeight: toolMetrics.tableRowHeight)
+                            .accessibilityElement(children: .combine)
+                            .accessibilityLabel(tab.title)
+                            .accessibilityValue(
+                                tab.id == project.activeTabID
+                                    ? String(localized: "Current Traffic Tab")
+                                    : String(localized: "Traffic Tab")
+                            )
+                        }
+                    }
+                    .listStyle(.inset(alternatesRowBackgrounds: true))
+                    .scrollContentBackground(.hidden)
+                    .background(Color(nsColor: .textBackgroundColor))
+                    .clipShape(RoundedRectangle(cornerRadius: 6))
+                    .overlay {
+                        RoundedRectangle(cornerRadius: 6)
+                            .stroke(Color(nsColor: .separatorColor), lineWidth: 1)
+                    }
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                }
+                .padding(toolMetrics.contentHorizontalPadding)
+
+                Divider()
+                infoBanner
+            }
+        } else {
+            ContentUnavailableView(
+                String(localized: "Select a Project"),
+                systemImage: "folder",
+                description: Text(String(localized: "Choose a Project to view its Traffic Tabs."))
+            )
+        }
+    }
+
+    private var addRemoveControl: some View {
+        HStack(spacing: 0) {
+            Button {
+                coordinator.presentNewProjectEditor()
+            } label: {
+                Image(systemName: "plus")
+                    .font(.system(size: toolMetrics.compactIconFontSize))
+                    .foregroundStyle(canCreateProject ? .primary : .tertiary)
+                    .frame(
+                        width: toolMetrics.compactButtonSize - 5,
+                        height: toolMetrics.compactButtonSize - 5
+                    )
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .keyboardShortcut("n", modifiers: [.command, .shift])
+            .help(String(localized: "New Project"))
+            .disabled(!canCreateProject)
+
+            Rectangle()
+                .fill(Color(nsColor: .separatorColor).opacity(0.7))
+                .frame(width: 1, height: 18)
+
+            Button {
+                guard let selectedProject else {
+                    return
+                }
+                coordinator.requestProjectDeletion(selectedProject)
+            } label: {
+                Image(systemName: "minus")
+                    .font(.system(size: toolMetrics.compactIconFontSize))
+                    .foregroundStyle(canDeleteSelectedProject ? .primary : .tertiary)
+                    .frame(
+                        width: toolMetrics.compactButtonSize - 5,
+                        height: toolMetrics.compactButtonSize - 5
+                    )
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .help(String(localized: "Delete Project"))
+            .disabled(!canDeleteSelectedProject)
+        }
+        .frame(
+            width: max(43, toolMetrics.compactButtonSize * 2 + 1),
+            height: toolMetrics.footerControlHeight
+        )
+        .background(Color(nsColor: .controlBackgroundColor))
+        .clipShape(RoundedRectangle(cornerRadius: 6))
+        .overlay {
+            RoundedRectangle(cornerRadius: 6)
+                .stroke(Color(nsColor: .separatorColor), lineWidth: 1)
+        }
+    }
+
+    private var canDeleteSelectedProject: Bool {
+        canTransitionProjects
+            && selectedProject != nil
+            && coordinator.projectStore.projects.count > 1
+    }
+
+    private var infoBanner: some View {
+        Label(
+            String(localized: "Projects save tab names, filters, and layout. Each Project keeps separate in-memory traffic."),
+            systemImage: "info.circle"
+        )
+        .font(toolMetrics.secondaryFont())
+        .foregroundStyle(.secondary)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, toolMetrics.contentHorizontalPadding)
+        .padding(.vertical, toolMetrics.controlSpacing)
+        .background(Color(nsColor: .controlBackgroundColor).opacity(0.5))
+    }
+
+    private var actionBar: some View {
+        HStack(spacing: toolMetrics.controlSpacing) {
+            if case .failed = coordinator.projectStore.loadState {
+                Label(
+                    String(localized: "Projects could not be loaded. Changes will not be saved."),
+                    systemImage: "exclamationmark.triangle.fill"
+                )
+                .font(toolMetrics.secondaryFont())
+                .foregroundStyle(.orange)
+            } else if case .failed = coordinator.projectStore.persistenceStatus {
+                Label(String(localized: "Could not save Projects"), systemImage: "exclamationmark.triangle.fill")
+                    .font(toolMetrics.secondaryFont())
+                    .foregroundStyle(.orange)
+            } else {
+                Text(String(localized: "Projects are stored locally on this Mac."))
+                    .font(toolMetrics.secondaryFont())
+                    .foregroundStyle(.secondary)
+            }
+            Spacer()
+            Button(String(localized: "Import…")) {
+                importProjectConfiguration()
+            }
+            .help(String(localized: "Import Project Configuration"))
+            .disabled(!canCreateProject)
+
+            Button(String(localized: "Export…")) {
+                exportSelectedProjectConfiguration()
+            }
+            .help(String(localized: "Export Selected Project Configuration"))
+            .disabled(!canExportSelectedProject)
+
+            Button(String(localized: "Done")) {
+                dismiss()
+            }
+            .keyboardShortcut(.defaultAction)
+        }
+        .padding(.horizontal, toolMetrics.contentHorizontalPadding)
+        .padding(.vertical, toolMetrics.footerTopPadding)
+        .frame(minHeight: 48)
+    }
+
+    private func trafficTabCountText(_ count: Int) -> String {
+        if count == 1 {
+            return String(localized: "1 Traffic Tab")
+        }
+        return String(localized: "\(count) Traffic Tabs")
+    }
+
+    private func projectAccessibilityValue(_ project: Project) -> String {
+        let count = trafficTabCountText(project.tabs.count)
+        if project.id == coordinator.projectStore.activeProjectID {
+            return String(localized: "\(count), Active Project")
+        }
+        return count
+    }
+
+    private var deleteConfirmation: Binding<Bool> {
+        Binding(
+            get: { coordinator.projectDeletionRequest != nil },
+            set: {
+                if !$0 {
+                    coordinator.projectDeletionRequest = nil
+                }
+            }
+        )
+    }
+
+    private func open(_ project: Project) {
+        guard coordinator.switchToProject(id: project.id) else {
+            return
+        }
+        selection = project.id
+        RockxyWorkspaceWindowManager.shared.projectDidChange(coordinator: coordinator)
+    }
+
+    private func importProjectConfiguration() {
+        guard coordinator.importProjectConfiguration() else {
+            return
+        }
+        selection = coordinator.projectStore.activeProjectID
+        RockxyWorkspaceWindowManager.shared.projectDidChange(coordinator: coordinator)
+    }
+
+    private func exportSelectedProjectConfiguration() {
+        guard let selectedProject else {
+            return
+        }
+        _ = coordinator.exportProjectConfiguration(id: selectedProject.id)
+    }
+
+    private func delete(_ request: ProjectDeletionRequest) {
+        let wasActive = request.projectID == coordinator.projectStore.activeProjectID
+        guard coordinator.deleteProject(id: request.projectID) else {
+            return
+        }
+        coordinator.projectDeletionRequest = nil
+        if selection == request.projectID {
+            selection = coordinator.projectStore.activeProjectID
+        }
+        if wasActive {
+            RockxyWorkspaceWindowManager.shared.projectDidChange(coordinator: coordinator)
+        }
+    }
+}
+
+// MARK: - ProjectRecoverySheet
+
+struct ProjectRecoverySheet: View {
+    let coordinator: MainContentCoordinator
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack(alignment: .top, spacing: 14) {
+                Image(systemName: "folder.badge.questionmark")
+                    .font(.system(size: 30))
+                    .foregroundStyle(.orange)
+                VStack(alignment: .leading, spacing: 6) {
+                    Text(String(localized: "Projects Could Not Be Loaded"))
+                        .font(.headline)
+                    Text(
+                        String(localized: "Rockxy kept the existing catalog unchanged and disabled Project edits to avoid overwriting data.")
+                    )
+                    .foregroundStyle(.secondary)
+                    Text(coordinator.projectStore.loadFailureMessage ?? String(localized: "Unknown catalog error"))
+                        .font(.caption.monospaced())
+                        .foregroundStyle(.secondary)
+                        .textSelection(.enabled)
+                        .lineLimit(4)
+                }
+                Spacer()
+            }
+            .padding(20)
+
+            Divider()
+
+            HStack {
+                Button(String(localized: "Close"), role: .cancel) {
+                    coordinator.isProjectRecoveryPresented = false
+                }
+                .keyboardShortcut(.cancelAction)
+                Spacer()
+                Button(String(localized: "Reset Projects…"), role: .destructive) {
+                    confirmsReset = true
+                }
+                Button(String(localized: "Retry")) {
+                    retry()
+                }
+                .keyboardShortcut(.defaultAction)
+            }
+            .padding(.horizontal, 20)
+            .frame(height: 56)
+        }
+        .frame(width: 540)
+        .alert(String(localized: "Reset Projects?"), isPresented: $confirmsReset) {
+            Button(String(localized: "Cancel"), role: .cancel) {}
+            Button(String(localized: "Reset Projects"), role: .destructive) {
+                reset()
+            }
+        } message: {
+            Text(
+                // swiftlint:disable:next line_length
+                "Rockxy will replace the current catalog with one default Project. A bounded regular catalog is preserved as catalog.recovery.json. Captured traffic, sessions, rules, and favorites are not deleted."
+            )
+        }
+    }
+
+    @State private var confirmsReset = false
+
+    private func retry() {
+        Task { @MainActor in
+            await coordinator.hydrateProjectsOnLaunch()
+            if coordinator.projectStore.loadState == .ready {
+                coordinator.isProjectRecoveryPresented = false
+                RockxyWorkspaceWindowManager.shared.projectDidChange(coordinator: coordinator)
+            }
+        }
+    }
+
+    private func reset() {
+        Task { @MainActor in
+            await coordinator.projectStore.resetToDefaultCatalog()
+            await coordinator.hydrateProjectsOnLaunch()
+            if coordinator.projectStore.loadState == .ready {
+                coordinator.isProjectRecoveryPresented = false
+                RockxyWorkspaceWindowManager.shared.projectDidChange(coordinator: coordinator)
+            }
+        }
+    }
+}

--- a/RockxyTests/Core/Plugins/ScriptMultiArgRuntimeTests.swift
+++ b/RockxyTests/Core/Plugins/ScriptMultiArgRuntimeTests.swift
@@ -65,6 +65,43 @@ struct ScriptMultiArgRuntimeTests {
         #expect(modified.url.host == "example.com")
     }
 
+    @Test("Multi-arg onRequest preserves request-start ownership")
+    func multiArgRequestPreservesCaptureContext() async throws {
+        let runtime = ScriptRuntime()
+        let script = """
+        function onRequest(context, url, request) {
+          request.path = "/mutated";
+          return request;
+        }
+        """
+        let plugin = try makeTempPlugin(id: "test.multiarg.capture-context", script: script)
+        try await runtime.loadPlugin(plugin)
+        let route = TrafficCaptureContext(projectID: UUID(), sessionID: UUID(), generation: 5)
+        let req = try HTTPRequestData(
+            method: "GET",
+            url: #require(URL(string: "https://example.com/original")),
+            httpVersion: "HTTP/1.1",
+            headers: [],
+            body: nil,
+            contentType: nil,
+            captureContext: route
+        )
+
+        let outcome = try await runtime.callOnRequest(
+            pluginID: plugin.id,
+            context: ScriptRequestContext(from: req),
+            behavior: ScriptBehavior.defaults(),
+            originalRequest: req
+        )
+        guard case let .forward(modified) = outcome else {
+            Issue.record("expected .forward")
+            return
+        }
+
+        #expect(modified.url.path == "/mutated")
+        #expect(modified.captureContext == route)
+    }
+
     @Test("Multi-arg onRequest preserves duplicate query parameter values")
     func multiArgRequestPreservesDuplicateQueries() async throws {
         let runtime = ScriptRuntime()

--- a/RockxyTests/Core/Storage/PortableProjectDocumentTests.swift
+++ b/RockxyTests/Core/Storage/PortableProjectDocumentTests.swift
@@ -1,0 +1,246 @@
+import Foundation
+@testable import Rockxy
+import Testing
+
+// MARK: - PortableProjectDocumentTests
+
+@Suite("PortableProjectDocument")
+struct PortableProjectDocumentTests {
+    // MARK: Internal
+
+    // MARK: Round trip
+
+    @Test("write then read roundtrips a portable document")
+    func writeReadRoundtrips() throws {
+        let dir = Self.makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let url = dir.appendingPathComponent("Alpha.\(PortableProjectDocument.fileExtension)")
+
+        let project = Self.makeProject()
+        try PortableProjectDocument.write(project, to: url)
+
+        let loaded = try PortableProjectDocument.read(from: url)
+        #expect(loaded == PortableProject(exporting: project))
+    }
+
+    @Test("exported file is written with 0600 permissions")
+    func writesRestrictivePermissions() throws {
+        let dir = Self.makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let url = dir.appendingPathComponent("Alpha.\(PortableProjectDocument.fileExtension)")
+
+        try PortableProjectDocument.write(Self.makeProject(), to: url)
+
+        let attrs = try FileManager.default.attributesOfItem(atPath: url.path)
+        #expect((attrs[.posixPermissions] as? Int) == 0o600)
+    }
+
+    @Test("export temporary file is private before atomic publication")
+    func temporaryFileIsPrivateBeforePublication() throws {
+        let dir = Self.makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let url = dir.appendingPathComponent("Alpha.\(PortableProjectDocument.fileExtension)")
+        var observedMode: Int?
+
+        try PortableProjectDocument.write(Self.makeProject(), to: url) { temporaryURL in
+            let attrs = try FileManager.default.attributesOfItem(atPath: temporaryURL.path)
+            observedMode = attrs[.posixPermissions] as? Int
+            #expect(!FileManager.default.fileExists(atPath: url.path))
+        }
+
+        #expect(observedMode == 0o600)
+    }
+
+    @Test("write replaces a destination symlink without modifying its target")
+    func writeDoesNotFollowDestinationSymlink() throws {
+        let dir = Self.makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let target = dir.appendingPathComponent("sensitive.txt")
+        let sentinel = Data("do-not-change".utf8)
+        try sentinel.write(to: target)
+        let link = dir.appendingPathComponent("Alpha.\(PortableProjectDocument.fileExtension)")
+        try FileManager.default.createSymbolicLink(at: link, withDestinationURL: target)
+
+        try PortableProjectDocument.write(Self.makeProject(), to: link)
+
+        #expect(try Data(contentsOf: target) == sentinel)
+        let attrs = try FileManager.default.attributesOfItem(atPath: link.path)
+        #expect((attrs[.type] as? FileAttributeType) == .typeRegular)
+        #expect(try PortableProjectDocument.read(from: link).name == "Alpha")
+    }
+
+    // MARK: Fail-closed reads
+
+    @Test("read rejects a missing file")
+    func rejectsMissingFile() {
+        let dir = Self.makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let url = dir.appendingPathComponent("Nope.\(PortableProjectDocument.fileExtension)")
+
+        #expect(throws: PortableProjectDocumentError.fileMissing) {
+            _ = try PortableProjectDocument.read(from: url)
+        }
+    }
+
+    @Test("read rejects a symlink without following it")
+    func rejectsSymlink() throws {
+        let dir = Self.makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let target = dir.appendingPathComponent("target.\(PortableProjectDocument.fileExtension)")
+        try PortableProjectDocument.write(Self.makeProject(), to: target)
+        let link = dir.appendingPathComponent("link.\(PortableProjectDocument.fileExtension)")
+        try FileManager.default.createSymbolicLink(at: link, withDestinationURL: target)
+
+        #expect(throws: PortableProjectDocumentError.symbolicLink) {
+            _ = try PortableProjectDocument.read(from: link)
+        }
+    }
+
+    @Test("read remains bound to the opened inode when the pathname is replaced")
+    func readUsesOpenedInodeAcrossPathReplacement() throws {
+        let dir = Self.makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let selected = dir.appendingPathComponent("selected.\(PortableProjectDocument.fileExtension)")
+        let opened = dir.appendingPathComponent("opened.\(PortableProjectDocument.fileExtension)")
+        let replacement = dir.appendingPathComponent("replacement.\(PortableProjectDocument.fileExtension)")
+        try PortableProjectDocument.write(Self.makeProject(), to: selected)
+        let oversized = Data(repeating: 0x20, count: PortableProjectDocument.maxDocumentByteSize + 1)
+        try oversized.write(to: replacement)
+
+        let loaded = try PortableProjectDocument.read(from: selected) {
+            try FileManager.default.moveItem(at: selected, to: opened)
+            try FileManager.default.moveItem(at: replacement, to: selected)
+        }
+
+        #expect(loaded.name == "Alpha")
+    }
+
+    @Test("read rejects a non-regular node")
+    func rejectsNonRegularFile() throws {
+        let dir = Self.makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let url = dir.appendingPathComponent("Alpha.\(PortableProjectDocument.fileExtension)")
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+
+        #expect(throws: PortableProjectDocumentError.notRegularFile) {
+            _ = try PortableProjectDocument.read(from: url)
+        }
+    }
+
+    @Test("read rejects an oversized file before decoding")
+    func rejectsOversizedFile() throws {
+        let dir = Self.makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let url = dir.appendingPathComponent("Alpha.\(PortableProjectDocument.fileExtension)")
+        let oversized = Data(repeating: 0x20, count: PortableProjectDocument.maxDocumentByteSize + 1)
+        try oversized.write(to: url)
+
+        #expect(throws: PortableProjectDocumentError.fileTooLarge(bytes: oversized.count)) {
+            _ = try PortableProjectDocument.read(from: url)
+        }
+    }
+
+    @Test("read rejects corrupt JSON")
+    func rejectsCorruptJSON() throws {
+        let dir = Self.makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let url = dir.appendingPathComponent("Alpha.\(PortableProjectDocument.fileExtension)")
+        try Data("{ not valid json".utf8).write(to: url)
+
+        #expect(throws: PortableProjectDocumentError.corruptData) {
+            _ = try PortableProjectDocument.read(from: url)
+        }
+    }
+
+    @Test("read rejects an unsupported format version without materializing")
+    func rejectsUnsupportedFormatVersion() throws {
+        let dir = Self.makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let url = dir.appendingPathComponent("Alpha.\(PortableProjectDocument.fileExtension)")
+
+        let future = PortableProject(
+            formatVersion: 999,
+            name: "Alpha",
+            activeTabIndex: 0,
+            tabs: [PortableProjectTab(title: "All Traffic", isClosable: false)]
+        )
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        try encoder.encode(future).write(to: url)
+
+        #expect(throws: PortableProjectDocumentError.unsupportedFormatVersion(found: 999)) {
+            _ = try PortableProjectDocument.read(from: url)
+        }
+    }
+
+    @Test("read rejects a structurally invalid document")
+    func rejectsInvalidDocument() throws {
+        let dir = Self.makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let url = dir.appendingPathComponent("Alpha.\(PortableProjectDocument.fileExtension)")
+
+        let invalid = PortableProject(
+            name: "Alpha",
+            activeTabIndex: 7,
+            tabs: [PortableProjectTab(title: "All Traffic", isClosable: false)]
+        )
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        try encoder.encode(invalid).write(to: url)
+
+        #expect(throws: PortableProjectDocumentError.invalid(.activeTabIndexOutOfRange(index: 7))) {
+            _ = try PortableProjectDocument.read(from: url)
+        }
+    }
+
+    @Test("read ignores unknown JSON keys")
+    func ignoresUnknownKeys() throws {
+        let dir = Self.makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let url = dir.appendingPathComponent("Alpha.\(PortableProjectDocument.fileExtension)")
+        let json = """
+        {
+          "formatVersion": 1,
+          "name": "Alpha",
+          "activeTabIndex": 0,
+          "tabs": [
+            {"title": "All Traffic", "isClosable": false, "filter": \(Self.emptyFilterJSON),
+             "advancedFilterRows": [], "isFilterBarVisible": false, "mainTabRawValue": "traffic",
+             "inspectorLayoutRawValue": "hidden", "isContextDockVisible": false,
+             "contextDockTabRawValue": "details", "focusNavigatorModeRawValue": "browse",
+             "mutedTrafficSources": []}
+          ],
+          "unexpectedFutureKey": {"nested": true}
+        }
+        """
+        try Data(json.utf8).write(to: url)
+
+        let loaded = try PortableProjectDocument.read(from: url)
+        #expect(loaded.name == "Alpha")
+        #expect(loaded.tabs.count == 1)
+    }
+
+    // MARK: Private
+
+    // MARK: Helpers
+
+    private static let fixedDate = Date(timeIntervalSince1970: 1_000_000)
+
+    private static let emptyFilterJSON: String = {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let data = (try? encoder.encode(FilterCriteriaSnapshot.empty)) ?? Data()
+        return String(bytes: data, encoding: .utf8) ?? "{}"
+    }()
+
+    private static func makeProject() -> Project {
+        Project.makeDefault(name: "Alpha", createdAt: fixedDate, updatedAt: fixedDate)
+    }
+
+    private static func makeTempDirectory() -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("Rockxy.PortableProjectDocumentTests.\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+}

--- a/RockxyTests/Core/Storage/ProjectCatalogRepositoryTests.swift
+++ b/RockxyTests/Core/Storage/ProjectCatalogRepositoryTests.swift
@@ -1,0 +1,347 @@
+import Foundation
+@testable import Rockxy
+import Testing
+
+// MARK: - ProjectCatalogRepositoryTests
+
+@Suite("ProjectCatalogRepository")
+struct ProjectCatalogRepositoryTests {
+    // MARK: Load: missing & roundtrip
+
+    @Test("missing file yields a valid default catalog")
+    func missingFileYieldsDefault() async throws {
+        let repo = makeRepo()
+        let catalog = try await repo.load()
+        #expect(catalog.projects.count == 1)
+        try catalog.validate()
+    }
+
+    @Test("save then load roundtrips the catalog")
+    func roundtrips() async throws {
+        let repo = makeRepo()
+        let original = ProjectCatalog.makeDefault(now: Self.fixedDate)
+        try await repo.save(original)
+        let loaded = try await repo.load()
+        #expect(loaded == original)
+    }
+
+    @Test("a missing catalog is created, persisted, and stable across loads")
+    func missingCatalogPersistsStableIdentity() async throws {
+        let repo = makeRepo()
+        let first = try await repo.load()
+        #expect(FileManager.default.fileExists(atPath: repo.fileURL.path))
+        // Reloading reads the persisted file, so identifiers survive relaunches.
+        let second = try await repo.load()
+        #expect(second == first)
+        #expect(second.projects[0].id == first.projects[0].id)
+        #expect(second.activeProjectID == first.activeProjectID)
+    }
+
+    // MARK: Load: fail-closed inputs
+
+    @Test("rejects a newer schema version without overwriting")
+    func rejectsNewerSchema() async throws {
+        let repo = makeRepo()
+        var catalog = ProjectCatalog.makeDefault(now: Self.fixedDate)
+        catalog.schemaVersion = 2
+        try writeCatalog(catalog, to: repo)
+
+        await #expect(throws: ProjectCatalogRepositoryError.unsupportedSchemaVersion(found: 2)) {
+            _ = try await repo.load()
+        }
+    }
+
+    @Test("rejects corrupt JSON")
+    func rejectsCorruptJSON() async throws {
+        let repo = makeRepo()
+        try writeRaw(Data("{ not valid json".utf8), to: repo)
+        await #expect(throws: ProjectCatalogRepositoryError.corruptData) {
+            _ = try await repo.load()
+        }
+    }
+
+    @Test("rejects an oversized file before decoding")
+    func rejectsOversizedFile() async throws {
+        let repo = makeRepo()
+        let oversized = Data(repeating: 0x20, count: ProjectCatalogRepository.maxCatalogByteSize + 1)
+        try writeRaw(oversized, to: repo)
+        await #expect(throws: ProjectCatalogRepositoryError.self) {
+            _ = try await repo.load()
+        }
+    }
+
+    @Test("rejects a symlink target")
+    func rejectsSymlink() async throws {
+        let repo = makeRepo()
+        try FileManager.default.createDirectory(at: repo.directoryURL, withIntermediateDirectories: true)
+        let target = repo.directoryURL.appendingPathComponent("target.json")
+        let encoder = JSONEncoder()
+        try encoder.encode(ProjectCatalog.makeDefault(now: Self.fixedDate)).write(to: target)
+        try FileManager.default.createSymbolicLink(at: repo.fileURL, withDestinationURL: target)
+
+        await #expect(throws: ProjectCatalogRepositoryError.symbolicLink) {
+            _ = try await repo.load()
+        }
+    }
+
+    @Test("rejects a non-regular target")
+    func rejectsNonRegularFile() async throws {
+        let repo = makeRepo()
+        try FileManager.default.createDirectory(at: repo.fileURL, withIntermediateDirectories: true)
+        await #expect(throws: ProjectCatalogRepositoryError.notRegularFile) {
+            _ = try await repo.load()
+        }
+    }
+
+    @Test("rejects a symlinked projects directory without following it")
+    func rejectsDirectorySymlink() async throws {
+        let repo = makeRepo()
+        let target = FileManager.default.temporaryDirectory
+            .appendingPathComponent("Rockxy.dirTarget.\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: target, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(
+            at: repo.directoryURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try FileManager.default.createSymbolicLink(at: repo.directoryURL, withDestinationURL: target)
+
+        await #expect(throws: ProjectCatalogRepositoryError.directorySymbolicLink) {
+            _ = try await repo.load()
+        }
+    }
+
+    @Test("rejects a non-directory projects container")
+    func rejectsNonDirectoryContainer() async throws {
+        let repo = makeRepo()
+        try FileManager.default.createDirectory(
+            at: repo.directoryURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try Data("not a directory".utf8).write(to: repo.directoryURL)
+
+        await #expect(throws: ProjectCatalogRepositoryError.notDirectory) {
+            _ = try await repo.load()
+        }
+    }
+
+    @Test("rejects duplicate project IDs")
+    func rejectsDuplicateProjectIDs() async throws {
+        let repo = makeRepo()
+        let shared = UUID()
+        let catalog = ProjectCatalog(
+            activeProjectID: shared,
+            projects: [
+                Project.makeDefault(id: shared, name: "Alpha", createdAt: Self.fixedDate, updatedAt: Self.fixedDate),
+                Project.makeDefault(id: shared, name: "Beta", createdAt: Self.fixedDate, updatedAt: Self.fixedDate),
+            ]
+        )
+        try writeCatalog(catalog, to: repo)
+
+        await #expect(throws: ProjectCatalogRepositoryError.validation(.duplicateProjectID(shared))) {
+            _ = try await repo.load()
+        }
+    }
+
+    @Test("rejects an unresolved active project ID")
+    func rejectsInvalidActiveID() async throws {
+        let repo = makeRepo()
+        let catalog = ProjectCatalog(
+            activeProjectID: UUID(),
+            projects: [Project.makeDefault(name: "Alpha", createdAt: Self.fixedDate, updatedAt: Self.fixedDate)]
+        )
+        try writeCatalog(catalog, to: repo)
+
+        await #expect(throws: ProjectCatalogRepositoryError.validation(.unresolvedActiveProjectID)) {
+            _ = try await repo.load()
+        }
+    }
+
+    @Test("an invalid file is preserved, never silently overwritten by load")
+    func invalidFilePreserved() async throws {
+        let repo = makeRepo()
+        let corrupt = Data("{ corrupt".utf8)
+        try writeRaw(corrupt, to: repo)
+        await #expect(throws: ProjectCatalogRepositoryError.corruptData) {
+            _ = try await repo.load()
+        }
+        let after = try Data(contentsOf: repo.fileURL)
+        #expect(after == corrupt)
+    }
+
+    // MARK: Write: permissions, atomicity, cleanup
+
+    @Test("writes with 0600 file and 0700 directory permissions")
+    func writesRestrictivePermissions() async throws {
+        let repo = makeRepo()
+        try await repo.save(ProjectCatalog.makeDefault(now: Self.fixedDate))
+
+        let fileAttrs = try FileManager.default.attributesOfItem(atPath: repo.fileURL.path)
+        #expect((fileAttrs[.posixPermissions] as? Int) == 0o600)
+        let dirAttrs = try FileManager.default.attributesOfItem(atPath: repo.directoryURL.path)
+        #expect((dirAttrs[.posixPermissions] as? Int) == 0o700)
+    }
+
+    @Test("leaves no temporary files after a successful write")
+    func cleansUpTemporaryFiles() async throws {
+        let repo = makeRepo()
+        try await repo.save(ProjectCatalog.makeDefault(now: Self.fixedDate))
+        let contents = try FileManager.default.contentsOfDirectory(atPath: repo.directoryURL.path)
+        #expect(!contents.contains { $0.hasSuffix(".tmp") })
+        #expect(contents.contains(ProjectCatalogRepository.catalogFileName))
+    }
+
+    // MARK: Write: stale revision guard
+
+    @Test("rejects a stale revision but accepts a newer one")
+    func rejectsStaleRevision() async throws {
+        let repo = makeRepo()
+        let base = ProjectCatalog.makeDefault(now: Self.fixedDate)
+
+        try await repo.save(withRevision(base, 5))
+        await #expect(throws: ProjectCatalogRepositoryError.staleRevision(attempted: 3, current: 5)) {
+            try await repo.save(withRevision(base, 3))
+        }
+        try await repo.save(withRevision(base, 6))
+        let loaded = try await repo.load()
+        #expect(loaded.revision == 6)
+    }
+
+    @Test("a save that never followed a load will not clobber a newer on-disk catalog")
+    func saveBeforeLoadRejectsStale() async throws {
+        let repo = makeRepo()
+        let existing = withRevision(ProjectCatalog.makeDefault(now: Self.fixedDate), 10)
+        try writeCatalog(existing, to: repo)
+
+        await #expect(throws: ProjectCatalogRepositoryError.staleRevision(attempted: 5, current: 10)) {
+            try await repo.save(withRevision(ProjectCatalog.makeDefault(now: Self.fixedDate), 5))
+        }
+        let onDisk = try await repo.load()
+        #expect(onDisk.revision == 10)
+        #expect(onDisk == existing)
+    }
+
+    @Test("a save that never followed a load refuses to overwrite a corrupt catalog")
+    func saveBeforeLoadRefusesCorrupt() async throws {
+        let repo = makeRepo()
+        let corrupt = Data("{ corrupt".utf8)
+        try writeRaw(corrupt, to: repo)
+
+        await #expect(throws: ProjectCatalogRepositoryError.corruptData) {
+            try await repo.save(ProjectCatalog.makeDefault(now: Self.fixedDate))
+        }
+        #expect(try Data(contentsOf: repo.fileURL) == corrupt)
+    }
+
+    @Test("save refuses a catalog corrupted after this repository loaded it")
+    func saveAfterLoadRefusesExternalCorruption() async throws {
+        let repo = makeRepo()
+        let loaded = try await repo.load()
+        let corrupt = Data("{ externally corrupt".utf8)
+        try corrupt.write(to: repo.fileURL)
+
+        await #expect(throws: ProjectCatalogRepositoryError.corruptData) {
+            try await repo.save(withRevision(loaded, loaded.revision + 1))
+        }
+
+        #expect(try Data(contentsOf: repo.fileURL) == corrupt)
+    }
+
+    // MARK: Reset / recovery
+
+    @Test("reset preserves the prior regular file as a bounded recovery backup")
+    func resetPreservesRecoveryBackup() async throws {
+        let repo = makeRepo()
+        let corrupt = Data("{ corrupt".utf8)
+        try writeRaw(corrupt, to: repo)
+
+        let fresh = try await repo.reset()
+        try fresh.validate()
+
+        let backupURL = repo.directoryURL.appendingPathComponent(ProjectCatalogRepository.recoveryBackupFileName)
+        #expect(try Data(contentsOf: backupURL) == corrupt)
+        let backupAttrs = try FileManager.default.attributesOfItem(atPath: backupURL.path)
+        #expect((backupAttrs[.posixPermissions] as? Int) == 0o600)
+
+        let reloaded = try await repo.load()
+        #expect(reloaded == fresh)
+    }
+
+    @Test("reset discards a symlinked catalog without following it")
+    func resetDiscardsSymlinkWithoutFollowing() async throws {
+        let repo = makeRepo()
+        try FileManager.default.createDirectory(at: repo.directoryURL, withIntermediateDirectories: true)
+        let secret = repo.directoryURL.appendingPathComponent("secret.json")
+        let secretData = Data("secret".utf8)
+        try secretData.write(to: secret)
+        try FileManager.default.createSymbolicLink(at: repo.fileURL, withDestinationURL: secret)
+
+        _ = try await repo.reset()
+
+        // The symlink target is untouched, and no backup was made for a symlink.
+        #expect(try Data(contentsOf: secret) == secretData)
+        let backupURL = repo.directoryURL.appendingPathComponent(ProjectCatalogRepository.recoveryBackupFileName)
+        #expect(!FileManager.default.fileExists(atPath: backupURL.path))
+        // The live file is now a valid regular default.
+        let reloaded = try await repo.load()
+        try reloaded.validate()
+    }
+
+    @Test("reset refuses to recursively remove a non-regular catalog node")
+    func resetPreservesNonRegularCatalogNode() async throws {
+        let repo = makeRepo()
+        try FileManager.default.createDirectory(at: repo.fileURL, withIntermediateDirectories: true)
+        let sentinel = repo.fileURL.appendingPathComponent("sentinel")
+        try Data("keep".utf8).write(to: sentinel)
+
+        await #expect(throws: ProjectCatalogRepositoryError.notRegularFile) {
+            try await repo.reset()
+        }
+
+        #expect(try Data(contentsOf: sentinel) == Data("keep".utf8))
+    }
+
+    @Test("reset refuses to recursively remove a non-regular recovery node")
+    func resetPreservesNonRegularRecoveryNode() async throws {
+        let repo = makeRepo()
+        try writeRaw(Data("{ corrupt".utf8), to: repo)
+        let backupURL = repo.directoryURL.appendingPathComponent(ProjectCatalogRepository.recoveryBackupFileName)
+        try FileManager.default.createDirectory(at: backupURL, withIntermediateDirectories: true)
+        let sentinel = backupURL.appendingPathComponent("sentinel")
+        try Data("keep".utf8).write(to: sentinel)
+
+        await #expect(throws: ProjectCatalogRepositoryError.notRegularFile) {
+            try await repo.reset()
+        }
+
+        #expect(try Data(contentsOf: repo.fileURL) == Data("{ corrupt".utf8))
+        #expect(try Data(contentsOf: sentinel) == Data("keep".utf8))
+    }
+
+    // MARK: Helpers
+
+    private static let fixedDate = Date(timeIntervalSince1970: 1_000_000)
+
+    private func makeRepo() -> ProjectCatalogRepository {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("Rockxy.ProjectCatalogRepositoryTests.\(UUID().uuidString)", isDirectory: true)
+            .appendingPathComponent("projects", isDirectory: true)
+        return ProjectCatalogRepository(directoryURL: dir, now: { Self.fixedDate })
+    }
+
+    private func writeRaw(_ data: Data, to repo: ProjectCatalogRepository) throws {
+        try FileManager.default.createDirectory(at: repo.directoryURL, withIntermediateDirectories: true)
+        try data.write(to: repo.fileURL)
+    }
+
+    private func writeCatalog(_ catalog: ProjectCatalog, to repo: ProjectCatalogRepository) throws {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        try writeRaw(try encoder.encode(catalog), to: repo)
+    }
+
+    private func withRevision(_ catalog: ProjectCatalog, _ revision: UInt64) -> ProjectCatalog {
+        var copy = catalog
+        copy.revision = revision
+        return copy
+    }
+}

--- a/RockxyTests/Core/TrafficCapture/TrafficCaptureContextTests.swift
+++ b/RockxyTests/Core/TrafficCapture/TrafficCaptureContextTests.swift
@@ -1,0 +1,81 @@
+import Foundation
+@testable import Rockxy
+import Testing
+
+@Suite("TrafficCaptureContext")
+struct TrafficCaptureContextTests {
+    @Test("lock-backed store publishes complete snapshots")
+    func storeSnapshots() {
+        let first = TrafficCaptureContext(projectID: UUID(), sessionID: UUID(), generation: 1)
+        let second = TrafficCaptureContext(projectID: UUID(), sessionID: UUID(), generation: 2)
+        let store = TrafficCaptureContextStore(first)
+
+        #expect(store.snapshot() == first)
+        store.update(second)
+        #expect(store.snapshot() == second)
+        store.update(nil)
+        #expect(store.snapshot() == nil)
+    }
+
+    @Test("transaction inherits request-start ownership and cannot be reassigned")
+    func transactionOwnershipIsStable() throws {
+        let original = TrafficCaptureContext(projectID: UUID(), sessionID: UUID(), generation: 4)
+        let replacement = TrafficCaptureContext(projectID: UUID(), sessionID: UUID(), generation: 9)
+        let request = try HTTPRequestData(
+            method: "GET",
+            url: #require(URL(string: "https://example.com")),
+            httpVersion: "1.1",
+            headers: [],
+            body: nil,
+            contentType: nil,
+            captureContext: original
+        )
+        let transaction = HTTPTransaction(request: request)
+
+        transaction.assignCaptureContextIfMissing(replacement)
+
+        #expect(transaction.captureContext == original)
+    }
+
+    @Test("single-argument script mutation preserves request-start ownership")
+    func scriptContextPreservesOwnership() throws {
+        let context = TrafficCaptureContext(projectID: UUID(), sessionID: UUID(), generation: 3)
+        var request = try HTTPRequestData(
+            method: "GET",
+            url: #require(URL(string: "https://example.com/one")),
+            httpVersion: "1.1",
+            headers: [],
+            body: nil,
+            contentType: nil,
+            captureContext: context
+        )
+        var script = ScriptRequestContext(from: request)
+        script.method = "POST"
+
+        script.apply(to: &request, pluginID: "test.capture-context")
+
+        #expect(request.method == "POST")
+        #expect(request.captureContext == context)
+    }
+
+    @Test("runtime ownership is excluded from portable session JSON")
+    func ownershipIsNotSerialized() throws {
+        let context = TrafficCaptureContext(projectID: UUID(), sessionID: UUID(), generation: 7)
+        let request = try HTTPRequestData(
+            method: "GET",
+            url: #require(URL(string: "https://example.com")),
+            httpVersion: "1.1",
+            headers: [],
+            body: nil,
+            contentType: nil,
+            captureContext: context
+        )
+        let transaction = HTTPTransaction(request: request)
+        let data = try JSONEncoder().encode(CodableTransaction(from: transaction))
+        let json = try #require(String(data: data, encoding: .utf8))
+
+        #expect(!json.contains(context.projectID.uuidString))
+        #expect(!json.contains(context.sessionID.uuidString))
+        #expect(!json.contains("captureContext"))
+    }
+}

--- a/RockxyTests/Helpers/ProjectCaptureTestSupport.swift
+++ b/RockxyTests/Helpers/ProjectCaptureTestSupport.swift
@@ -1,0 +1,18 @@
+@testable import Rockxy
+
+@MainActor
+extension MainContentCoordinator {
+    /// Test-only convenience for production-equivalent request-start ownership.
+    /// Tests that intentionally exercise stale, inactive, or missing routes call
+    /// `processBatch` directly instead.
+    func processActiveProjectTestBatch(
+        _ batch: [HTTPTransaction],
+        generation: UInt? = nil
+    ) {
+        let context = activeCaptureContext
+        for transaction in batch {
+            transaction.assignCaptureContextIfMissing(context)
+        }
+        processBatch(batch, generation: generation ?? sessionGeneration)
+    }
+}

--- a/RockxyTests/Models/Projects/PortableProjectTests.swift
+++ b/RockxyTests/Models/Projects/PortableProjectTests.swift
@@ -1,0 +1,214 @@
+import Foundation
+@testable import Rockxy
+import Testing
+
+// MARK: - PortableProjectTests
+
+@Suite("PortableProject")
+struct PortableProjectTests {
+    // MARK: Internal
+
+    // MARK: Round trip
+
+    @Test("export then import preserves name and portable tab view intent")
+    func roundTripsPortableIntent() throws {
+        let project = Self.makeRichProject()
+
+        let portable = PortableProject(exporting: project)
+        let rebuilt = try portable.makeProject(now: Self.fixedDate, maxTabs: 8)
+
+        // Structural invariants hold on the materialized Project.
+        try rebuilt.validate()
+        #expect(rebuilt.name == project.name)
+        #expect(rebuilt.tabs.count == project.tabs.count)
+
+        // The customized second tab's allowlisted intent survives the round trip.
+        let source = project.tabs[1]
+        let restored = rebuilt.tabs[1]
+        #expect(restored.title == source.title)
+        #expect(restored.filter == source.filter)
+        #expect(restored.mainTabRawValue == source.mainTabRawValue)
+        #expect(restored.inspectorLayoutRawValue == source.inspectorLayoutRawValue)
+        #expect(restored.activeTrafficSignalRawValue == source.activeTrafficSignalRawValue)
+        #expect(restored.mutedTrafficSources == source.mutedTrafficSources)
+        #expect(restored.advancedFilterRows.map(\.value) == source.advancedFilterRows.map(\.value))
+    }
+
+    @Test("active tab is preserved by index, not by identifier")
+    func preservesActiveTabByIndex() throws {
+        let project = Self.makeRichProject() // active tab is index 1
+        let portable = PortableProject(exporting: project)
+        #expect(portable.activeTabIndex == 1)
+
+        let rebuilt = try portable.makeProject(now: Self.fixedDate, maxTabs: 8)
+        #expect(rebuilt.activeTabID == rebuilt.tabs[1].id)
+    }
+
+    // MARK: Default-deny / fresh identifiers
+
+    @Test("import mints fresh tab UUIDs and drops focus-set references")
+    func importRegeneratesIdentifiers() throws {
+        let project = Self.makeRichProject()
+        let portable = PortableProject(exporting: project)
+        let rebuilt = try portable.makeProject(now: Self.fixedDate, maxTabs: 8)
+
+        let originalTabIDs = Set(project.tabs.map(\.id))
+        #expect(rebuilt.id != project.id)
+        for tab in rebuilt.tabs {
+            #expect(!originalTabIDs.contains(tab.id))
+            #expect(tab.activeFocusSetID == nil)
+        }
+    }
+
+    @Test("encoded document contains no project, tab, or focus-set identifiers")
+    func encodedFormEncodesNoIdentifiers() throws {
+        let focusID = UUID()
+        let tabID = UUID()
+        let defaultTab = ProjectTabSnapshot.makeDefaultAllTraffic()
+        let customTab = ProjectTabSnapshot(
+            id: tabID,
+            title: "Errors",
+            isClosable: true,
+            filter: FilterCriteriaSnapshot(searchText: "secret", domains: ["internal.example.com"]),
+            activeFocusSetID: focusID
+        )
+        let project = Project(
+            id: UUID(),
+            name: "Alpha",
+            createdAt: Self.fixedDate,
+            updatedAt: Self.fixedDate,
+            activeTabID: tabID,
+            tabs: [defaultTab, customTab]
+        )
+
+        let data = try PortableProjectDocument.encode(project)
+        let json = try #require(String(bytes: data, encoding: .utf8))
+
+        // No identifier of any kind should cross the machine boundary...
+        #expect(!json.contains(project.id.uuidString))
+        #expect(!json.contains(tabID.uuidString))
+        #expect(!json.contains(defaultTab.id.uuidString))
+        #expect(!json.contains(focusID.uuidString))
+        #expect(!json.localizedCaseInsensitiveContains("activeFocusSetID"))
+        // ...while genuine, allowlisted view intent is retained.
+        #expect(json.contains("formatVersion"))
+        #expect(json.contains("internal.example.com"))
+    }
+
+    // MARK: Validation / fail-closed
+
+    @Test("rejects an unsupported format version")
+    func rejectsUnsupportedFormatVersion() {
+        let portable = PortableProject(
+            formatVersion: 2,
+            name: "Alpha",
+            activeTabIndex: 0,
+            tabs: [PortableProjectTab(title: "All Traffic", isClosable: false)]
+        )
+        #expect(throws: PortableProjectError.unsupportedFormatVersion(found: 2)) {
+            try portable.validate()
+        }
+    }
+
+    @Test("rejects an empty tab list")
+    func rejectsEmptyTabList() {
+        let portable = PortableProject(name: "Alpha", activeTabIndex: 0, tabs: [])
+        #expect(throws: PortableProjectError.tabCountOutOfRange(count: 0)) {
+            try portable.validate()
+        }
+    }
+
+    @Test("rejects an out-of-range active tab index")
+    func rejectsActiveTabIndexOutOfRange() {
+        let portable = PortableProject(
+            name: "Alpha",
+            activeTabIndex: 5,
+            tabs: [PortableProjectTab(title: "All Traffic", isClosable: false)]
+        )
+        #expect(throws: PortableProjectError.activeTabIndexOutOfRange(index: 5)) {
+            try portable.validate()
+        }
+    }
+
+    @Test("rejects an unnormalizable project name")
+    func rejectsInvalidName() {
+        let portable = PortableProject(
+            name: "   ",
+            activeTabIndex: 0,
+            tabs: [PortableProjectTab(title: "All Traffic", isClosable: false)]
+        )
+        #expect(throws: PortableProjectError.nameInvalid(.empty)) {
+            try portable.validate()
+        }
+    }
+
+    @Test("rejects an oversized filter value inside a tab")
+    func rejectsOversizedFilterValue() {
+        let huge = String(repeating: "a", count: ProjectStructuralLimits.maxFilterStringGraphemes + 1)
+        let tab = PortableProjectTab(
+            title: "Errors",
+            isClosable: true,
+            advancedFilterRows: [PortableFilterRule(value: huge)]
+        )
+        let portable = PortableProject(name: "Alpha", activeTabIndex: 0, tabs: [tab])
+        #expect(throws: PortableProjectError.self) {
+            try portable.validate()
+        }
+    }
+
+    @Test("materialization rejects an all-closable tab set that needs one slot for the default")
+    func rejectsLossyDefaultInsertionAtCapacity() {
+        let tabs = (0 ..< 8).map { index in
+            PortableProjectTab(title: "Tab \(index)", isClosable: true)
+        }
+        let portable = PortableProject(name: "Alpha", activeTabIndex: 7, tabs: tabs)
+
+        #expect(throws: PortableProjectError.tabCapacityExceededAfterDefaultInsertion(
+            required: 9,
+            limit: 8
+        )) {
+            _ = try portable.makeProject(now: Self.fixedDate, maxTabs: 8)
+        }
+    }
+
+    // MARK: Private
+
+    // MARK: Helpers
+
+    private static let fixedDate = Date(timeIntervalSince1970: 1_000_000)
+
+    /// A two-tab Project whose second tab is active and carries a full spread of
+    /// allowlisted view intent (filter, layout, signal, mutes, focus reference).
+    private static func makeRichProject() -> Project {
+        let defaultTab = ProjectTabSnapshot.makeDefaultAllTraffic()
+        let customTab = ProjectTabSnapshot(
+            id: UUID(),
+            title: "Errors",
+            isClosable: true,
+            filter: FilterCriteriaSnapshot(searchText: "500", methods: ["POST"], statusCodes: [500]),
+            advancedFilterRows: [
+                FilterRuleSnapshot(value: "example.com"),
+                FilterRuleSnapshot(value: "token"),
+            ],
+            isFilterBarVisible: true,
+            mainTabRawValue: MainTab.traffic.rawValue,
+            inspectorLayoutRawValue: InspectorLayoutCoding.bottom,
+            isContextDockVisible: true,
+            contextDockTabRawValue: ContextDockTabCoding.details,
+            focusNavigatorModeRawValue: FocusNavigatorMode.focus.rawValue,
+            activeTrafficSignalRawValue: TrafficSignal.errors.rawValue,
+            activeFocusSetID: UUID(),
+            mutedTrafficSources: [
+                MutedTrafficSourceSnapshot(kindRawValue: "host", value: "noise.example.com"),
+            ]
+        )
+        return Project(
+            id: UUID(),
+            name: "Alpha",
+            createdAt: fixedDate,
+            updatedAt: fixedDate,
+            activeTabID: customTab.id,
+            tabs: [defaultTab, customTab]
+        )
+    }
+}

--- a/RockxyTests/Models/Projects/ProjectCatalogTests.swift
+++ b/RockxyTests/Models/Projects/ProjectCatalogTests.swift
@@ -1,0 +1,208 @@
+import Foundation
+@testable import Rockxy
+import Testing
+
+// MARK: - ProjectCatalogTests
+
+@Suite("ProjectCatalog")
+struct ProjectCatalogTests {
+    // MARK: Defaults & invariants
+
+    @Test("default catalog is valid with one non-closable All Traffic tab")
+    func defaultCatalogValid() throws {
+        let catalog = ProjectCatalog.makeDefault(now: Self.fixedDate)
+        try catalog.validate()
+        #expect(catalog.projects.count == 1)
+        #expect(catalog.schemaVersion == 1)
+        #expect(catalog.revision == 1)
+        let project = try #require(catalog.activeProject)
+        #expect(project.tabs.count == 1)
+        #expect(project.tabs[0].isClosable == false)
+        #expect(project.activeTabID == project.tabs[0].id)
+    }
+
+    // MARK: Catalog-level validation
+
+    @Test("rejects an empty catalog")
+    func rejectsEmptyCatalog() {
+        let catalog = ProjectCatalog(activeProjectID: UUID(), projects: [])
+        #expect(throws: ProjectCatalogValidationError.projectCountOutOfRange(count: 0)) {
+            try catalog.validate()
+        }
+    }
+
+    @Test("rejects duplicate project IDs")
+    func rejectsDuplicateProjectIDs() {
+        let sharedID = UUID()
+        let projects = [
+            Self.makeProject(id: sharedID, name: "Alpha"),
+            Self.makeProject(id: sharedID, name: "Beta"),
+        ]
+        let catalog = ProjectCatalog(activeProjectID: sharedID, projects: projects)
+        #expect(throws: ProjectCatalogValidationError.duplicateProjectID(sharedID)) {
+            try catalog.validate()
+        }
+    }
+
+    @Test("rejects names that collide after folding")
+    func rejectsDuplicateFoldedNames() {
+        let projects = [
+            Self.makeProject(name: "Café"),
+            Self.makeProject(name: "cafe"),
+        ]
+        let catalog = ProjectCatalog(activeProjectID: projects[0].id, projects: projects)
+        #expect(throws: ProjectCatalogValidationError.self) {
+            try catalog.validate()
+        }
+    }
+
+    @Test("rejects an unresolved active project ID")
+    func rejectsUnresolvedActiveProject() {
+        let projects = [Self.makeProject(name: "Alpha")]
+        let catalog = ProjectCatalog(activeProjectID: UUID(), projects: projects)
+        #expect(throws: ProjectCatalogValidationError.unresolvedActiveProjectID) {
+            try catalog.validate()
+        }
+    }
+
+    @Test("rejects a stored project name that is not canonical")
+    func rejectsNoncanonicalProjectName() {
+        // A leading/trailing-space name decodes structurally but is noncanonical.
+        let project = Project(
+            name: "  Staging  ",
+            createdAt: Self.fixedDate,
+            updatedAt: Self.fixedDate,
+            activeTabID: UUID(),
+            tabs: [ProjectTabSnapshot.makeDefaultAllTraffic()]
+        )
+        var project2 = project
+        project2.activeTabID = project.tabs[0].id
+        #expect(throws: ProjectCatalogValidationError.projectNameInvalid(.notCanonical)) {
+            try project2.validate()
+        }
+    }
+
+    @Test("rejects a stored tab title that is not canonical")
+    func rejectsNoncanonicalTabTitle() {
+        let tab = ProjectTabSnapshot(title: "All Traffic ", isClosable: false)
+        let project = Project(
+            name: "Alpha",
+            createdAt: Self.fixedDate,
+            updatedAt: Self.fixedDate,
+            activeTabID: tab.id,
+            tabs: [tab]
+        )
+        #expect(throws: ProjectCatalogValidationError.self) {
+            try project.validate()
+        }
+    }
+
+    // MARK: Project-level validation
+
+    @Test("rejects a project with zero tabs")
+    func rejectsEmptyProject() {
+        let project = Project(
+            name: "Alpha",
+            createdAt: Self.fixedDate,
+            updatedAt: Self.fixedDate,
+            activeTabID: UUID(),
+            tabs: []
+        )
+        #expect(throws: ProjectCatalogValidationError.self) {
+            try project.validate()
+        }
+    }
+
+    @Test("rejects a project with no non-closable tab")
+    func rejectsMissingNonClosableTab() {
+        let tab = ProjectTabSnapshot(title: "Closable", isClosable: true)
+        let project = Project(
+            name: "Alpha",
+            createdAt: Self.fixedDate,
+            updatedAt: Self.fixedDate,
+            activeTabID: tab.id,
+            tabs: [tab]
+        )
+        #expect(throws: ProjectCatalogValidationError.missingNonClosableTab(projectID: project.id)) {
+            try project.validate()
+        }
+    }
+
+    @Test("rejects an unresolved active tab ID")
+    func rejectsUnresolvedActiveTab() {
+        let tab = ProjectTabSnapshot.makeDefaultAllTraffic()
+        let project = Project(
+            name: "Alpha",
+            createdAt: Self.fixedDate,
+            updatedAt: Self.fixedDate,
+            activeTabID: UUID(),
+            tabs: [tab]
+        )
+        #expect(throws: ProjectCatalogValidationError.unresolvedActiveTabID(projectID: project.id)) {
+            try project.validate()
+        }
+    }
+
+    @Test("rejects duplicate tab IDs")
+    func rejectsDuplicateTabIDs() {
+        let sharedID = UUID()
+        let tabs = [
+            ProjectTabSnapshot(id: sharedID, title: "All Traffic", isClosable: false),
+            ProjectTabSnapshot(id: sharedID, title: "Second", isClosable: true),
+        ]
+        let project = Project(
+            name: "Alpha",
+            createdAt: Self.fixedDate,
+            updatedAt: Self.fixedDate,
+            activeTabID: sharedID,
+            tabs: tabs
+        )
+        #expect(throws: ProjectCatalogValidationError.duplicateTabID(sharedID)) {
+            try project.validate()
+        }
+    }
+
+    // MARK: Tab normalization
+
+    @Test("normalizedTabs injects a non-closable default when none exists")
+    func normalizedTabsInjectsDefault() {
+        let closable = ProjectTabSnapshot(title: "One", isClosable: true)
+        let (tabs, activeTabID) = Project.normalizedTabs([closable], activeTabID: closable.id, maxTabs: 8)
+        #expect(tabs.contains { !$0.isClosable })
+        #expect(tabs.contains { $0.id == activeTabID })
+        #expect(activeTabID == closable.id)
+    }
+
+    @Test("normalizedTabs produces a default tab for an empty input")
+    func normalizedTabsFromEmpty() {
+        let (tabs, activeTabID) = Project.normalizedTabs([], activeTabID: UUID(), maxTabs: 8)
+        #expect(tabs.count == 1)
+        #expect(tabs[0].isClosable == false)
+        #expect(activeTabID == tabs[0].id)
+    }
+
+    @Test("normalizedTabs clamps to capacity while keeping the default tab")
+    func normalizedTabsClampsCapacity() {
+        let base = ProjectTabSnapshot.makeDefaultAllTraffic()
+        let extras = (0 ..< 10).map { ProjectTabSnapshot(title: "Tab \($0)", isClosable: true) }
+        let (tabs, _) = Project.normalizedTabs([base] + extras, activeTabID: base.id, maxTabs: 4)
+        #expect(tabs.count == 4)
+        #expect(tabs.contains { $0.id == base.id })
+        #expect(tabs.contains { !$0.isClosable })
+    }
+
+    @Test("normalizedTabs drops duplicate tab IDs")
+    func normalizedTabsDropsDuplicates() {
+        let base = ProjectTabSnapshot.makeDefaultAllTraffic()
+        let (tabs, _) = Project.normalizedTabs([base, base], activeTabID: base.id, maxTabs: 8)
+        #expect(tabs.count == 1)
+    }
+
+    // MARK: Helpers
+
+    private static let fixedDate = Date(timeIntervalSince1970: 1_000_000)
+
+    private static func makeProject(id: UUID = UUID(), name: String) -> Project {
+        Project.makeDefault(id: id, name: name, createdAt: fixedDate, updatedAt: fixedDate)
+    }
+}

--- a/RockxyTests/Models/Projects/ProjectNormalizationTests.swift
+++ b/RockxyTests/Models/Projects/ProjectNormalizationTests.swift
@@ -1,0 +1,127 @@
+@testable import Rockxy
+import Testing
+
+// MARK: - ProjectNormalizationTests
+
+@Suite("ProjectNormalization")
+struct ProjectNormalizationTests {
+    @Test("trims surrounding whitespace and newlines")
+    func trimsSurroundingWhitespace() throws {
+        #expect(try ProjectNormalization.normalizedDisplayName("  Staging  ") == "Staging")
+        #expect(try ProjectNormalization.normalizedDisplayName("\n\tStaging\n") == "Staging")
+    }
+
+    @Test("applies canonical Unicode composition")
+    func canonicalComposition() throws {
+        // "e" + combining acute accent normalizes to precomposed "é".
+        let decomposed = "Cafe\u{0301}"
+        let normalized = try ProjectNormalization.normalizedDisplayName(decomposed)
+        #expect(normalized == "Café")
+        #expect(normalized.unicodeScalars.count == 4)
+    }
+
+    @Test("rejects an empty or whitespace-only name")
+    func rejectsEmpty() {
+        #expect(throws: ProjectNameNormalizationError.empty) {
+            _ = try ProjectNormalization.normalizedDisplayName("   \n\t ")
+        }
+    }
+
+    @Test("rejects interior control characters")
+    func rejectsControlCharacters() {
+        #expect(throws: ProjectNameNormalizationError.containsControlCharacters) {
+            _ = try ProjectNormalization.normalizedDisplayName("Stag\ning")
+        }
+        #expect(throws: ProjectNameNormalizationError.containsControlCharacters) {
+            _ = try ProjectNormalization.normalizedDisplayName("Stag\u{0007}ing")
+        }
+    }
+
+    @Test("rejects unsafe invisible and directional formatting characters")
+    func rejectsUnsafeFormatCharacters() {
+        // U+202E RIGHT-TO-LEFT OVERRIDE — directional spoofing.
+        #expect(throws: ProjectNameNormalizationError.containsControlCharacters) {
+            _ = try ProjectNormalization.normalizedDisplayName("Stag\u{202E}ing")
+        }
+        // U+200B ZERO WIDTH SPACE — invisible.
+        #expect(throws: ProjectNameNormalizationError.containsControlCharacters) {
+            _ = try ProjectNormalization.normalizedDisplayName("Stag\u{200B}ing")
+        }
+        // U+00AD SOFT HYPHEN — invisible.
+        #expect(throws: ProjectNameNormalizationError.containsControlCharacters) {
+            _ = try ProjectNormalization.normalizedDisplayName("Stag\u{00AD}ing")
+        }
+    }
+
+    @Test("preserves legitimate joining controls (ZWNJ/ZWJ)")
+    func preservesJoiningControls() throws {
+        // U+200D ZERO WIDTH JOINER binds the family emoji into one grapheme cluster.
+        let family = "👨‍👩‍👧‍👦"
+        #expect(try ProjectNormalization.normalizedDisplayName(family) == family)
+
+        // U+200C ZERO WIDTH NON-JOINER is legitimate in joining scripts.
+        let zwnj = "a\u{200C}b"
+        #expect(try ProjectNormalization.normalizedDisplayName(zwnj) == zwnj)
+    }
+
+    @Test("enforces the 1...80 grapheme bound")
+    func enforcesGraphemeBound() throws {
+        let maxName = String(repeating: "a", count: 80)
+        #expect(try ProjectNormalization.normalizedDisplayName(maxName).count == 80)
+
+        let tooLong = String(repeating: "a", count: 81)
+        #expect(throws: ProjectNameNormalizationError.tooLong(graphemeCount: 81)) {
+            _ = try ProjectNormalization.normalizedDisplayName(tooLong)
+        }
+    }
+
+    @Test("counts grapheme clusters, not scalars, for emoji")
+    func countsGraphemeClusters() throws {
+        // A single family emoji is one grapheme cluster but many scalars.
+        let emoji = "👨‍👩‍👧‍👦"
+        #expect(emoji.unicodeScalars.count > 1)
+        let name = String(repeating: emoji, count: 80)
+        #expect(try ProjectNormalization.normalizedDisplayName(name).count == 80)
+    }
+
+    @Test("folds case and diacritics deterministically for uniqueness")
+    func foldsCaseAndDiacritics() throws {
+        let a = try ProjectNormalization.foldedKey(forRawName: "Café")
+        let b = try ProjectNormalization.foldedKey(forRawName: "cafe")
+        let c = try ProjectNormalization.foldedKey(forRawName: "  CAFE ")
+        #expect(a == b)
+        #expect(b == c)
+    }
+
+    @Test("distinct names fold to distinct keys")
+    func distinctNamesDistinctKeys() throws {
+        let a = try ProjectNormalization.foldedKey(forRawName: "Staging")
+        let b = try ProjectNormalization.foldedKey(forRawName: "Production")
+        #expect(a != b)
+    }
+
+    @Test("requireCanonical accepts an already-canonical value")
+    func requireCanonicalAcceptsCanonical() throws {
+        try ProjectNormalization.requireCanonical("Staging")
+        try ProjectNormalization.requireCanonical("Café")
+    }
+
+    @Test("requireCanonical rejects a value that is not its own normalized form")
+    func requireCanonicalRejectsNoncanonical() {
+        // Untrimmed: normalizes to "Staging", so it is not canonical as stored.
+        #expect(throws: ProjectNameNormalizationError.notCanonical) {
+            try ProjectNormalization.requireCanonical("  Staging  ")
+        }
+        // Decomposed accent: canonical form is precomposed, so the stored value differs.
+        #expect(throws: ProjectNameNormalizationError.notCanonical) {
+            try ProjectNormalization.requireCanonical("Cafe\u{0301}")
+        }
+    }
+
+    @Test("requireCanonical surfaces the underlying invalidity for a corrupt value")
+    func requireCanonicalSurfacesInvalidity() {
+        #expect(throws: ProjectNameNormalizationError.empty) {
+            try ProjectNormalization.requireCanonical("   ")
+        }
+    }
+}

--- a/RockxyTests/Models/Projects/ProjectStoreTests.swift
+++ b/RockxyTests/Models/Projects/ProjectStoreTests.swift
@@ -1,0 +1,734 @@
+import Foundation
+@testable import Rockxy
+import Testing
+
+// MARK: - ProjectStoreTests
+
+@MainActor
+@Suite("ProjectStore")
+struct ProjectStoreTests {
+    // MARK: Internal
+
+    // MARK: Creation & naming
+
+    @Test("creates a project, normalizes its name, and activates it")
+    func createsAndActivates() throws {
+        let store = ProjectStore(now: { Self.fixedDate })
+        let project = try store.createProject(name: "  Staging  ")
+        #expect(project.name == "Staging")
+        #expect(store.activeProjectID == project.id)
+        #expect(store.projects.count == 2)
+        try project.validate()
+    }
+
+    @Test("rejects a name that collides after folding")
+    func rejectsDuplicateName() throws {
+        let store = ProjectStore(now: { Self.fixedDate })
+        _ = try store.createProject(name: "Café")
+        #expect(throws: ProjectMutationError.duplicateName) {
+            _ = try store.createProject(name: "cafe")
+        }
+    }
+
+    @Test("rejects an invalid name")
+    func rejectsInvalidName() {
+        let store = ProjectStore(now: { Self.fixedDate })
+        #expect(throws: ProjectMutationError.self) {
+            _ = try store.createProject(name: "   ")
+        }
+    }
+
+    // MARK: Capacity & clamping
+
+    @Test("enforces the effective project capacity")
+    func enforcesCapacity() throws {
+        let store = ProjectStore(policy: CapacityPolicy(maxProjects: 2), now: { Self.fixedDate })
+        // Default catalog already holds one project.
+        _ = try store.createProject(name: "Second")
+        #expect(!store.canCreateProject)
+        #expect(throws: ProjectMutationError.capacityReached(limit: 2)) {
+            _ = try store.createProject(name: "Third")
+        }
+    }
+
+    @Test("clamps policy capacity into the structural range")
+    func clampsCapacity() {
+        #expect(ProjectStore(policy: CapacityPolicy(maxProjects: 500)).maxProjects == 128)
+        #expect(ProjectStore(policy: CapacityPolicy(maxProjects: 0)).maxProjects == 1)
+        #expect(ProjectStore(policy: CapacityPolicy(maxWorkspaceTabs: 100)).maxTabsPerProject == 32)
+        #expect(ProjectStore(policy: CapacityPolicy(maxWorkspaceTabs: 0)).maxTabsPerProject == 1)
+    }
+
+    // MARK: Portable import
+
+    @Test("portable import creates and activates a new project with fresh identifiers")
+    func importsPortableProjectAsNew() throws {
+        let source = Self.makeProject(name: "Imported API")
+        let store = ProjectStore(now: { Self.fixedDate })
+
+        let imported = try store.importProject(PortableProject(exporting: source))
+
+        #expect(store.activeProjectID == imported.id)
+        #expect(imported.id != source.id)
+        #expect(Set(imported.tabs.map(\.id)).isDisjoint(with: Set(source.tabs.map(\.id))))
+        #expect(store.projects.contains { $0.id == imported.id })
+    }
+
+    @Test("portable import resolves name collisions without replacing existing projects")
+    func importDeduplicatesName() throws {
+        let store = ProjectStore(now: { Self.fixedDate })
+        let original = store.activeProject
+        let imported = try store.importProject(PortableProject(exporting: original))
+
+        #expect(store.projects.count == 2)
+        #expect(store.projects.contains { $0.id == original.id && $0.name == original.name })
+        #expect(imported.name == "My Project (Imported)")
+    }
+
+    @Test("capacity refusal leaves the project catalog unchanged")
+    func importCapacityFailureIsAtomic() {
+        let store = ProjectStore(policy: CapacityPolicy(maxProjects: 1), now: { Self.fixedDate })
+        let before = store.catalog
+        let portable = PortableProject(exporting: Self.makeProject(name: "Extra"))
+
+        #expect(throws: ProjectMutationError.capacityReached(limit: 1)) {
+            _ = try store.importProject(portable)
+        }
+        #expect(store.catalog == before)
+    }
+
+    @Test("portable import rejects excess tabs without silently truncating")
+    func importTabCapacityFailureIsAtomic() {
+        let store = ProjectStore(policy: CapacityPolicy(maxWorkspaceTabs: 2), now: { Self.fixedDate })
+        let before = store.catalog
+        let portable = PortableProject(
+            name: "Too Many Tabs",
+            activeTabIndex: 0,
+            tabs: (0 ..< 3).map {
+                PortableProjectTab(title: "Tab \($0)", isClosable: $0 != 0)
+            }
+        )
+
+        #expect(throws: ProjectMutationError.tabCapacityReached(limit: 2)) {
+            _ = try store.importProject(portable)
+        }
+        #expect(store.catalog == before)
+    }
+
+    @Test("portable import rejects default insertion above the tab policy atomically")
+    func importRejectsLossyDefaultInsertion() {
+        let store = ProjectStore(policy: CapacityPolicy(maxWorkspaceTabs: 2), now: { Self.fixedDate })
+        let before = store.catalog
+        let portable = PortableProject(
+            name: "Closable Only",
+            activeTabIndex: 1,
+            tabs: [
+                PortableProjectTab(title: "One", isClosable: true),
+                PortableProjectTab(title: "Two", isClosable: true),
+            ]
+        )
+
+        #expect(throws: ProjectMutationError.tabCapacityReached(limit: 2)) {
+            _ = try store.importProject(portable)
+        }
+        #expect(store.catalog == before)
+    }
+
+    // MARK: Rename & select
+
+    @Test("renames a project and rejects unknown IDs")
+    func renames() throws {
+        let store = ProjectStore(now: { Self.fixedDate })
+        let project = try store.createProject(name: "Staging")
+        try store.renameProject(id: project.id, to: "  Production ")
+        #expect(store.projects.first { $0.id == project.id }?.name == "Production")
+        #expect(throws: ProjectMutationError.projectNotFound) {
+            try store.renameProject(id: UUID(), to: "Nope")
+        }
+    }
+
+    @Test("rename rejects a colliding name")
+    func renameRejectsCollision() throws {
+        let store = ProjectStore(now: { Self.fixedDate })
+        let a = try store.createProject(name: "Alpha")
+        _ = try store.createProject(name: "Beta")
+        #expect(throws: ProjectMutationError.duplicateName) {
+            try store.renameProject(id: a.id, to: "beta")
+        }
+    }
+
+    @Test("renaming to the identical canonical name is a no-op")
+    func renameNoOpKeepsRevision() throws {
+        let store = ProjectStore(now: { Self.fixedDate })
+        let project = try store.createProject(name: "Staging")
+        let revisionBefore = store.catalog.revision
+        try store.renameProject(id: project.id, to: "  Staging  ")
+        #expect(store.catalog.revision == revisionBefore)
+    }
+
+    @Test("selects an existing project and rejects unknown IDs")
+    func selects() throws {
+        let store = ProjectStore(now: { Self.fixedDate })
+        let first = store.activeProjectID
+        let project = try store.createProject(name: "Staging")
+        try store.selectProject(id: first)
+        #expect(store.activeProjectID == first)
+        #expect(throws: ProjectMutationError.projectNotFound) {
+            try store.selectProject(id: UUID())
+        }
+        #expect(store.activeProjectID == first)
+        try store.selectProject(id: project.id)
+        #expect(store.activeProjectID == project.id)
+    }
+
+    @Test("re-selecting the active project is a no-op that does not bump the revision")
+    func selectActiveIsNoOp() throws {
+        let store = ProjectStore(now: { Self.fixedDate })
+        let active = store.activeProjectID
+        let revisionBefore = store.catalog.revision
+        try store.selectProject(id: active)
+        #expect(store.catalog.revision == revisionBefore)
+    }
+
+    // MARK: Deletion
+
+    @Test("cannot delete the final project")
+    func cannotDeleteFinal() {
+        let store = ProjectStore(now: { Self.fixedDate })
+        #expect(throws: ProjectMutationError.cannotDeleteFinalProject) {
+            try store.deleteProject(id: store.activeProjectID)
+        }
+        #expect(store.projects.count == 1)
+    }
+
+    @Test("deleting the active project activates the following, then the previous")
+    func deleteActivatesAdjacent() throws {
+        let projects = (0 ..< 3).map { Self.makeProject(name: "P\($0)") }
+        let catalog = ProjectCatalog(activeProjectID: projects[1].id, projects: projects)
+        let store = ProjectStore(catalog: catalog, now: { Self.fixedDate })
+
+        try store.deleteProject(id: projects[1].id)
+        #expect(store.activeProjectID == projects[2].id)
+
+        try store.deleteProject(id: projects[2].id)
+        #expect(store.activeProjectID == projects[0].id)
+        #expect(store.projects.count == 1)
+    }
+
+    // MARK: Reorder
+
+    @Test("reorders projects to the requested order")
+    func reorders() throws {
+        let projects = (0 ..< 3).map { Self.makeProject(name: "P\($0)") }
+        let catalog = ProjectCatalog(activeProjectID: projects[0].id, projects: projects)
+        let store = ProjectStore(catalog: catalog, now: { Self.fixedDate })
+
+        try store.reorderProjects([projects[2].id, projects[0].id, projects[1].id])
+        #expect(store.projects.map(\.id) == [projects[2].id, projects[0].id, projects[1].id])
+    }
+
+    @Test("reordering to the current order is a no-op")
+    func reorderNoOpKeepsRevision() throws {
+        let projects = (0 ..< 3).map { Self.makeProject(name: "P\($0)") }
+        let catalog = ProjectCatalog(activeProjectID: projects[0].id, projects: projects)
+        let store = ProjectStore(catalog: catalog, now: { Self.fixedDate })
+        let revisionBefore = store.catalog.revision
+        try store.reorderProjects(projects.map(\.id))
+        #expect(store.catalog.revision == revisionBefore)
+    }
+
+    // MARK: Active tab updates
+
+    @Test("updating active tabs re-establishes tab invariants")
+    func updatesActiveTabsWithInvariants() throws {
+        let store = ProjectStore(now: { Self.fixedDate })
+        let closable = ProjectTabSnapshot(title: "One", isClosable: true)
+        try store.updateActiveProjectTabs([closable], activeTabID: closable.id)
+
+        let tabs = store.activeProject.tabs
+        #expect(tabs.contains { !$0.isClosable })
+        #expect(tabs.contains { $0.id == store.activeProject.activeTabID })
+    }
+
+    @Test("updating active tabs clamps to the structural upper bound, not the creation limit")
+    func updatesActiveTabsClampsCapacity() throws {
+        // A low product creation limit must not truncate captured tabs: retention is
+        // bounded only by the structural upper bound.
+        let store = ProjectStore(policy: CapacityPolicy(maxWorkspaceTabs: 4), now: { Self.fixedDate })
+        let base = ProjectTabSnapshot.makeDefaultAllTraffic()
+        let extras = (0 ..< 40).map { ProjectTabSnapshot(title: "Tab \($0)", isClosable: true) }
+        try store.updateActiveProjectTabs([base] + extras, activeTabID: base.id)
+        #expect(store.activeProject.tabs.count == ProjectStructuralLimits.tabCountRange.upperBound)
+        #expect(store.activeProject.tabs.count > store.maxTabsPerProject)
+    }
+
+    @Test("updating active tabs canonicalizes a merely-untrimmed title")
+    func updatesActiveTabsCanonicalizesTitle() throws {
+        let store = ProjectStore(now: { Self.fixedDate })
+        let tab = ProjectTabSnapshot(title: "Payments ", isClosable: true)
+        try store.updateActiveProjectTabs([tab], activeTabID: tab.id)
+        #expect(store.activeProject.tabs.contains { $0.title == "Payments" })
+    }
+
+    @Test("a corrupt tab snapshot is rejected and leaves the tabs unchanged")
+    func rejectsCorruptTabSnapshotWithoutMutating() {
+        let store = ProjectStore(now: { Self.fixedDate })
+        let before = store.activeProject.tabs
+        let oversized = String(repeating: "y", count: ProjectStructuralLimits.maxFilterStringGraphemes + 1)
+        let corrupt = ProjectTabSnapshot(
+            title: "Bad",
+            isClosable: true,
+            filter: FilterCriteriaSnapshot(searchText: oversized)
+        )
+        #expect(throws: ProjectMutationError.self) {
+            try store.updateActiveProjectTabs([corrupt], activeTabID: corrupt.id)
+        }
+        #expect(store.activeProject.tabs == before)
+    }
+
+    @Test("a noncanonical tab title is rejected and leaves the tabs unchanged")
+    func rejectsNoncanonicalTabTitleWithoutMutating() {
+        let store = ProjectStore(now: { Self.fixedDate })
+        let before = store.activeProject.tabs
+        let corrupt = ProjectTabSnapshot(title: "Bad\nTitle", isClosable: true)
+        #expect(throws: ProjectMutationError.self) {
+            try store.updateActiveProjectTabs([corrupt], activeTabID: corrupt.id)
+        }
+        #expect(store.activeProject.tabs == before)
+    }
+
+    // MARK: Revision exhaustion
+
+    @Test("a mutation at the maximum revision fails without changing the catalog")
+    func revisionExhaustionFailsClosed() {
+        var catalog = ProjectCatalog.makeDefault(now: Self.fixedDate)
+        catalog.revision = UInt64.max
+        let store = ProjectStore(catalog: catalog, now: { Self.fixedDate })
+        #expect(throws: ProjectMutationError.revisionExhausted) {
+            _ = try store.createProject(name: "Staging")
+        }
+        #expect(store.catalog.revision == UInt64.max)
+        #expect(store.projects.count == 1)
+    }
+
+    // MARK: Load lifecycle & mutation gates
+
+    @Test("an in-memory store is mutable immediately")
+    func inMemoryStoreIsReady() {
+        let store = ProjectStore(now: { Self.fixedDate })
+        #expect(store.loadState == .ready)
+        #expect(store.isMutable)
+    }
+
+    @Test("a repository-backed store is not mutable before loading")
+    func mutationsRefusedBeforeLoad() {
+        let repo = FakeCatalogRepository()
+        let store = ProjectStore(repository: repo, now: { Self.fixedDate })
+        #expect(store.loadState == .idle)
+        #expect(!store.isMutable)
+        #expect(!store.canCreateProject)
+        #expect(throws: ProjectMutationError.storeNotReady) {
+            _ = try store.createProject(name: "Staging")
+        }
+        let revisionBefore = store.catalog.revision
+        #expect(throws: ProjectMutationError.storeNotReady) {
+            try store.selectProject(id: UUID())
+        }
+        #expect(throws: ProjectMutationError.storeNotReady) {
+            try store.reorderProjects([UUID()])
+        }
+        #expect(store.catalog.revision == revisionBefore)
+        #expect(throws: ProjectMutationError.storeNotReady) {
+            try store.updateActiveProjectTabs([], activeTabID: UUID())
+        }
+    }
+
+    @Test("a successful load makes the store mutable and adopts the catalog")
+    func loadMakesStoreMutable() async throws {
+        let repo = FakeCatalogRepository()
+        let store = ProjectStore(repository: repo, now: { Self.fixedDate })
+        await store.loadPersistedCatalog()
+        #expect(store.loadState == .ready)
+        #expect(store.isMutable)
+        _ = try store.createProject(name: "Staging")
+        #expect(store.projects.count == 2)
+    }
+
+    @Test("mutations remain refused after a failed load, and no save is attempted")
+    func mutationsRefusedAfterFailedLoad() async {
+        let repo = FakeCatalogRepository(loadResult: .failure(FakeError.boom))
+        let store = ProjectStore(repository: repo, now: { Self.fixedDate })
+        await store.loadPersistedCatalog()
+        #expect(store.loadState == .failed(String(describing: FakeError.boom)))
+        #expect(!store.isMutable)
+        #expect(throws: ProjectMutationError.storeNotReady) {
+            _ = try store.createProject(name: "Staging")
+        }
+        #expect(await repo.saveCount == 0)
+    }
+
+    @Test("a loaded catalog above project-count capacity loads and stays mutable for non-creation actions")
+    func loadRetainsOverProjectCapacity() async throws {
+        let projects = (0 ..< 3).map { Self.makeProject(name: "P\($0)") }
+        let over = ProjectCatalog(activeProjectID: projects[0].id, projects: projects)
+        let repo = FakeCatalogRepository(loadResult: .success(over))
+        let store = ProjectStore(policy: CapacityPolicy(maxProjects: 2), repository: repo, now: { Self.fixedDate })
+
+        await store.loadPersistedCatalog()
+
+        #expect(store.loadState == .ready)
+        #expect(store.isMutable)
+        #expect(store.loadFailureMessage == nil)
+        // Existing over-capacity Projects are retained, never truncated.
+        #expect(store.projects.count == 3)
+        // Creation is blocked while over capacity, but other mutations remain allowed.
+        #expect(!store.canCreateProject)
+        #expect(throws: ProjectMutationError.capacityReached(limit: 2)) {
+            _ = try store.createProject(name: "Blocked")
+        }
+        try store.renameProject(id: projects[2].id, to: "Renamed")
+        #expect(store.projects.contains { $0.name == "Renamed" })
+        try store.deleteProject(id: projects[2].id)
+        #expect(store.projects.count == 2)
+    }
+
+    @Test("a loaded project above per-project tab capacity retains all of its tabs")
+    func loadRetainsOverTabCapacity() async {
+        let base = ProjectTabSnapshot.makeDefaultAllTraffic()
+        let tabs = [base]
+            + (0 ..< 4).map { ProjectTabSnapshot(title: "Tab \($0)", isClosable: true) }
+        let project = Project(
+            name: "Alpha",
+            createdAt: Self.fixedDate,
+            updatedAt: Self.fixedDate,
+            activeTabID: base.id,
+            tabs: tabs
+        )
+        let over = ProjectCatalog(activeProjectID: project.id, projects: [project])
+        let repo = FakeCatalogRepository(loadResult: .success(over))
+        let store = ProjectStore(policy: CapacityPolicy(maxWorkspaceTabs: 2), repository: repo, now: { Self.fixedDate })
+
+        await store.loadPersistedCatalog()
+
+        #expect(store.loadState == .ready)
+        #expect(store.isMutable)
+        #expect(store.activeProject.tabs.count == 5)
+    }
+
+    @Test("a structurally invalid loaded catalog is rejected even from an injected repository")
+    func loadRejectsStructurallyInvalidCatalog() async {
+        // Two Projects sharing one folded name violate a structural invariant and
+        // must fail closed regardless of the injected repository.
+        let duplicate = [Self.makeProject(name: "Same"), Self.makeProject(name: "same")]
+        let invalid = ProjectCatalog(activeProjectID: duplicate[0].id, projects: duplicate)
+        let repo = FakeCatalogRepository(loadResult: .success(invalid))
+        let store = ProjectStore(repository: repo, now: { Self.fixedDate })
+
+        await store.loadPersistedCatalog()
+
+        #expect(!store.isMutable)
+        #expect(store.loadFailureMessage != nil)
+        #expect(store.projects.count == 1)
+    }
+
+    // MARK: Runtime capacity refresh
+
+    @Test("lowering capacity at runtime keeps existing state and only blocks new creation")
+    func capacityDecreaseRetainsState() throws {
+        let store = ProjectStore(policy: CapacityPolicy(maxProjects: 4), now: { Self.fixedDate })
+        _ = try store.createProject(name: "Second")
+        _ = try store.createProject(name: "Third")
+        #expect(store.projects.count == 3)
+
+        store.refreshCapacity(with: CapacityPolicy(maxProjects: 2))
+
+        #expect(store.maxProjects == 2)
+        #expect(store.projects.count == 3)
+        #expect(!store.canCreateProject)
+        #expect(throws: ProjectMutationError.capacityReached(limit: 2)) {
+            _ = try store.createProject(name: "Blocked")
+        }
+    }
+
+    @Test("raising capacity at runtime re-enables creation without disturbing state")
+    func capacityIncreaseReenablesCreation() throws {
+        let store = ProjectStore(policy: CapacityPolicy(maxProjects: 1), now: { Self.fixedDate })
+        #expect(!store.canCreateProject)
+        let activeBefore = store.activeProjectID
+
+        store.refreshCapacity(with: CapacityPolicy(maxProjects: 3))
+
+        #expect(store.maxProjects == 3)
+        #expect(store.activeProjectID == activeBefore)
+        #expect(store.canCreateProject)
+        _ = try store.createProject(name: "Second")
+        #expect(store.projects.count == 2)
+    }
+
+    @Test("a capacity refresh clamps into the structural range and bumps no revision")
+    func capacityRefreshClampsAndKeepsRevision() {
+        let store = ProjectStore(policy: CapacityPolicy(maxProjects: 2), now: { Self.fixedDate })
+        let revisionBefore = store.catalog.revision
+        store.refreshCapacity(with: CapacityPolicy(maxWorkspaceTabs: 0, maxProjects: 999))
+        #expect(store.maxProjects == 128)
+        #expect(store.maxTabsPerProject == 1)
+        #expect(store.catalog.revision == revisionBefore)
+    }
+
+    // MARK: Reconciliation
+
+    @Test("reconciliation accepts a matching revision, adopts entities, preserves active, and bumps the revision")
+    func reconcileAdoptsAndPreservesActive() throws {
+        let store = ProjectStore(now: { Self.fixedDate })
+        let active = store.activeProject
+        let revisionBefore = store.catalog.revision
+        let added = Self.makeProject(name: "Reconciled")
+
+        let changed = try store.reconcile(projects: [active, added], expectedRevision: revisionBefore)
+
+        #expect(changed)
+        #expect(store.projects.map(\.id) == [active.id, added.id])
+        #expect(store.activeProjectID == active.id)
+        #expect(store.catalog.revision == revisionBefore + 1)
+    }
+
+    @Test("reconciliation selects a deterministic active project when the local one is gone")
+    func reconcileFallsBackToFirstWhenActiveRemoved() throws {
+        let store = ProjectStore(now: { Self.fixedDate })
+        let replacement = Self.makeProject(name: "First")
+        let second = Self.makeProject(name: "Second")
+
+        try store.reconcile(projects: [replacement, second], expectedRevision: store.catalog.revision)
+
+        #expect(store.activeProjectID == replacement.id)
+        #expect(store.projects.map(\.id) == [replacement.id, second.id])
+    }
+
+    @Test("reconciliation with identical entities is an accepted no-op under a matching revision")
+    func reconcileIdenticalIsNoOp() async throws {
+        let repo = FakeCatalogRepository()
+        let store = ProjectStore(repository: repo, now: { Self.fixedDate })
+        await store.loadPersistedCatalog()
+        let revisionBefore = store.catalog.revision
+
+        let changed = try store.reconcile(projects: store.projects, expectedRevision: revisionBefore)
+
+        #expect(!changed)
+        #expect(store.catalog.revision == revisionBefore)
+        await store.waitForPendingPersistence()
+        #expect(await repo.saveCount == 0)
+    }
+
+    @Test("reconciliation rejects a stale revision atomically and writes nothing")
+    func reconcileRejectsStaleRevisionAtomically() async throws {
+        let repo = FakeCatalogRepository()
+        let store = ProjectStore(repository: repo, now: { Self.fixedDate })
+        await store.loadPersistedCatalog()
+        let staleRevision = store.catalog.revision
+        // Advance the catalog so the captured revision is now stale.
+        _ = try store.createProject(name: "Advancing")
+        await store.waitForPendingPersistence()
+        let before = store.catalog
+        let savesBefore = await repo.saveCount
+
+        #expect(throws: ProjectMutationError.staleRevision(expected: staleRevision, actual: store.catalog.revision)) {
+            _ = try store.reconcile(
+                projects: [store.activeProject, Self.makeProject(name: "Rejected")],
+                expectedRevision: staleRevision
+            )
+        }
+        #expect(store.catalog == before)
+        await store.waitForPendingPersistence()
+        #expect(await repo.saveCount == savesBefore)
+    }
+
+    @Test("reconciliation rejects structurally invalid entities atomically")
+    func reconcileRejectsInvalidAtomically() {
+        let store = ProjectStore(now: { Self.fixedDate })
+        let before = store.catalog
+        let clash = [Self.makeProject(name: "Same"), Self.makeProject(name: "same")]
+
+        #expect(throws: ProjectMutationError.self) {
+            _ = try store.reconcile(projects: clash, expectedRevision: store.catalog.revision)
+        }
+        #expect(store.catalog == before)
+    }
+
+    @Test("reconciliation rejects an empty entity set without mutating state")
+    func reconcileRejectsEmptySet() {
+        let store = ProjectStore(now: { Self.fixedDate })
+        let before = store.catalog
+        #expect(throws: ProjectMutationError.self) {
+            _ = try store.reconcile(projects: [], expectedRevision: store.catalog.revision)
+        }
+        #expect(store.catalog == before)
+    }
+
+    @Test("reconciliation persists atomically with the incremented local revision")
+    func reconcilePersistsWithLocalRevision() async throws {
+        let repo = FakeCatalogRepository()
+        let store = ProjectStore(repository: repo, now: { Self.fixedDate })
+        await store.loadPersistedCatalog()
+        let active = store.activeProject
+
+        try store.reconcile(
+            projects: [active, Self.makeProject(name: "Extra")],
+            expectedRevision: store.catalog.revision
+        )
+        await store.waitForPendingPersistence()
+
+        #expect(await repo.saveCount == 1)
+        #expect(await repo.lastSaved?.revision == 2)
+        #expect(await repo.lastSaved?.projects.count == 2)
+    }
+
+    @Test("reconciliation is refused on a not-ready store and writes nothing")
+    func reconcileRefusedBeforeLoad() async {
+        let repo = FakeCatalogRepository()
+        let store = ProjectStore(repository: repo, now: { Self.fixedDate })
+        #expect(throws: ProjectMutationError.storeNotReady) {
+            _ = try store.reconcile(
+                projects: [Self.makeProject(name: "Nope")],
+                expectedRevision: store.catalog.revision
+            )
+        }
+        #expect(await repo.saveCount == 0)
+    }
+
+    // MARK: Persistence status
+
+    @Test("a mutation persists the catalog with an incremented revision")
+    func mutationPersists() async throws {
+        let repo = FakeCatalogRepository()
+        let store = ProjectStore(repository: repo, now: { Self.fixedDate })
+        await store.loadPersistedCatalog()
+        _ = try store.createProject(name: "Staging")
+        for _ in 0 ..< 1_000 where store.persistenceStatus != .saved {
+            await Task.yield()
+        }
+        #expect(await repo.lastSaved?.revision == 2)
+        #expect(store.persistenceStatus == .saved)
+    }
+
+    @Test("a save failure is surfaced as explicit persistence state")
+    func persistenceFailureSurfaced() async throws {
+        let repo = FakeCatalogRepository(saveError: FakeError.boom)
+        let store = ProjectStore(repository: repo, now: { Self.fixedDate })
+        await store.loadPersistedCatalog()
+        _ = try store.createProject(name: "Staging")
+        for _ in 0 ..< 1_000 where store.persistenceStatus == .saving || store.persistenceStatus == .idle {
+            await Task.yield()
+        }
+        #expect(store.persistenceStatus == .failed(String(describing: FakeError.boom)))
+    }
+
+    @Test("a load failure keeps the safe default and exposes the reason")
+    func loadFailureSurfaced() async {
+        let repo = FakeCatalogRepository(loadResult: .failure(FakeError.boom))
+        let store = ProjectStore(repository: repo, now: { Self.fixedDate })
+        await store.loadPersistedCatalog()
+        #expect(store.loadFailureMessage != nil)
+        #expect(store.projects.count == 1)
+    }
+
+    // MARK: Reset / recovery
+
+    @Test("explicit reset recovers a failed load into a mutable default")
+    func resetRecoversFailedLoad() async throws {
+        let repo = FakeCatalogRepository(loadResult: .failure(FakeError.boom))
+        let store = ProjectStore(repository: repo, now: { Self.fixedDate })
+        await store.loadPersistedCatalog()
+        #expect(!store.isMutable)
+
+        await store.resetToDefaultCatalog()
+        #expect(store.loadState == .ready)
+        #expect(store.isMutable)
+        #expect(store.loadFailureMessage == nil)
+        #expect(await repo.resetCount == 1)
+
+        _ = try store.createProject(name: "Fresh")
+        #expect(store.projects.count == 2)
+    }
+
+    // MARK: Private
+
+    // MARK: Helpers
+
+    private static let fixedDate = Date(timeIntervalSince1970: 1_000_000)
+
+    private static func makeProject(name: String) -> Project {
+        Project.makeDefault(name: name, createdAt: fixedDate, updatedAt: fixedDate)
+    }
+}
+
+// MARK: - FakeCatalogRepository
+
+/// Actor-isolated persistence double. It mirrors the real repository's actor
+/// isolation so the store's `Sendable` seam is exercised faithfully rather than
+/// relaxed to satisfy the compiler.
+private actor FakeCatalogRepository: ProjectCatalogPersisting {
+    // MARK: Lifecycle
+
+    init(
+        loadResult: Result<ProjectCatalog, Error> = .success(
+            ProjectCatalog.makeDefault(now: Date(timeIntervalSince1970: 1_000_000))
+        ),
+        saveError: Error? = nil
+    ) {
+        self.loadResult = loadResult
+        self.saveError = saveError
+    }
+
+    // MARK: Internal
+
+    private(set) var savedCatalogs: [ProjectCatalog] = []
+    private(set) var resetCount = 0
+
+    var saveCount: Int {
+        savedCatalogs.count
+    }
+
+    var lastSaved: ProjectCatalog? {
+        savedCatalogs.last
+    }
+
+    func load() async throws -> ProjectCatalog {
+        try loadResult.get()
+    }
+
+    func save(_ catalog: ProjectCatalog) async throws {
+        if let saveError {
+            throw saveError
+        }
+        savedCatalogs.append(catalog)
+    }
+
+    func reset() async throws -> ProjectCatalog {
+        resetCount += 1
+        let fresh = ProjectCatalog.makeDefault(now: Date(timeIntervalSince1970: 1_000_000))
+        savedCatalogs.append(fresh)
+        return fresh
+    }
+
+    // MARK: Private
+
+    private let loadResult: Result<ProjectCatalog, Error>
+    private let saveError: Error?
+}
+
+// MARK: - FakeError
+
+private enum FakeError: Error, Equatable {
+    case boom
+}
+
+// MARK: - CapacityPolicy
+
+private struct CapacityPolicy: AppPolicy {
+    var maxWorkspaceTabs = 8
+    var maxProjects = 32
+    var maxDomainFavorites = 5
+    var maxActiveRulesPerTool = 10
+    var maxEnabledScripts = 10
+    var maxLiveHistoryEntries = 1_000
+}

--- a/RockxyTests/Models/Projects/ProjectTabSnapshotTests.swift
+++ b/RockxyTests/Models/Projects/ProjectTabSnapshotTests.swift
@@ -1,0 +1,182 @@
+import Foundation
+@testable import Rockxy
+import Testing
+
+// MARK: - ProjectTabSnapshotTests
+
+@MainActor
+@Suite("ProjectTabSnapshot")
+struct ProjectTabSnapshotTests {
+    // MARK: Capture / roundtrip
+
+    @Test("captures durable view intent from a workspace")
+    func capturesDurableIntent() {
+        let workspace = WorkspaceState(title: "Payments", isClosable: true)
+        var filter = FilterCriteria()
+        filter.searchText = "checkout"
+        filter.methods = ["GET", "POST"]
+        filter.statusCodes = [200, 404]
+        workspace.filterCriteria = filter
+        workspace.isFilterBarVisible = true
+        workspace.activeMainTab = .logs
+        workspace.inspectorLayout = .bottom
+        workspace.isContextDockVisible = true
+        workspace.contextDockTab = .aiAssistant
+        workspace.focusNavigatorMode = .focus
+        workspace.activeTrafficSignal = .errors
+        let focusSetID = UUID()
+        workspace.activeFocusSetID = focusSetID
+        workspace.mutedTrafficSources = [.host("ads.example.com"), .pathPrefix("/telemetry")]
+
+        let snapshot = ProjectTabSnapshot(capturing: workspace)
+
+        #expect(snapshot.id == workspace.id)
+        #expect(snapshot.title == "Payments")
+        #expect(snapshot.isClosable)
+        #expect(snapshot.filter.searchText == "checkout")
+        #expect(Set(snapshot.filter.methods) == ["GET", "POST"])
+        #expect(Set(snapshot.filter.statusCodes) == [200, 404])
+        #expect(snapshot.isFilterBarVisible)
+        #expect(snapshot.mainTabRawValue == MainTab.logs.rawValue)
+        #expect(snapshot.inspectorLayoutRawValue == InspectorLayoutCoding.bottom)
+        #expect(snapshot.isContextDockVisible)
+        #expect(snapshot.contextDockTabRawValue == ContextDockTabCoding.aiAssistant)
+        #expect(snapshot.focusNavigatorModeRawValue == FocusNavigatorMode.focus.rawValue)
+        #expect(snapshot.activeTrafficSignalRawValue == TrafficSignal.errors.rawValue)
+        #expect(snapshot.activeFocusSetID == focusSetID)
+        #expect(snapshot.mutedTrafficSources.count == 2)
+    }
+
+    @Test("roundtrips durable intent through hydrate")
+    func roundtripsThroughHydrate() {
+        let workspace = WorkspaceState(title: "Payments", isClosable: true)
+        workspace.activeMainTab = .timeline
+        workspace.inspectorLayout = .bottom
+        workspace.contextDockTab = .aiAssistant
+        workspace.focusNavigatorMode = .library
+        workspace.activeTrafficSignal = .slow
+        let focusSetID = UUID()
+        workspace.activeFocusSetID = focusSetID
+        workspace.mutedTrafficSources = [.host("ads.example.com")]
+        workspace.isFilterBarVisible = true
+
+        let snapshot = ProjectTabSnapshot(capturing: workspace)
+        let hydrated = snapshot.hydrateWorkspaceState()
+        let recaptured = ProjectTabSnapshot(capturing: hydrated)
+
+        #expect(hydrated.id == workspace.id)
+        #expect(hydrated.title == "Payments")
+        #expect(hydrated.isClosable)
+        #expect(hydrated.activeMainTab == .timeline)
+        #expect(hydrated.inspectorLayout == .bottom)
+        #expect(hydrated.contextDockTab == .aiAssistant)
+        #expect(hydrated.focusNavigatorMode == .library)
+        #expect(hydrated.activeTrafficSignal == .slow)
+        #expect(hydrated.activeFocusSetID == focusSetID)
+        #expect(hydrated.mutedTrafficSources == [.host("ads.example.com")])
+        #expect(hydrated.isFilterBarVisible)
+        #expect(recaptured == snapshot)
+    }
+
+    // MARK: Exclusions
+
+    @Test("excludes the transient exact-transaction filter reference")
+    func excludesExactTransactionID() {
+        let workspace = WorkspaceState()
+        var filter = FilterCriteria()
+        filter.exactTransactionID = UUID()
+        workspace.filterCriteria = filter
+
+        let snapshot = ProjectTabSnapshot(capturing: workspace)
+        #expect(snapshot.filter.resolved.exactTransactionID == nil)
+    }
+
+    @Test("encoded snapshot omits live/sensitive workspace state")
+    func encodedSnapshotOmitsLiveState() throws {
+        let workspace = WorkspaceState(title: "Payments", isClosable: false)
+        workspace.publishTrafficRevealRequest(for: UUID())
+        workspace.isFollowingLiveTraffic = true
+        let snapshot = ProjectTabSnapshot(capturing: workspace)
+        let hydrated = snapshot.hydrateWorkspaceState()
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let json = try #require(String(data: try encoder.encode(snapshot), encoding: .utf8))
+
+        for forbidden in [
+            "debugAssistant",
+            "selectedTransaction",
+            "filteredTransactions",
+            "filteredRows",
+            "sortDescriptor",
+            "domainTree",
+            "appNodes",
+            "trafficSelectionIndex",
+            "trafficRevealRequest",
+            "isFollowingLiveTraffic",
+        ] {
+            #expect(!json.contains(forbidden), "snapshot leaked \(forbidden)")
+        }
+
+        #expect(hydrated.trafficRevealRequest == nil)
+        #expect(!hydrated.isFollowingLiveTraffic)
+    }
+
+    // MARK: Resilience
+
+    @Test("resolves unknown raw enum values to safe defaults")
+    func resolvesUnknownRawValues() throws {
+        let snapshot = ProjectTabSnapshot(
+            title: "Legacy",
+            isClosable: true,
+            filter: FilterCriteriaSnapshot(searchFieldRawValue: "future_field"),
+            mainTabRawValue: "future_tab",
+            inspectorLayoutRawValue: "future_layout",
+            contextDockTabRawValue: "future_dock",
+            focusNavigatorModeRawValue: "future_mode",
+            activeTrafficSignalRawValue: "future_signal"
+        )
+
+        // Survives a JSON round-trip without throwing.
+        let data = try JSONEncoder().encode(snapshot)
+        let decoded = try JSONDecoder().decode(ProjectTabSnapshot.self, from: data)
+        let hydrated = decoded.hydrateWorkspaceState()
+
+        #expect(hydrated.activeMainTab == .traffic)
+        #expect(hydrated.inspectorLayout == .hidden)
+        #expect(hydrated.contextDockTab == .details)
+        #expect(hydrated.focusNavigatorMode == .browse)
+        #expect(hydrated.activeTrafficSignal == nil)
+        #expect(hydrated.filterCriteria.searchField == .url)
+    }
+
+    // MARK: Bounds
+
+    @Test("bounds filter strings and collections on capture")
+    func boundsFilterStringsAndCollections() {
+        let workspace = WorkspaceState()
+        var filter = FilterCriteria()
+        filter.searchText = String(repeating: "x", count: 600)
+        filter.methods = Set((0 ..< 200).map { "M\($0)" })
+        workspace.filterCriteria = filter
+        workspace.mutedTrafficSources = Set((0 ..< 200).map { MutedTrafficSource.host("h\($0).example.com") })
+
+        let snapshot = ProjectTabSnapshot(capturing: workspace)
+        #expect(snapshot.filter.searchText.count == ProjectStructuralLimits.maxFilterStringGraphemes)
+        #expect(snapshot.filter.methods.count <= ProjectStructuralLimits.maxFilterCollectionCount)
+        #expect(snapshot.mutedTrafficSources.count <= ProjectStructuralLimits.maxMutedTrafficSources)
+    }
+
+    @Test("validate rejects an oversized decoded filter string")
+    func validateRejectsOversizedString() {
+        let oversized = String(repeating: "y", count: ProjectStructuralLimits.maxFilterStringGraphemes + 1)
+        let snapshot = ProjectTabSnapshot(
+            title: "Legacy",
+            isClosable: false,
+            filter: FilterCriteriaSnapshot(searchText: oversized)
+        )
+        #expect(throws: ProjectSnapshotValidationError.self) {
+            try snapshot.validate()
+        }
+    }
+}

--- a/RockxyTests/Models/Settings/AppPolicyTests.swift
+++ b/RockxyTests/Models/Settings/AppPolicyTests.swift
@@ -8,6 +8,7 @@ struct AppPolicyTests {
     func defaultValues() {
         let policy = DefaultAppPolicy()
         #expect(policy.maxWorkspaceTabs == 8)
+        #expect(policy.maxProjects == 3)
         #expect(policy.maxDomainFavorites == 5)
         #expect(policy.maxActiveRulesPerTool == 10)
         #expect(policy.maxEnabledScripts == 10)
@@ -34,6 +35,13 @@ struct AppPolicyTests {
         let coordinator = MainContentCoordinator(policy: custom)
         #expect(coordinator.policy.maxWorkspaceTabs == 3)
         #expect(coordinator.policy.maxDomainFavorites == 2)
+    }
+
+    @Test("maxProjects falls back to the public default via the protocol extension")
+    func maxProjectsExtensionDefault() {
+        // TestPolicy does not set maxProjects, so it resolves through the default.
+        #expect(TestPolicy().maxProjects == ProjectStructuralLimits.defaultProjectCapacity)
+        #expect(TestPolicy().maxProjects == 3)
     }
 }
 

--- a/RockxyTests/Models/UI/WorkspaceStoreCapacityTests.swift
+++ b/RockxyTests/Models/UI/WorkspaceStoreCapacityTests.swift
@@ -64,6 +64,33 @@ struct WorkspaceStoreCapacityTests {
         #expect(store.maxWorkspaces == 1)
         #expect(store.workspaces.count == 1)
     }
+
+    @Test("construction clamps above the structural tab upper bound")
+    @MainActor
+    func constructionClampsAboveStructuralBound() {
+        let store = WorkspaceStore(maxWorkspaces: 10_000)
+        #expect(store.maxWorkspaces == ProjectStructuralLimits.tabCountRange.upperBound)
+    }
+
+    @Test("runtime refresh clamps above the structural tab upper bound")
+    @MainActor
+    func refreshClampsAboveStructuralBound() {
+        let store = WorkspaceStore(maxWorkspaces: 4)
+        store.refreshCapacity(maxWorkspaces: 10_000)
+        #expect(store.maxWorkspaces == ProjectStructuralLimits.tabCountRange.upperBound)
+    }
+
+    @Test("an expanded policy cannot authorize more live tabs than the structural bound")
+    @MainActor
+    func expandedPolicyCappedAtStructuralBound() {
+        let store = WorkspaceStore(maxWorkspaces: Int.max)
+        let upperBound = ProjectStructuralLimits.tabCountRange.upperBound
+        for index in 1 ..< (upperBound + 5) {
+            _ = store.createWorkspace(title: "Tab \(index)")
+        }
+        #expect(store.workspaces.count == upperBound)
+        #expect(!store.canCreateWorkspace)
+    }
 }
 
 // MARK: - SmallPolicy

--- a/RockxyTests/Models/UI/WorkspaceStoreTests.swift
+++ b/RockxyTests/Models/UI/WorkspaceStoreTests.swift
@@ -322,4 +322,90 @@ struct WorkspaceStoreTests {
         let store = WorkspaceStore()
         #expect(store.maxWorkspaces == 8)
     }
+
+    // MARK: - Hydration retention vs creation capacity
+
+    @Test("hydration retains tabs above the creation limit up to the structural bound")
+    func hydrationRetainsOverCreationCapacity() {
+        let store = WorkspaceStore(maxWorkspaces: 8)
+        let base = ProjectTabSnapshot.makeDefaultAllTraffic()
+        let extras = (0 ..< 12).map { ProjectTabSnapshot(title: "Tab \($0)", isClosable: true) }
+
+        store.applyTabSnapshots([base] + extras, activeTabID: base.id)
+
+        // 13 tabs exceed the creation limit of 8 but sit under the structural bound,
+        // so every one is retained rather than truncated to the creation limit.
+        #expect(store.workspaces.count == 13)
+        #expect(store.workspaces.count > store.maxWorkspaces)
+        #expect(store.activeWorkspaceID == base.id)
+    }
+
+    @Test("hydration never exceeds the structural tab upper bound")
+    func hydrationClampsToStructuralBound() {
+        let store = WorkspaceStore(maxWorkspaces: 8)
+        let base = ProjectTabSnapshot.makeDefaultAllTraffic()
+        let extras = (0 ..< 40).map { ProjectTabSnapshot(title: "Tab \($0)", isClosable: true) }
+
+        store.applyTabSnapshots([base] + extras, activeTabID: base.id)
+
+        #expect(store.workspaces.count == ProjectStructuralLimits.tabCountRange.upperBound)
+        #expect(store.workspaces.contains { !$0.isClosable })
+    }
+
+    // MARK: - Runtime capacity refresh
+
+    @Test("lowering capacity at runtime keeps existing tabs and only blocks new creation")
+    func refreshCapacityDecreaseRetainsTabs() {
+        let store = WorkspaceStore(maxWorkspaces: 8)
+        _ = store.createWorkspace(title: "Tab 1")
+        _ = store.createWorkspace(title: "Tab 2")
+        #expect(store.workspaces.count == 3)
+
+        store.refreshCapacity(maxWorkspaces: 2)
+
+        #expect(store.maxWorkspaces == 2)
+        // No hydrated/created tab is closed by a lower limit.
+        #expect(store.workspaces.count == 3)
+        #expect(!store.canCreateWorkspace)
+        let extra = store.createWorkspace(title: "Blocked")
+        #expect(store.workspaces.count == 3)
+        #expect(extra.title != "Blocked")
+    }
+
+    @Test("raising capacity at runtime re-enables creation")
+    func refreshCapacityIncreaseReenablesCreation() {
+        let store = WorkspaceStore(maxWorkspaces: 1)
+        #expect(!store.canCreateWorkspace)
+
+        store.refreshCapacity(maxWorkspaces: 3)
+
+        #expect(store.maxWorkspaces == 3)
+        #expect(store.canCreateWorkspace)
+        _ = store.createWorkspace(title: "Now Allowed")
+        #expect(store.workspaces.count == 2)
+    }
+
+    @Test("capacity refresh clamps to at least one")
+    func refreshCapacityClampsToMinimum() {
+        let store = WorkspaceStore(maxWorkspaces: 4)
+        store.refreshCapacity(maxWorkspaces: 0)
+        #expect(store.maxWorkspaces == 1)
+    }
+
+    @Test("construction clamps into the structural tab range above and below")
+    func constructionClampsIntoStructuralRange() {
+        #expect(WorkspaceStore(maxWorkspaces: 0).maxWorkspaces == ProjectStructuralLimits.tabCountRange.lowerBound)
+        #expect(
+            WorkspaceStore(maxWorkspaces: 10_000).maxWorkspaces == ProjectStructuralLimits.tabCountRange.upperBound
+        )
+    }
+
+    @Test("capacity refresh clamps into the structural tab range above and below")
+    func refreshCapacityClampsIntoStructuralRange() {
+        let store = WorkspaceStore(maxWorkspaces: 4)
+        store.refreshCapacity(maxWorkspaces: 10_000)
+        #expect(store.maxWorkspaces == ProjectStructuralLimits.tabCountRange.upperBound)
+        store.refreshCapacity(maxWorkspaces: -3)
+        #expect(store.maxWorkspaces == ProjectStructuralLimits.tabCountRange.lowerBound)
+    }
 }

--- a/RockxyTests/Views/Main/BabylonCaptureCoordinatorTests.swift
+++ b/RockxyTests/Views/Main/BabylonCaptureCoordinatorTests.swift
@@ -6,7 +6,7 @@ import Testing
 @Suite("Babylon capture coordinator")
 struct BabylonCaptureCoordinatorTests {
     @Test("Connection identity creates source-filtered workspace once")
-    func createsSourceWorkspaceOnce() {
+    func createsSourceWorkspaceOnce() async {
         let coordinator = MainContentCoordinator()
         let sessionID = UUID().uuidString
         let identity = BabylonCaptureIdentity(
@@ -18,8 +18,8 @@ struct BabylonCaptureCoordinatorTests {
             deviceModel: "iPhone"
         )
 
-        coordinator.registerBabylonCapture(identity: identity)
-        coordinator.registerBabylonCapture(identity: identity)
+        await coordinator.registerBabylonCapture(identity: identity)
+        await coordinator.registerBabylonCapture(identity: identity)
 
         #expect(coordinator.workspaceStore.workspaces.count == 2)
         #expect(coordinator.activeWorkspace.title == "Checkout • Test iPhone")

--- a/RockxyTests/Views/Main/FilteringTests.swift
+++ b/RockxyTests/Views/Main/FilteringTests.swift
@@ -843,7 +843,7 @@ struct FilteringTests {
         }
 
         let fresh = TestFixtures.makeTransaction(url: "https://fresh.example.net/new")
-        coordinator.processBatch([fresh], generation: coordinator.sessionGeneration)
+        coordinator.processActiveProjectTestBatch([fresh])
 
         #expect(firstWorkspace.filteredTransactions.map(\.id) == [fresh.id])
         #expect(secondWorkspace.filteredTransactions.map(\.id) == [fresh.id])

--- a/RockxyTests/Views/Main/HistoryRetentionTests.swift
+++ b/RockxyTests/Views/Main/HistoryRetentionTests.swift
@@ -64,7 +64,7 @@ struct HistoryRetentionTests {
             TestFixtures.makeTransaction(url: "https://api\(index % 20).example.com/events/\(index)")
         }
 
-        coordinator.processBatch(batch, generation: coordinator.sessionGeneration)
+        coordinator.processActiveProjectTestBatch(batch)
 
         #expect(coordinator.transactions.count == 1_000)
         #expect(coordinator.filteredRows.count == 1_000)
@@ -85,10 +85,7 @@ struct HistoryRetentionTests {
         let hidden = TestFixtures.makeTransaction(url: "https://hidden.example.com/first")
         let firstVisible = TestFixtures.makeTransaction(url: "https://visible.example.com/one")
         let latestVisible = TestFixtures.makeTransaction(url: "https://visible.example.com/two")
-        coordinator.processBatch(
-            [hidden, firstVisible, latestVisible],
-            generation: coordinator.sessionGeneration
-        )
+        coordinator.processActiveProjectTestBatch([hidden, firstVisible, latestVisible])
 
         #expect(coordinator.isFollowingLiveTraffic)
         #expect(coordinator.selectedTransaction?.id == latestVisible.id)
@@ -106,7 +103,7 @@ struct HistoryRetentionTests {
         coordinator.setFollowingLiveTraffic(true)
 
         let hidden = TestFixtures.makeTransaction(url: "https://hidden.example.com/new")
-        coordinator.processBatch([hidden], generation: coordinator.sessionGeneration)
+        coordinator.processActiveProjectTestBatch([hidden])
 
         #expect(coordinator.selectedTransaction?.id == existing.id)
         #expect(coordinator.isFollowingLiveTraffic)
@@ -186,12 +183,12 @@ struct HistoryRetentionTests {
 
         // Anchor a manual selection on the active, non-following workspace.
         let anchor = TestFixtures.makeTransaction(url: "https://anchor.example.com/keep")
-        coordinator.processBatch([anchor], generation: coordinator.sessionGeneration)
+        coordinator.processActiveProjectTestBatch([anchor])
         active.selectedTransaction = anchor
         active.selectedTransactionIDs = [anchor.id]
 
         let latest = TestFixtures.makeTransaction(url: "https://live.example.com/new")
-        coordinator.processBatch([latest], generation: coordinator.sessionGeneration)
+        coordinator.processActiveProjectTestBatch([latest])
 
         // The inactive follower advanced to the newest batch transaction.
         #expect(follower.selectedTransaction?.id == latest.id)
@@ -210,7 +207,7 @@ struct HistoryRetentionTests {
         let alpha = TestFixtures.makeTransaction(url: "https://alpha.example.com/1")
         let betaOld = TestFixtures.makeTransaction(url: "https://beta.example.com/1")
         let betaNew = TestFixtures.makeTransaction(url: "https://beta.example.com/2")
-        coordinator.processBatch([alpha, betaOld, betaNew], generation: coordinator.sessionGeneration)
+        coordinator.processActiveProjectTestBatch([alpha, betaOld, betaNew])
 
         coordinator.setFollowingLiveTraffic(true)
         #expect(coordinator.selectedTransaction?.id == betaNew.id)
@@ -233,7 +230,7 @@ struct HistoryRetentionTests {
         coordinator.isRecording = true
 
         let alpha = TestFixtures.makeTransaction(url: "https://alpha.example.com/1")
-        coordinator.processBatch([alpha], generation: coordinator.sessionGeneration)
+        coordinator.processActiveProjectTestBatch([alpha])
         coordinator.setFollowingLiveTraffic(true)
         #expect(coordinator.selectedTransaction?.id == alpha.id)
 
@@ -256,7 +253,7 @@ struct HistoryRetentionTests {
 
         let firstByTime = TestFixtures.makeTransaction(url: "https://aaa.example.com/first")
         let newestByTime = TestFixtures.makeTransaction(url: "https://zzz.example.com/second")
-        coordinator.processBatch([firstByTime, newestByTime], generation: coordinator.sessionGeneration)
+        coordinator.processActiveProjectTestBatch([firstByTime, newestByTime])
 
         // Display order (URL ascending) puts the older `firstByTime` first, but Follow Live must
         // still choose the chronological newest, `newestByTime`.
@@ -383,7 +380,7 @@ struct HistoryRetentionTests {
                 return
             }
             Task { @MainActor in
-                coordinator.processBatch(batch, generation: generation)
+                coordinator.processActiveProjectTestBatch(batch, generation: generation)
             }
         }
         await coordinator.sessionManager.setMaxBufferSize(retainedCount)
@@ -569,7 +566,7 @@ struct HistoryRetentionTests {
                 return
             }
             Task { @MainActor in
-                coordinator.processBatch(batch, generation: generation)
+                coordinator.processActiveProjectTestBatch(batch, generation: generation)
             }
         }
         await coordinator.sessionManager.startBatchTimer()
@@ -641,7 +638,7 @@ struct HistoryRetentionTests {
                 return
             }
             Task { @MainActor in
-                coordinator.processBatch(batch, generation: generation)
+                coordinator.processActiveProjectTestBatch(batch, generation: generation)
             }
         }
         // Align the actor-side cap with the coordinator policy so the eviction
@@ -695,9 +692,11 @@ struct HistoryRetentionTests {
 
         let stale = TestFixtures.makeTransaction(url: "https://stale-during-clear.com")
         let fresh = TestFixtures.makeTransaction(url: "https://fresh-during-clear.com")
+        stale.assignCaptureContextIfMissing(coordinator.activeCaptureContext)
 
         await coordinator.sessionManager.setOnBeginNewSession { generation in
             await MainActor.run {
+                fresh.assignCaptureContextIfMissing(coordinator.activeCaptureContext)
                 coordinator.processBatch([stale], generation: generation &- 1)
                 coordinator.processBatch([fresh], generation: generation)
             }

--- a/RockxyTests/Views/Main/NativeWorkspaceSplitViewTests.swift
+++ b/RockxyTests/Views/Main/NativeWorkspaceSplitViewTests.swift
@@ -151,10 +151,14 @@ struct NativeWorkspaceSplitViewTests {
         let trackingSeparatorIndex = identifiers.firstIndex(
             of: NativeWorkspaceToolbar.sidebarTrackingSeparatorIdentifier
         )
+        let projectSelectorIndex = identifiers.firstIndex(
+            of: NativeWorkspaceToolbar.projectSelectorIdentifier
+        )
 
         #expect(identifiers.first == .flexibleSpace)
         #expect(toggleIndex != nil)
         #expect(trackingSeparatorIndex == toggleIndex.map { $0 + 1 })
+        #expect(projectSelectorIndex == trackingSeparatorIndex.map { $0 + 1 })
         #expect(!identifiers.contains {
             $0.rawValue.hasSuffix(".toolbar.workspaceTitle")
         })
@@ -163,6 +167,19 @@ struct NativeWorkspaceSplitViewTests {
                 toolbar.managedToolbar.items[trackingSeparatorIndex]
                     is NSTrackingSeparatorToolbarItem
             )
+        }
+        if let projectSelectorIndex,
+           let selectorView = toolbar.managedToolbar.items[projectSelectorIndex].view
+        {
+            let width = selectorView.fittingSize.width
+            let expectedInnerWidth = ProjectToolbarSelectorMetrics.preferredWidth(
+                for: coordinator.projectStore.activeProject.name
+            )
+            #expect(width >= expectedInnerWidth)
+            #expect(width >= ProjectToolbarSelectorMetrics.minimumWidth)
+            #expect(width <= ProjectToolbarSelectorMetrics.maximumWidth)
+        } else {
+            Issue.record("Project selector toolbar item was not hosted")
         }
     }
 
@@ -192,6 +209,80 @@ struct NativeWorkspaceSplitViewTests {
 
         NSApp.sendAction(action, to: toggleItem.target, from: toggleItem)
         #expect(controller.isSidebarPresented)
+    }
+
+    // MARK: - Project selector sizing metrics
+
+    @Test("Project selector preferred width stays within its metric bounds")
+    func projectSelectorPreferredWidthWithinBounds() {
+        let names = [
+            "",
+            "QA",
+            "My Project",
+            "Checkout Service API",
+            String(repeating: "Extremely Long Project Name ", count: 8),
+        ]
+
+        for name in names {
+            let width = ProjectToolbarSelectorMetrics.preferredWidth(for: name)
+            #expect(width >= ProjectToolbarSelectorMetrics.minimumWidth)
+            #expect(width <= ProjectToolbarSelectorMetrics.maximumWidth)
+        }
+    }
+
+    @Test("Project selector width grows monotonically and clamps at both extremes")
+    func projectSelectorPreferredWidthMonotonicAndClamped() {
+        let shortWidth = ProjectToolbarSelectorMetrics.preferredWidth(for: "QA")
+        let mediumWidth = ProjectToolbarSelectorMetrics.preferredWidth(for: "Checkout Service API")
+        let longWidth = ProjectToolbarSelectorMetrics.preferredWidth(
+            for: String(repeating: "Extremely Long Project Name ", count: 8)
+        )
+
+        #expect(shortWidth <= mediumWidth)
+        #expect(mediumWidth <= longWidth)
+
+        #expect(shortWidth == ProjectToolbarSelectorMetrics.minimumWidth)
+        #expect(longWidth == ProjectToolbarSelectorMetrics.maximumWidth)
+
+        #expect(mediumWidth > ProjectToolbarSelectorMetrics.minimumWidth)
+        #expect(mediumWidth < ProjectToolbarSelectorMetrics.maximumWidth)
+    }
+
+    @Test("Hosted Project selector responds to the active Project name")
+    func hostedProjectSelectorRespondsToProjectName() throws {
+        let shortCoordinator = MainContentCoordinator()
+        try shortCoordinator.projectStore.renameProject(
+            id: shortCoordinator.projectStore.activeProjectID,
+            to: "QA"
+        )
+        let longCoordinator = MainContentCoordinator()
+        try longCoordinator.projectStore.renameProject(
+            id: longCoordinator.projectStore.activeProjectID,
+            to: String(repeating: "Long Project ", count: 6)
+        )
+
+        let shortView = NSHostingView(
+            rootView: ProjectToolbarSelectorView(coordinator: shortCoordinator)
+        )
+        let longView = NSHostingView(
+            rootView: ProjectToolbarSelectorView(coordinator: longCoordinator)
+        )
+
+        #expect(shortView.fittingSize.width == ProjectToolbarSelectorMetrics.minimumWidth)
+        #expect(longView.fittingSize.width == ProjectToolbarSelectorMetrics.maximumWidth)
+        #expect(shortView.fittingSize.width < longView.fittingSize.width)
+    }
+
+    @Test("Project manager adopts useful resizable tool-window geometry")
+    func projectManagerToolWindowGeometry() {
+        let hostingView = NSHostingView(
+            rootView: ProjectManagerSheet(coordinator: MainContentCoordinator())
+        )
+        let size = hostingView.fittingSize
+
+        #expect(size.width >= 720)
+        #expect(size.height >= 500)
+        #expect(size.width > size.height)
     }
 
     // MARK: - Startup geometry readiness

--- a/RockxyTests/Views/Main/ProjectCoordinationTests.swift
+++ b/RockxyTests/Views/Main/ProjectCoordinationTests.swift
@@ -1,0 +1,853 @@
+import AppKit
+import Foundation
+@testable import Rockxy
+import Testing
+
+// Non-visual orchestration tests for `MainContentCoordinator+Projects`: startup
+// hydration, Project switching/creation/deletion, Observation-driven debounced
+// autosave, and snapshot exclusion. All persistence goes through an in-memory
+// fake repository; no Application Support I/O and no sleeps beyond a few hundred ms.
+
+// MARK: - ProjectCoordinationTests
+
+@MainActor
+@Suite("ProjectCoordination")
+struct ProjectCoordinationTests {
+    // MARK: Internal
+
+    // MARK: Startup hydration
+
+    @Test("successful hydration applies the active project's tabs and traffic")
+    func successfulInitialHydration() async {
+        let defaultTab = ProjectTabSnapshot.makeDefaultAllTraffic()
+        let apiTab = ProjectTabSnapshot(
+            title: "APIs",
+            isClosable: true,
+            filter: FilterCriteriaSnapshot(domains: ["api.example.com"])
+        )
+        let project = Project(
+            name: "Alpha",
+            createdAt: Self.fixedDate,
+            updatedAt: Self.fixedDate,
+            activeTabID: defaultTab.id,
+            tabs: [defaultTab, apiTab]
+        )
+        let repo = FakeProjectRepo(loadResult: .success(
+            ProjectCatalog(activeProjectID: project.id, projects: [project])
+        ))
+        let coordinator = MainContentCoordinator(projectCatalogRepository: repo)
+        let api = TestFixtures.makeTransaction(url: "https://api.example.com/x")
+        let other = TestFixtures.makeTransaction(url: "https://other.example.com/y")
+        coordinator.transactions = [api, other]
+
+        await coordinator.hydrateProjectsOnLaunch()
+
+        #expect(coordinator.hasHydratedProjects)
+        #expect(coordinator.isObservingProjectTabs)
+        #expect(coordinator.workspaceStore.workspaces.count == 2)
+        let allTraffic = coordinator.workspaceStore.activeWorkspace
+        #expect(allTraffic.filteredTransactions.count == 2)
+        let apiWorkspace = coordinator.workspaceStore.workspaces.first { $0.title == "APIs" }
+        #expect(apiWorkspace?.filteredTransactions.map(\.id) == [api.id])
+    }
+
+    @Test("a failed load leaves current workspaces unchanged and blocks autosave")
+    func failedLoadLeavesWorkspacesUnchanged() async {
+        let repo = FakeProjectRepo(loadResult: .failure(FakeError.boom))
+        let coordinator = MainContentCoordinator(projectCatalogRepository: repo)
+        let beforeIDs = coordinator.workspaceStore.workspaces.map(\.id)
+
+        await coordinator.hydrateProjectsOnLaunch()
+
+        #expect(!coordinator.hasHydratedProjects)
+        #expect(!coordinator.isObservingProjectTabs)
+        #expect(coordinator.projectStore.loadState == .failed(String(describing: FakeError.boom)))
+        #expect(coordinator.workspaceStore.workspaces.map(\.id) == beforeIDs)
+        // The store is not mutable, so an explicit flush must refuse and write nothing.
+        #expect(!coordinator.flushProjectTabSnapshot())
+        coordinator.scheduleProjectTabAutosave()
+        try? await Task.sleep(for: .milliseconds(120))
+        #expect(await repo.saveCount == 0)
+    }
+
+    @Test("Babylon intake hydrates before assigning Project ownership")
+    func babylonIntakeHydratesBeforeOwnership() async {
+        let (catalog, alpha, _) = Self.twoProjectCatalog()
+        let coordinator = MainContentCoordinator(
+            projectCatalogRepository: FakeProjectRepo(loadResult: .success(catalog))
+        )
+        let provisionalProjectID = coordinator.projectStore.activeProjectID
+        let transaction = TestFixtures.makeTransaction(url: "https://babylon.example.com/pre-hydration")
+
+        await coordinator.receiveBabylonTransaction(transaction)
+
+        #expect(provisionalProjectID != alpha.id)
+        #expect(coordinator.hasHydratedProjects)
+        #expect(transaction.captureContext?.projectID == alpha.id)
+        #expect(await coordinator.sessionManager.flushPendingUpdates().map(\.id) == [transaction.id])
+    }
+
+    @Test("Babylon workspace registration hydrates before replacing tabs")
+    func babylonWorkspaceHydratesBeforeRegistration() async {
+        let (catalog, alpha, _) = Self.twoProjectCatalog()
+        let coordinator = MainContentCoordinator(
+            projectCatalogRepository: FakeProjectRepo(loadResult: .success(catalog))
+        )
+        let identity = BabylonCaptureIdentity(
+            clientID: UUID().uuidString,
+            sessionID: UUID().uuidString,
+            projectName: "Checkout",
+            bundleIdentifier: "com.example.checkout",
+            deviceName: "Test iPhone",
+            deviceModel: "iPhone"
+        )
+
+        await coordinator.registerBabylonCapture(identity: identity)
+
+        #expect(coordinator.hasHydratedProjects)
+        #expect(coordinator.workspaceStore.workspaces.contains { $0.title == alpha.tabs[0].title })
+        #expect(coordinator.workspaceStore.workspaces.contains { $0.title == identity.displayName })
+    }
+
+    @Test("external intake fails closed when the Project catalog cannot load")
+    func externalIntakeFailsClosedOnCatalogFailure() async {
+        let repo = FakeProjectRepo(loadResult: .failure(FakeError.boom))
+        let coordinator = MainContentCoordinator(projectCatalogRepository: repo)
+        let transaction = TestFixtures.makeTransaction(url: "https://babylon.example.com/rejected")
+
+        await coordinator.receiveBabylonTransaction(transaction)
+        await coordinator.receiveBabylonTransaction(
+            TestFixtures.makeTransaction(url: "https://babylon.example.com/still-rejected")
+        )
+
+        #expect(transaction.captureContext == nil)
+        #expect(await coordinator.sessionManager.flushPendingUpdates().isEmpty)
+        #expect(!coordinator.hasHydratedProjects)
+        #expect(await repo.loadCount == 1)
+    }
+
+    // MARK: Switching
+
+    @Test("switching persists outgoing tabs and restores each project's traffic")
+    func projectSwitchPersistsOutgoingHydratesIncoming() async {
+        let (catalog, alpha, beta) = Self.twoProjectCatalog()
+        let repo = FakeProjectRepo(loadResult: .success(catalog))
+        let coordinator = MainContentCoordinator(projectCatalogRepository: repo)
+        let t1 = TestFixtures.makeTransaction(url: "https://api.example.com/x")
+        let t2 = TestFixtures.makeTransaction(url: "https://other.example.com/y")
+        coordinator.transactions = [t1, t2]
+        await coordinator.hydrateProjectsOnLaunch()
+
+        // An outgoing edit that must be captured before the switch.
+        coordinator.workspaceStore.createWorkspace(title: "Scratch")
+
+        #expect(coordinator.switchToProject(id: beta.id))
+
+        #expect(coordinator.projectStore.activeProjectID == beta.id)
+        #expect(coordinator.workspaceStore.workspaces.contains { $0.title == "BetaTab" })
+        // Outgoing Alpha durably captured the scratch tab.
+        let persistedAlpha = coordinator.projectStore.projects.first { $0.id == alpha.id }
+        #expect(persistedAlpha?.tabs.contains { $0.title == "Scratch" } == true)
+        // Beta starts with independent traffic history.
+        #expect(coordinator.transactions.isEmpty)
+        #expect(coordinator.workspaceStore.activeWorkspace.filteredTransactions.isEmpty)
+
+        let betaTraffic = TestFixtures.makeTransaction(url: "https://beta.example.com/new")
+        coordinator.processActiveProjectTestBatch([betaTraffic])
+        #expect(coordinator.transactions.map(\.id) == [betaTraffic.id])
+
+        #expect(coordinator.switchToProject(id: alpha.id))
+        #expect(coordinator.transactions.map(\.id) == [t1.id, t2.id])
+        #expect(coordinator.workspaceStore.activeWorkspace.filteredTransactions.count == 2)
+    }
+
+    @Test("a request completing after a switch stays with its request-start project")
+    func lateCompletionRoutesToOriginalProject() async {
+        let (catalog, alpha, beta) = Self.twoProjectCatalog()
+        let coordinator = MainContentCoordinator(
+            projectCatalogRepository: FakeProjectRepo(loadResult: .success(catalog))
+        )
+        await coordinator.hydrateProjectsOnLaunch()
+        let alphaRoute = coordinator.activeCaptureContext
+        let lateAlpha = TestFixtures.makeTransaction(url: "https://alpha.example.com/late")
+        lateAlpha.assignCaptureContextIfMissing(alphaRoute)
+
+        #expect(coordinator.switchToProject(id: beta.id))
+        coordinator.processBatch([lateAlpha], generation: coordinator.sessionGeneration)
+
+        #expect(coordinator.transactions.isEmpty)
+        #expect(coordinator.switchToProject(id: alpha.id))
+        #expect(coordinator.transactions.map(\.id) == [lateAlpha.id])
+    }
+
+    @Test("clearing one project preserves another project and its late completions")
+    func clearIsScopedToActiveProject() async {
+        let (catalog, alpha, beta) = Self.twoProjectCatalog()
+        let coordinator = MainContentCoordinator(
+            projectCatalogRepository: FakeProjectRepo(loadResult: .success(catalog))
+        )
+        await coordinator.hydrateProjectsOnLaunch()
+        let alphaRoute = coordinator.activeCaptureContext
+        let alphaTraffic = TestFixtures.makeTransaction(url: "https://alpha.example.com/first")
+        coordinator.processActiveProjectTestBatch([alphaTraffic])
+
+        #expect(coordinator.switchToProject(id: beta.id))
+        let betaTraffic = TestFixtures.makeTransaction(url: "https://beta.example.com/first")
+        coordinator.processActiveProjectTestBatch([betaTraffic])
+        await coordinator.clearSession()
+        #expect(coordinator.transactions.isEmpty)
+
+        let lateAlpha = TestFixtures.makeTransaction(url: "https://alpha.example.com/late")
+        lateAlpha.assignCaptureContextIfMissing(alphaRoute)
+        coordinator.processBatch([lateAlpha], generation: coordinator.sessionGeneration)
+
+        #expect(coordinator.transactions.isEmpty)
+        #expect(coordinator.switchToProject(id: alpha.id))
+        #expect(coordinator.transactions.map(\.id) == [alphaTraffic.id, lateAlpha.id])
+    }
+
+    @Test("clearing one project preserves completed traffic pending for another project")
+    func clearPreservesInactivePendingBatch() async {
+        let (catalog, alpha, beta) = Self.twoProjectCatalog()
+        let coordinator = MainContentCoordinator(
+            projectCatalogRepository: FakeProjectRepo(loadResult: .success(catalog))
+        )
+        await coordinator.hydrateProjectsOnLaunch()
+        let alphaRoute = coordinator.activeCaptureContext
+        #expect(coordinator.switchToProject(id: beta.id))
+
+        let pendingAlpha = TestFixtures.makeTransaction(url: "https://alpha.example.com/pending")
+        pendingAlpha.assignCaptureContextIfMissing(alphaRoute)
+        await coordinator.sessionManager.addTransaction(pendingAlpha)
+
+        await coordinator.clearSession()
+
+        #expect(coordinator.transactions.isEmpty)
+        #expect(coordinator.switchToProject(id: alpha.id))
+        #expect(coordinator.transactions.map(\.id) == [pendingAlpha.id])
+    }
+
+    @Test("project transitions are serialized while a capture clear crosses actors")
+    func clearBlocksProjectTransitionDuringSuspension() async {
+        let (catalog, alpha, beta) = Self.twoProjectCatalog()
+        let coordinator = MainContentCoordinator(
+            projectCatalogRepository: FakeProjectRepo(loadResult: .success(catalog))
+        )
+        await coordinator.hydrateProjectsOnLaunch()
+        let alphaTraffic = TestFixtures.makeTransaction(url: "https://alpha.example.com/keep")
+        coordinator.processActiveProjectTestBatch([alphaTraffic])
+        #expect(coordinator.switchToProject(id: beta.id))
+        coordinator.processActiveProjectTestBatch([
+            TestFixtures.makeTransaction(url: "https://beta.example.com/clear"),
+        ])
+
+        await coordinator.sessionManager.setOnBeginNewSession { _ in
+            await MainActor.run {
+                _ = coordinator.switchToProject(id: alpha.id)
+            }
+        }
+        await coordinator.clearSession()
+
+        #expect(coordinator.projectStore.activeProjectID == beta.id)
+        #expect(coordinator.transactions.isEmpty)
+        #expect(coordinator.lastProjectOperationError == .captureClearInProgress)
+        #expect(coordinator.switchToProject(id: alpha.id))
+        #expect(coordinator.transactions.map(\.id) == [alphaTraffic.id])
+    }
+
+    @Test("clear retains an already-flushed old-generation batch for an inactive project")
+    func clearPreservesAlreadyFlushedInactiveBatch() async {
+        let (catalog, alpha, beta) = Self.twoProjectCatalog()
+        let coordinator = MainContentCoordinator(
+            projectCatalogRepository: FakeProjectRepo(loadResult: .success(catalog))
+        )
+        await coordinator.hydrateProjectsOnLaunch()
+        let alphaRoute = coordinator.activeCaptureContext
+        #expect(coordinator.switchToProject(id: beta.id))
+        let flushedAlpha = TestFixtures.makeTransaction(url: "https://alpha.example.com/flushed")
+        flushedAlpha.assignCaptureContextIfMissing(alphaRoute)
+
+        await coordinator.sessionManager.setOnBeginNewSession { generation in
+            await MainActor.run {
+                coordinator.processBatch([flushedAlpha], generation: generation &- 1)
+            }
+        }
+        await coordinator.clearSession()
+
+        #expect(coordinator.transactions.isEmpty)
+        #expect(coordinator.switchToProject(id: alpha.id))
+        #expect(coordinator.transactions.map(\.id) == [flushedAlpha.id])
+    }
+
+    @Test("Babylon intake stamps project ownership before shared batching")
+    func babylonIntakeUsesArrivalProject() async {
+        let (catalog, alpha, beta) = Self.twoProjectCatalog()
+        let coordinator = MainContentCoordinator(
+            projectCatalogRepository: FakeProjectRepo(loadResult: .success(catalog))
+        )
+        await coordinator.hydrateProjectsOnLaunch()
+        let babylon = TestFixtures.makeTransaction(url: "https://babylon.example.com/intake")
+
+        await coordinator.receiveBabylonTransaction(babylon)
+        #expect(babylon.captureContext?.projectID == alpha.id)
+        let pending = await coordinator.sessionManager.flushPendingUpdates()
+        #expect(coordinator.switchToProject(id: beta.id))
+        coordinator.processBatch(pending, generation: coordinator.sessionGeneration)
+
+        #expect(coordinator.transactions.isEmpty)
+        #expect(coordinator.switchToProject(id: alpha.id))
+        #expect(coordinator.transactions.map(\.id) == [babylon.id])
+    }
+
+    @Test("batch routing fails closed when ownership is missing")
+    func unownedBatchIsDropped() async {
+        let coordinator = MainContentCoordinator(projectCatalogRepository: FakeProjectRepo())
+        await coordinator.hydrateProjectsOnLaunch()
+        let unowned = TestFixtures.makeTransaction(url: "https://unowned.example.com")
+
+        coordinator.processBatch([unowned], generation: coordinator.sessionGeneration)
+
+        #expect(coordinator.transactions.isEmpty)
+    }
+
+    @Test("batch routing fails closed when session identity does not match its Project")
+    func mismatchedSessionIdentityIsDropped() async {
+        let coordinator = MainContentCoordinator(projectCatalogRepository: FakeProjectRepo())
+        await coordinator.hydrateProjectsOnLaunch()
+        let transaction = TestFixtures.makeTransaction(url: "https://mismatch.example.com")
+        transaction.assignCaptureContextIfMissing(TrafficCaptureContext(
+            projectID: coordinator.projectStore.activeProjectID,
+            sessionID: UUID(),
+            generation: 0
+        ))
+
+        coordinator.processBatch([transaction], generation: coordinator.sessionGeneration)
+
+        #expect(coordinator.transactions.isEmpty)
+    }
+
+    @Test("logs retain delivery-time Project ownership across a switch")
+    func logsRouteToDeliveryProject() async {
+        let (catalog, alpha, beta) = Self.twoProjectCatalog()
+        let coordinator = MainContentCoordinator(
+            projectCatalogRepository: FakeProjectRepo(loadResult: .success(catalog))
+        )
+        await coordinator.hydrateProjectsOnLaunch()
+        let alphaTransaction = TestFixtures.makeTransaction(url: "https://alpha.example.com/log")
+        coordinator.processActiveProjectTestBatch([alphaTransaction])
+        let alphaContext = coordinator.activeCaptureContext
+        let log = TestFixtures.makeLogEntry(message: "Alpha request finished")
+
+        #expect(coordinator.switchToProject(id: beta.id))
+        coordinator.addLogEntry(log, captureContext: alphaContext)
+
+        #expect(coordinator.logEntries.isEmpty)
+        #expect(coordinator.switchToProject(id: alpha.id))
+        #expect(coordinator.logEntries.map(\.id) == [log.id])
+        #expect(coordinator.logEntries.first?.correlatedTransactionId == alphaTransaction.id)
+    }
+
+    @Test("live traffic history is capped independently for every bounded Project")
+    func perProjectHistoryIsBounded() async {
+        let (catalog, alpha, beta) = Self.twoProjectCatalog()
+        let coordinator = MainContentCoordinator(
+            policy: TinyProjectHistoryPolicy(),
+            projectCatalogRepository: FakeProjectRepo(loadResult: .success(catalog))
+        )
+        await coordinator.hydrateProjectsOnLaunch()
+
+        let alphaTraffic = (0 ..< 4).map {
+            TestFixtures.makeTransaction(url: "https://alpha.example.com/\($0)")
+        }
+        coordinator.processActiveProjectTestBatch(alphaTraffic)
+        #expect(coordinator.transactions.map(\.id) == Array(alphaTraffic.suffix(2)).map(\.id))
+
+        #expect(coordinator.switchToProject(id: beta.id))
+        let betaTraffic = (0 ..< 4).map {
+            TestFixtures.makeTransaction(url: "https://beta.example.com/\($0)")
+        }
+        coordinator.processActiveProjectTestBatch(betaTraffic)
+        #expect(coordinator.transactions.map(\.id) == Array(betaTraffic.suffix(2)).map(\.id))
+
+        #expect(coordinator.switchToProject(id: alpha.id))
+        #expect(coordinator.transactions.map(\.id) == Array(alphaTraffic.suffix(2)).map(\.id))
+    }
+
+    @Test("multiple tabs are views over one project traffic history")
+    func tabsShareProjectTraffic() async {
+        let coordinator = MainContentCoordinator(projectCatalogRepository: FakeProjectRepo())
+        await coordinator.hydrateProjectsOnLaunch()
+        coordinator.workspaceStore.createWorkspace(title: "Errors")
+        let traffic = TestFixtures.makeTransaction(url: "https://api.example.com/one")
+
+        coordinator.processActiveProjectTestBatch([traffic])
+
+        #expect(coordinator.workspaceStore.workspaces.count == 2)
+        #expect(coordinator.workspaceStore.workspaces.allSatisfy {
+            $0.filteredTransactions.map(\.id) == [traffic.id]
+        })
+    }
+
+    @Test("switching to an unknown project leaves state unchanged")
+    func invalidTargetLeavesStateUnchanged() async {
+        let (catalog, _, _) = Self.twoProjectCatalog()
+        let repo = FakeProjectRepo(loadResult: .success(catalog))
+        let coordinator = MainContentCoordinator(projectCatalogRepository: repo)
+        await coordinator.hydrateProjectsOnLaunch()
+        let activeBefore = coordinator.projectStore.activeProjectID
+        let tabsBefore = coordinator.workspaceStore.workspaces.map(\.id)
+        let savesBefore = await repo.saveCount
+
+        #expect(!coordinator.switchToProject(id: UUID()))
+
+        #expect(coordinator.lastProjectOperationError == .projectNotFound)
+        #expect(coordinator.projectStore.activeProjectID == activeBefore)
+        #expect(coordinator.workspaceStore.workspaces.map(\.id) == tabsBefore)
+        #expect(await repo.saveCount == savesBefore)
+    }
+
+    // MARK: Create / delete
+
+    @Test("creating a project persists the outgoing snapshot and applies the new default tabs")
+    func createActiveTransition() async {
+        let (catalog, alpha, _) = Self.twoProjectCatalog()
+        let repo = FakeProjectRepo(loadResult: .success(catalog))
+        let coordinator = MainContentCoordinator(projectCatalogRepository: repo)
+        await coordinator.hydrateProjectsOnLaunch()
+        coordinator.workspaceStore.createWorkspace(title: "Scratch")
+
+        let created = coordinator.createProject(named: "Gamma")
+
+        #expect(created != nil)
+        #expect(coordinator.projectStore.activeProjectID == created?.id)
+        // The new project shows only its single default tab.
+        #expect(coordinator.workspaceStore.workspaces.count == 1)
+        #expect(coordinator.workspaceStore.workspaces[0].isClosable == false)
+        // Outgoing Alpha kept the scratch tab.
+        let persistedAlpha = coordinator.projectStore.projects.first { $0.id == alpha.id }
+        #expect(persistedAlpha?.tabs.contains { $0.title == "Scratch" } == true)
+    }
+
+    @Test("deleting the active project applies the adjacent project")
+    func deleteActiveTransition() async {
+        let (catalog, alpha, beta) = Self.twoProjectCatalog()
+        let repo = FakeProjectRepo(loadResult: .success(catalog))
+        let coordinator = MainContentCoordinator(projectCatalogRepository: repo)
+        await coordinator.hydrateProjectsOnLaunch()
+
+        #expect(coordinator.deleteProject(id: alpha.id))
+
+        #expect(coordinator.projectStore.activeProjectID == beta.id)
+        #expect(coordinator.workspaceStore.workspaces.contains { $0.title == "BetaTab" })
+    }
+
+    @Test("deleting an inactive project does not disturb the current tabs")
+    func inactiveDeleteStability() async {
+        let (catalog, _, beta) = Self.twoProjectCatalog()
+        let repo = FakeProjectRepo(loadResult: .success(catalog))
+        let coordinator = MainContentCoordinator(projectCatalogRepository: repo)
+        await coordinator.hydrateProjectsOnLaunch()
+        coordinator.workspaceStore.createWorkspace(title: "Scratch")
+        let activeWorkspaceBefore = coordinator.workspaceStore.activeWorkspaceID
+        let tabIDsBefore = coordinator.workspaceStore.workspaces.map(\.id)
+
+        #expect(coordinator.deleteProject(id: beta.id))
+
+        #expect(coordinator.workspaceStore.activeWorkspaceID == activeWorkspaceBefore)
+        #expect(coordinator.workspaceStore.workspaces.map(\.id) == tabIDsBefore)
+        #expect(coordinator.workspaceStore.workspaces.contains { $0.title == "Scratch" })
+    }
+
+    // MARK: Reconciliation
+
+    @Test("reconciliation rejects a stale candidate after an unsaved tab flush and preserves local state")
+    func reconcileStaleAfterFlushRejected() async {
+        let (catalog, alpha, beta) = Self.twoProjectCatalog()
+        let coordinator = MainContentCoordinator(
+            projectCatalogRepository: FakeProjectRepo(loadResult: .success(catalog))
+        )
+        await coordinator.hydrateProjectsOnLaunch()
+        let staleRevision = coordinator.projectStore.catalog.revision
+        // A live, unsaved tab edit. The pre-apply flush persists it, advancing the
+        // revision so the candidate built against `staleRevision` is now stale.
+        coordinator.workspaceStore.createWorkspace(title: "Unsaved")
+        let workspaceIDsBefore = coordinator.workspaceStore.workspaces.map(\.id)
+
+        let candidate = [alpha, beta, Self.makeProject(name: "Reconciled")]
+        #expect(!coordinator.reconcileProjects(candidate, expectedRevision: staleRevision))
+
+        guard case .staleRevision = coordinator.lastProjectOperationError else {
+            Issue.record("expected staleRevision, got \(String(describing: coordinator.lastProjectOperationError))")
+            return
+        }
+        // Candidate was not applied.
+        #expect(coordinator.projectStore.projects.count == 2)
+        // The flushed edit is retained and the live workspace is untouched.
+        #expect(coordinator.workspaceStore.workspaces.map(\.id) == workspaceIDsBefore)
+        #expect(coordinator.workspaceStore.workspaces.contains { $0.title == "Unsaved" })
+        #expect(coordinator.projectStore.activeProject.tabs.contains { $0.title == "Unsaved" })
+    }
+
+    @Test("removing the active project selects the first and refreshes capture context and workspace")
+    func reconcileActiveRemovalRefreshes() async {
+        let (catalog, alpha, beta) = Self.twoProjectCatalog()
+        let coordinator = MainContentCoordinator(
+            projectCatalogRepository: FakeProjectRepo(loadResult: .success(catalog))
+        )
+        await coordinator.hydrateProjectsOnLaunch()
+        coordinator.processActiveProjectTestBatch([
+            TestFixtures.makeTransaction(url: "https://alpha.example.com/x"),
+        ])
+        #expect(coordinator.projectStore.activeProjectID == alpha.id)
+
+        let revision = coordinator.projectStore.catalog.revision
+        #expect(coordinator.reconcileProjects([beta], expectedRevision: revision))
+
+        #expect(coordinator.projectStore.activeProjectID == beta.id)
+        #expect(coordinator.activeCaptureContext.projectID == beta.id)
+        #expect(coordinator.captureContextStore.snapshot()?.projectID == beta.id)
+        #expect(coordinator.workspaceStore.workspaces.contains { $0.title == "BetaTab" })
+        // Beta starts from its own (empty) runtime projection.
+        #expect(coordinator.transactions.isEmpty)
+    }
+
+    @Test("updating the active project's tabs refreshes the workspace but retains runtime capture")
+    func reconcileActiveTabUpdateRetainsCapture() async {
+        let (catalog, alpha, beta) = Self.twoProjectCatalog()
+        let coordinator = MainContentCoordinator(
+            projectCatalogRepository: FakeProjectRepo(loadResult: .success(catalog))
+        )
+        await coordinator.hydrateProjectsOnLaunch()
+        let alphaTraffic = TestFixtures.makeTransaction(url: "https://alpha.example.com/x")
+        coordinator.processActiveProjectTestBatch([alphaTraffic])
+
+        let revision = coordinator.projectStore.catalog.revision
+        var updatedAlpha = alpha
+        updatedAlpha.tabs = alpha.tabs + [ProjectTabSnapshot(title: "Reconciled Tab", isClosable: true)]
+
+        #expect(coordinator.reconcileProjects([updatedAlpha, beta], expectedRevision: revision))
+
+        #expect(coordinator.projectStore.activeProjectID == alpha.id)
+        #expect(coordinator.workspaceStore.workspaces.contains { $0.title == "Reconciled Tab" })
+        // The surviving active project keeps its live capture history.
+        #expect(coordinator.transactions.map(\.id) == [alphaTraffic.id])
+    }
+
+    @Test("an inactive-only reconciliation does not reset the current live workspace")
+    func reconcileInactiveOnlyPreservesWorkspace() async {
+        let (catalog, alpha, beta) = Self.twoProjectCatalog()
+        let coordinator = MainContentCoordinator(
+            projectCatalogRepository: FakeProjectRepo(loadResult: .success(catalog))
+        )
+        await coordinator.hydrateProjectsOnLaunch()
+        coordinator.workspaceStore.createWorkspace(title: "Live Scratch")
+        _ = coordinator.flushProjectTabSnapshot()
+        let flushedAlpha = coordinator.projectStore.activeProject
+        let revision = coordinator.projectStore.catalog.revision
+        let workspaceIDsBefore = coordinator.workspaceStore.workspaces.map(\.id)
+        let activeWorkspaceBefore = coordinator.workspaceStore.activeWorkspaceID
+
+        var renamedBeta = beta
+        renamedBeta.name = "Beta Renamed"
+        #expect(coordinator.reconcileProjects([flushedAlpha, renamedBeta], expectedRevision: revision))
+
+        #expect(coordinator.projectStore.projects.contains { $0.name == "Beta Renamed" })
+        // Active identity and tab configuration are unchanged, so the live workspace
+        // (and its scratch tab) is not reset.
+        #expect(coordinator.workspaceStore.workspaces.map(\.id) == workspaceIDsBefore)
+        #expect(coordinator.workspaceStore.activeWorkspaceID == activeWorkspaceBefore)
+        #expect(coordinator.workspaceStore.workspaces.contains { $0.title == "Live Scratch" })
+    }
+
+    @Test("reconciliation clears runtime buckets only for removed project IDs")
+    func reconcileClearsRemovedProjectBuckets() async {
+        let (catalog, alpha, beta) = Self.twoProjectCatalog()
+        let coordinator = MainContentCoordinator(
+            projectCatalogRepository: FakeProjectRepo(loadResult: .success(catalog))
+        )
+        await coordinator.hydrateProjectsOnLaunch()
+        #expect(coordinator.switchToProject(id: beta.id))
+        coordinator.processActiveProjectTestBatch([
+            TestFixtures.makeTransaction(url: "https://beta.example.com/x"),
+        ])
+        #expect(coordinator.switchToProject(id: alpha.id))
+        coordinator.processActiveProjectTestBatch([
+            TestFixtures.makeTransaction(url: "https://alpha.example.com/x"),
+        ])
+        #expect(coordinator.transactionsByProjectID[beta.id] != nil)
+        #expect(coordinator.transactionsByProjectID[alpha.id] != nil)
+
+        let revision = coordinator.projectStore.catalog.revision
+        #expect(coordinator.reconcileProjects([alpha], expectedRevision: revision))
+
+        #expect(coordinator.transactionsByProjectID[beta.id] == nil)
+        #expect(coordinator.logEntriesByProjectID[beta.id] == nil)
+        #expect(coordinator.sessionProvenanceByProjectID[beta.id] == nil)
+        // The surviving active project keeps its bucket.
+        #expect(coordinator.transactionsByProjectID[alpha.id] != nil)
+        #expect(coordinator.projectStore.activeProjectID == alpha.id)
+    }
+
+    // MARK: Capacity refresh
+
+    @Test("capacity refresh updates both creation gates and retains over-limit projects and tabs")
+    func capacityRefreshUpdatesGatesRetainingState() async {
+        let coordinator = MainContentCoordinator(
+            policy: FlexibleProjectPolicy(maxWorkspaceTabs: 8, maxProjects: 6),
+            projectCatalogRepository: FakeProjectRepo()
+        )
+        await coordinator.hydrateProjectsOnLaunch()
+        _ = coordinator.createProject(named: "Second")
+        _ = coordinator.createProject(named: "Third")
+        coordinator.workspaceStore.createWorkspace(title: "Tab A")
+        coordinator.workspaceStore.createWorkspace(title: "Tab B")
+        #expect(coordinator.projectStore.projects.count == 3)
+        #expect(coordinator.workspaceStore.workspaces.count == 3)
+
+        coordinator.refreshProjectCreationCapacity(
+            with: FlexibleProjectPolicy(maxWorkspaceTabs: 2, maxProjects: 2)
+        )
+
+        #expect(coordinator.projectStore.maxProjects == 2)
+        #expect(coordinator.workspaceStore.maxWorkspaces == 2)
+        // No retained state is deleted or truncated by the lower limits.
+        #expect(coordinator.projectStore.projects.count == 3)
+        #expect(coordinator.workspaceStore.workspaces.count == 3)
+        #expect(!coordinator.projectStore.canCreateProject)
+        #expect(!coordinator.workspaceStore.canCreateWorkspace)
+    }
+
+    // MARK: Autosave debounce & exclusion
+
+    @Test("rapid edits coalesce into a single durable autosave")
+    func debounceCoalescing() async {
+        let repo = FakeProjectRepo()
+        let coordinator = MainContentCoordinator(
+            projectCatalogRepository: repo,
+            projectTabAutosaveDebounce: .milliseconds(50)
+        )
+        await coordinator.hydrateProjectsOnLaunch()
+
+        coordinator.workspaceStore.activeWorkspace.title = "One"
+        coordinator.scheduleProjectTabAutosave()
+        coordinator.workspaceStore.activeWorkspace.title = "Two"
+        coordinator.scheduleProjectTabAutosave()
+        coordinator.workspaceStore.activeWorkspace.title = "Three"
+        coordinator.scheduleProjectTabAutosave()
+
+        await repo.waitForFirstSave()
+
+        #expect(await repo.saveCount == 1)
+        #expect(coordinator.projectStore.activeProject.tabs.contains { $0.title == "Three" })
+    }
+
+    @Test("non-durable changes do not trigger a durable autosave")
+    func snapshotExclusionForNonDurableState() async throws {
+        let repo = FakeProjectRepo()
+        let coordinator = MainContentCoordinator(
+            projectCatalogRepository: repo,
+            projectTabAutosaveDebounce: .milliseconds(50)
+        )
+        await coordinator.hydrateProjectsOnLaunch()
+        let revisionBefore = coordinator.projectStore.catalog.revision
+
+        // Traffic, filtered rows, sidebar indexes, and selection are excluded from
+        // the durable snapshot seams, so recomputing them must not autosave.
+        coordinator.transactions = [
+            TestFixtures.makeTransaction(url: "https://a.example.com/x"),
+            TestFixtures.makeTransaction(url: "https://b.example.com/y"),
+        ]
+        coordinator.recomputeAllWorkspaces()
+        coordinator.selectedTransactionIDs = [coordinator.transactions[0].id]
+
+        try await Task.sleep(for: .milliseconds(200))
+
+        #expect(await repo.saveCount == 0)
+        #expect(coordinator.projectStore.catalog.revision == revisionBefore)
+    }
+
+    @Test("termination flush persists pending durable tab edits immediately")
+    func terminationFlushPersistsPendingEdits() async {
+        let repo = FakeProjectRepo()
+        let coordinator = MainContentCoordinator(
+            projectCatalogRepository: repo,
+            projectTabAutosaveDebounce: .seconds(30)
+        )
+        await coordinator.hydrateProjectsOnLaunch()
+        coordinator.workspaceStore.activeWorkspace.title = "Before Quit"
+
+        await coordinator.flushProjectStateForTermination()
+
+        #expect(await repo.saveCount == 1)
+        #expect(await repo.lastSavedCatalog?.activeProject?.tabs[0].title == "Before Quit")
+    }
+
+    @Test("termination flush remains reachable after the primary window closes")
+    func terminationFlushSurvivesWindowClosure() async {
+        let repo = FakeProjectRepo()
+        let coordinator = MainContentCoordinator(
+            projectCatalogRepository: repo,
+            projectTabAutosaveDebounce: .seconds(30)
+        )
+        await coordinator.hydrateProjectsOnLaunch()
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 900, height: 600),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        let manager = RockxyWorkspaceWindowManager.shared
+        manager.registerPrimaryWindow(window, coordinator: coordinator)
+        coordinator.workspaceStore.activeWorkspace.title = "Closed Before Quit"
+
+        manager.handleWindowWillClose(window)
+        #expect(!manager.canCreateWorkspaceTab)
+        await manager.flushProjectStateForTermination()
+
+        #expect(await repo.lastSavedCatalog?.activeProject?.tabs[0].title == "Closed Before Quit")
+    }
+
+    // MARK: Store failure surfacing
+
+    @Test("store-not-ready is surfaced to operations after a failed load")
+    func storeNotReadySurfaced() async {
+        let repo = FakeProjectRepo(loadResult: .failure(FakeError.boom))
+        let coordinator = MainContentCoordinator(projectCatalogRepository: repo)
+        await coordinator.hydrateProjectsOnLaunch()
+
+        #expect(!coordinator.switchToProject(id: UUID()))
+        #expect(coordinator.lastProjectOperationError == .storeNotReady)
+        #expect(coordinator.createProject(named: "Nope") == nil)
+        #expect(coordinator.lastProjectOperationError == .storeNotReady)
+        #expect(coordinator.projectPersistenceWarningMessage != nil)
+    }
+
+    @Test("revision exhaustion is surfaced without a successful create")
+    func revisionExhaustionSurfaced() async {
+        var catalog = ProjectCatalog.makeDefault(now: Self.fixedDate)
+        catalog.revision = UInt64.max
+        let repo = FakeProjectRepo(loadResult: .success(catalog))
+        let coordinator = MainContentCoordinator(projectCatalogRepository: repo)
+        await coordinator.hydrateProjectsOnLaunch()
+
+        #expect(coordinator.createProject(named: "Gamma") == nil)
+        #expect(coordinator.lastProjectOperationError == .revisionExhausted)
+    }
+
+    // MARK: Private
+
+    // MARK: Helpers
+
+    private static let fixedDate = Date(timeIntervalSince1970: 1_000_000)
+
+    private static func makeProject(name: String) -> Project {
+        Project.makeDefault(name: name, createdAt: fixedDate, updatedAt: fixedDate)
+    }
+
+    /// A two-project catalog: Alpha (active, single default tab) and Beta
+    /// (default tab plus a distinctive closable "BetaTab").
+    private static func twoProjectCatalog() -> (catalog: ProjectCatalog, alpha: Project, beta: Project) {
+        let alpha = Project.makeDefault(name: "Alpha", createdAt: fixedDate, updatedAt: fixedDate)
+        let betaDefault = ProjectTabSnapshot.makeDefaultAllTraffic()
+        let betaTab = ProjectTabSnapshot(title: "BetaTab", isClosable: true)
+        let beta = Project(
+            name: "Beta",
+            createdAt: fixedDate,
+            updatedAt: fixedDate,
+            activeTabID: betaDefault.id,
+            tabs: [betaDefault, betaTab]
+        )
+        let catalog = ProjectCatalog(activeProjectID: alpha.id, projects: [alpha, beta])
+        return (catalog, alpha, beta)
+    }
+}
+
+// MARK: - FakeProjectRepo
+
+/// Actor-isolated persistence double mirroring the real repository's isolation so
+/// the store's `Sendable` seam is exercised faithfully.
+private actor FakeProjectRepo: ProjectCatalogPersisting {
+    // MARK: Lifecycle
+
+    init(
+        loadResult: Result<ProjectCatalog, Error> = .success(
+            ProjectCatalog.makeDefault(now: Date(timeIntervalSince1970: 1_000_000))
+        )
+    ) {
+        self.loadResult = loadResult
+    }
+
+    // MARK: Internal
+
+    private(set) var savedCatalogs: [ProjectCatalog] = []
+    private(set) var loadCount = 0
+
+    var saveCount: Int {
+        savedCatalogs.count
+    }
+
+    var lastSavedCatalog: ProjectCatalog? {
+        savedCatalogs.last
+    }
+
+    func load() async throws -> ProjectCatalog {
+        loadCount += 1
+        return try loadResult.get()
+    }
+
+    func save(_ catalog: ProjectCatalog) async throws {
+        savedCatalogs.append(catalog)
+        let waiters = firstSaveWaiters
+        firstSaveWaiters.removeAll()
+        for waiter in waiters {
+            waiter.resume()
+        }
+    }
+
+    func reset() async throws -> ProjectCatalog {
+        let fresh = ProjectCatalog.makeDefault(now: Date(timeIntervalSince1970: 1_000_000))
+        savedCatalogs.append(fresh)
+        return fresh
+    }
+
+    func waitForFirstSave() async {
+        guard savedCatalogs.isEmpty else {
+            return
+        }
+        await withCheckedContinuation { continuation in
+            firstSaveWaiters.append(continuation)
+        }
+    }
+
+    // MARK: Private
+
+    private let loadResult: Result<ProjectCatalog, Error>
+    private var firstSaveWaiters: [CheckedContinuation<Void, Never>] = []
+}
+
+// MARK: - FakeError
+
+private enum FakeError: Error, Equatable {
+    case boom
+}
+
+// MARK: - TinyProjectHistoryPolicy
+
+private struct TinyProjectHistoryPolicy: AppPolicy {
+    let maxWorkspaceTabs = 8
+    let maxDomainFavorites = 5
+    let maxActiveRulesPerTool = 10
+    let maxEnabledScripts = 10
+    let maxLiveHistoryEntries = 2
+}
+
+// MARK: - FlexibleProjectPolicy
+
+private struct FlexibleProjectPolicy: AppPolicy {
+    var maxWorkspaceTabs: Int
+    var maxProjects: Int
+    var maxDomainFavorites = 5
+    var maxActiveRulesPerTool = 10
+    var maxEnabledScripts = 10
+    var maxLiveHistoryEntries = 1_000
+}

--- a/Shared/RockxyIdentity.swift
+++ b/Shared/RockxyIdentity.swift
@@ -130,6 +130,10 @@ struct RockxyIdentity {
         "\(sharedUTTypePrefix).session"
     }
 
+    var projectUTTypeIdentifier: String {
+        "\(sharedUTTypePrefix).project"
+    }
+
     var harUTTypeIdentifier: String {
         "\(sharedUTTypePrefix).har"
     }

--- a/docs/design-specs/main-window.md
+++ b/docs/design-specs/main-window.md
@@ -10,7 +10,7 @@ The primary application window — a 3-column developer debugging interface foll
 
 ```
 ┌─────────────────────────────────────────────────────────────────────────────────────┐
-│ ◉ ◉ ◉    [▶ Start] [⏺ Record] [🗑 Clear]  |  [⊞] [⊟]       Rockxy | Listening    │  ← Toolbar (38pt)
+│ ◉ ◉ ◉  [Sidebar] │ [📁 Checkout API ▾]       ● Listening        [▶] [Inspector]  │  ← Toolbar
 ├────────────┬────────────────────────────────────────────┬───────────────────────────┤
 │            │ [All][HTTP][HTTPS][WS][GQL]..│[2xx][3xx].. │                           │  ← Filter Bar (28pt)
 │  SIDEBAR   ├────────────────────────────────────────────┤    INSPECTOR PANEL        │
@@ -51,8 +51,7 @@ The primary application window — a 3-column developer debugging interface foll
 
 ### Layout
 ```
-[▶ Start/Stop] [⏺ Record] [🗑 Clear]  |  [⊞ Inspector] [⊟ Orientation]    {Rockxy | Listening on 127.0.0.1:9090}
-← primaryAction placement ───────────────────────────────────────────────→    ← principal placement (centered) ──→
+[Sidebar] │ [📁 Active Project ▾]     {● Listening on 127.0.0.1:9090}     [▶ Start/Stop] [Inspector] [Context Dock]
 ```
 
 ### Controls
@@ -65,9 +64,14 @@ The primary application window — a 3-column developer debugging interface foll
 | Inspector | `rectangle.split.1x2` | Toggle visibility | — | Medium |
 | Orientation | `rectangle.split.2x1` | Toggle H/V split | — | Low |
 
+### Project Selector (Leading)
+- Appears immediately after the sidebar tracking separator.
+- Shows the active local Project name and opens switching/management actions.
+- Sizes to the active Project name within a 104–240 pt band; short names stay compact and long names truncate without displacing the centered status.
+
 ### Status Indicator (Center)
 - Circle: 8pt diameter, `NSColor.systemGreen` (running) / `NSColor.secondaryLabelColor` (stopped)
-- Text: `"Rockxy | Listening on 127.0.0.1:9090"` or `"Rockxy | Not Running"`
+- Text: `"Listening on 127.0.0.1:9090"` or `"Not Running"`
 - Font: `.systemFont(ofSize: 12)`, `NSColor.secondaryLabelColor`
 
 ### Styling

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -41,6 +41,7 @@
           "features/graphql",
           "core-features/logs-and-timeline",
           "features/request-replay",
+          "features/projects",
           "features/workspaces",
           "features/sessions"
         ]

--- a/docs/features/projects.mdx
+++ b/docs/features/projects.mdx
@@ -1,0 +1,67 @@
+---
+title: "Projects"
+description: "Organize Project-scoped live traffic and durable Traffic Tab layouts in a bounded, local-first workspace."
+---
+
+# Projects
+
+Projects are the top-level organization unit in Rockxy. A Project owns its in-memory traffic history and the durable names, filters, and layout of its Traffic Tabs.
+
+Use the Project selector beside the sidebar control in the main toolbar to switch Projects. There is still one app-wide proxy listener. A request is assigned to the active Project when its request head begins, so an in-flight request or WebSocket does not jump Projects during a switch.
+
+## Project → Traffic Tabs
+
+Each Project stores a bounded set of Traffic Tab configurations:
+
+- tab name and active tab
+- search, protocol, status, domain, and advanced filters
+- Traffic or Logs surface
+- inspector placement and Context Dock selection
+- Focus Navigator references and muted-source view settings
+
+Captured headers, bodies, cookies, logs, selections, rendered rows, sort descriptors, and assistant payloads are deliberately excluded from the durable Project catalog. Traffic history remains separated in memory while Rockxy is running.
+
+## Capture behavior
+
+Switching Projects never starts or stops the proxy:
+
+- new requests start in the newly active Project
+- in-flight requests and WebSockets finish in their request-start Project
+- switching back restores the earlier Project's retained in-memory history
+- **Clear** clears only the active Project and invalidates its older in-flight generation
+- every Traffic Tab inside a Project sees that same Project history through its own filters
+
+Proxy, certificate and recording state, rules, favorites, scripts, plugins, Focus Set definitions, and MCP state remain app-wide in this release. Project-specific rule/network profiles are not implied by switching Projects.
+
+## Manage Projects
+
+Choose **Project → Manage Projects…** to create, open, rename, or delete Projects and inspect their Traffic Tabs. Deleting a Project removes that Project's local tab configuration and in-memory history; it does not delete manually saved session files, rules, or favorites.
+
+The management window also provides **Import…** and **Export…** actions. Export uses the Project selected in the sidebar, even when it is not currently open; a successful import creates and opens a new Project.
+
+Project names are normalized, limited to 80 characters, and unique without regard to case, accents, or full-width forms.
+
+## Local save and transfer
+
+Project and Traffic Tab configuration auto-saves locally. **Project → Export Project Configuration…** creates a config-only `.rockxyproject` file, and import always creates a new Project with fresh identifiers. It includes allowlisted tab names, user-authored filter text, host/path patterns, and layout preferences—never captured traffic, bodies, headers, cookies, scripts, or local file paths. Filter text can itself be sensitive, so review the file before sharing it.
+
+Traffic is intentionally not embedded in the Project catalog or `.rockxyproject` file. Use **Save Session** for the active Project when you need a durable traffic artifact across app relaunches. Session import is assigned to the Project that is active at import time.
+
+## Capacity and storage safety
+
+The Community app supports up to **3 local Projects**. Each Project supports up to 8 Traffic Tabs under the current public policy. Independent structural safety ceilings remain higher so corrupt or future documents are bounded before allocation.
+
+The catalog is stored at a constant local Application Support path. Rockxy bounds it to 2 MiB, writes atomically, uses restrictive filesystem permissions, rejects symbolic links and malformed/newer schemas, and refuses to overwrite a catalog it cannot validate.
+
+If loading fails, Project edits remain disabled until you retry or explicitly reset. Reset preserves a bounded regular catalog as `catalog.recovery.json` before creating a fresh default. Portable Project imports are capped at 1 MiB, reject symbolic links and malformed/newer formats, and never replace an existing Project.
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card title="Traffic Tabs" icon="table-columns" href="/features/workspaces">
+    Build independent filtered views inside each Project.
+  </Card>
+  <Card title="Sessions and Export" icon="floppy-disk" href="/features/sessions">
+    Save or share the captured traffic that Projects view.
+  </Card>
+</CardGroup>

--- a/docs/features/workspaces.mdx
+++ b/docs/features/workspaces.mdx
@@ -1,17 +1,17 @@
 ---
-title: "Workspaces"
-description: "Native macOS tabs that split a single capture into independently filtered, sorted, and inspected views."
+title: "Traffic Tabs"
+description: "Project-owned tabs that present one Project capture through independent filters and inspector layouts."
 ---
 
-# Workspaces
+# Traffic Tabs
 
-A workspace is an independent view onto the same live traffic stream. Each tab keeps its own filter, sort, sidebar selection, inspector tab, and inspector layout — but every tab is reading the **same underlying capture**, so traffic shows up in all of them at once. Workspaces are native macOS tabs at the window level: drag, reorder, rename in place, and `Cmd`-click as expected.
+A Traffic Tab is an independent view onto its Project's traffic history. Each tab keeps its own filters and inspector layout, but every tab in that Project reads the **same underlying Project capture**. Switching tabs never changes where traffic is recorded.
 
 <Frame caption="Multiple workspace tabs in the main window">
   <img src="/images/features/DemoMultipleTabWorkingSpace.png" alt="Workspace tabs" />
 </Frame>
 
-## Why workspaces
+## Why Traffic Tabs
 
 A single capture often serves several investigations at once:
 
@@ -19,11 +19,11 @@ A single capture often serves several investigations at once:
 - a tab dedicated to the request you are about to replay, with the inspector docked to the right
 - a tab kept on **Logs** with a process filter while the main tab stays on **Traffic**
 
-Without workspaces, every change to filter or layout would clobber the previous setup. Workspaces let multiple investigations stay parked side-by-side.
+Without Traffic Tabs, every change to filter or layout would clobber the previous setup. Tabs let multiple investigations stay parked side-by-side, while Projects keep related tabs together across launches.
 
 ## What's per-tab vs. shared
 
-Per-tab state (each workspace owns its own copy):
+Per-tab runtime state:
 
 - Filter criteria and the visible filter bar
 - Active main tab (`Traffic` / `Logs`)
@@ -33,13 +33,16 @@ Per-tab state (each workspace owns its own copy):
 - Per-workspace sort descriptors
 - Per-workspace domain tree, app nodes, and grouping index
 
-Shared across all workspaces:
+Shared by the Traffic Tabs inside one Project:
 
-- The proxy capture itself — bodies, headers, timing
+- The Project's live traffic history — bodies, headers, and timing
+
+Shared app-wide:
+
 - Recording state, rules, certificates, plugins
 - Favorites, allow list, SSL proxying list, MCP server state
 
-In other words, you cannot "stop recording" in one tab and "keep recording" in another. The proxy is the proxy. Workspaces only change what you are *looking at*.
+In other words, you cannot "stop recording" in one tab and "keep recording" in another. There is one proxy listener, while request-start ownership determines which Project receives each completed transaction.
 
 ## Tab management
 
@@ -57,7 +60,7 @@ Up to **8 tabs** can be open at a time (`AppPolicy.maxWorkspaceTabs`). Hitting t
 
 ## Default tab
 
-Every new window starts with a single, non-closable workspace titled **All Traffic**. Its filter is `.empty`, so it always shows the full capture. Treat it as your unfiltered baseline — close other tabs to come back to it.
+Every new Project starts with a single, non-closable Traffic Tab titled **All Traffic**. Its filter is `.empty`, so it always shows the full capture. Treat it as your unfiltered baseline.
 
 ## Workflow examples
 
@@ -79,14 +82,14 @@ Sorting is a workspace preference, not a window preference. Sort the **Errors** 
 
 ## Eviction and per-tab views
 
-When the in-memory ring buffer overflows (50k transactions by default), the oldest entries are evicted from every workspace at once. Filter state is preserved; only the underlying rows go away. The sidebar indexes (domain tree + app tree) rebuild automatically per workspace after an eviction — see `MainContentCoordinator+Eviction` for the exact path.
+When a Project's in-memory history reaches its configured cap, its oldest entries are evicted from every Traffic Tab in that Project at once. Other Projects keep their own histories. Filter state is preserved; only the underlying rows go away.
 
 ## Limits and gotchas
 
 - The **All Traffic** tab cannot be closed by design. <kbd>Cmd</kbd>+<kbd>W</kbd> when it is the only tab is a no-op.
-- Workspaces share the proxy. There is no per-tab "start" or "stop".
+- Projects and Traffic Tabs share one proxy listener and recording control. There is no per-tab "start" or "stop".
 - Selection is per-tab, but the inspector window scenes (Compose, Diff, Map Local editor, etc.) are app-level — opening one from any tab shows the same draft state.
-- The 8-tab cap is a `Community` policy value (`AppPolicy.maxWorkspaceTabs`); a future Pro tier may raise it.
+- The 8-tab cap is the current `AppPolicy.maxWorkspaceTabs` value.
 
 ## Next Steps
 
@@ -95,6 +98,6 @@ When the in-memory ring buffer overflows (50k transactions by default), the olde
     All workspace and inspector shortcuts in one table.
   </Card>
   <Card title="Sessions and Export" icon="floppy-disk" href="/features/sessions">
-    Save, load, and export the underlying capture that workspaces share.
+    Save, load, and export the active Project's captured traffic.
   </Card>
 </CardGroup>


### PR DESCRIPTION
## Summary

- promote the local Project domain with stable Project and Traffic Tab identities, bounded atomic catalog persistence, and native management surfaces
- promote Project-scoped live traffic, logs, and capture routing while preserving independent filters and inspector layouts for each Traffic Tab
- promote configuration-only `.rockxyproject` import and export with restrictive validation and no captured traffic in portable documents
- promote documentation and focused regression coverage for storage, capture ownership, Project switching, capacity policy, and native window behavior

## Why

Rockxy needs a durable investigation boundary above individual Traffic Tabs. Projects separate unrelated debugging work without creating multiple proxy listeners or forcing users to rebuild filters and layouts whenever they switch context.

This promotion keeps the proxy and recording controls app-wide while making Project ownership explicit: new requests belong to the Project that was active when the request began, and every Traffic Tab within that Project presents the same capture through its own configuration.

## Impact

- fresh installations start with a durable default Project
- switching Projects restores the selected Project's retained in-memory traffic and persisted Traffic Tab configuration
- in-flight requests and WebSockets remain assigned to their request-start Project during a switch
- Traffic Tabs share their Project's capture while retaining independent filters and inspector layouts
- Community capacity is bounded to 3 local Projects and 8 Traffic Tabs per Project without truncating retained configuration
- Project configuration can be imported or exported without captured bodies, headers, cookies, scripts, or local file paths
- malformed, oversized, stale, symlinked, and unsupported Project documents fail closed
- rules, certificates, recording state, favorites, scripts, plugins, and MCP state remain app-wide in this release

## Related issues

Refs #10

## Validation

- complete Build & Validate workflow passed for PR #276, including SwiftLint and the full macOS test job
- Universal macOS build passed for arm64 and x86_64, including bundled helper-resource verification
- 212 focused Project, persistence, Traffic Tab, capture-context, policy, and coordination tests passed with 0 failures and 0 skips
- clean merge simulation against current `main`
- `git diff --check origin/main..origin/develop`
