### PR TITLE
fix(projects): harden lifecycle and retention

### DIFF
--- a/Rockxy/AppDelegate.swift
+++ b/Rockxy/AppDelegate.swift
@@ -91,7 +91,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSUserInterfaceValidat
 
         Self.logger.info("Rockxy terminating — cleaning up system proxy")
         Task {
-            await RockxyWorkspaceWindowManager.shared.flushProjectStateForTermination()
             Self.logger.info("Quit: starting proxy restore")
             do {
                 try await SystemProxyManager.shared.disableSystemProxy()
@@ -99,6 +98,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSUserInterfaceValidat
             } catch {
                 Self.logger.error("Quit: proxy restore failed — \(error.localizedDescription)")
             }
+            await RockxyWorkspaceWindowManager.shared.flushProjectStateForTermination()
             await MCPServerCoordinator.shared.stop()
             MCPHandshakeStore.delete()
             NSApplication.shared.reply(toApplicationShouldTerminate: true)

--- a/Rockxy/Core/Storage/ProjectCatalogRepository.swift
+++ b/Rockxy/Core/Storage/ProjectCatalogRepository.swift
@@ -280,6 +280,11 @@ actor ProjectCatalogRepository: ProjectCatalogPersisting {
         guard let type = fileType(at: fileURL) else {
             return
         }
+        // Validate the live node before touching the prior recovery copy. A
+        // malformed live directory must not destroy the last usable backup.
+        guard type == .typeRegular || type == .typeSymbolicLink else {
+            throw ProjectCatalogRepositoryError.notRegularFile
+        }
         if let recoveryType = fileType(at: recoveryBackupURL) {
             guard recoveryType == .typeRegular || recoveryType == .typeSymbolicLink else {
                 throw ProjectCatalogRepositoryError.notRegularFile
@@ -290,9 +295,6 @@ actor ProjectCatalogRepository: ProjectCatalogPersisting {
             // Explicit reset may remove the link itself, but never follows it.
             try fileManager.removeItem(at: fileURL)
             return
-        }
-        guard type == .typeRegular else {
-            throw ProjectCatalogRepositoryError.notRegularFile
         }
         let attributes = try fileManager.attributesOfItem(atPath: fileURL.path)
         if let size = attributes[.size] as? Int, size > Self.maxCatalogByteSize {

--- a/Rockxy/Models/Projects/ProjectNormalization.swift
+++ b/Rockxy/Models/Projects/ProjectNormalization.swift
@@ -103,7 +103,7 @@ enum ProjectNormalization {
     /// preserving the joining controls in ``allowedFormatScalars``.
     private static func isDisallowedScalar(_ scalar: Unicode.Scalar) -> Bool {
         switch scalar.properties.generalCategory {
-        case .control:
+        case .control, .lineSeparator, .paragraphSeparator:
             true
         case .format:
             !allowedFormatScalars.contains(scalar)

--- a/Rockxy/Models/Projects/ProjectStore.swift
+++ b/Rockxy/Models/Projects/ProjectStore.swift
@@ -530,8 +530,10 @@ final class ProjectStore {
             return
         }
         let snapshot = catalog
+        let previousTask = persistenceTask
         persistenceStatus = .saving
         persistenceTask = Task { @MainActor in
+            await previousTask?.value
             do {
                 try await repository.save(snapshot)
                 if catalog.revision == snapshot.revision {

--- a/Rockxy/Models/Projects/ProjectStructuralLimits.swift
+++ b/Rockxy/Models/Projects/ProjectStructuralLimits.swift
@@ -39,5 +39,8 @@ enum ProjectStructuralLimits {
     static let defaultProjectName = "My Project"
 
     /// Title of the guaranteed non-closable default tab.
-    static let defaultTabTitle = "All Traffic"
+    static let defaultTabTitle: String = {
+        let localized = String(localized: "All Traffic")
+        return (try? ProjectNormalization.normalizedDisplayName(localized)) ?? "All Traffic"
+    }()
 }

--- a/Rockxy/Models/UI/WorkspaceStore.swift
+++ b/Rockxy/Models/UI/WorkspaceStore.swift
@@ -14,7 +14,7 @@ final class WorkspaceStore {
         self.maxWorkspaces = Self.clampCreationCapacity(maxWorkspaces)
         self.layoutPreferences = layoutPreferences
         let defaultWorkspace = Self.makeWorkspace(
-            title: String(localized: "All Traffic"),
+            title: ProjectStructuralLimits.defaultTabTitle,
             isClosable: false,
             filter: .empty,
             layoutPreferences: layoutPreferences
@@ -65,15 +65,19 @@ final class WorkspaceStore {
             Self.logger.warning("Maximum workspace count (\(self.maxWorkspaces)) reached")
             return activeWorkspace
         }
+        guard let normalizedTitle = try? ProjectNormalization.normalizedDisplayName(title) else {
+            Self.logger.warning("Refused to create a workspace with an invalid title")
+            return activeWorkspace
+        }
         let workspace = Self.makeWorkspace(
-            title: title,
+            title: normalizedTitle,
             isClosable: true,
             filter: filter,
             layoutPreferences: layoutPreferences
         )
         workspaces.append(workspace)
         activeWorkspaceID = workspace.id
-        Self.logger.info("Created workspace: \(title)")
+        Self.logger.info("Created workspace: \(normalizedTitle)")
         return workspace
     }
 
@@ -163,8 +167,18 @@ final class WorkspaceStore {
         {
             return nil
         }
+        let suffix = " " + String(localized: "Copy")
+        let maximumBaseCount = max(
+            1,
+            ProjectStructuralLimits.nameGraphemeRange.upperBound - suffix.count
+        )
+        let candidateTitle = source.title.boundedToGraphemes(maximumBaseCount) + suffix
+        guard let normalizedTitle = try? ProjectNormalization.normalizedDisplayName(candidateTitle) else {
+            Self.logger.warning("Refused to duplicate a workspace with an invalid title")
+            return nil
+        }
         let duplicate = WorkspaceState(
-            title: source.title + " " + String(localized: "Copy"),
+            title: normalizedTitle,
             isClosable: true,
             initialFilter: source.filterCriteria
         )
@@ -198,10 +212,12 @@ final class WorkspaceStore {
     }
 
     func renameWorkspace(id: UUID, to newTitle: String) {
-        guard let workspace = workspaces.first(where: { $0.id == id }) else {
+        guard let workspace = workspaces.first(where: { $0.id == id }),
+              let normalizedTitle = try? ProjectNormalization.normalizedDisplayName(newTitle) else {
+            Self.logger.warning("Refused to rename a workspace with an invalid title")
             return
         }
-        workspace.title = newTitle
+        workspace.title = normalizedTitle
     }
 
     // MARK: Project snapshot seams
@@ -223,7 +239,7 @@ final class WorkspaceStore {
 
         if hydrated.isEmpty {
             hydrated = [Self.makeWorkspace(
-                title: String(localized: "All Traffic"),
+                title: ProjectStructuralLimits.defaultTabTitle,
                 isClosable: false,
                 filter: .empty,
                 layoutPreferences: layoutPreferences
@@ -231,7 +247,7 @@ final class WorkspaceStore {
         } else if !hydrated.contains(where: { !$0.isClosable }) {
             hydrated.insert(
                 Self.makeWorkspace(
-                    title: String(localized: "All Traffic"),
+                    title: ProjectStructuralLimits.defaultTabTitle,
                     isClosable: false,
                     filter: .empty,
                     layoutPreferences: layoutPreferences

--- a/Rockxy/Views/Main/Extensions/MainContentCoordinator+Import.swift
+++ b/Rockxy/Views/Main/Extensions/MainContentCoordinator+Import.swift
@@ -136,6 +136,15 @@ extension MainContentCoordinator {
         importPreview = nil
 
         Task { @MainActor in
+            guard await ensureProjectCatalogReadyForDataIntake() else {
+                showImportError(
+                    title: String(localized: "Import Unavailable"),
+                    message: String(
+                        localized: "Projects could not be loaded. Repair Projects before importing captured traffic."
+                    )
+                )
+                return
+            }
             switch preview.fileType {
             case .har:
                 await executeHARImport(from: preview.sourceURL, fileName: preview.fileName)

--- a/Rockxy/Views/Main/Extensions/MainContentCoordinator+Logs.swift
+++ b/Rockxy/Views/Main/Extensions/MainContentCoordinator+Logs.swift
@@ -68,12 +68,6 @@ extension MainContentCoordinator {
         } else {
             transactionsByProjectID[projectID] ?? []
         }
-        var projectLogs = if projectID == projectStore.activeProjectID {
-            logEntries
-        } else {
-            logEntriesByProjectID[projectID] ?? []
-        }
-
         if let correlatedId = LogCorrelator.correlate(
             logEntry: entry,
             with: projectTransactions
@@ -81,16 +75,22 @@ extension MainContentCoordinator {
             mutableEntry.correlatedTransactionId = correlatedId
         }
 
-        projectLogs.append(mutableEntry)
-
-        if projectLogs.count > settings.maxLogBufferSize {
-            let excess = projectLogs.count - settings.maxLogBufferSize
-            projectLogs.removeFirst(excess)
-            Self.logger.debug("Evicted \(excess) oldest log entries")
-        }
-        logEntriesByProjectID[projectID] = projectLogs
         if projectID == projectStore.activeProjectID {
-            logEntries = projectLogs
+            logEntries.append(mutableEntry)
+            if logEntries.count > settings.maxLogBufferSize {
+                let excess = logEntries.count - settings.maxLogBufferSize
+                logEntries.removeFirst(excess)
+                Self.logger.debug("Evicted \(excess) oldest log entries")
+            }
+        } else {
+            var projectLogs = logEntriesByProjectID[projectID] ?? []
+            projectLogs.append(mutableEntry)
+            if projectLogs.count > settings.maxLogBufferSize {
+                let excess = projectLogs.count - settings.maxLogBufferSize
+                projectLogs.removeFirst(excess)
+                Self.logger.debug("Evicted \(excess) oldest log entries")
+            }
+            logEntriesByProjectID[projectID] = projectLogs
         }
     }
 }

--- a/Rockxy/Views/Main/Extensions/MainContentCoordinator+NearbyTransfer.swift
+++ b/Rockxy/Views/Main/Extensions/MainContentCoordinator+NearbyTransfer.swift
@@ -40,7 +40,10 @@ extension MainContentCoordinator {
         transactionsByProjectID[projectStore.activeProjectID] = transactions
         nextSequenceNumberByProjectID[projectStore.activeProjectID] = nextSequenceNumber
         refreshDomainTree(for: destinationWorkspace)
-        destinationWorkspace.filteredTransactions = importedTransactions.filter { !$0.isTLSFailure }
+        let retainedTransactionIDs = Set(transactions.map(\.id))
+        destinationWorkspace.filteredTransactions = importedTransactions.filter {
+            retainedTransactionIDs.contains($0.id) && !$0.isTLSFailure
+        }
         destinationWorkspace.lastDeriveWasAppendOnly = false
         deriveFilteredRows(for: destinationWorkspace)
         rebuildObservedDomainsByApp()

--- a/Rockxy/Views/Main/Extensions/MainContentCoordinator+ProjectPresentation.swift
+++ b/Rockxy/Views/Main/Extensions/MainContentCoordinator+ProjectPresentation.swift
@@ -48,7 +48,9 @@ extension MainContentCoordinator {
             case .containsControlCharacters:
                 String(localized: "Project names cannot contain control characters.")
             case let .tooLong(count):
-                String(localized: "Project names are limited to 80 characters (received \(count)).")
+                String(
+                    localized: "Project names are limited to \(ProjectStructuralLimits.nameGraphemeRange.upperBound) characters (received \(count))."
+                )
             case .notCanonical:
                 String(localized: "The Project name is not in canonical Unicode form.")
             }

--- a/Rockxy/Views/Main/Extensions/MainContentCoordinator+ProjectTransfer.swift
+++ b/Rockxy/Views/Main/Extensions/MainContentCoordinator+ProjectTransfer.swift
@@ -139,9 +139,9 @@ extension MainContentCoordinator {
         Self.logger.error("Project transfer failed: \(String(describing: error))")
         let alert = NSAlert()
         alert.messageText = title
-        alert
-            .informativeText =
-            String(localized: "The Project configuration could not be processed safely. \(String(describing: error))")
+        alert.informativeText = String(
+            localized: "The Project configuration could not be processed safely. Verify the file and try again."
+        )
         alert.alertStyle = .warning
         alert.addButton(withTitle: String(localized: "OK"))
         alert.runModal()

--- a/Rockxy/Views/Main/Extensions/MainContentCoordinator+Projects.swift
+++ b/Rockxy/Views/Main/Extensions/MainContentCoordinator+Projects.swift
@@ -465,7 +465,9 @@ extension MainContentCoordinator {
         transactions = transactionsByProjectID[projectID] ?? []
         logEntries = logEntriesByProjectID[projectID] ?? []
         sessionProvenance = sessionProvenanceByProjectID[projectID]
-        nextSequenceNumber = (transactions.map(\.sequenceNumber).max() ?? -1) + 1
+        let maximumLiveSequence = transactions.map(\.sequenceNumber).max() ?? -1
+        let maximumFavoriteSequence = persistedFavorites.map(\.sequenceNumber).max() ?? -1
+        nextSequenceNumber = max(maximumLiveSequence, maximumFavoriteSequence) + 1
         nextSequenceNumberByProjectID[projectID] = nextSequenceNumber
         recomputeErrorCount()
         resetTrafficMetrics()

--- a/Rockxy/Views/Main/Extensions/MainContentCoordinator+ProxyControl.swift
+++ b/Rockxy/Views/Main/Extensions/MainContentCoordinator+ProxyControl.swift
@@ -486,8 +486,16 @@ extension MainContentCoordinator {
             nextSequenceNumberByProjectID[projectID] = sequence
 
             let overflow = max(0, history.count - liveHistoryLimit)
+            let evictionCount: Int
             if overflow > 0 {
-                history.removeFirst(overflow)
+                let evictionHeadroom = min(
+                    liveHistoryLimit,
+                    max(2, min(100, (liveHistoryLimit + 9) / 10))
+                )
+                evictionCount = min(history.count, max(overflow, evictionHeadroom))
+                history.removeFirst(evictionCount)
+            } else {
+                evictionCount = 0
             }
             transactionsByProjectID[projectID] = history
 
@@ -498,7 +506,7 @@ extension MainContentCoordinator {
 
             transactions = history
             nextSequenceNumber = sequence
-            if overflow > 0 {
+            if evictionCount > 0 {
                 rebuildObservedDomainsByApp()
                 debugAssistantTransactionsByHost.removeAll()
                 debugAssistantIndexedTransactionIDs.removeAll()

--- a/Rockxy/Views/Main/WorkspaceWindowManager.swift
+++ b/Rockxy/Views/Main/WorkspaceWindowManager.swift
@@ -627,7 +627,9 @@ private final class WorkspaceTabBarView: NSView, NSTextFieldDelegate {
             return
         }
 
-        endEditing(commit: true)
+        guard endEditing(commit: true) else {
+            return
+        }
         editingWorkspaceID = workspaceID
         originalTitle = workspace.title
 
@@ -648,28 +650,42 @@ private final class WorkspaceTabBarView: NSView, NSTextFieldDelegate {
         needsDisplay = true
     }
 
-    func endEditing(commit: Bool) {
+    @discardableResult
+    func endEditing(commit: Bool) -> Bool {
         guard let editingWorkspaceID,
               let field = editField else {
-            return
+            return true
         }
-        removeEditingMonitor()
 
-        let fallbackTitle = originalTitle
-        let committedTitle: String
+        var committedTitle = originalTitle
         if commit {
-            let trimmed = field.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
-            committedTitle = trimmed.isEmpty ? fallbackTitle : trimmed
-        } else {
-            committedTitle = fallbackTitle
+            do {
+                committedTitle = try ProjectNormalization.normalizedDisplayName(field.stringValue)
+            } catch let error as ProjectNameNormalizationError {
+                field.textColor = .systemRed
+                field.toolTip = inlineRenameErrorMessage(for: error)
+                NSSound.beep()
+                window?.makeFirstResponder(field)
+                return false
+            } catch {
+                field.textColor = .systemRed
+                field.toolTip = String(localized: "Enter a valid Traffic Tab name.")
+                NSSound.beep()
+                window?.makeFirstResponder(field)
+                return false
+            }
         }
 
+        removeEditingMonitor()
         self.editingWorkspaceID = nil
         originalTitle = ""
         editField = nil
         field.removeFromSuperview()
-        manager.renameWorkspace(editingWorkspaceID, to: committedTitle)
+        if commit {
+            manager.renameWorkspace(editingWorkspaceID, to: committedTitle)
+        }
         needsDisplay = true
+        return true
     }
 
     func controlTextDidEndEditing(_ notification: Notification) {
@@ -1388,8 +1404,22 @@ private final class WorkspaceTabBarView: NSView, NSTextFieldDelegate {
                 return event
             }
         }
-        endEditing(commit: true)
-        return event
+        return endEditing(commit: true) ? event : nil
+    }
+
+    private func inlineRenameErrorMessage(for error: ProjectNameNormalizationError) -> String {
+        switch error {
+        case .empty:
+            String(localized: "Enter a Traffic Tab name.")
+        case .containsControlCharacters:
+            String(localized: "Traffic Tab names cannot contain control characters.")
+        case let .tooLong(count):
+            String(
+                localized: "Traffic Tab names are limited to \(ProjectStructuralLimits.nameGraphemeRange.upperBound) characters (received \(count))."
+            )
+        case .notCanonical:
+            String(localized: "The Traffic Tab name is not in canonical Unicode form.")
+        }
     }
 
     @objc private func renameTabFromMenu(_ sender: NSMenuItem) {

--- a/Rockxy/Views/Projects/ProjectPresentation.swift
+++ b/Rockxy/Views/Projects/ProjectPresentation.swift
@@ -167,6 +167,7 @@ struct ProjectNameEditorSheet: View {
         self.context = context
         self.coordinator = coordinator
         _name = State(initialValue: context.initialName)
+        _operationErrorMessage = State(initialValue: nil)
     }
 
     let context: ProjectNameEditorContext
@@ -197,9 +198,12 @@ struct ProjectNameEditorSheet: View {
                     .font(.subheadline.weight(.medium))
                 TextField(String(localized: "For example: Checkout API"), text: $name)
                     .textFieldStyle(.roundedBorder)
-                Text(validationMessage ?? String(localized: "1–80 characters. Names must be unique."))
+                    .onChange(of: name) { _, _ in
+                        operationErrorMessage = nil
+                    }
+                Text(editorMessage)
                     .font(.caption)
-                    .foregroundStyle(validationMessage == nil ? Color.secondary : Color.orange)
+                    .foregroundStyle(hasEditorError ? Color.orange : Color.secondary)
             }
             .padding(18)
 
@@ -225,6 +229,19 @@ struct ProjectNameEditorSheet: View {
 
     @Environment(\.dismiss) private var dismiss
     @State private var name: String
+    @State private var operationErrorMessage: String?
+
+    private var editorMessage: String {
+        validationMessage
+            ?? operationErrorMessage
+            ?? String(
+                localized: "1–\(ProjectStructuralLimits.nameGraphemeRange.upperBound) characters. Names must be unique."
+            )
+    }
+
+    private var hasEditorError: Bool {
+        validationMessage != nil || operationErrorMessage != nil
+    }
 
     private var normalizedName: String? {
         try? ProjectNormalization.normalizedDisplayName(name)
@@ -258,6 +275,8 @@ struct ProjectNameEditorSheet: View {
             coordinator.renameProject(id: id, to: normalizedName)
         }
         guard succeeded else {
+            operationErrorMessage = coordinator.projectOperationErrorMessage
+                ?? String(localized: "The Project could not be updated. Try again.")
             return
         }
         RockxyWorkspaceWindowManager.shared.projectDidChange(coordinator: coordinator)
@@ -529,6 +548,7 @@ struct ProjectManagerSheet: View {
             .buttonStyle(.plain)
             .keyboardShortcut("n", modifiers: [.command, .shift])
             .help(String(localized: "New Project"))
+            .accessibilityLabel(String(localized: "New Project"))
             .disabled(!canCreateProject)
 
             Rectangle()
@@ -552,6 +572,7 @@ struct ProjectManagerSheet: View {
             }
             .buttonStyle(.plain)
             .help(String(localized: "Delete Project"))
+            .accessibilityLabel(String(localized: "Delete Project"))
             .disabled(!canDeleteSelectedProject)
         }
         .frame(
@@ -627,10 +648,8 @@ struct ProjectManagerSheet: View {
     }
 
     private func trafficTabCountText(_ count: Int) -> String {
-        if count == 1 {
-            return String(localized: "1 Traffic Tab")
-        }
-        return String(localized: "\(count) Traffic Tabs")
+        let inflected = AttributedString(localized: "^[\(count) Traffic Tab](inflect: true)")
+        return String(inflected.characters)
     }
 
     private func projectAccessibilityValue(_ project: Project) -> String {

--- a/RockxyTests/Core/Storage/ProjectCatalogRepositoryTests.swift
+++ b/RockxyTests/Core/Storage/ProjectCatalogRepositoryTests.swift
@@ -300,6 +300,23 @@ struct ProjectCatalogRepositoryTests {
         #expect(try Data(contentsOf: sentinel) == Data("keep".utf8))
     }
 
+    @Test("reset preserves an existing recovery backup when the live catalog is non-regular")
+    func resetKeepsRecoveryBackupWhenLiveCatalogIsInvalid() async throws {
+        let repo = makeRepo()
+        try FileManager.default.createDirectory(at: repo.directoryURL, withIntermediateDirectories: true)
+        let backupURL = repo.directoryURL.appendingPathComponent(ProjectCatalogRepository.recoveryBackupFileName)
+        let recoveryData = Data("previous recovery".utf8)
+        try recoveryData.write(to: backupURL)
+        try FileManager.default.createDirectory(at: repo.fileURL, withIntermediateDirectories: true)
+
+        await #expect(throws: ProjectCatalogRepositoryError.notRegularFile) {
+            try await repo.reset()
+        }
+
+        #expect(try Data(contentsOf: backupURL) == recoveryData)
+        #expect(FileManager.default.fileExists(atPath: repo.fileURL.path))
+    }
+
     @Test("reset refuses to recursively remove a non-regular recovery node")
     func resetPreservesNonRegularRecoveryNode() async throws {
         let repo = makeRepo()

--- a/RockxyTests/Models/Projects/ProjectNormalizationTests.swift
+++ b/RockxyTests/Models/Projects/ProjectNormalizationTests.swift
@@ -35,6 +35,12 @@ struct ProjectNormalizationTests {
         #expect(throws: ProjectNameNormalizationError.containsControlCharacters) {
             _ = try ProjectNormalization.normalizedDisplayName("Stag\u{0007}ing")
         }
+        #expect(throws: ProjectNameNormalizationError.containsControlCharacters) {
+            _ = try ProjectNormalization.normalizedDisplayName("Stag\u{2028}ing")
+        }
+        #expect(throws: ProjectNameNormalizationError.containsControlCharacters) {
+            _ = try ProjectNormalization.normalizedDisplayName("Stag\u{2029}ing")
+        }
     }
 
     @Test("rejects unsafe invisible and directional formatting characters")

--- a/RockxyTests/Models/Projects/ProjectStoreTests.swift
+++ b/RockxyTests/Models/Projects/ProjectStoreTests.swift
@@ -603,9 +603,7 @@ struct ProjectStoreTests {
         let store = ProjectStore(repository: repo, now: { Self.fixedDate })
         await store.loadPersistedCatalog()
         _ = try store.createProject(name: "Staging")
-        for _ in 0 ..< 1_000 where store.persistenceStatus != .saved {
-            await Task.yield()
-        }
+        await store.waitForPendingPersistence()
         #expect(await repo.lastSaved?.revision == 2)
         #expect(store.persistenceStatus == .saved)
     }
@@ -616,9 +614,7 @@ struct ProjectStoreTests {
         let store = ProjectStore(repository: repo, now: { Self.fixedDate })
         await store.loadPersistedCatalog()
         _ = try store.createProject(name: "Staging")
-        for _ in 0 ..< 1_000 where store.persistenceStatus == .saving || store.persistenceStatus == .idle {
-            await Task.yield()
-        }
+        await store.waitForPendingPersistence()
         #expect(store.persistenceStatus == .failed(String(describing: FakeError.boom)))
     }
 
@@ -705,9 +701,7 @@ private actor FakeCatalogRepository: ProjectCatalogPersisting {
 
     func reset() async throws -> ProjectCatalog {
         resetCount += 1
-        let fresh = ProjectCatalog.makeDefault(now: Date(timeIntervalSince1970: 1_000_000))
-        savedCatalogs.append(fresh)
-        return fresh
+        return ProjectCatalog.makeDefault(now: Date(timeIntervalSince1970: 1_000_000))
     }
 
     // MARK: Private

--- a/RockxyTests/Models/UI/WorkspaceStoreTests.swift
+++ b/RockxyTests/Models/UI/WorkspaceStoreTests.swift
@@ -28,6 +28,24 @@ struct WorkspaceStoreTests {
         #expect(ws.isClosable == true)
     }
 
+    @Test("Create workspace canonicalizes its title")
+    func createWorkspaceCanonicalizesTitle() {
+        let store = WorkspaceStore()
+        let workspace = store.createWorkspace(title: "  Cafe\u{0301}  ")
+
+        #expect(workspace.title == "Café")
+    }
+
+    @Test("Create workspace rejects an invalid title without changing tabs")
+    func createWorkspaceRejectsInvalidTitle() {
+        let store = WorkspaceStore()
+        let active = store.activeWorkspace
+        let returned = store.createWorkspace(title: "Bad\nTitle")
+
+        #expect(returned.id == active.id)
+        #expect(store.workspaces.count == 1)
+    }
+
     @Test("Create workspace with filter sets initial filter")
     func createWithFilter() {
         let store = WorkspaceStore()
@@ -251,6 +269,20 @@ struct WorkspaceStoreTests {
         #expect(store.activeWorkspaceID == copy.id)
     }
 
+    @Test("Duplicate keeps its generated title within the structural bound")
+    func duplicateWorkspaceBoundsGeneratedTitle() throws {
+        let store = WorkspaceStore()
+        let maximumTitle = String(
+            repeating: "a",
+            count: ProjectStructuralLimits.nameGraphemeRange.upperBound
+        )
+        let original = store.createWorkspace(title: maximumTitle)
+        let copy = try #require(store.duplicateWorkspace(id: original.id))
+
+        #expect(copy.title.count <= ProjectStructuralLimits.nameGraphemeRange.upperBound)
+        #expect(copy.title.hasSuffix(" Copy"))
+    }
+
     @Test("Duplicate inserts after source workspace")
     func duplicatePosition() throws {
         let store = WorkspaceStore()
@@ -289,11 +321,23 @@ struct WorkspaceStoreTests {
         #expect(ws.title == "New Name")
     }
 
+    @Test("Rename canonicalizes valid titles and rejects invalid titles")
+    func renameEnforcesTitleBoundary() {
+        let store = WorkspaceStore()
+        let workspace = store.createWorkspace(title: "Original")
+
+        store.renameWorkspace(id: workspace.id, to: "  Cafe\u{0301}  ")
+        #expect(workspace.title == "Café")
+
+        store.renameWorkspace(id: workspace.id, to: String(repeating: "x", count: 81))
+        #expect(workspace.title == "Café")
+    }
+
     @Test("Rename with invalid ID does nothing")
     func renameInvalid() {
         let store = WorkspaceStore()
         store.renameWorkspace(id: UUID(), to: "Ghost")
-        #expect(store.workspaces[0].title == String(localized: "All Traffic"))
+        #expect(store.workspaces[0].title == ProjectStructuralLimits.defaultTabTitle)
     }
 
     // MARK: - Active Workspace Computed Properties

--- a/RockxyTests/Views/Main/HistoryRetentionTests.swift
+++ b/RockxyTests/Views/Main/HistoryRetentionTests.swift
@@ -73,6 +73,27 @@ struct HistoryRetentionTests {
         #expect(coordinator.observedDomainsByApp[String(localized: "Unknown")]?.count == 20)
     }
 
+    @Test("Saturated capture evicts with headroom instead of rebuilding every batch")
+    @MainActor
+    func saturatedCaptureUsesEvictionHeadroom() {
+        let coordinator = MainContentCoordinator(policy: SmallHistoryPolicy())
+        coordinator.isRecording = true
+        coordinator.processActiveProjectTestBatch((0 ..< 10).map {
+            TestFixtures.makeTransaction(url: "https://example.com/\($0)")
+        })
+
+        coordinator.processActiveProjectTestBatch([
+            TestFixtures.makeTransaction(url: "https://example.com/10"),
+        ])
+        #expect(coordinator.transactions.count == 9)
+
+        coordinator.processActiveProjectTestBatch([
+            TestFixtures.makeTransaction(url: "https://example.com/11"),
+        ])
+        #expect(coordinator.transactions.count == 10)
+        #expect(coordinator.activeWorkspace.lastDeriveWasAppendOnly)
+    }
+
     @Test("Follow Live selects the newest request that survives the active view")
     @MainActor
     func followLiveSelectsNewestVisibleRequest() {

--- a/RockxyTests/Views/Main/NearbyTransferImportTests.swift
+++ b/RockxyTests/Views/Main/NearbyTransferImportTests.swift
@@ -57,4 +57,52 @@ struct NearbyTransferImportTests {
         #expect(coordinator.activeWorkspace.filteredTransactions.count == 1)
         #expect(coordinator.activeWorkspace.filteredTransactions.first?.request.host == "ios.example.com")
     }
+
+    @Test("Import never reintroduces transactions evicted by the live-history cap")
+    func importFiltersOnlyRetainedTransactions() async throws {
+        let coordinator = MainContentCoordinator(policy: SingleEntryHistoryPolicy())
+        let timestamp = ISO8601DateFormatter().string(from: Date())
+        let transferred = (0 ..< 3).map { index in
+            RockxyNearbyTransferSession.Transaction(
+                id: UUID().uuidString,
+                timestamp: timestamp,
+                request: .init(
+                    method: "GET",
+                    url: "https://ios.example.com/\(index)",
+                    headers: [:],
+                    body: nil,
+                    statusCode: nil,
+                    contentType: nil
+                ),
+                response: nil,
+                timing: nil,
+                clientApp: "Example iOS App"
+            )
+        }
+        let session = RockxyNearbyTransferSession(
+            version: "1",
+            metadata: .init(
+                title: "Bounded Import",
+                createdAt: timestamp,
+                appVersion: "1.0",
+                deviceName: "iPhone"
+            ),
+            transactions: transferred
+        )
+
+        try await coordinator.importNearbyTransfer(session, deviceName: "iPhone")
+
+        let retainedIDs = Set(coordinator.transactions.map(\.id))
+        #expect(coordinator.transactions.count == 1)
+        #expect(coordinator.activeWorkspace.filteredTransactions.count == 1)
+        #expect(coordinator.activeWorkspace.filteredTransactions.allSatisfy { retainedIDs.contains($0.id) })
+    }
+}
+
+private struct SingleEntryHistoryPolicy: AppPolicy {
+    let maxWorkspaceTabs = 8
+    let maxDomainFavorites = 5
+    let maxActiveRulesPerTool = 10
+    let maxEnabledScripts = 10
+    let maxLiveHistoryEntries = 1
 }

--- a/RockxyTests/Views/Main/ProjectCoordinationTests.swift
+++ b/RockxyTests/Views/Main/ProjectCoordinationTests.swift
@@ -347,6 +347,25 @@ struct ProjectCoordinationTests {
         #expect(coordinator.logEntries.first?.correlatedTransactionId == alphaTransaction.id)
     }
 
+    @Test("project switching advances live sequence numbers beyond persisted favorites")
+    func projectSwitchAccountsForFavoriteSequences() async {
+        let (catalog, alpha, beta) = Self.twoProjectCatalog()
+        let coordinator = MainContentCoordinator(
+            projectCatalogRepository: FakeProjectRepo(loadResult: .success(catalog))
+        )
+        await coordinator.hydrateProjectsOnLaunch()
+        let favorite = TestFixtures.makeTransaction(url: "https://favorite.example.com")
+        favorite.sequenceNumber = 100
+        coordinator.persistedFavorites = [favorite]
+
+        #expect(coordinator.switchToProject(id: beta.id))
+        #expect(coordinator.switchToProject(id: alpha.id))
+        let fresh = TestFixtures.makeTransaction(url: "https://alpha.example.com/fresh")
+        coordinator.processActiveProjectTestBatch([fresh])
+
+        #expect(fresh.sequenceNumber == 101)
+    }
+
     @Test("live traffic history is capped independently for every bounded Project")
     func perProjectHistoryIsBounded() async {
         let (catalog, alpha, beta) = Self.twoProjectCatalog()

--- a/docs/design-specs/main-window.md
+++ b/docs/design-specs/main-window.md
@@ -58,11 +58,11 @@ The primary application window — a 3-column developer debugging interface foll
 
 | Control | Icon (SF Symbol) | States | Shortcut | Priority |
 |---------|-----------------|--------|----------|----------|
+| Project Selector | `folder.fill` | Active Project menu | — | High |
 | Start/Stop | `play.fill` / `stop.fill` | Toggle | ⌘⇧R / ⌘. | High |
-| Record | `record.circle` / `record.circle.fill` | Toggle, red when active | ⌘⇧E | High |
-| Clear | `trash` | Enabled when sessions > 0 | ⌘K | Medium |
-| Inspector | `rectangle.split.1x2` | Toggle visibility | — | Medium |
-| Orientation | `rectangle.split.2x1` | Toggle H/V split | — | Low |
+| Developer Hub | `command` | Opens tool launcher | — | Medium |
+| Bottom Inspector | `rectangle.split.1x2` | Toggle visibility | — | Medium |
+| Context Dock | `sidebar.trailing` | Toggle visibility | — | Medium |
 
 ### Project Selector (Leading)
 - Appears immediately after the sidebar tracking separator.

--- a/docs/features/workspaces.mdx
+++ b/docs/features/workspaces.mdx
@@ -7,8 +7,8 @@ description: "Project-owned tabs that present one Project capture through indepe
 
 A Traffic Tab is an independent view onto its Project's traffic history. Each tab keeps its own filters and inspector layout, but every tab in that Project reads the **same underlying Project capture**. Switching tabs never changes where traffic is recorded.
 
-<Frame caption="Multiple workspace tabs in the main window">
-  <img src="/images/features/DemoMultipleTabWorkingSpace.png" alt="Workspace tabs" />
+<Frame caption="Multiple Traffic Tabs in the main window">
+  <img src="/images/features/DemoMultipleTabWorkingSpace.png" alt="Traffic Tabs" />
 </Frame>
 
 ## Why Traffic Tabs
@@ -30,8 +30,8 @@ Per-tab runtime state:
 - Sidebar selection (domain, app, or favorite)
 - Inspector tab and layout (right / bottom / hidden)
 - Selected request and selected log entry
-- Per-workspace sort descriptors
-- Per-workspace domain tree, app nodes, and grouping index
+- Per-Traffic-Tab sort descriptors
+- Per-Traffic-Tab domain tree, app nodes, and grouping index
 
 Shared by the Traffic Tabs inside one Project:
 
@@ -74,11 +74,11 @@ Keep your default **All Traffic** tab unchanged. In a second tab, set a filter r
 
 ### Replay and compare
 
-When focusing on a specific app or domain, use the sidebar context menu **Open in New Tab** to spawn a fresh workspace filtered to that source. The replayed flow then lands next to its source request rather than buried in the global list.
+When focusing on a specific app or domain, use the sidebar context menu **Open in New Tab** to create a fresh Traffic Tab filtered to that source. The replayed flow then lands next to its source request rather than buried in the global list.
 
 ## Per-tab sort
 
-Sorting is a workspace preference, not a window preference. Sort the **Errors** tab by `Duration ↓` to surface the worst offenders, leave the default tab sorted by `Time ↑`, and the two views stay independent. Sorts persist across `Clear Session` so you do not have to re-pick every time.
+Sorting is a Traffic Tab preference, not a window preference. Sort the **Errors** tab by `Duration ↓` to surface the worst offenders, leave the default tab sorted by `Time ↑`, and the two views stay independent. Sorts persist across `Clear Session` so you do not have to re-pick every time.
 
 ## Eviction and per-tab views
 
@@ -95,7 +95,7 @@ When a Project's in-memory history reaches its configured cap, its oldest entrie
 
 <CardGroup cols={2}>
   <Card title="Keyboard Shortcuts" icon="keyboard" href="/customization/keyboard-shortcuts">
-    All workspace and inspector shortcuts in one table.
+    All Traffic Tab and inspector shortcuts in one table.
   </Card>
   <Card title="Sessions and Export" icon="floppy-disk" href="/features/sessions">
     Save, load, and export the active Project's captured traffic.


### PR DESCRIPTION
## Summary

Hardens project lifecycle, capture retention, import readiness, recovery, and management UI behavior identified during review of the project-management release.

## Changes

- Preserve ordered project persistence and validate recovery state before removing backups
- Normalize project and tab names at model boundaries with bounded duplicate naming
- Gate confirmed imports on project readiness and isolate nearby-transfer data to retained transactions
- Preserve favorite sequence ordering across project switches
- Amortize saturated capture-history trimming while maintaining strict capacity limits
- Restore the system proxy before waiting for final project persistence during termination
- Keep project and inline rename UI active with clear validation and accessibility feedback
- Align public documentation with the current Project and Traffic Tab terminology

## Validation

- `swiftlint lint --strict`
- `git diff --check`
- Focused project, persistence, transfer, history, and coordination test suites
- Debug application build
- Full test suite exercised; an unrelated timing-sensitive BreakpointManager test failed in the combined run and passed on immediate isolated rerun

Refs #10