### PR TITLE
feat(ui): adopt native Liquid Glass across Rockxy

### DIFF
--- a/Rockxy/AppDelegate.swift
+++ b/Rockxy/AppDelegate.swift
@@ -91,7 +91,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSUserInterfaceValidat
 
         Self.logger.info("Rockxy terminating — cleaning up system proxy")
         Task {
-            await RockxyWorkspaceWindowManager.shared.flushProjectStateForTermination()
             Self.logger.info("Quit: starting proxy restore")
             do {
                 try await SystemProxyManager.shared.disableSystemProxy()
@@ -99,6 +98,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSUserInterfaceValidat
             } catch {
                 Self.logger.error("Quit: proxy restore failed — \(error.localizedDescription)")
             }
+            await RockxyWorkspaceWindowManager.shared.flushProjectStateForTermination()
             await MCPServerCoordinator.shared.stop()
             MCPHandshakeStore.delete()
             NSApplication.shared.reply(toApplicationShouldTerminate: true)

--- a/Rockxy/ContentView.swift
+++ b/Rockxy/ContentView.swift
@@ -94,7 +94,7 @@ struct ContentView: View {
         } inspector: {
             ContextDockView(
                 coordinator: coordinator,
-                onOpenSettings: openSettings.callAsFunction
+                onOpenSettings: { openWindow(id: "settings") }
             )
         }
         .frame(
@@ -262,8 +262,13 @@ struct ContentView: View {
 
     // MARK: Private
 
+    private static let workspaceSplitAutosaveName = RockxyIdentity.current.defaultsKey(
+        // Establish compact utility panes once, then preserve every user-adjusted divider
+        // position normally again.
+        "nativeWorkspaceSplit.compactUtilityPanes.v1"
+    )
+
     @Environment(\.openWindow) private var openWindow
-    @Environment(\.openSettings) private var openSettings
     @Bindable private var coordinator: MainContentCoordinator
     @State private var nearbyTransferReceiver = RockxyNearbyTransferReceiver.shared
     @State private var isSidebarPresented = true
@@ -271,26 +276,6 @@ struct ContentView: View {
     private let settingsManager = AppSettingsManager.shared
     private let managesLifecycle: Bool
     private let representedWorkspaceID: UUID?
-
-    @ViewBuilder
-    private var toastOverlay: some View {
-        if let toast = coordinator.activeToast {
-            ToastView(message: toast) {
-                coordinator.dismissToast(id: toast.id)
-            }
-            .id(toast.id)
-            .padding(.horizontal, 16)
-            .padding(.bottom, 24)
-            .allowsHitTesting(false)
-            .zIndex(100)
-        }
-    }
-
-    private static let workspaceSplitAutosaveName = RockxyIdentity.current.defaultsKey(
-        // Establish compact utility panes once, then preserve every user-adjusted divider
-        // position normally again.
-        "nativeWorkspaceSplit.compactUtilityPanes.v1"
-    )
 
     private var displayMetrics: AppUIDisplayMetrics {
         AppUIDisplayMetrics(settings: settingsManager.appUI)
@@ -310,12 +295,26 @@ struct ContentView: View {
         return String(localized: "Receive from \(invitation.deviceName)?")
     }
 
+    @ViewBuilder private var toastOverlay: some View {
+        if let toast = coordinator.activeToast {
+            ToastView(message: toast) {
+                coordinator.dismissToast(id: toast.id)
+            }
+            .id(toast.id)
+            .padding(.horizontal, 16)
+            .padding(.bottom, 24)
+            .allowsHitTesting(false)
+            .zIndex(100)
+        }
+    }
+
     private func handleSystemProxyWarningAction(_ action: SystemProxyWarning.Action?) {
         switch action {
         case .retry:
             coordinator.retrySystemProxy()
         case .openGeneralSettings:
-            openSettings()
+            RockxySettingsTab.select(.general)
+            openWindow(id: "settings")
         case .openAdvancedProxySettings:
             openWindow(id: "advancedProxySettings")
         case .reinstallAndTrust:

--- a/Rockxy/Core/Storage/ProjectCatalogRepository.swift
+++ b/Rockxy/Core/Storage/ProjectCatalogRepository.swift
@@ -280,6 +280,11 @@ actor ProjectCatalogRepository: ProjectCatalogPersisting {
         guard let type = fileType(at: fileURL) else {
             return
         }
+        // Validate the live node before touching the prior recovery copy. A
+        // malformed live directory must not destroy the last usable backup.
+        guard type == .typeRegular || type == .typeSymbolicLink else {
+            throw ProjectCatalogRepositoryError.notRegularFile
+        }
         if let recoveryType = fileType(at: recoveryBackupURL) {
             guard recoveryType == .typeRegular || recoveryType == .typeSymbolicLink else {
                 throw ProjectCatalogRepositoryError.notRegularFile
@@ -290,9 +295,6 @@ actor ProjectCatalogRepository: ProjectCatalogPersisting {
             // Explicit reset may remove the link itself, but never follows it.
             try fileManager.removeItem(at: fileURL)
             return
-        }
-        guard type == .typeRegular else {
-            throw ProjectCatalogRepositoryError.notRegularFile
         }
         let attributes = try fileManager.attributesOfItem(atPath: fileURL.path)
         if let size = attributes[.size] as? Int, size > Self.maxCatalogByteSize {

--- a/Rockxy/Models/Projects/ProjectNormalization.swift
+++ b/Rockxy/Models/Projects/ProjectNormalization.swift
@@ -103,7 +103,7 @@ enum ProjectNormalization {
     /// preserving the joining controls in ``allowedFormatScalars``.
     private static func isDisallowedScalar(_ scalar: Unicode.Scalar) -> Bool {
         switch scalar.properties.generalCategory {
-        case .control:
+        case .control, .lineSeparator, .paragraphSeparator:
             true
         case .format:
             !allowedFormatScalars.contains(scalar)

--- a/Rockxy/Models/Projects/ProjectStore.swift
+++ b/Rockxy/Models/Projects/ProjectStore.swift
@@ -530,8 +530,10 @@ final class ProjectStore {
             return
         }
         let snapshot = catalog
+        let previousTask = persistenceTask
         persistenceStatus = .saving
         persistenceTask = Task { @MainActor in
+            await previousTask?.value
             do {
                 try await repository.save(snapshot)
                 if catalog.revision == snapshot.revision {

--- a/Rockxy/Models/Projects/ProjectStructuralLimits.swift
+++ b/Rockxy/Models/Projects/ProjectStructuralLimits.swift
@@ -39,5 +39,8 @@ enum ProjectStructuralLimits {
     static let defaultProjectName = "My Project"
 
     /// Title of the guaranteed non-closable default tab.
-    static let defaultTabTitle = "All Traffic"
+    static let defaultTabTitle: String = {
+        let localized = String(localized: "All Traffic")
+        return (try? ProjectNormalization.normalizedDisplayName(localized)) ?? "All Traffic"
+    }()
 }

--- a/Rockxy/Models/UI/AppUIDisplayMetrics.swift
+++ b/Rockxy/Models/UI/AppUIDisplayMetrics.swift
@@ -4,11 +4,15 @@ import SwiftUI
 // MARK: - AppUIDisplayMetrics
 
 struct AppUIDisplayMetrics: Equatable {
-    let settings: AppUISettings
+    // MARK: Lifecycle
 
     init(settings: AppUISettings = .default) {
         self.settings = settings
     }
+
+    // MARK: Internal
+
+    let settings: AppUISettings
 
     var fontSize: CGFloat {
         CGFloat(settings.fontSize)
@@ -165,7 +169,9 @@ struct AppUIDisplayMetrics: Equatable {
         size: CGFloat,
         weight: Font.Weight = .regular,
         monospaced: Bool = false
-    ) -> Font {
+    )
+        -> Font
+    {
         if monospaced || settings.useMonospacedFont {
             return .system(size: size, weight: weight, design: .monospaced)
         }
@@ -220,11 +226,15 @@ struct BottomInspectorLayoutMetrics: Equatable {
 // MARK: - DeveloperSetupDisplayMetrics
 
 struct DeveloperSetupDisplayMetrics: Equatable {
-    let appMetrics: AppUIDisplayMetrics
+    // MARK: Lifecycle
 
     init(appMetrics: AppUIDisplayMetrics = AppUIDisplayMetrics()) {
         self.appMetrics = appMetrics
     }
+
+    // MARK: Internal
+
+    let appMetrics: AppUIDisplayMetrics
 
     var titleFontSize: CGFloat {
         max(15, appMetrics.primaryFontSize + 5)
@@ -296,11 +306,15 @@ struct DeveloperSetupDisplayMetrics: Equatable {
 // MARK: - ToolWindowDisplayMetrics
 
 struct ToolWindowDisplayMetrics: Equatable {
-    let appMetrics: AppUIDisplayMetrics
+    // MARK: Lifecycle
 
     init(appMetrics: AppUIDisplayMetrics = AppUIDisplayMetrics()) {
         self.appMetrics = appMetrics
     }
+
+    // MARK: Internal
+
+    let appMetrics: AppUIDisplayMetrics
 
     var bodyFontSize: CGFloat {
         appMetrics.primaryFontSize
@@ -485,35 +499,34 @@ struct SettingsDisplayMetrics: Equatable {
     // panes stay usable at 13 / 20 / 28pt without clipping or forcing a tiny sidebar.
 
     var sidebarMinWidth: CGFloat {
-        max(196, bodyFontSize * 6 + 118)
+        max(200, bodyFontSize * 5 + 130)
     }
 
     var sidebarIdealWidth: CGFloat {
-        sidebarMinWidth
+        max(220, sidebarMinWidth)
     }
 
     var sidebarMaxWidth: CGFloat {
-        sidebarMinWidth + 96
+        max(280, sidebarIdealWidth + 60)
     }
 
     var contentMinWidth: CGFloat {
-        // Accommodates the widest shared label + 420pt field row, section
-        // insets, and the standalone 640pt GitHub guidance block.
-        max(700, labelWidth + 16 + 420 + contentPadding * 2 + 24)
+        // Rows reflow vertically when a label plus control no longer fits.
+        // Keep the same compact working width as Developer Setup instead of
+        // forcing every Settings pane to accommodate its widest field.
+        max(600, bodyFontSize * 8 + 496)
     }
 
     var windowMinWidth: CGFloat {
-        sidebarMinWidth + contentMinWidth
+        max(820, sidebarMinWidth + contentMinWidth)
     }
 
     var windowIdealWidth: CGFloat {
-        windowMinWidth + 132
+        max(1_000, windowMinWidth + 140)
     }
 
     var windowMinHeight: CGFloat {
-        // Panes scroll vertically, so the minimum stays usable on compact
-        // displays even when Rockxy's app font is set to 28pt.
-        max(500, bodyFontSize * 6 + 382)
+        max(560, bodyFontSize * 5 + 430)
     }
 
     var windowIdealHeight: CGFloat {
@@ -539,11 +552,15 @@ struct SettingsDisplayMetrics: Equatable {
     }
 
     var contentPadding: CGFloat {
-        28
+        20
+    }
+
+    var contentMaxWidth: CGFloat {
+        max(820, bodyFontSize * 10 + 680)
     }
 
     var labelWidth: CGFloat {
-        max(160, bodyFontSize * 8 + 56)
+        max(136, bodyFontSize * 6 + 58)
     }
 
     var wideLabelWidth: CGFloat {
@@ -551,7 +568,11 @@ struct SettingsDisplayMetrics: Equatable {
     }
 
     var rowLeading: CGFloat {
-        labelWidth + 16
+        labelWidth + fieldSpacing
+    }
+
+    var fieldSpacing: CGFloat {
+        14
     }
 
     var controlHeight: CGFloat {
@@ -590,18 +611,16 @@ struct SettingsDisplayMetrics: Equatable {
         }
         return .system(size: metadataFontSize, weight: weight)
     }
+
+    func sectionTitleFont() -> Font {
+        font(weight: .semibold)
+    }
 }
 
 // MARK: - InspectorTextEditorSettings
 
 struct InspectorTextEditorSettings: Equatable, Sendable {
-    var fontSize: Int = AppUISettings.defaultFontSize
-    var tabWidth: Int = AppUISettings.defaultTabWidth
-    var useMonospacedFont = false
-    var wordWrap = true
-    var showInvisibles = false
-    var showMinimap = false
-    var scrollBeyondLastLine = false
+    // MARK: Lifecycle
 
     init(
         fontSize: Int = AppUISettings.defaultFontSize,
@@ -632,6 +651,16 @@ struct InspectorTextEditorSettings: Equatable, Sendable {
             scrollBeyondLastLine: appUI.bodyScrollBeyondLastLine
         )
     }
+
+    // MARK: Internal
+
+    var fontSize: Int = AppUISettings.defaultFontSize
+    var tabWidth: Int = AppUISettings.defaultTabWidth
+    var useMonospacedFont = false
+    var wordWrap = true
+    var showInvisibles = false
+    var showMinimap = false
+    var scrollBeyondLastLine = false
 
     var cgFontSize: CGFloat {
         CGFloat(fontSize)
@@ -671,16 +700,16 @@ extension View {
 // MARK: - AppUIDisplayMetricsProvider
 
 struct AppUIDisplayMetricsProvider<Content: View>: View {
-    let content: Content
+    // MARK: Internal
 
-    init(@ViewBuilder content: () -> Content) {
-        self.content = content()
-    }
+    @ViewBuilder let content: Content
 
     var body: some View {
         content
             .appUIDisplayMetrics(AppUIDisplayMetrics(settings: settingsManager.appUI))
     }
+
+    // MARK: Private
 
     private let settingsManager = AppSettingsManager.shared
 }
@@ -688,11 +717,7 @@ struct AppUIDisplayMetricsProvider<Content: View>: View {
 // MARK: - ToolWindowDisplayMetricsProvider
 
 struct ToolWindowDisplayMetricsProvider<Content: View>: View {
-    let content: Content
-
-    init(@ViewBuilder content: () -> Content) {
-        self.content = content()
-    }
+    @ViewBuilder let content: Content
 
     var body: some View {
         AppUIDisplayMetricsProvider {
@@ -703,17 +728,19 @@ struct ToolWindowDisplayMetricsProvider<Content: View>: View {
     }
 }
 
-private struct ToolWindowReadableContent<Content: View>: View {
-    let content: Content
+// MARK: - ToolWindowReadableContent
 
-    init(@ViewBuilder content: () -> Content) {
-        self.content = content()
-    }
+private struct ToolWindowReadableContent<Content: View>: View {
+    // MARK: Internal
+
+    @ViewBuilder let content: Content
 
     var body: some View {
         content
             .font(toolMetrics.font())
     }
+
+    // MARK: Private
 
     @Environment(\.appUIDisplayMetrics) private var appMetrics
 

--- a/Rockxy/Models/UI/AppUIDisplayMetrics.swift
+++ b/Rockxy/Models/UI/AppUIDisplayMetrics.swift
@@ -707,10 +707,15 @@ struct AppUIDisplayMetricsProvider<Content: View>: View {
     var body: some View {
         content
             .appUIDisplayMetrics(AppUIDisplayMetrics(settings: settingsManager.appUI))
+            .environment(
+                \.colorScheme,
+                settingsManager.appTheme.resolvedColorScheme(inheriting: inheritedColorScheme)
+            )
     }
 
     // MARK: Private
 
+    @Environment(\.colorScheme) private var inheritedColorScheme
     private let settingsManager = AppSettingsManager.shared
 }
 

--- a/Rockxy/Models/UI/FocusNavigatorState.swift
+++ b/Rockxy/Models/UI/FocusNavigatorState.swift
@@ -16,6 +16,17 @@ enum FocusNavigatorMode: String, CaseIterable, Identifiable {
         case .library: String(localized: "Library")
         }
     }
+
+    /// Monochrome symbols keep the compact navigator switcher aligned with Xcode's native
+    /// navigator and inspector controls. The localized title remains the help and accessibility
+    /// label, so the icon-only presentation never removes meaning.
+    var systemImage: String {
+        switch self {
+        case .browse: "list.bullet.rectangle"
+        case .focus: "scope"
+        case .library: "books.vertical"
+        }
+    }
 }
 
 // MARK: - TrafficSignal

--- a/Rockxy/Models/UI/WorkspaceStore.swift
+++ b/Rockxy/Models/UI/WorkspaceStore.swift
@@ -14,7 +14,7 @@ final class WorkspaceStore {
         self.maxWorkspaces = Self.clampCreationCapacity(maxWorkspaces)
         self.layoutPreferences = layoutPreferences
         let defaultWorkspace = Self.makeWorkspace(
-            title: String(localized: "All Traffic"),
+            title: ProjectStructuralLimits.defaultTabTitle,
             isClosable: false,
             filter: .empty,
             layoutPreferences: layoutPreferences
@@ -65,15 +65,19 @@ final class WorkspaceStore {
             Self.logger.warning("Maximum workspace count (\(self.maxWorkspaces)) reached")
             return activeWorkspace
         }
+        guard let normalizedTitle = try? ProjectNormalization.normalizedDisplayName(title) else {
+            Self.logger.warning("Refused to create a workspace with an invalid title")
+            return activeWorkspace
+        }
         let workspace = Self.makeWorkspace(
-            title: title,
+            title: normalizedTitle,
             isClosable: true,
             filter: filter,
             layoutPreferences: layoutPreferences
         )
         workspaces.append(workspace)
         activeWorkspaceID = workspace.id
-        Self.logger.info("Created workspace: \(title)")
+        Self.logger.info("Created workspace: \(normalizedTitle)")
         return workspace
     }
 
@@ -163,8 +167,18 @@ final class WorkspaceStore {
         {
             return nil
         }
+        let suffix = " " + String(localized: "Copy")
+        let maximumBaseCount = max(
+            1,
+            ProjectStructuralLimits.nameGraphemeRange.upperBound - suffix.count
+        )
+        let candidateTitle = source.title.boundedToGraphemes(maximumBaseCount) + suffix
+        guard let normalizedTitle = try? ProjectNormalization.normalizedDisplayName(candidateTitle) else {
+            Self.logger.warning("Refused to duplicate a workspace with an invalid title")
+            return nil
+        }
         let duplicate = WorkspaceState(
-            title: source.title + " " + String(localized: "Copy"),
+            title: normalizedTitle,
             isClosable: true,
             initialFilter: source.filterCriteria
         )
@@ -198,10 +212,12 @@ final class WorkspaceStore {
     }
 
     func renameWorkspace(id: UUID, to newTitle: String) {
-        guard let workspace = workspaces.first(where: { $0.id == id }) else {
+        guard let workspace = workspaces.first(where: { $0.id == id }),
+              let normalizedTitle = try? ProjectNormalization.normalizedDisplayName(newTitle) else {
+            Self.logger.warning("Refused to rename a workspace with an invalid title")
             return
         }
-        workspace.title = newTitle
+        workspace.title = normalizedTitle
     }
 
     // MARK: Project snapshot seams
@@ -223,7 +239,7 @@ final class WorkspaceStore {
 
         if hydrated.isEmpty {
             hydrated = [Self.makeWorkspace(
-                title: String(localized: "All Traffic"),
+                title: ProjectStructuralLimits.defaultTabTitle,
                 isClosable: false,
                 filter: .empty,
                 layoutPreferences: layoutPreferences
@@ -231,7 +247,7 @@ final class WorkspaceStore {
         } else if !hydrated.contains(where: { !$0.isClosable }) {
             hydrated.insert(
                 Self.makeWorkspace(
-                    title: String(localized: "All Traffic"),
+                    title: ProjectStructuralLimits.defaultTabTitle,
                     isClosable: false,
                     filter: .empty,
                     layoutPreferences: layoutPreferences

--- a/Rockxy/RockxyApp.swift
+++ b/Rockxy/RockxyApp.swift
@@ -5,7 +5,7 @@ import SwiftUI
 import UniformTypeIdentifiers
 
 // Application entry point. Declares the main window scene with `ContentView`,
-// the macOS `Settings` scene, and the full set of custom menu bar commands.
+// the native Settings utility window, and the full set of custom menu bar commands.
 
 // MARK: - AppLifecycleState
 
@@ -97,6 +97,8 @@ struct RockxyApp: App {
 
         developerSetupWindow
 
+        settingsWindow
+
         macCertificateSetupGuideWindow
 
         customCertificatesWindow
@@ -131,6 +133,7 @@ struct RockxyApp: App {
         .commandsRemoved()
         .windowResizability(.contentSize)
         .defaultPosition(.center)
+        .windowToolbarStyle(.unifiedCompact)
 
         Window(String(localized: "Map Local Editor"), id: "mapLocalEditor") {
             ToolWindowDisplayMetricsProvider {
@@ -141,6 +144,7 @@ struct RockxyApp: App {
         .defaultSize(width: 960, height: 640)
         .defaultPosition(.center)
         .windowResizability(.contentSize)
+        .windowToolbarStyle(.unifiedCompact)
 
         Window(String(localized: "Map Remote"), id: "mapRemote") {
             ToolWindowDisplayMetricsProvider {
@@ -161,6 +165,7 @@ struct RockxyApp: App {
         .defaultSize(width: 834, height: 584)
         .defaultPosition(.center)
         .windowResizability(.contentSize)
+        .windowToolbarStyle(.unifiedCompact)
 
         Window(String(localized: "Block List"), id: "blockList") {
             ToolWindowDisplayMetricsProvider {
@@ -180,6 +185,7 @@ struct RockxyApp: App {
         .commandsRemoved()
         .windowResizability(.contentSize)
         .defaultPosition(.center)
+        .windowToolbarStyle(.unifiedCompact)
 
         Window(String(localized: "Network Conditions"), id: "networkConditions") {
             ToolWindowDisplayMetricsProvider {
@@ -362,14 +368,6 @@ struct RockxyApp: App {
         composeWindow
 
         detachedInspectorWindow
-
-        Settings {
-            AppUIDisplayMetricsProvider {
-                SettingsView()
-            }
-        }
-        .windowResizability(.contentMinSize)
-        .windowToolbarStyle(.unifiedCompact)
     }
 
     // MARK: Private
@@ -382,6 +380,10 @@ struct RockxyApp: App {
 
     private var developerSetupWindow: some Scene {
         DeveloperSetupWindowScene(coordinator: mainCoordinator)
+    }
+
+    private var settingsWindow: some Scene {
+        SettingsWindowScene()
     }
 
     private var macCertificateSetupGuideWindow: some Scene {
@@ -741,7 +743,7 @@ struct RockxyMenuCommands: Commands {
             }
         }
 
-        CommandGroup(before: .appSettings) {
+        CommandGroup(replacing: .appSettings) {
             Button(String(localized: "Check for Updates…")) {
                 updater.checkForUpdates()
             }
@@ -754,6 +756,11 @@ struct RockxyMenuCommands: Commands {
             }
 
             Divider()
+
+            Button(String(localized: "Settings…")) {
+                openWindow(id: "settings")
+            }
+            .keyboardShortcut(",", modifiers: .command)
         }
     }
 

--- a/Rockxy/Theme/LiquidGlass.swift
+++ b/Rockxy/Theme/LiquidGlass.swift
@@ -1,0 +1,289 @@
+import AppKit
+import SwiftUI
+
+// MARK: - LiquidGlassRenderingPolicy
+
+/// Pure, testable policy that decides how a Rockxy glass surface should render.
+///
+/// The resolver deliberately avoids `#available` checks and SwiftUI environment reads so every
+/// combination can be unit-tested. Callers pass the runtime facts (macOS 26 availability plus the
+/// two accessibility preferences) and the resolver returns a single deterministic decision.
+enum LiquidGlassRenderingPolicy {
+    /// The rendering treatment selected for a glass surface.
+    enum Decision: Equatable {
+        /// Native macOS 26 Liquid Glass — only when the API exists and no accessibility preference
+        /// forces an opaque surface.
+        case liquidGlass
+        /// System material fallback on older supported systems when accessibility does not require
+        /// opacity.
+        case systemMaterial
+        /// Deterministic opaque system color when Reduce Transparency or Increase Contrast is on.
+        case opaqueColor
+    }
+
+    /// Resolves the rendering decision from the current runtime facts.
+    ///
+    /// Accessibility wins first: if either Reduce Transparency or Increase Contrast is on, the
+    /// surface is opaque regardless of macOS version. Otherwise Liquid Glass is used when available,
+    /// falling back to system material on older systems.
+    static func resolve(
+        liquidGlassAvailable: Bool,
+        reduceTransparency: Bool,
+        increaseContrast: Bool
+    )
+        -> Decision
+    {
+        if reduceTransparency || increaseContrast {
+            return .opaqueColor
+        }
+        return liquidGlassAvailable ? .liquidGlass : .systemMaterial
+    }
+}
+
+// MARK: - RockxyGlassEffectGroup
+
+/// Availability-safe grouping for nearby Liquid Glass controls.
+///
+/// macOS 26 shares one sampling region across the group so adjacent glass controls render
+/// consistently. Earlier releases keep the same layout and use each control's material fallback.
+struct RockxyGlassEffectGroup<Content: View>: View {
+    // MARK: Lifecycle
+
+    init(spacing: CGFloat? = nil, @ViewBuilder content: () -> Content) {
+        self.spacing = spacing
+        self.content = content()
+    }
+
+    // MARK: Internal
+
+    var body: some View {
+        if #available(macOS 26.0, *) {
+            GlassEffectContainer(spacing: spacing) {
+                content
+            }
+        } else {
+            content
+        }
+    }
+
+    // MARK: Private
+
+    private let spacing: CGFloat?
+    private let content: Content
+}
+
+// MARK: - Liquid Glass compatibility
+
+extension View {
+    /// Applies Liquid Glass to a custom functional surface while preserving Rockxy's macOS 14
+    /// deployment target. The rendering treatment is chosen by ``LiquidGlassRenderingPolicy`` from
+    /// the live SwiftUI accessibility environment: Liquid Glass on macOS 26 when no accessibility
+    /// preference forces opacity, system material on older systems, and a deterministic opaque
+    /// system color whenever Reduce Transparency or Increase Contrast is on.
+    func rockxyGlassEffect(
+        tint: Color? = nil,
+        interactive: Bool = false,
+        in shape: some InsettableShape
+    )
+        -> some View
+    {
+        modifier(RockxyGlassEffectModifier(tint: tint, interactive: interactive, shape: shape))
+    }
+
+    /// Uses the native Liquid Glass button family on macOS 26 and standard bordered controls on
+    /// older supported systems. Callers retain their existing control size and accessibility.
+    @ViewBuilder
+    func rockxyGlassButtonStyle(prominent: Bool = false) -> some View {
+        if #available(macOS 26.0, *) {
+            if prominent {
+                buttonStyle(.glassProminent)
+            } else {
+                buttonStyle(.glass)
+            }
+        } else if prominent {
+            buttonStyle(.borderedProminent)
+        } else {
+            buttonStyle(.bordered)
+        }
+    }
+
+    /// Applies Rockxy's readable semantic-chip treatment. Chips intentionally remain a tinted,
+    /// high-contrast status surface rather than becoming tiny nested glass islands. Active and
+    /// hover states use a tint wash plus stroke, so accent color never replaces the label.
+    func rockxyChipStyle(
+        tint: Color = .accentColor,
+        isActive: Bool = false,
+        isHovered: Bool = false,
+        isEnabled: Bool = true
+    )
+        -> some View
+    {
+        modifier(RockxyChipModifier(
+            tint: tint,
+            isActive: isActive,
+            isHovered: isHovered,
+            isEnabled: isEnabled
+        ))
+    }
+
+    /// Gives an edge-attached header or footer the native macOS bar material. This is for fixed
+    /// functional chrome around opaque tables/editors; it deliberately does not create a custom
+    /// floating glass container or add padding that could disturb tool-window geometry.
+    func rockxyFunctionalBar() -> some View {
+        background(.bar)
+    }
+}
+
+// MARK: - RockxyChipModifier
+
+private struct RockxyChipModifier: ViewModifier {
+    let tint: Color
+    let isActive: Bool
+    let isHovered: Bool
+    let isEnabled: Bool
+
+    func body(content: Content) -> some View {
+        content
+            .foregroundStyle(foregroundColor)
+            .background(fillColor, in: Capsule(style: .continuous))
+            .overlay {
+                Capsule(style: .continuous)
+                    .strokeBorder(strokeColor, lineWidth: colorSchemeContrast == .increased ? 1 : 0.75)
+                    .allowsHitTesting(false)
+            }
+            .contentShape(Capsule(style: .continuous))
+            .opacity(isEnabled ? 1 : 0.45)
+    }
+
+    @Environment(\.colorSchemeContrast) private var colorSchemeContrast
+
+    private var foregroundColor: Color {
+        isActive ? tint : .primary
+    }
+
+    private var fillColor: Color {
+        if isActive {
+            return tint.opacity(
+                isHovered ? Theme.Glass.semanticHoverFillOpacity : Theme.Glass.semanticFillOpacity
+            )
+        }
+        return Color.primary.opacity(isHovered ? Theme.Glass.hoverFillOpacity : Theme.Glass.neutralFillOpacity)
+    }
+
+    private var strokeColor: Color {
+        if isActive {
+            return tint.opacity(
+                isHovered ? Theme.Glass.semanticHoverStrokeOpacity : Theme.Glass.semanticStrokeOpacity
+            )
+        }
+        return Color.primary.opacity(
+            colorSchemeContrast == .increased
+                ? Theme.Glass.semanticStrokeOpacity
+                : Theme.Glass.neutralStrokeOpacity
+        )
+    }
+}
+
+// MARK: - RockxyGlassEffectModifier
+
+/// Reads the SwiftUI accessibility environment, resolves the rendering decision via
+/// ``LiquidGlassRenderingPolicy``, and applies the matching surface treatment.
+private struct RockxyGlassEffectModifier<S: InsettableShape>: ViewModifier {
+    // MARK: Internal
+
+    let tint: Color?
+    let interactive: Bool
+    let shape: S
+
+    func body(content: Content) -> some View {
+        content.rockxyGlassRendering(
+            LiquidGlassRenderingPolicy.resolve(
+                liquidGlassAvailable: Self.isLiquidGlassAvailable,
+                reduceTransparency: reduceTransparency,
+                increaseContrast: colorSchemeContrast == .increased
+            ),
+            tint: tint,
+            interactive: interactive,
+            in: shape
+        )
+    }
+
+    // MARK: Private
+
+    private static var isLiquidGlassAvailable: Bool {
+        if #available(macOS 26.0, *) {
+            return true
+        }
+        return false
+    }
+
+    @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
+    @Environment(\.colorSchemeContrast) private var colorSchemeContrast
+}
+
+// MARK: - Rendering treatments
+
+private extension View {
+    @ViewBuilder
+    func rockxyGlassRendering(
+        _ decision: LiquidGlassRenderingPolicy.Decision,
+        tint: Color?,
+        interactive: Bool,
+        in shape: some InsettableShape
+    )
+        -> some View
+    {
+        switch decision {
+        case .liquidGlass:
+            if #available(macOS 26.0, *) {
+                glassEffect(
+                    Glass.regular
+                        .tint(tint)
+                        .interactive(interactive),
+                    in: shape
+                )
+            } else {
+                rockxyMaterialSurface(tint: tint, in: shape)
+            }
+        case .systemMaterial:
+            rockxyMaterialSurface(tint: tint, in: shape)
+        case .opaqueColor:
+            rockxyOpaqueSurface(tint: tint, in: shape)
+        }
+    }
+
+    /// System material fallback — the closest system-managed translucency for older systems.
+    @ViewBuilder
+    func rockxyMaterialSurface(tint: Color?, in shape: some InsettableShape) -> some View {
+        if let tint {
+            background(tint.opacity(Theme.Glass.fallbackTintOpacity), in: shape)
+                .overlay {
+                    shape.strokeBorder(tint.opacity(Theme.Glass.fallbackStrokeOpacity), lineWidth: 0.5)
+                }
+        } else {
+            background(.regularMaterial, in: shape)
+                .overlay {
+                    shape.strokeBorder(Color.primary.opacity(Theme.Glass.neutralStrokeOpacity), lineWidth: 0.5)
+                }
+        }
+    }
+
+    /// Deterministic opaque fallback for Reduce Transparency / Increase Contrast. The opaque system
+    /// window color forms the base so the surface never reads as translucent, while the same tint
+    /// wash and stroke keep tint behavior and shape identical to the material path.
+    func rockxyOpaqueSurface(tint: Color?, in shape: some InsettableShape) -> some View {
+        background(Color(nsColor: .windowBackgroundColor), in: shape)
+            .overlay {
+                if let tint {
+                    shape.fill(tint.opacity(Theme.Glass.fallbackTintOpacity))
+                }
+            }
+            .overlay {
+                shape.strokeBorder(
+                    tint?.opacity(Theme.Glass.fallbackStrokeOpacity)
+                        ?? Color.primary.opacity(Theme.Glass.neutralStrokeOpacity),
+                    lineWidth: 0.5
+                )
+            }
+    }
+}

--- a/Rockxy/Theme/LiquidGlass.swift
+++ b/Rockxy/Theme/LiquidGlass.swift
@@ -40,6 +40,18 @@ enum LiquidGlassRenderingPolicy {
     }
 }
 
+// MARK: - LiquidGlassAppearanceIdentity
+
+/// Identity for native glass instances whose sampled tone is retained by AppKit across an
+/// in-place appearance transition. Changing any appearance input deliberately recreates the
+/// native effect instead of letting a Light material survive inside a Dark hierarchy (or vice
+/// versa).
+struct LiquidGlassAppearanceIdentity: Hashable {
+    let isDark: Bool
+    let reduceTransparency: Bool
+    let increaseContrast: Bool
+}
+
 // MARK: - RockxyGlassEffectGroup
 
 /// Availability-safe grouping for nearby Liquid Glass controls.
@@ -61,6 +73,7 @@ struct RockxyGlassEffectGroup<Content: View>: View {
             GlassEffectContainer(spacing: spacing) {
                 content
             }
+            .id(appearanceIdentity)
         } else {
             content
         }
@@ -70,6 +83,18 @@ struct RockxyGlassEffectGroup<Content: View>: View {
 
     private let spacing: CGFloat?
     private let content: Content
+
+    @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
+    @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.colorSchemeContrast) private var colorSchemeContrast
+
+    private var appearanceIdentity: LiquidGlassAppearanceIdentity {
+        LiquidGlassAppearanceIdentity(
+            isDark: colorScheme == .dark,
+            reduceTransparency: reduceTransparency,
+            increaseContrast: colorSchemeContrast == .increased
+        )
+    }
 }
 
 // MARK: - Liquid Glass compatibility
@@ -92,19 +117,8 @@ extension View {
 
     /// Uses the native Liquid Glass button family on macOS 26 and standard bordered controls on
     /// older supported systems. Callers retain their existing control size and accessibility.
-    @ViewBuilder
     func rockxyGlassButtonStyle(prominent: Bool = false) -> some View {
-        if #available(macOS 26.0, *) {
-            if prominent {
-                buttonStyle(.glassProminent)
-            } else {
-                buttonStyle(.glass)
-            }
-        } else if prominent {
-            buttonStyle(.borderedProminent)
-        } else {
-            buttonStyle(.bordered)
-        }
+        modifier(RockxyGlassButtonStyleModifier(prominent: prominent))
     }
 
     /// Applies Rockxy's readable semantic-chip treatment. Chips intentionally remain a tinted,
@@ -126,11 +140,102 @@ extension View {
         ))
     }
 
-    /// Gives an edge-attached header or footer the native macOS bar material. This is for fixed
-    /// functional chrome around opaque tables/editors; it deliberately does not create a custom
-    /// floating glass container or add padding that could disturb tool-window geometry.
+    /// Gives a compact header or footer the native macOS floating functional material. On macOS 26
+    /// this is real Liquid Glass, so shared feature-window chrome gains refraction and specular
+    /// response instead of remaining a flat `.bar` blur.
+    /// Accessibility preferences and earlier macOS releases retain the deterministic fallbacks
+    /// used by every other Rockxy glass surface.
     func rockxyFunctionalBar() -> some View {
-        background(.bar)
+        modifier(RockxyFunctionalBarModifier())
+    }
+}
+
+// MARK: - RockxyFunctionalBarModifier
+
+/// Turns the dozens of compact feature-window bars into one coherent floating functional layer.
+/// The small outer inset lets surrounding content remain visible beneath the glass. Native glass
+/// owns its optical edge and elevation; adding a painted stroke or shadow here would flatten the
+/// adaptive highlight that distinguishes Liquid Glass from a translucent rounded rectangle.
+private struct RockxyFunctionalBarModifier: ViewModifier {
+    func body(content: Content) -> some View {
+        let shape = RoundedRectangle(
+            cornerRadius: Theme.Glass.functionalBarCornerRadius,
+            style: .continuous
+        )
+
+        content
+            .rockxyGlassRendering(
+                LiquidGlassRenderingPolicy.resolve(
+                    liquidGlassAvailable: Self.isLiquidGlassAvailable,
+                    reduceTransparency: reduceTransparency,
+                    increaseContrast: colorSchemeContrast == .increased
+                ),
+                tint: nil,
+                interactive: false,
+                in: shape
+            )
+            .id(appearanceIdentity)
+            .padding(.horizontal, Theme.Glass.functionalBarHorizontalInset)
+            .padding(.vertical, Theme.Glass.functionalBarVerticalInset)
+    }
+
+    @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
+    @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.colorSchemeContrast) private var colorSchemeContrast
+
+    private var appearanceIdentity: LiquidGlassAppearanceIdentity {
+        LiquidGlassAppearanceIdentity(
+            isDark: colorScheme == .dark,
+            reduceTransparency: reduceTransparency,
+            increaseContrast: colorSchemeContrast == .increased
+        )
+    }
+
+    private static var isLiquidGlassAvailable: Bool {
+        if #available(macOS 26.0, *) {
+            return true
+        }
+        return false
+    }
+}
+
+// MARK: - RockxyGlassButtonStyleModifier
+
+/// Native glass controls can retain their previous sampled tone through an in-place app theme
+/// change. Keying the styled control to the live appearance inputs keeps buttons aligned with the
+/// surrounding glass surface without changing their state or accessibility contract otherwise.
+private struct RockxyGlassButtonStyleModifier: ViewModifier {
+    let prominent: Bool
+
+    @ViewBuilder
+    func body(content: Content) -> some View {
+        if #available(macOS 26.0, *) {
+            if prominent {
+                content
+                    .buttonStyle(.glassProminent)
+                    .id(appearanceIdentity)
+            } else {
+                content
+                    .buttonStyle(.glass)
+                    .id(appearanceIdentity)
+            }
+        } else if prominent {
+            content.buttonStyle(.borderedProminent)
+        } else {
+            content.buttonStyle(.bordered)
+        }
+    }
+
+    @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
+    @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.colorSchemeContrast) private var colorSchemeContrast
+
+    private var appearanceIdentity: LiquidGlassAppearanceIdentity {
+        LiquidGlassAppearanceIdentity(
+            isDark: colorScheme == .dark,
+            reduceTransparency: reduceTransparency,
+            increaseContrast: colorSchemeContrast == .increased
+        )
     }
 }
 
@@ -206,6 +311,7 @@ private struct RockxyGlassEffectModifier<S: InsettableShape>: ViewModifier {
             interactive: interactive,
             in: shape
         )
+        .id(appearanceIdentity)
     }
 
     // MARK: Private
@@ -218,7 +324,16 @@ private struct RockxyGlassEffectModifier<S: InsettableShape>: ViewModifier {
     }
 
     @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
+    @Environment(\.colorScheme) private var colorScheme
     @Environment(\.colorSchemeContrast) private var colorSchemeContrast
+
+    private var appearanceIdentity: LiquidGlassAppearanceIdentity {
+        LiquidGlassAppearanceIdentity(
+            isDark: colorScheme == .dark,
+            reduceTransparency: reduceTransparency,
+            increaseContrast: colorSchemeContrast == .increased
+        )
+    }
 }
 
 // MARK: - Rendering treatments

--- a/Rockxy/Theme/LiquidGlass.swift
+++ b/Rockxy/Theme/LiquidGlass.swift
@@ -69,6 +69,7 @@ struct RockxyGlassEffectGroup<Content: View>: View {
     // MARK: Internal
 
     var body: some View {
+        #if compiler(>=6.2)
         if #available(macOS 26.0, *) {
             GlassEffectContainer(spacing: spacing) {
                 content
@@ -77,6 +78,9 @@ struct RockxyGlassEffectGroup<Content: View>: View {
         } else {
             content
         }
+        #else
+        content
+        #endif
     }
 
     // MARK: Private
@@ -192,9 +196,11 @@ private struct RockxyFunctionalBarModifier: ViewModifier {
     }
 
     private static var isLiquidGlassAvailable: Bool {
+        #if compiler(>=6.2)
         if #available(macOS 26.0, *) {
             return true
         }
+        #endif
         return false
     }
 }
@@ -209,6 +215,7 @@ private struct RockxyGlassButtonStyleModifier: ViewModifier {
 
     @ViewBuilder
     func body(content: Content) -> some View {
+        #if compiler(>=6.2)
         if #available(macOS 26.0, *) {
             if prominent {
                 content
@@ -224,6 +231,13 @@ private struct RockxyGlassButtonStyleModifier: ViewModifier {
         } else {
             content.buttonStyle(.bordered)
         }
+        #else
+        if prominent {
+            content.buttonStyle(.borderedProminent)
+        } else {
+            content.buttonStyle(.bordered)
+        }
+        #endif
     }
 
     @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
@@ -317,9 +331,11 @@ private struct RockxyGlassEffectModifier<S: InsettableShape>: ViewModifier {
     // MARK: Private
 
     private static var isLiquidGlassAvailable: Bool {
+        #if compiler(>=6.2)
         if #available(macOS 26.0, *) {
             return true
         }
+        #endif
         return false
     }
 
@@ -350,6 +366,7 @@ private extension View {
     {
         switch decision {
         case .liquidGlass:
+            #if compiler(>=6.2)
             if #available(macOS 26.0, *) {
                 glassEffect(
                     Glass.regular
@@ -360,6 +377,9 @@ private extension View {
             } else {
                 rockxyMaterialSurface(tint: tint, in: shape)
             }
+            #else
+            rockxyMaterialSurface(tint: tint, in: shape)
+            #endif
         case .systemMaterial:
             rockxyMaterialSurface(tint: tint, in: shape)
         case .opaqueColor:

--- a/Rockxy/Theme/Theme.swift
+++ b/Rockxy/Theme/Theme.swift
@@ -110,9 +110,45 @@ enum Theme {
 
     enum FilterPill {
         static let activeBackground = Color.accentColor.opacity(0.15)
-        static let activeForeground = Color.accentColor
+        static let activeForeground = Color.primary
         static let inactiveBackground = Color.clear
         static let inactiveForeground = Color.secondary
+    }
+
+    // MARK: - Liquid Glass
+
+    /// Shared geometry and fallback treatments for the top-level functional layer.
+    /// Keep these values centralized so custom glass surfaces remain visually related
+    /// and their macOS 14/accessibility fallbacks don't drift apart.
+    enum Glass {
+        static let shelfCornerRadius: CGFloat = 16
+        static let shelfInset: CGFloat = 6
+        static let shelfOuterPadding: CGFloat = 10
+        static let shelfSectionSpacing: CGFloat = 2
+        static let fallbackTintOpacity = 0.15
+        static let fallbackStrokeOpacity = 0.28
+        static let neutralStrokeOpacity = 0.10
+        static let activeStrokeOpacity = 0.55
+        static let activeFillOpacity = 0.13
+        static let neutralFillOpacity = 0.06
+        static let hoverFillOpacity = 0.10
+        static let semanticFillOpacity = 0.14
+        static let semanticHoverFillOpacity = 0.20
+        static let semanticStrokeOpacity = 0.34
+        static let semanticHoverStrokeOpacity = 0.52
+        static let ambientAccentOpacity = 0.20
+        static let ambientSecondaryOpacity = 0.08
+        static let separatorOpacity = 0.55
+        static let shelfStrokeOpacity = 0.20
+        static let shelfShadowOpacity = 0.24
+        static let shelfShadowRadius: CGFloat = 12
+        static let shelfShadowY: CGFloat = 4
+        static let toastCornerRadius: CGFloat = 14
+        static let toastHorizontalPadding: CGFloat = 16
+        static let toastVerticalPadding: CGFloat = 10
+        static let toastShadowOpacity = 0.14
+        static let toastShadowRadius: CGFloat = 10
+        static let toastShadowY: CGFloat = 3
     }
 
     // MARK: - Status Bar

--- a/Rockxy/Theme/Theme.swift
+++ b/Rockxy/Theme/Theme.swift
@@ -6,15 +6,81 @@ import SwiftUI
 // MARK: - AppThemeApplier
 
 /// Applies the user's theme preference (system / light / dark) to all app windows.
+@MainActor
 enum AppThemeApplier {
     static func apply(_ theme: String) {
-        switch theme {
+        let appearance: NSAppearance? = switch theme {
         case "light":
-            NSApp.appearance = NSAppearance(named: .aqua)
+            NSAppearance(named: .aqua)
         case "dark":
-            NSApp.appearance = NSAppearance(named: .darkAqua)
+            NSAppearance(named: .darkAqua)
         default:
-            NSApp.appearance = nil
+            nil
+        }
+
+        NSApp.appearance = appearance
+        refreshExistingWindowChrome(with: appearance)
+
+        // SwiftUI owns the views hosted by NSToolbarItems and can finish its update after this
+        // settings action returns. Refresh once more on the next main-loop turn so an existing
+        // Light toolbar cannot survive inside a window whose content has already changed to Dark
+        // (or vice versa).
+        DispatchQueue.main.async {
+            refreshExistingWindowChrome(with: appearance)
+        }
+    }
+
+    /// Rebinds AppKit chrome that is hosted outside the SwiftUI content hierarchy. SwiftUI toolbar
+    /// hosts can retain their previous explicit appearance even after the window changes theme, so
+    /// app-selected themes must be applied directly to every hosted toolbar view. `nil` keeps the
+    /// System setting live and inherited.
+    static func refreshWindowChrome(_ window: NSWindow, appearance: NSAppearance?) {
+        window.appearance = appearance
+        window.contentView?.appearance = nil
+        window.contentView?.needsLayout = true
+        window.contentView?.needsDisplay = true
+
+        guard let toolbar = window.toolbar else {
+            return
+        }
+
+        let itemViews = (toolbar.items + (toolbar.visibleItems ?? [])).compactMap(\.view)
+        for view in itemViews {
+            refreshToolbarView(view, appearance: appearance)
+        }
+        toolbar.validateVisibleItems()
+    }
+
+    private static func refreshExistingWindowChrome(with appearance: NSAppearance?) {
+        for window in NSApp.windows {
+            refreshWindowChrome(window, appearance: appearance)
+        }
+    }
+
+    static func refreshToolbarView(_ view: NSView, appearance: NSAppearance?) {
+        view.appearance = appearance
+        view.needsLayout = true
+        view.needsDisplay = true
+        for subview in view.subviews {
+            refreshToolbarView(subview, appearance: appearance)
+        }
+    }
+}
+
+// MARK: - AppTheme SwiftUI Presentation
+
+extension AppTheme {
+    /// Resolves the app override without consulting the process-wide system setting from a
+    /// toolbar host. SwiftUI may create that host outside the scene's presentation boundary, so
+    /// the resolved scheme is injected as a normal environment value by every scene provider.
+    func resolvedColorScheme(inheriting colorScheme: ColorScheme) -> ColorScheme {
+        switch self {
+        case .system:
+            colorScheme
+        case .light:
+            .light
+        case .dark:
+            .dark
         }
     }
 }
@@ -124,7 +190,13 @@ enum Theme {
         static let shelfCornerRadius: CGFloat = 16
         static let shelfInset: CGFloat = 6
         static let shelfOuterPadding: CGFloat = 10
-        static let shelfSectionSpacing: CGFloat = 2
+        static let shelfSectionSpacing: CGFloat = 7
+        static let footerCornerRadius: CGFloat = 13
+        static let footerOuterHorizontalPadding: CGFloat = 8
+        static let footerOuterVerticalPadding: CGFloat = 6
+        static let functionalBarCornerRadius: CGFloat = 12
+        static let functionalBarHorizontalInset: CGFloat = 7
+        static let functionalBarVerticalInset: CGFloat = 5
         static let fallbackTintOpacity = 0.15
         static let fallbackStrokeOpacity = 0.28
         static let neutralStrokeOpacity = 0.10
@@ -139,16 +211,9 @@ enum Theme {
         static let ambientAccentOpacity = 0.20
         static let ambientSecondaryOpacity = 0.08
         static let separatorOpacity = 0.55
-        static let shelfStrokeOpacity = 0.20
-        static let shelfShadowOpacity = 0.24
-        static let shelfShadowRadius: CGFloat = 12
-        static let shelfShadowY: CGFloat = 4
         static let toastCornerRadius: CGFloat = 14
         static let toastHorizontalPadding: CGFloat = 16
         static let toastVerticalPadding: CGFloat = 10
-        static let toastShadowOpacity = 0.14
-        static let toastShadowRadius: CGFloat = 10
-        static let toastShadowY: CGFloat = 3
     }
 
     // MARK: - Status Bar

--- a/Rockxy/Views/BabylonCapture/BabylonPairingView.swift
+++ b/Rockxy/Views/BabylonCapture/BabylonPairingView.swift
@@ -288,6 +288,7 @@ struct BabylonPairingView: View {
         .padding(.horizontal, toolMetrics.contentHorizontalPadding)
         .padding(.top, toolMetrics.headerTopPadding)
         .padding(.bottom, toolMetrics.headerBottomPadding)
+        .rockxyFunctionalBar()
     }
 
     // MARK: - Connection
@@ -488,6 +489,7 @@ struct BabylonPairingView: View {
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(.horizontal, toolMetrics.contentHorizontalPadding)
             .padding(.vertical, toolMetrics.footerTopPadding)
+            .rockxyFunctionalBar()
     }
 
     private func detailLabel(_ label: String) -> some View {

--- a/Rockxy/Views/BabylonCapture/BabylonRuntimeView.swift
+++ b/Rockxy/Views/BabylonCapture/BabylonRuntimeView.swift
@@ -219,6 +219,7 @@ struct BabylonRuntimeView: View {
         .padding(.horizontal, toolMetrics.contentHorizontalPadding)
         .padding(.top, toolMetrics.headerTopPadding)
         .padding(.bottom, toolMetrics.headerBottomPadding)
+        .rockxyFunctionalBar()
     }
 
     private var searchField: some View {
@@ -485,6 +486,7 @@ struct BabylonRuntimeView: View {
         }
         .padding(.horizontal, toolMetrics.contentHorizontalPadding)
         .padding(.vertical, toolMetrics.footerTopPadding)
+        .rockxyFunctionalBar()
     }
 
     private func kindCell(for event: BabylonRuntimeEvent) -> some View {

--- a/Rockxy/Views/Breakpoint/BreakpointEditorView.swift
+++ b/Rockxy/Views/Breakpoint/BreakpointEditorView.swift
@@ -686,6 +686,7 @@ struct BreakpointEditorView: View {
                     savePendingTemplate()
                 }
                 .keyboardShortcut(.defaultAction)
+                .rockxyGlassButtonStyle(prominent: true)
                 .disabled(!validation.isValid)
             }
         }

--- a/Rockxy/Views/Breakpoint/BreakpointRuleEditorWindowView.swift
+++ b/Rockxy/Views/Breakpoint/BreakpointRuleEditorWindowView.swift
@@ -94,6 +94,7 @@ struct BreakpointRuleEditorWindowView: View {
                         )
                     }
                     .keyboardShortcut(.defaultAction)
+                    .rockxyGlassButtonStyle(prominent: true)
                     .disabled(!isValid || isSaving)
                 }
             }

--- a/Rockxy/Views/Breakpoint/BreakpointRuleRow.swift
+++ b/Rockxy/Views/Breakpoint/BreakpointRuleRow.swift
@@ -56,10 +56,9 @@ struct BreakpointRuleRow: View {
         }()
         return Text(label)
             .font(.system(size: toolMetrics.smallIconFontSize, weight: .bold, design: .monospaced))
-            .foregroundStyle(.white)
             .padding(.horizontal, 4)
             .padding(.vertical, 1)
-            .background(Color.purple, in: Capsule())
+            .rockxyChipStyle(tint: .purple, isActive: true, isEnabled: true)
     }
 
     private var toolMetrics: ToolWindowDisplayMetrics {

--- a/Rockxy/Views/Breakpoint/BreakpointRulesWindowView.swift
+++ b/Rockxy/Views/Breakpoint/BreakpointRulesWindowView.swift
@@ -664,7 +664,7 @@ struct BreakpointRulesWindowView: View {
             }
         }
         .menuIndicator(.hidden)
-        .buttonStyle(.bordered)
+        .rockxyGlassButtonStyle()
         .fixedSize()
     }
 

--- a/Rockxy/Views/Breakpoint/BreakpointRulesWindowView.swift
+++ b/Rockxy/Views/Breakpoint/BreakpointRulesWindowView.swift
@@ -427,6 +427,7 @@ struct BreakpointRulesWindowView: View {
         }
         .padding(.horizontal, toolMetrics.contentHorizontalPadding)
         .padding(.vertical, toolMetrics.headerTopPadding)
+        .rockxyFunctionalBar()
     }
 
     private var infoBanner: some View {
@@ -574,6 +575,7 @@ struct BreakpointRulesWindowView: View {
         }
         .padding(.horizontal, toolMetrics.contentHorizontalPadding)
         .padding(.vertical, toolMetrics.footerTopPadding)
+        .rockxyFunctionalBar()
     }
 
     private var compactAddRemoveControl: some View {
@@ -669,22 +671,9 @@ struct BreakpointRulesWindowView: View {
     private var statusCapsule: some View {
         Text(statusText)
             .font(toolMetrics.secondaryFont(weight: .semibold))
-            .foregroundStyle(viewModel.isBreakpointToolEnabled ? Color.accentColor : Color.secondary)
             .padding(.horizontal, 9)
             .frame(height: toolMetrics.footerControlHeight)
-            .background(
-                (viewModel.isBreakpointToolEnabled ? Color.accentColor : Color.secondary)
-                    .opacity(0.1)
-            )
-            .clipShape(Capsule())
-            .overlay {
-                Capsule()
-                    .stroke(
-                        (viewModel.isBreakpointToolEnabled ? Color.accentColor : Color.secondary)
-                            .opacity(0.25),
-                        lineWidth: 1
-                    )
-            }
+            .rockxyChipStyle(isActive: viewModel.isBreakpointToolEnabled)
     }
 
     private var enableDisableLabel: String {

--- a/Rockxy/Views/Breakpoint/BreakpointTemplateWindowView.swift
+++ b/Rockxy/Views/Breakpoint/BreakpointTemplateWindowView.swift
@@ -257,7 +257,7 @@ struct BreakpointTemplateWindowView: View {
             }
         }
         .menuIndicator(.hidden)
-        .buttonStyle(.bordered)
+        .rockxyGlassButtonStyle()
         .fixedSize()
     }
 

--- a/Rockxy/Views/Breakpoint/BreakpointTemplateWindowView.swift
+++ b/Rockxy/Views/Breakpoint/BreakpointTemplateWindowView.swift
@@ -95,6 +95,7 @@ struct BreakpointTemplateWindowView: View {
             .padding(.horizontal, toolMetrics.contentHorizontalPadding)
             .padding(.top, toolMetrics.headerTopPadding)
             .padding(.bottom, toolMetrics.headerBottomPadding)
+            .rockxyFunctionalBar()
 
             Divider()
 
@@ -176,6 +177,7 @@ struct BreakpointTemplateWindowView: View {
         }
         .padding(.horizontal, toolMetrics.contentHorizontalPadding)
         .padding(.vertical, toolMetrics.footerTopPadding)
+        .rockxyFunctionalBar()
     }
 
     private var compactAddRemoveControl: some View {
@@ -310,6 +312,7 @@ struct BreakpointTemplateWindowView: View {
         }
         .padding(.horizontal, toolMetrics.contentHorizontalPadding)
         .padding(.vertical, toolMetrics.headerTopPadding)
+        .rockxyFunctionalBar()
     }
 
     private var infoBanner: some View {
@@ -420,6 +423,7 @@ struct BreakpointTemplateWindowView: View {
         }
         .padding(.horizontal, toolMetrics.contentHorizontalPadding)
         .padding(.vertical, toolMetrics.footerTopPadding)
+        .rockxyFunctionalBar()
     }
 
     private var filteredTemplates: [BreakpointTemplate] {

--- a/Rockxy/Views/Breakpoint/BreakpointWindowView.swift
+++ b/Rockxy/Views/Breakpoint/BreakpointWindowView.swift
@@ -206,6 +206,7 @@ struct BreakpointWindowView: View {
         .frame(minHeight: toolMetrics.footerControlHeight)
         .padding(.horizontal, 12)
         .padding(.vertical, 7)
+        .rockxyFunctionalBar()
     }
 
     private var editor: some View {
@@ -245,14 +246,14 @@ struct BreakpointWindowView: View {
                     .frame(minWidth: 180)
             }
             .keyboardShortcut(.return, modifiers: .command)
-            .buttonStyle(.borderedProminent)
+            .rockxyGlassButtonStyle(prominent: true)
             .help(applyButtonHelp)
             .disabled(!canApplySelection)
         }
         .controlSize(.regular)
         .padding(.horizontal, 14)
         .padding(.vertical, 10)
-        .background(Color(nsColor: .windowBackgroundColor))
+        .rockxyFunctionalBar()
     }
 
     private var moreMenu: some View {

--- a/Rockxy/Views/Certificate/CertificateStatusPanel.swift
+++ b/Rockxy/Views/Certificate/CertificateStatusPanel.swift
@@ -290,77 +290,91 @@ struct CertificateStatusPanel: View {
     }
 
     private var actionRow: some View {
-        HStack(spacing: 8) {
-            if isLoading {
-                ProgressView()
-                    .controlSize(.small)
+        ViewThatFits(in: .horizontal) {
+            HStack(spacing: 8) {
+                actionButtons
             }
 
-            switch state {
-            case .notAvailable:
-                Button(String(localized: "Generate New\u{2026}")) {
-                    onAction(.generate)
-                }
-                .disabled(isLoading)
-
-            case .generatedOnly:
-                Button(String(localized: "Install & Trust")) {
-                    onAction(.installAndTrust)
-                }
-                .disabled(isLoading)
-                shareCertificateButton
-                Button(String(localized: "Generate New\u{2026}")) {
-                    onAction(.generate)
-                }
-                .disabled(isLoading)
-
-            case .trustIncomplete:
-                Button(String(localized: "Install & Trust")) {
-                    onAction(.installAndTrust)
-                }
-                .disabled(isLoading)
-                shareCertificateButton
-                Button(String(localized: "Reset Certificate"), role: .destructive) {
-                    onAction(.reset)
-                }
-                .disabled(isLoading)
-                Button(String(localized: "Recheck Status")) {
-                    onAction(.recheck)
-                }
-                .disabled(isLoading)
-
-            case .installedNotTrusted:
-                Button(String(localized: "Install & Trust")) {
-                    onAction(.installAndTrust)
-                }
-                .disabled(isLoading)
-                shareCertificateButton
-                Button(String(localized: "Reset Certificate"), role: .destructive) {
-                    onAction(.reset)
-                }
-                .disabled(isLoading)
-                Button(String(localized: "Recheck Status")) {
-                    onAction(.recheck)
-                }
-                .disabled(isLoading)
-
-            case .trusted:
-                Button(String(localized: "Export Certificate\u{2026}")) {
-                    onAction(.export)
-                }
-                .disabled(isLoading)
-                shareCertificateButton
-                Button(String(localized: "Generate New\u{2026}")) {
-                    onAction(.generate)
-                }
-                .disabled(isLoading)
-                Button(String(localized: "Reset Certificate"), role: .destructive) {
-                    onAction(.reset)
-                }
-                .disabled(isLoading)
+            VStack(alignment: .leading, spacing: 8) {
+                actionButtons
             }
         }
         .font(actionFont)
+    }
+
+    @ViewBuilder private var actionButtons: some View {
+        if isLoading {
+            ProgressView()
+                .controlSize(.small)
+        }
+
+        switch state {
+        case .notAvailable:
+            Button(String(localized: "Generate New\u{2026}")) {
+                onAction(.generate)
+            }
+            .rockxyGlassButtonStyle(prominent: true)
+            .disabled(isLoading)
+
+        case .generatedOnly:
+            Button(String(localized: "Install & Trust")) {
+                onAction(.installAndTrust)
+            }
+            .rockxyGlassButtonStyle(prominent: true)
+            .disabled(isLoading)
+            shareCertificateButton
+            Button(String(localized: "Generate New\u{2026}")) {
+                onAction(.generate)
+            }
+            .disabled(isLoading)
+
+        case .trustIncomplete:
+            Button(String(localized: "Install & Trust")) {
+                onAction(.installAndTrust)
+            }
+            .rockxyGlassButtonStyle(prominent: true)
+            .disabled(isLoading)
+            shareCertificateButton
+            Button(String(localized: "Reset Certificate"), role: .destructive) {
+                onAction(.reset)
+            }
+            .disabled(isLoading)
+            Button(String(localized: "Recheck Status")) {
+                onAction(.recheck)
+            }
+            .disabled(isLoading)
+
+        case .installedNotTrusted:
+            Button(String(localized: "Install & Trust")) {
+                onAction(.installAndTrust)
+            }
+            .rockxyGlassButtonStyle(prominent: true)
+            .disabled(isLoading)
+            shareCertificateButton
+            Button(String(localized: "Reset Certificate"), role: .destructive) {
+                onAction(.reset)
+            }
+            .disabled(isLoading)
+            Button(String(localized: "Recheck Status")) {
+                onAction(.recheck)
+            }
+            .disabled(isLoading)
+
+        case .trusted:
+            Button(String(localized: "Export Certificate\u{2026}")) {
+                onAction(.export)
+            }
+            .disabled(isLoading)
+            shareCertificateButton
+            Button(String(localized: "Generate New\u{2026}")) {
+                onAction(.generate)
+            }
+            .disabled(isLoading)
+            Button(String(localized: "Reset Certificate"), role: .destructive) {
+                onAction(.reset)
+            }
+            .disabled(isLoading)
+        }
     }
 
     private var shareCertificateButton: some View {

--- a/Rockxy/Views/Certificate/CertificateWizardView.swift
+++ b/Rockxy/Views/Certificate/CertificateWizardView.swift
@@ -233,7 +233,7 @@ struct CertificateWizardView: View {
                     Label(String(localized: "Install & Trust"), systemImage: "checkmark.shield.fill")
                 }
                 .controlSize(.large)
-                .buttonStyle(.borderedProminent)
+                .rockxyGlassButtonStyle(prominent: true)
                 .padding(.top, 8)
             }
         }
@@ -352,14 +352,14 @@ struct CertificateWizardView: View {
                 Button(String(localized: "Get Started")) {
                     goForward()
                 }
-                .buttonStyle(.borderedProminent)
+                .rockxyGlassButtonStyle(prominent: true)
                 .controlSize(.large)
 
             case .generate:
                 Button(String(localized: "Next")) {
                     goForward()
                 }
-                .buttonStyle(.borderedProminent)
+                .rockxyGlassButtonStyle(prominent: true)
                 .controlSize(.large)
                 .disabled(!generateSuccess)
 
@@ -367,7 +367,7 @@ struct CertificateWizardView: View {
                 Button(String(localized: "Next")) {
                     goForward()
                 }
-                .buttonStyle(.borderedProminent)
+                .rockxyGlassButtonStyle(prominent: true)
                 .controlSize(.large)
                 .disabled(!installSuccess)
 
@@ -375,7 +375,7 @@ struct CertificateWizardView: View {
                 Button(String(localized: "Next")) {
                     goForward()
                 }
-                .buttonStyle(.borderedProminent)
+                .rockxyGlassButtonStyle(prominent: true)
                 .controlSize(.large)
                 .disabled(!isTrusted)
 
@@ -384,7 +384,7 @@ struct CertificateWizardView: View {
                     Self.logger.info("Certificate wizard completed")
                     onDismiss()
                 }
-                .buttonStyle(.borderedProminent)
+                .rockxyGlassButtonStyle(prominent: true)
                 .controlSize(.large)
             }
         }

--- a/Rockxy/Views/Certificate/CustomCertificatesView.swift
+++ b/Rockxy/Views/Certificate/CustomCertificatesView.swift
@@ -266,7 +266,7 @@ struct CustomCertificatesView: View {
             Button(viewModel.primaryDestructiveTitle, role: .destructive) {
                 viewModel.requestPrimaryDeletion()
             }
-            .buttonStyle(.bordered)
+            .rockxyGlassButtonStyle()
             .disabled(!viewModel.canPerformPrimaryDestructive || viewModel.isBusy)
 
             if viewModel.isBusy {
@@ -286,7 +286,7 @@ struct CustomCertificatesView: View {
             Button(String(localized: "Preview")) {
                 presentPreview()
             }
-            .buttonStyle(.bordered)
+            .rockxyGlassButtonStyle()
             .disabled(!viewModel.canPreview || viewModel.isBusy)
 
             if let helpURL = Self.helpURL {

--- a/Rockxy/Views/Certificate/CustomCertificatesView.swift
+++ b/Rockxy/Views/Certificate/CustomCertificatesView.swift
@@ -154,6 +154,7 @@ struct CustomCertificatesView: View {
         .padding(.horizontal, toolMetrics.contentHorizontalPadding)
         .padding(.top, toolMetrics.headerTopPadding)
         .padding(.bottom, toolMetrics.headerBottomPadding)
+        .rockxyFunctionalBar()
     }
 
     @ViewBuilder private var content: some View {
@@ -294,6 +295,7 @@ struct CustomCertificatesView: View {
         }
         .padding(.horizontal, toolMetrics.contentHorizontalPadding)
         .padding(.vertical, toolMetrics.footerTopPadding)
+        .rockxyFunctionalBar()
     }
 
     private var importMenu: some View {

--- a/Rockxy/Views/Certificate/MacCertificateSetupGuideView.swift
+++ b/Rockxy/Views/Certificate/MacCertificateSetupGuideView.swift
@@ -94,7 +94,7 @@ struct MacCertificateSetupGuideView: View {
         }
     }
 
-    @Environment(\.openSettings) private var openSettings
+    @Environment(\.openWindow) private var openWindow
     @Environment(\.appUIDisplayMetrics) private var appMetrics
     @State private var selectedTab = Tab.automatic
     @State private var snapshot: RootCAStatusSnapshot?
@@ -225,6 +225,7 @@ struct MacCertificateSetupGuideView: View {
         }
         .padding(.horizontal, toolMetrics.contentHorizontalPadding)
         .padding(.vertical, toolMetrics.headerTopPadding)
+        .rockxyFunctionalBar()
     }
 
     private var modePicker: some View {
@@ -375,8 +376,8 @@ struct MacCertificateSetupGuideView: View {
         } label: {
             Label(primaryActionTitle, systemImage: primaryActionIcon)
         }
-        .buttonStyle(.borderedProminent)
         .keyboardShortcut(.defaultAction)
+        .rockxyGlassButtonStyle(prominent: true)
         .disabled(activeOperation != nil || currentState.isReady || !hasLoadedSnapshot)
 
         Button {
@@ -603,7 +604,7 @@ struct MacCertificateSetupGuideView: View {
             } label: {
                 Label(String(localized: "Generate Certificate"), systemImage: "plus.circle")
             }
-            .buttonStyle(.borderedProminent)
+            .rockxyGlassButtonStyle(prominent: true)
             .disabled(activeOperation != nil || !hasLoadedSnapshot)
         }
 
@@ -815,7 +816,7 @@ struct MacCertificateSetupGuideView: View {
 
     private func openGeneralSettings() {
         RockxySettingsTab.select(.general)
-        openSettings()
+        openWindow(id: "settings")
     }
 
     private func openKeychainAccess() {

--- a/Rockxy/Views/Common/NativeWorkspaceWindowChrome.swift
+++ b/Rockxy/Views/Common/NativeWorkspaceWindowChrome.swift
@@ -19,6 +19,7 @@ enum NativeWorkspaceWindowChrome {
     ) {
         window.titlebarAppearsTransparent = true
         window.styleMask.insert(.fullSizeContentView)
+        window.toolbarStyle = .unified
 
         if let workspaceSplitController,
            let toolbarConfiguration

--- a/Rockxy/Views/Common/ToastView.swift
+++ b/Rockxy/Views/Common/ToastView.swift
@@ -22,13 +22,16 @@ struct ToastView: View {
                 .font(.system(size: 12, weight: .medium))
                 .foregroundStyle(Color(nsColor: .labelColor))
         }
-        .padding(.horizontal, 16)
-        .padding(.vertical, 10)
-        .background {
-            RoundedRectangle(cornerRadius: 8)
-                .fill(.regularMaterial)
-                .shadow(color: .black.opacity(0.12), radius: 8, y: 2)
-        }
+        .padding(.horizontal, Theme.Glass.toastHorizontalPadding)
+        .padding(.vertical, Theme.Glass.toastVerticalPadding)
+        .rockxyGlassEffect(
+            in: RoundedRectangle(cornerRadius: Theme.Glass.toastCornerRadius, style: .continuous)
+        )
+        .shadow(
+            color: .black.opacity(Theme.Glass.toastShadowOpacity),
+            radius: Theme.Glass.toastShadowRadius,
+            y: Theme.Glass.toastShadowY
+        )
         .transition(.move(edge: .bottom).combined(with: .opacity))
         .onAppear {
             dismissTask = Task { @MainActor in

--- a/Rockxy/Views/Common/ToastView.swift
+++ b/Rockxy/Views/Common/ToastView.swift
@@ -27,11 +27,6 @@ struct ToastView: View {
         .rockxyGlassEffect(
             in: RoundedRectangle(cornerRadius: Theme.Glass.toastCornerRadius, style: .continuous)
         )
-        .shadow(
-            color: .black.opacity(Theme.Glass.toastShadowOpacity),
-            radius: Theme.Glass.toastShadowRadius,
-            y: Theme.Glass.toastShadowY
-        )
         .transition(.move(edge: .bottom).combined(with: .opacity))
         .onAppear {
             dismissTask = Task { @MainActor in

--- a/Rockxy/Views/Common/UtilitySegmentedHeader.swift
+++ b/Rockxy/Views/Common/UtilitySegmentedHeader.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 
 // MARK: - UtilitySegmentedHeader
@@ -18,6 +19,132 @@ struct UtilitySegmentedHeader<Content: View>: View {
     }
 }
 
+// MARK: - WorkspaceModeSegment
+
+/// One icon-first mode in the native navigator and inspector switchers used by Xcode.
+struct WorkspaceModeSegment<Value: Hashable> {
+    let value: Value
+    let title: String
+    let systemImage: String
+}
+
+// MARK: - WorkspaceModeSegmentedControl
+
+/// A native equal-width `NSSegmentedControl`. SwiftUI's segmented `Picker` keeps its intrinsic
+/// icon width on macOS, while Xcode's navigator and inspector switchers fill their available bar.
+struct WorkspaceModeSegmentedControl<Value: Hashable>: NSViewRepresentable {
+    // MARK: Lifecycle
+
+    init(
+        selection: Binding<Value>,
+        segments: [WorkspaceModeSegment<Value>],
+        accessibilityLabel: String
+    ) {
+        _selection = selection
+        self.segments = segments
+        self.accessibilityLabel = accessibilityLabel
+    }
+
+    // MARK: Internal
+
+    @Binding var selection: Value
+    let segments: [WorkspaceModeSegment<Value>]
+    let accessibilityLabel: String
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(selection: $selection, segments: segments)
+    }
+
+    func makeNSView(context: Context) -> EqualWidthSegmentedControl {
+        let control = EqualWidthSegmentedControl()
+        control.trackingMode = .selectOne
+        control.segmentStyle = .capsule
+        control.controlSize = .regular
+        control.selectedSegmentBezelColor = .controlAccentColor
+        control.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        control.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        control.target = context.coordinator
+        control.action = #selector(Coordinator.selectionChanged(_:))
+        update(control, coordinator: context.coordinator)
+        return control
+    }
+
+    func updateNSView(_ control: EqualWidthSegmentedControl, context: Context) {
+        update(control, coordinator: context.coordinator)
+    }
+
+    // MARK: Private
+
+    private func update(_ control: EqualWidthSegmentedControl, coordinator: Coordinator) {
+        coordinator.selection = $selection
+        coordinator.segments = segments
+
+        if control.segmentCount != segments.count {
+            control.segmentCount = segments.count
+        }
+
+        for (index, segment) in segments.enumerated() {
+            let image = NSImage(
+                systemSymbolName: segment.systemImage,
+                accessibilityDescription: segment.title
+            )
+            image?.isTemplate = true
+            control.setLabel("", forSegment: index)
+            control.setImage(image, forSegment: index)
+            control.setImageScaling(.scaleProportionallyDown, forSegment: index)
+            control.setToolTip(segment.title, forSegment: index)
+            control.setEnabled(true, forSegment: index)
+        }
+
+        control.selectedSegment = segments.firstIndex { $0.value == selection } ?? -1
+        control.setAccessibilityLabel(accessibilityLabel)
+        control.needsLayout = true
+    }
+
+    final class Coordinator: NSObject {
+        // MARK: Lifecycle
+
+        init(selection: Binding<Value>, segments: [WorkspaceModeSegment<Value>]) {
+            self.selection = selection
+            self.segments = segments
+        }
+
+        // MARK: Internal
+
+        var selection: Binding<Value>
+        var segments: [WorkspaceModeSegment<Value>]
+
+        @objc
+        func selectionChanged(_ sender: NSSegmentedControl) {
+            guard segments.indices.contains(sender.selectedSegment) else {
+                return
+            }
+            selection.wrappedValue = segments[sender.selectedSegment].value
+        }
+    }
+}
+
+// MARK: - EqualWidthSegmentedControl
+
+final class EqualWidthSegmentedControl: NSSegmentedControl {
+    override var intrinsicContentSize: NSSize {
+        var size = super.intrinsicContentSize
+        size.width = NSView.noIntrinsicMetric
+        return size
+    }
+
+    override func layout() {
+        super.layout()
+        guard segmentCount > 0, bounds.width > 0 else {
+            return
+        }
+        let segmentWidth = bounds.width / CGFloat(segmentCount)
+        for index in 0 ..< segmentCount where abs(width(forSegment: index) - segmentWidth) > 0.5 {
+            setWidth(segmentWidth, forSegment: index)
+        }
+    }
+}
+
 // MARK: - WorkspaceModeSwitcherStyle
 
 extension View {
@@ -33,11 +160,8 @@ private struct WorkspaceModeSwitcherModifier: ViewModifier {
 
     func body(content: Content) -> some View {
         content
-            .pickerStyle(.segmented)
-            .labelsHidden()
-            .controlSize(.regular)
             .font(.system(size: metrics.workspaceTabFontSize, weight: .medium))
-            .frame(height: metrics.inspectorTabHeight)
+            .frame(maxWidth: .infinity, minHeight: metrics.inspectorTabHeight)
             .padding(.horizontal, 10)
             .padding(.vertical, 8)
     }

--- a/Rockxy/Views/Compose/ComposeWindowView.swift
+++ b/Rockxy/Views/Compose/ComposeWindowView.swift
@@ -167,6 +167,7 @@ struct ComposeWindowView: View {
         }
         .padding(.horizontal, toolMetrics.contentHorizontalPadding)
         .padding(.vertical, toolMetrics.controlSpacing)
+        .rockxyFunctionalBar()
     }
 
     @ViewBuilder private var sendButton: some View {
@@ -189,7 +190,7 @@ struct ComposeWindowView: View {
                 Text(String(localized: "Send"))
                     .frame(width: sendControlWidth)
             }
-            .buttonStyle(.borderedProminent)
+            .rockxyGlassButtonStyle(prominent: true)
             .controlSize(.regular)
             .frame(height: toolMetrics.formControlHeight)
             .keyboardShortcut(.return, modifiers: .command)
@@ -249,6 +250,7 @@ struct ComposeWindowView: View {
         }
         .padding(.horizontal, toolMetrics.contentHorizontalPadding)
         .padding(.vertical, toolMetrics.footerTopPadding)
+        .rockxyFunctionalBar()
     }
 
     private var templateMenu: some View {

--- a/Rockxy/Views/Compose/ComposeWindowView.swift
+++ b/Rockxy/Views/Compose/ComposeWindowView.swift
@@ -178,7 +178,7 @@ struct ComposeWindowView: View {
                 Text(String(localized: "Cancel"))
                     .frame(width: sendControlWidth)
             }
-            .buttonStyle(.bordered)
+            .rockxyGlassButtonStyle()
             .controlSize(.regular)
             .frame(height: toolMetrics.formControlHeight)
             .keyboardShortcut(".", modifiers: .command)
@@ -229,7 +229,7 @@ struct ComposeWindowView: View {
                     Button(String(localized: "Use Empty Body")) {
                         viewModel.replaceUnavailableBody(with: "")
                     }
-                    .buttonStyle(.bordered)
+                    .rockxyGlassButtonStyle()
                 }
             }
             .padding(.horizontal, toolMetrics.contentHorizontalPadding)

--- a/Rockxy/Views/DeveloperSetup/DeveloperSetupAutomaticWindowView.swift
+++ b/Rockxy/Views/DeveloperSetup/DeveloperSetupAutomaticWindowView.swift
@@ -13,17 +13,7 @@ struct DeveloperSetupAutomaticWindowView: View {
     // MARK: Internal
 
     var body: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: 16) {
-                header
-                Divider()
-                terminalSection
-                footer
-            }
-            .padding(.horizontal, 24)
-            .padding(.vertical, 20)
-            .frame(maxWidth: .infinity, alignment: .topLeading)
-        }
+        setupLayout
         .frame(minWidth: 620, minHeight: 440)
         .background(Color(nsColor: .windowBackgroundColor))
         .font(setupMetrics.font())
@@ -51,6 +41,39 @@ struct DeveloperSetupAutomaticWindowView: View {
         viewModel.selectedTerminalApp == .custom
             ? String(localized: "Copy Setup Command")
             : String(localized: "Open Prepared Terminal…")
+    }
+
+    @ViewBuilder private var setupLayout: some View {
+        if #available(macOS 26.0, *) {
+            ScrollView {
+                terminalSection
+                    .padding(.horizontal, 24)
+                    .padding(.vertical, 20)
+                    .frame(maxWidth: .infinity, alignment: .topLeading)
+            }
+            .safeAreaBar(edge: .top, spacing: 0) {
+                header
+                    .padding(.horizontal, 24)
+                    .padding(.vertical, 16)
+            }
+            .safeAreaBar(edge: .bottom, spacing: 0) {
+                footer
+                    .padding(.horizontal, 24)
+                    .padding(.vertical, 12)
+            }
+        } else {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 16) {
+                    header
+                    Divider()
+                    terminalSection
+                    footer
+                }
+                .padding(.horizontal, 24)
+                .padding(.vertical, 20)
+                .frame(maxWidth: .infinity, alignment: .topLeading)
+            }
+        }
     }
 
     private var header: some View {
@@ -137,8 +160,8 @@ struct DeveloperSetupAutomaticWindowView: View {
         Button(openTerminalTitle) {
             Task { await viewModel.openPreparedTerminal() }
         }
-        .buttonStyle(.borderedProminent)
         .keyboardShortcut(.defaultAction)
+        .rockxyGlassButtonStyle(prominent: true)
     }
 
     private var footer: some View {

--- a/Rockxy/Views/DeveloperSetup/DeveloperSetupAutomaticWindowView.swift
+++ b/Rockxy/Views/DeveloperSetup/DeveloperSetupAutomaticWindowView.swift
@@ -44,6 +44,7 @@ struct DeveloperSetupAutomaticWindowView: View {
     }
 
     @ViewBuilder private var setupLayout: some View {
+        #if compiler(>=6.2)
         if #available(macOS 26.0, *) {
             ScrollView {
                 terminalSection
@@ -62,17 +63,24 @@ struct DeveloperSetupAutomaticWindowView: View {
                     .padding(.vertical, 12)
             }
         } else {
-            ScrollView {
-                VStack(alignment: .leading, spacing: 16) {
-                    header
-                    Divider()
-                    terminalSection
-                    footer
-                }
-                .padding(.horizontal, 24)
-                .padding(.vertical, 20)
-                .frame(maxWidth: .infinity, alignment: .topLeading)
+            legacySetupLayout
+        }
+        #else
+        legacySetupLayout
+        #endif
+    }
+
+    private var legacySetupLayout: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                header
+                Divider()
+                terminalSection
+                footer
             }
+            .padding(.horizontal, 24)
+            .padding(.vertical, 20)
+            .frame(maxWidth: .infinity, alignment: .topLeading)
         }
     }
 

--- a/Rockxy/Views/DeveloperSetup/DeveloperSetupManualWindowView.swift
+++ b/Rockxy/Views/DeveloperSetup/DeveloperSetupManualWindowView.swift
@@ -13,21 +13,7 @@ struct DeveloperSetupManualWindowView: View {
     // MARK: Internal
 
     var body: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: 16) {
-                header
-                Divider()
-                if viewModel.isRuntimeTerminalTarget {
-                    terminalCard
-                } else {
-                    targetManualCard
-                }
-                footer
-            }
-            .padding(.horizontal, 24)
-            .padding(.vertical, 20)
-            .frame(maxWidth: .infinity, alignment: .topLeading)
-        }
+        setupLayout
         .frame(minWidth: 640, minHeight: 460)
         .background(Color(nsColor: .windowBackgroundColor))
         .font(setupMetrics.font())
@@ -55,6 +41,47 @@ struct DeveloperSetupManualWindowView: View {
 
     private var setupMetrics: DeveloperSetupDisplayMetrics {
         DeveloperSetupDisplayMetrics(appMetrics: appMetrics)
+    }
+
+    @ViewBuilder private var setupLayout: some View {
+        if #available(macOS 26.0, *) {
+            ScrollView {
+                setupContent
+                    .padding(.horizontal, 24)
+                    .padding(.vertical, 20)
+                    .frame(maxWidth: .infinity, alignment: .topLeading)
+            }
+            .safeAreaBar(edge: .top, spacing: 0) {
+                header
+                    .padding(.horizontal, 24)
+                    .padding(.vertical, 16)
+            }
+            .safeAreaBar(edge: .bottom, spacing: 0) {
+                footer
+                    .padding(.horizontal, 24)
+                    .padding(.vertical, 12)
+            }
+        } else {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 16) {
+                    header
+                    Divider()
+                    setupContent
+                    footer
+                }
+                .padding(.horizontal, 24)
+                .padding(.vertical, 20)
+                .frame(maxWidth: .infinity, alignment: .topLeading)
+            }
+        }
+    }
+
+    @ViewBuilder private var setupContent: some View {
+        if viewModel.isRuntimeTerminalTarget {
+            terminalCard
+        } else {
+            targetManualCard
+        }
     }
 
     private var header: some View {

--- a/Rockxy/Views/DeveloperSetup/DeveloperSetupManualWindowView.swift
+++ b/Rockxy/Views/DeveloperSetup/DeveloperSetupManualWindowView.swift
@@ -44,6 +44,7 @@ struct DeveloperSetupManualWindowView: View {
     }
 
     @ViewBuilder private var setupLayout: some View {
+        #if compiler(>=6.2)
         if #available(macOS 26.0, *) {
             ScrollView {
                 setupContent
@@ -62,17 +63,24 @@ struct DeveloperSetupManualWindowView: View {
                     .padding(.vertical, 12)
             }
         } else {
-            ScrollView {
-                VStack(alignment: .leading, spacing: 16) {
-                    header
-                    Divider()
-                    setupContent
-                    footer
-                }
-                .padding(.horizontal, 24)
-                .padding(.vertical, 20)
-                .frame(maxWidth: .infinity, alignment: .topLeading)
+            legacySetupLayout
+        }
+        #else
+        legacySetupLayout
+        #endif
+    }
+
+    private var legacySetupLayout: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                header
+                Divider()
+                setupContent
+                footer
             }
+            .padding(.horizontal, 24)
+            .padding(.vertical, 20)
+            .frame(maxWidth: .infinity, alignment: .topLeading)
         }
     }
 

--- a/Rockxy/Views/DeveloperSetup/DeveloperSetupWindowView.swift
+++ b/Rockxy/Views/DeveloperSetup/DeveloperSetupWindowView.swift
@@ -96,6 +96,7 @@ struct DeveloperSetupWindowView: View {
 
     @Environment(\.openWindow) private var openWindow
     @Environment(\.appUIDisplayMetrics) private var appMetrics
+    @Environment(\.colorScheme) private var colorScheme
     @State private var viewModel: DeveloperSetupViewModel
     @State private var routeStore = DeveloperSetupRouteStore.shared
     @StateObject private var caShareController = CAShareController()
@@ -154,7 +155,7 @@ struct DeveloperSetupWindowView: View {
         }
 
         ToolbarItemGroup(placement: .primaryAction) {
-            Menu(String(localized: "Set Up…")) {
+            Menu {
                 Button(String(localized: "Open Setup Guide…")) {
                     openManualSetup()
                 }
@@ -163,14 +164,37 @@ struct DeveloperSetupWindowView: View {
                         openAutomaticSetup()
                     }
                 }
+            } label: {
+                HStack(spacing: 6) {
+                    Text(String(localized: "Set Up…"))
+                    Image(systemName: "chevron.down")
+                        .font(setupMetrics.secondaryFont(weight: .semibold))
+                }
+                .padding(.horizontal, 14)
+                .frame(height: 36)
             }
+            .menuStyle(.borderlessButton)
+            .buttonStyle(.plain)
+            .fixedSize()
+            .rockxyGlassEffect(
+                tint: toolbarGlassTint,
+                interactive: true,
+                in: Capsule(style: .continuous)
+            )
             .help(String(localized: "Open a guided or configured setup for this target"))
 
             Button {
                 inspectorPresented.toggle()
             } label: {
                 Image(systemName: "sidebar.trailing")
+                    .frame(width: 42, height: 36)
             }
+            .buttonStyle(.plain)
+            .rockxyGlassEffect(
+                tint: toolbarGlassTint,
+                interactive: true,
+                in: Capsule(style: .continuous)
+            )
             .help(String(localized: "Toggle the readiness inspector"))
             .accessibilityLabel(String(localized: "Toggle readiness inspector"))
         }
@@ -291,27 +315,78 @@ struct DeveloperSetupWindowView: View {
     }
 
     private var segmentedTabPicker: some View {
-        tabPickerBase
-            .pickerStyle(.segmented)
-            .frame(minWidth: 380)
+        HStack(spacing: 0) {
+            ForEach(SetupDetailTab.allCases) { tab in
+                Button {
+                    viewModel.selectTab(tab)
+                } label: {
+                    Text(tab.title)
+                        .lineLimit(1)
+                        .frame(maxWidth: .infinity)
+                        .padding(.horizontal, 8)
+                        .frame(height: 32)
+                        .background {
+                            if viewModel.selectedTab == tab {
+                                Capsule(style: .continuous)
+                                    .fill(toolbarSelectionFill)
+                            }
+                        }
+                        .contentShape(Capsule(style: .continuous))
+                }
+                .buttonStyle(.plain)
+                .accessibilityAddTraits(viewModel.selectedTab == tab ? .isSelected : [])
+            }
+        }
+        .padding(4)
+        .frame(minWidth: 380)
+        .rockxyGlassEffect(
+            tint: toolbarGlassTint,
+            interactive: true,
+            in: Capsule(style: .continuous)
+        )
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel(String(localized: "Section"))
     }
 
     private var menuTabPicker: some View {
-        tabPickerBase
-            .pickerStyle(.menu)
-            .fixedSize()
+        Menu {
+            ForEach(SetupDetailTab.allCases) { tab in
+                Button {
+                    viewModel.selectTab(tab)
+                } label: {
+                    if viewModel.selectedTab == tab {
+                        Label(tab.title, systemImage: "checkmark")
+                    } else {
+                        Text(tab.title)
+                    }
+                }
+            }
+        } label: {
+            HStack(spacing: 6) {
+                Text(viewModel.selectedTab.title)
+                Image(systemName: "chevron.down")
+                    .font(setupMetrics.secondaryFont(weight: .semibold))
+            }
+            .padding(.horizontal, 14)
+            .frame(height: 36)
+        }
+        .menuStyle(.borderlessButton)
+        .buttonStyle(.plain)
+        .fixedSize()
+        .rockxyGlassEffect(
+            tint: toolbarGlassTint,
+            interactive: true,
+            in: Capsule(style: .continuous)
+        )
+        .accessibilityLabel(String(localized: "Section"))
     }
 
-    private var tabPickerBase: some View {
-        Picker(String(localized: "Section"), selection: Binding(
-            get: { viewModel.selectedTab },
-            set: { viewModel.selectTab($0) }
-        )) {
-            ForEach(SetupDetailTab.allCases) { tab in
-                Text(tab.title).tag(tab)
-            }
-        }
-        .labelsHidden()
+    private var toolbarGlassTint: Color? {
+        colorScheme == .light ? Color.white.opacity(0.28) : nil
+    }
+
+    private var toolbarSelectionFill: Color {
+        Color.primary.opacity(colorScheme == .light ? 0.10 : 0.14)
     }
 
     private var centerContent: some View {
@@ -454,7 +529,7 @@ struct DeveloperSetupWindowView: View {
                 Button(String(localized: "Share Certificate")) {
                     shareRootCAForSelectedTarget()
                 }
-                .rockxyGlassButtonStyle(prominent: true)
+                .rockxyGlassButtonStyle()
 
                 Button(String(localized: "Open Certificate Guide")) {
                     openWindow(id: "certificateSetup")

--- a/Rockxy/Views/DeveloperSetup/DeveloperSetupWindowView.swift
+++ b/Rockxy/Views/DeveloperSetup/DeveloperSetupWindowView.swift
@@ -454,7 +454,7 @@ struct DeveloperSetupWindowView: View {
                 Button(String(localized: "Share Certificate")) {
                     shareRootCAForSelectedTarget()
                 }
-                .buttonStyle(.borderedProminent)
+                .rockxyGlassButtonStyle(prominent: true)
 
                 Button(String(localized: "Open Certificate Guide")) {
                     openWindow(id: "certificateSetup")
@@ -571,7 +571,7 @@ struct DeveloperSetupWindowView: View {
         Button(String(localized: "Start Check")) {
             viewModel.startValidation()
         }
-        .buttonStyle(.borderedProminent)
+        .rockxyGlassButtonStyle(prominent: true)
         .disabled(!viewModel.toolbarVerifyEnabled || viewModel.activeIssue != nil)
         .keyboardShortcut("r", modifiers: .command)
 

--- a/Rockxy/Views/Diff/DiffControlBar.swift
+++ b/Rockxy/Views/Diff/DiffControlBar.swift
@@ -33,7 +33,7 @@ struct DiffControlBar: View {
         .frame(minHeight: toolMetrics.footerControlHeight)
         .padding(.horizontal, toolMetrics.contentHorizontalPadding)
         .padding(.vertical, toolMetrics.footerTopPadding)
-        .background(.bar)
+        .rockxyFunctionalBar()
     }
 
     // MARK: Private

--- a/Rockxy/Views/Diff/DiffWindowView.swift
+++ b/Rockxy/Views/Diff/DiffWindowView.swift
@@ -116,6 +116,7 @@ struct DiffWindowView: View {
         .padding(.horizontal, toolMetrics.contentHorizontalPadding)
         .padding(.top, toolMetrics.headerTopPadding)
         .padding(.bottom, toolMetrics.headerBottomPadding)
+        .rockxyFunctionalBar()
     }
 
     private var contextBadge: some View {
@@ -129,11 +130,7 @@ struct DiffWindowView: View {
         .foregroundStyle(.secondary)
         .padding(.horizontal, 8)
         .padding(.vertical, 3)
-        .background(Color(nsColor: .controlBackgroundColor))
-        .clipShape(Capsule())
-        .overlay {
-            Capsule().stroke(Color(nsColor: .separatorColor), lineWidth: 1)
-        }
+        .rockxyChipStyle()
         .help(String(localized: "Comparison runs on your captured transactions and never modifies live traffic."))
         .accessibilityElement(children: .combine)
         .accessibilityLabel(String(localized: "Local, read-only comparison"))

--- a/Rockxy/Views/Export/ExportScopeSheet.swift
+++ b/Rockxy/Views/Export/ExportScopeSheet.swift
@@ -222,9 +222,10 @@ struct ExportScopeSheet: View {
                 Text(String(localized: "Export\u{2026}"))
                     .frame(width: footerActionWidth)
             }
-            .buttonStyle(.borderedProminent)
+            .rockxyGlassButtonStyle(prominent: true)
             .frame(minHeight: toolMetrics.formControlHeight)
             .keyboardShortcut(.defaultAction)
+            .rockxyGlassButtonStyle(prominent: true)
             .disabled(!context.isEnabled(selectedScope))
             .accessibilityIdentifier("exportScope.exportButton")
         }

--- a/Rockxy/Views/Export/ExportScopeSheet.swift
+++ b/Rockxy/Views/Export/ExportScopeSheet.swift
@@ -211,7 +211,7 @@ struct ExportScopeSheet: View {
                 Text(String(localized: "Cancel"))
                     .frame(width: footerActionWidth)
             }
-            .buttonStyle(.bordered)
+            .rockxyGlassButtonStyle()
             .frame(minHeight: toolMetrics.formControlHeight)
             .keyboardShortcut(.cancelAction)
             .accessibilityIdentifier("exportScope.cancelButton")
@@ -225,7 +225,6 @@ struct ExportScopeSheet: View {
             .rockxyGlassButtonStyle(prominent: true)
             .frame(minHeight: toolMetrics.formControlHeight)
             .keyboardShortcut(.defaultAction)
-            .rockxyGlassButtonStyle(prominent: true)
             .disabled(!context.isEnabled(selectedScope))
             .accessibilityIdentifier("exportScope.exportButton")
         }

--- a/Rockxy/Views/Export/GistPublishConfirmationSheet.swift
+++ b/Rockxy/Views/Export/GistPublishConfirmationSheet.swift
@@ -283,7 +283,7 @@ struct GistPublishConfirmationSheet: View {
                     .frame(width: footerActionWidth)
                     .frame(minHeight: toolMetrics.formControlHeight)
             }
-            .buttonStyle(.bordered)
+            .rockxyGlassButtonStyle()
             .keyboardShortcut(.cancelAction)
             .disabled(isPublishing)
             .accessibilityIdentifier("gistPublish.cancelButton")

--- a/Rockxy/Views/Export/GistPublishConfirmationSheet.swift
+++ b/Rockxy/Views/Export/GistPublishConfirmationSheet.swift
@@ -301,8 +301,8 @@ struct GistPublishConfirmationSheet: View {
                 .frame(width: footerActionWidth)
                 .frame(minHeight: toolMetrics.formControlHeight)
             }
-            .buttonStyle(.borderedProminent)
             .keyboardShortcut(.defaultAction)
+            .rockxyGlassButtonStyle(prominent: true)
             .disabled(isPublishing)
             .accessibilityIdentifier("gistPublish.publishButton")
         }

--- a/Rockxy/Views/Import/ImportReviewSheet.swift
+++ b/Rockxy/Views/Import/ImportReviewSheet.swift
@@ -315,8 +315,8 @@ struct ImportReviewSheet: View {
                     .frame(width: footerActionWidth)
                     .frame(minHeight: toolMetrics.formControlHeight)
             }
-            .buttonStyle(.borderedProminent)
             .keyboardShortcut(.defaultAction)
+            .rockxyGlassButtonStyle(prominent: true)
             .accessibilityIdentifier("importReview.actionButton")
         }
     }

--- a/Rockxy/Views/Import/ImportReviewSheet.swift
+++ b/Rockxy/Views/Import/ImportReviewSheet.swift
@@ -288,7 +288,7 @@ struct ImportReviewSheet: View {
                     .frame(width: footerActionWidth)
                     .frame(minHeight: toolMetrics.formControlHeight)
             }
-            .buttonStyle(.bordered)
+            .rockxyGlassButtonStyle()
             .keyboardShortcut(.cancelAction)
             .accessibilityIdentifier("importReview.cancelButton")
 
@@ -305,7 +305,7 @@ struct ImportReviewSheet: View {
                     .frame(width: footerActionWidth)
                     .frame(minHeight: toolMetrics.formControlHeight)
             }
-            .buttonStyle(.bordered)
+            .rockxyGlassButtonStyle()
             .accessibilityIdentifier("importReview.actionButton")
         } else {
             Button {

--- a/Rockxy/Views/Inspector/AssistantConversationComponents.swift
+++ b/Rockxy/Views/Inspector/AssistantConversationComponents.swift
@@ -100,7 +100,7 @@ struct AssistantConversationContextMismatchBanner: View {
                     .controlSize(.small)
 
                 Button(String(localized: "New Conversation"), action: onStartNew)
-                    .buttonStyle(.borderedProminent)
+                    .rockxyGlassButtonStyle(prominent: true)
                     .controlSize(.small)
             }
         }

--- a/Rockxy/Views/Inspector/AssistantConversationComponents.swift
+++ b/Rockxy/Views/Inspector/AssistantConversationComponents.swift
@@ -96,7 +96,7 @@ struct AssistantConversationContextMismatchBanner: View {
 
             HStack(spacing: 7) {
                 Button(String(localized: "Restore Traffic"), action: onRestore)
-                    .buttonStyle(.bordered)
+                    .rockxyGlassButtonStyle()
                     .controlSize(.small)
 
                 Button(String(localized: "New Conversation"), action: onStartNew)

--- a/Rockxy/Views/Inspector/AuthInspectorView.swift
+++ b/Rockxy/Views/Inspector/AuthInspectorView.swift
@@ -22,7 +22,7 @@ struct AuthInspectorView: View {
                             } label: {
                                 Label(String(localized: "Preview JWT"), systemImage: "key.viewfinder")
                             }
-                            .buttonStyle(.bordered)
+                            .rockxyGlassButtonStyle()
                             .controlSize(.small)
                             .popover(isPresented: $isJWTPreviewPresented, arrowEdge: .bottom) {
                                 if let jwtPreview {

--- a/Rockxy/Views/Inspector/ContextDockView.swift
+++ b/Rockxy/Views/Inspector/ContextDockView.swift
@@ -11,10 +11,22 @@ struct ContextDockView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            Picker(String(localized: "Inspector"), selection: selectedTab) {
-                Text(String(localized: "Details")).tag(ContextDockTab.details)
-                Text(String(localized: "AI Assistant")).tag(ContextDockTab.aiAssistant)
-            }
+            WorkspaceModeSegmentedControl(
+                selection: selectedTab,
+                segments: [
+                    WorkspaceModeSegment(
+                        value: ContextDockTab.details,
+                        title: String(localized: "Details"),
+                        systemImage: "doc.text.magnifyingglass"
+                    ),
+                    WorkspaceModeSegment(
+                        value: ContextDockTab.aiAssistant,
+                        title: String(localized: "AI Assistant"),
+                        systemImage: "sparkles"
+                    ),
+                ],
+                accessibilityLabel: String(localized: "Inspector")
+            )
             .workspaceModeSwitcherStyle()
 
             Divider()
@@ -40,7 +52,7 @@ struct ContextDockView: View {
                 guard coordinator.activeWorkspace.contextDockTab != tab else {
                     return
                 }
-                // Picker callbacks can arrive during the native inspector's constraint pass.
+                // Segmented-control callbacks can arrive during the native inspector's constraint pass.
                 // Publish the content swap on the next run-loop turn so both tab roots keep
                 // a stable inspector size while AppKit finishes the current layout.
                 DispatchQueue.main.async { [weak coordinator] in
@@ -837,7 +849,7 @@ private struct AIAssistantDockView: View {
             }
             .frame(maxWidth: .infinity, alignment: .leading)
         }
-        .buttonStyle(.bordered)
+        .rockxyGlassButtonStyle()
         .controlSize(.small)
         .disabled(isBusy)
         .help(recipe.detail)

--- a/Rockxy/Views/Inspector/ContextDockView.swift
+++ b/Rockxy/Views/Inspector/ContextDockView.swift
@@ -361,7 +361,7 @@ private struct AIAssistantDockView: View {
         }
         .padding(.horizontal, 10)
         .frame(minHeight: max(36, appMetrics.primaryFontSize + 20))
-        .background(Color.clear)
+        .rockxyFunctionalBar()
     }
 
     private var conversationSwitcher: some View {
@@ -734,7 +734,7 @@ private struct AIAssistantDockView: View {
                         .font(assistantFont(appMetrics.controlFontSize, weight: .semibold))
                         .frame(width: 16, height: 16)
                 }
-                .buttonStyle(.borderedProminent)
+                .rockxyGlassButtonStyle(prominent: true)
                 .controlSize(.small)
                 .keyboardShortcut(.return, modifiers: .command)
                 .disabled(!canSendDraft)
@@ -821,7 +821,7 @@ private struct AIAssistantDockView: View {
         }
         .padding(.horizontal, 10)
         .padding(.vertical, 8)
-        .background(Color.clear)
+        .rockxyFunctionalBar()
     }
 
     private func suggestionCard(_ recipe: DebugAssistantRecipe) -> some View {

--- a/Rockxy/Views/Inspector/DebugAssistantReviewDataSheet.swift
+++ b/Rockxy/Views/Inspector/DebugAssistantReviewDataSheet.swift
@@ -245,7 +245,7 @@ struct DebugAssistantReviewDataSheet: View {
                 }
             } else {
                 Button(String(localized: "Include Excluded Traffic Once"), action: onOverride)
-                    .buttonStyle(.bordered)
+                    .rockxyGlassButtonStyle()
                     .controlSize(.small)
                     .accessibilityLabel(String(localized: "Include Excluded Traffic Once"))
                     .help(String(localized: "Focus and Noise settings will not change."))

--- a/Rockxy/Views/Inspector/DebugAssistantReviewDataSheet.swift
+++ b/Rockxy/Views/Inspector/DebugAssistantReviewDataSheet.swift
@@ -180,8 +180,8 @@ struct DebugAssistantReviewDataSheet: View {
                 .keyboardShortcut(.cancelAction)
 
             Button(primaryActionTitle, action: onSend)
-                .buttonStyle(.borderedProminent)
                 .keyboardShortcut(.defaultAction)
+                .rockxyGlassButtonStyle(prominent: true)
                 .disabled(!canSend)
         }
         .padding(.horizontal, toolMetrics.contentHorizontalPadding)

--- a/Rockxy/Views/Inspector/HTTPSInspectionPromptView.swift
+++ b/Rockxy/Views/Inspector/HTTPSInspectionPromptView.swift
@@ -79,7 +79,7 @@ struct HTTPSInspectionPromptView: View {
                 onAction(action)
             }
         }
-        .buttonStyle(.borderedProminent)
+        .rockxyGlassButtonStyle(prominent: true)
         .controlSize(.small)
         .accessibilityHint(String(localized: "Installs and trusts the Rockxy root certificate"))
     }

--- a/Rockxy/Views/Inspector/HTTPSInspectionPromptView.swift
+++ b/Rockxy/Views/Inspector/HTTPSInspectionPromptView.swift
@@ -65,7 +65,7 @@ struct HTTPSInspectionPromptView: View {
                     .lineLimit(1)
                     .frame(minWidth: promptActionLabelWidth)
             }
-            .buttonStyle(.bordered)
+            .rockxyGlassButtonStyle()
             .controlSize(.small)
             .fixedSize()
             .help(String(localized: "Open HTTPS Decryption Settings"))
@@ -236,7 +236,7 @@ struct HTTPSInspectionPromptView: View {
                     .lineLimit(1)
                     .frame(minWidth: promptActionLabelWidth)
             }
-            .buttonStyle(.bordered)
+            .rockxyGlassButtonStyle()
             .controlSize(.small)
             .fixedSize()
             .help(scope.actionDescription)

--- a/Rockxy/Views/Inspector/ImagePreviewView.swift
+++ b/Rockxy/Views/Inspector/ImagePreviewView.swift
@@ -11,7 +11,7 @@ struct ImagePreviewView: View {
                 Spacer()
                 Image(nsImage: nsImage)
                     .resizable()
-                    .aspectRatio(contentMode: .fit)
+                    .scaledToFit()
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
 
                 let rep = nsImage.representations.first

--- a/Rockxy/Views/Inspector/InspectorTabButton.swift
+++ b/Rockxy/Views/Inspector/InspectorTabButton.swift
@@ -11,14 +11,17 @@ struct InspectorTabButton: View {
         Button(action: action) {
             Text(title)
                 .font(.system(size: metrics.controlFontSize, weight: isActive ? .bold : .regular))
-                .foregroundStyle(isActive ? Theme.Inspector.tabActive : Theme.Inspector.tabInactive)
                 .lineLimit(1)
                 .fixedSize(horizontal: true, vertical: false)
+                .padding(.horizontal, 6)
+                .frame(minHeight: max(18, metrics.inspectorTabHeight - 4))
+                .rockxyChipStyle(isActive: isActive, isHovered: isHovered)
         }
         .buttonStyle(.plain)
-        .padding(.horizontal, 6)
         .frame(minHeight: metrics.inspectorTabHeight)
+        .onHover { isHovered = $0 }
     }
 
     @Environment(\.appUIDisplayMetrics) private var metrics
+    @State private var isHovered = false
 }

--- a/Rockxy/Views/Inspector/InspectorURLBar.swift
+++ b/Rockxy/Views/Inspector/InspectorURLBar.swift
@@ -31,7 +31,7 @@ struct InspectorURLBar: View {
         }
         .padding(.horizontal, 8)
         .padding(.vertical, 6)
-        .background(Theme.Inspector.urlBarBackground)
+        .rockxyFunctionalBar()
     }
 
     // MARK: Private

--- a/Rockxy/Views/Main/Extensions/MainContentCoordinator+Import.swift
+++ b/Rockxy/Views/Main/Extensions/MainContentCoordinator+Import.swift
@@ -136,6 +136,15 @@ extension MainContentCoordinator {
         importPreview = nil
 
         Task { @MainActor in
+            guard await ensureProjectCatalogReadyForDataIntake() else {
+                showImportError(
+                    title: String(localized: "Import Unavailable"),
+                    message: String(
+                        localized: "Projects could not be loaded. Repair Projects before importing captured traffic."
+                    )
+                )
+                return
+            }
             switch preview.fileType {
             case .har:
                 await executeHARImport(from: preview.sourceURL, fileName: preview.fileName)

--- a/Rockxy/Views/Main/Extensions/MainContentCoordinator+Logs.swift
+++ b/Rockxy/Views/Main/Extensions/MainContentCoordinator+Logs.swift
@@ -68,12 +68,6 @@ extension MainContentCoordinator {
         } else {
             transactionsByProjectID[projectID] ?? []
         }
-        var projectLogs = if projectID == projectStore.activeProjectID {
-            logEntries
-        } else {
-            logEntriesByProjectID[projectID] ?? []
-        }
-
         if let correlatedId = LogCorrelator.correlate(
             logEntry: entry,
             with: projectTransactions
@@ -81,16 +75,22 @@ extension MainContentCoordinator {
             mutableEntry.correlatedTransactionId = correlatedId
         }
 
-        projectLogs.append(mutableEntry)
-
-        if projectLogs.count > settings.maxLogBufferSize {
-            let excess = projectLogs.count - settings.maxLogBufferSize
-            projectLogs.removeFirst(excess)
-            Self.logger.debug("Evicted \(excess) oldest log entries")
-        }
-        logEntriesByProjectID[projectID] = projectLogs
         if projectID == projectStore.activeProjectID {
-            logEntries = projectLogs
+            logEntries.append(mutableEntry)
+            if logEntries.count > settings.maxLogBufferSize {
+                let excess = logEntries.count - settings.maxLogBufferSize
+                logEntries.removeFirst(excess)
+                Self.logger.debug("Evicted \(excess) oldest log entries")
+            }
+        } else {
+            var projectLogs = logEntriesByProjectID[projectID] ?? []
+            projectLogs.append(mutableEntry)
+            if projectLogs.count > settings.maxLogBufferSize {
+                let excess = projectLogs.count - settings.maxLogBufferSize
+                projectLogs.removeFirst(excess)
+                Self.logger.debug("Evicted \(excess) oldest log entries")
+            }
+            logEntriesByProjectID[projectID] = projectLogs
         }
     }
 }

--- a/Rockxy/Views/Main/Extensions/MainContentCoordinator+NearbyTransfer.swift
+++ b/Rockxy/Views/Main/Extensions/MainContentCoordinator+NearbyTransfer.swift
@@ -40,7 +40,10 @@ extension MainContentCoordinator {
         transactionsByProjectID[projectStore.activeProjectID] = transactions
         nextSequenceNumberByProjectID[projectStore.activeProjectID] = nextSequenceNumber
         refreshDomainTree(for: destinationWorkspace)
-        destinationWorkspace.filteredTransactions = importedTransactions.filter { !$0.isTLSFailure }
+        let retainedTransactionIDs = Set(transactions.map(\.id))
+        destinationWorkspace.filteredTransactions = importedTransactions.filter {
+            retainedTransactionIDs.contains($0.id) && !$0.isTLSFailure
+        }
         destinationWorkspace.lastDeriveWasAppendOnly = false
         deriveFilteredRows(for: destinationWorkspace)
         rebuildObservedDomainsByApp()

--- a/Rockxy/Views/Main/Extensions/MainContentCoordinator+ProjectPresentation.swift
+++ b/Rockxy/Views/Main/Extensions/MainContentCoordinator+ProjectPresentation.swift
@@ -48,7 +48,9 @@ extension MainContentCoordinator {
             case .containsControlCharacters:
                 String(localized: "Project names cannot contain control characters.")
             case let .tooLong(count):
-                String(localized: "Project names are limited to 80 characters (received \(count)).")
+                String(
+                    localized: "Project names are limited to \(ProjectStructuralLimits.nameGraphemeRange.upperBound) characters (received \(count))."
+                )
             case .notCanonical:
                 String(localized: "The Project name is not in canonical Unicode form.")
             }

--- a/Rockxy/Views/Main/Extensions/MainContentCoordinator+ProjectTransfer.swift
+++ b/Rockxy/Views/Main/Extensions/MainContentCoordinator+ProjectTransfer.swift
@@ -139,9 +139,9 @@ extension MainContentCoordinator {
         Self.logger.error("Project transfer failed: \(String(describing: error))")
         let alert = NSAlert()
         alert.messageText = title
-        alert
-            .informativeText =
-            String(localized: "The Project configuration could not be processed safely. \(String(describing: error))")
+        alert.informativeText = String(
+            localized: "The Project configuration could not be processed safely. Verify the file and try again."
+        )
         alert.alertStyle = .warning
         alert.addButton(withTitle: String(localized: "OK"))
         alert.runModal()

--- a/Rockxy/Views/Main/Extensions/MainContentCoordinator+Projects.swift
+++ b/Rockxy/Views/Main/Extensions/MainContentCoordinator+Projects.swift
@@ -465,7 +465,9 @@ extension MainContentCoordinator {
         transactions = transactionsByProjectID[projectID] ?? []
         logEntries = logEntriesByProjectID[projectID] ?? []
         sessionProvenance = sessionProvenanceByProjectID[projectID]
-        nextSequenceNumber = (transactions.map(\.sequenceNumber).max() ?? -1) + 1
+        let maximumLiveSequence = transactions.map(\.sequenceNumber).max() ?? -1
+        let maximumFavoriteSequence = persistedFavorites.map(\.sequenceNumber).max() ?? -1
+        nextSequenceNumber = max(maximumLiveSequence, maximumFavoriteSequence) + 1
         nextSequenceNumberByProjectID[projectID] = nextSequenceNumber
         recomputeErrorCount()
         resetTrafficMetrics()

--- a/Rockxy/Views/Main/Extensions/MainContentCoordinator+ProxyControl.swift
+++ b/Rockxy/Views/Main/Extensions/MainContentCoordinator+ProxyControl.swift
@@ -486,8 +486,16 @@ extension MainContentCoordinator {
             nextSequenceNumberByProjectID[projectID] = sequence
 
             let overflow = max(0, history.count - liveHistoryLimit)
+            let evictionCount: Int
             if overflow > 0 {
-                history.removeFirst(overflow)
+                let evictionHeadroom = min(
+                    liveHistoryLimit,
+                    max(2, min(100, (liveHistoryLimit + 9) / 10))
+                )
+                evictionCount = min(history.count, max(overflow, evictionHeadroom))
+                history.removeFirst(evictionCount)
+            } else {
+                evictionCount = 0
             }
             transactionsByProjectID[projectID] = history
 
@@ -498,7 +506,7 @@ extension MainContentCoordinator {
 
             transactions = history
             nextSequenceNumber = sequence
-            if overflow > 0 {
+            if evictionCount > 0 {
                 rebuildObservedDomainsByApp()
                 debugAssistantTransactionsByHost.removeAll()
                 debugAssistantIndexedTransactionIDs.removeAll()

--- a/Rockxy/Views/Main/WorkspaceWindowManager.swift
+++ b/Rockxy/Views/Main/WorkspaceWindowManager.swift
@@ -55,7 +55,7 @@ final class RockxyWorkspaceWindowManager: NSObject {
         configure(window)
         installObserversIfNeeded(for: window)
         updateTabAccessory()
-        updateWindowTitles(coordinator: coordinator)
+        enforceToolbarOnlyProjectPresentation()
     }
 
     func openWorkspaceTab(coordinator: MainContentCoordinator, workspaceID: UUID) {
@@ -65,7 +65,7 @@ final class RockxyWorkspaceWindowManager: NSObject {
         self.coordinator = coordinator
         coordinator.workspaceStore.selectWorkspace(id: workspaceID)
         updateTabAccessory()
-        updateWindowTitles(coordinator: coordinator)
+        enforceToolbarOnlyProjectPresentation()
     }
 
     func openNewWorkspaceTabFromNativeControl() {
@@ -90,21 +90,21 @@ final class RockxyWorkspaceWindowManager: NSObject {
         self.coordinator = coordinator
         coordinator.workspaceStore.selectWorkspace(at: index)
         updateTabAccessory()
-        updateWindowTitles(coordinator: coordinator)
+        enforceToolbarOnlyProjectPresentation()
     }
 
     func selectPreviousWorkspaceTab(coordinator: MainContentCoordinator) {
         self.coordinator = coordinator
         coordinator.workspaceStore.selectPreviousWorkspace()
         updateTabAccessory()
-        updateWindowTitles(coordinator: coordinator)
+        enforceToolbarOnlyProjectPresentation()
     }
 
     func selectNextWorkspaceTab(coordinator: MainContentCoordinator) {
         self.coordinator = coordinator
         coordinator.workspaceStore.selectNextWorkspace()
         updateTabAccessory()
-        updateWindowTitles(coordinator: coordinator)
+        enforceToolbarOnlyProjectPresentation()
     }
 
     func handleWindowDidBecomeKey(_ window: NSWindow) {
@@ -112,9 +112,7 @@ final class RockxyWorkspaceWindowManager: NSObject {
             return
         }
         updateTabAccessory()
-        if let coordinator {
-            updateWindowTitles(coordinator: coordinator)
-        }
+        enforceToolbarOnlyProjectPresentation()
     }
 
     func handleWindowWillClose(_ window: NSWindow) {
@@ -127,14 +125,10 @@ final class RockxyWorkspaceWindowManager: NSObject {
         coordinator = nil
     }
 
-    func updateWindowTitles(coordinator: MainContentCoordinator) {
-        primaryWindow?.title = coordinator.projectStore.activeProject.name
-    }
-
     func projectDidChange(coordinator: MainContentCoordinator) {
         self.coordinator = coordinator
         updateTabAccessory(forceVisible: coordinator.workspaceStore.workspaces.count > 1)
-        updateWindowTitles(coordinator: coordinator)
+        enforceToolbarOnlyProjectPresentation()
     }
 
     func flushProjectStateForTermination() async {
@@ -175,6 +169,23 @@ final class RockxyWorkspaceWindowManager: NSObject {
     private(set) weak var primaryWindow: NSWindow?
     private var accessoryControllers: [ObjectIdentifier: WorkspaceTabBarAccessoryController] = [:]
     private var observersByWindow: [ObjectIdentifier: [NSObjectProtocol]] = [:]
+    private var titleObservationsByWindow: [ObjectIdentifier: [NSKeyValueObservation]] = [:]
+
+    /// The toolbar's Project selector and workspace tabs already communicate the
+    /// active context. Keep a stable app title for Window-menu and accessibility
+    /// semantics, but never let a Project name become a second visible title.
+    private func enforceToolbarOnlyProjectPresentation(on window: NSWindow? = nil) {
+        guard let window = window ?? primaryWindow,
+              window === primaryWindow else {
+            return
+        }
+        if window.title != RockxyIdentity.current.displayName {
+            window.title = RockxyIdentity.current.displayName
+        }
+        if window.titleVisibility != .hidden {
+            window.titleVisibility = .hidden
+        }
+    }
 
     private func configure(_ window: NSWindow) {
         window.identifier = Self.mainWindowIdentifier
@@ -218,6 +229,18 @@ final class RockxyWorkspaceWindowManager: NSObject {
         }
 
         observersByWindow[key] = [didBecomeKey, willClose]
+        titleObservationsByWindow[key] = [
+            window.observe(\.title, options: [.new]) { [weak self, weak window] _, _ in
+                MainActor.assumeIsolated {
+                    self?.enforceToolbarOnlyProjectPresentation(on: window)
+                }
+            },
+            window.observe(\.titleVisibility, options: [.new]) { [weak self, weak window] _, _ in
+                MainActor.assumeIsolated {
+                    self?.enforceToolbarOnlyProjectPresentation(on: window)
+                }
+            },
+        ]
     }
 
     private func removeObservers(for window: NSWindow) {
@@ -228,6 +251,7 @@ final class RockxyWorkspaceWindowManager: NSObject {
         for observer in observers {
             NotificationCenter.default.removeObserver(observer)
         }
+        titleObservationsByWindow.removeValue(forKey: key)
     }
 
     private func updateTabAccessory(forceVisible: Bool = false) {
@@ -289,7 +313,7 @@ final class RockxyWorkspaceWindowManager: NSObject {
         }
         coordinator.workspaceStore.selectWorkspace(id: workspaceID)
         updateTabAccessory()
-        updateWindowTitles(coordinator: coordinator)
+        enforceToolbarOnlyProjectPresentation()
     }
 
     fileprivate func closeWorkspace(_ workspaceID: UUID) {
@@ -300,7 +324,7 @@ final class RockxyWorkspaceWindowManager: NSObject {
         }
         coordinator.closeWorkspace(id: workspaceID)
         updateTabAccessory()
-        updateWindowTitles(coordinator: coordinator)
+        enforceToolbarOnlyProjectPresentation()
     }
 
     fileprivate func createWorkspace() {
@@ -315,7 +339,7 @@ final class RockxyWorkspaceWindowManager: NSObject {
         }
         coordinator.workspaceStore.renameWorkspace(id: workspaceID, to: normalizedTitle)
         updateTabAccessory(forceVisible: coordinator.workspaceStore.workspaces.count > 1)
-        updateWindowTitles(coordinator: coordinator)
+        enforceToolbarOnlyProjectPresentation()
     }
 
     @discardableResult
@@ -335,7 +359,7 @@ final class RockxyWorkspaceWindowManager: NSObject {
         }
         coordinator.workspaceStore.moveWorkspace(from: sourceIndex, to: destinationIndex)
         updateTabAccessory()
-        updateWindowTitles(coordinator: coordinator)
+        enforceToolbarOnlyProjectPresentation()
         return true
     }
 }
@@ -403,7 +427,9 @@ private final class WorkspaceTabBarView: NSView, NSTextFieldDelegate {
             object: nil,
             queue: .main
         ) { [weak self] _ in
-            self?.appearanceDidChange()
+            MainActor.assumeIsolated {
+                self?.appearanceDidChange()
+            }
         }
     }
 
@@ -430,6 +456,11 @@ private final class WorkspaceTabBarView: NSView, NSTextFieldDelegate {
 
     override var intrinsicContentSize: NSSize {
         NSSize(width: NSView.noIntrinsicMetric, height: WorkspaceTabBarMetrics.barHeight)
+    }
+
+    override func viewDidChangeEffectiveAppearance() {
+        super.viewDidChangeEffectiveAppearance()
+        needsDisplay = true
     }
 
     override func updateTrackingAreas() {

--- a/Rockxy/Views/Main/WorkspaceWindowManager.swift
+++ b/Rockxy/Views/Main/WorkspaceWindowManager.swift
@@ -627,7 +627,9 @@ private final class WorkspaceTabBarView: NSView, NSTextFieldDelegate {
             return
         }
 
-        endEditing(commit: true)
+        guard endEditing(commit: true) else {
+            return
+        }
         editingWorkspaceID = workspaceID
         originalTitle = workspace.title
 
@@ -648,28 +650,42 @@ private final class WorkspaceTabBarView: NSView, NSTextFieldDelegate {
         needsDisplay = true
     }
 
-    func endEditing(commit: Bool) {
+    @discardableResult
+    func endEditing(commit: Bool) -> Bool {
         guard let editingWorkspaceID,
               let field = editField else {
-            return
+            return true
         }
-        removeEditingMonitor()
 
-        let fallbackTitle = originalTitle
-        let committedTitle: String
+        var committedTitle = originalTitle
         if commit {
-            let trimmed = field.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
-            committedTitle = trimmed.isEmpty ? fallbackTitle : trimmed
-        } else {
-            committedTitle = fallbackTitle
+            do {
+                committedTitle = try ProjectNormalization.normalizedDisplayName(field.stringValue)
+            } catch let error as ProjectNameNormalizationError {
+                field.textColor = .systemRed
+                field.toolTip = inlineRenameErrorMessage(for: error)
+                NSSound.beep()
+                window?.makeFirstResponder(field)
+                return false
+            } catch {
+                field.textColor = .systemRed
+                field.toolTip = String(localized: "Enter a valid Traffic Tab name.")
+                NSSound.beep()
+                window?.makeFirstResponder(field)
+                return false
+            }
         }
 
+        removeEditingMonitor()
         self.editingWorkspaceID = nil
         originalTitle = ""
         editField = nil
         field.removeFromSuperview()
-        manager.renameWorkspace(editingWorkspaceID, to: committedTitle)
+        if commit {
+            manager.renameWorkspace(editingWorkspaceID, to: committedTitle)
+        }
         needsDisplay = true
+        return true
     }
 
     func controlTextDidEndEditing(_ notification: Notification) {
@@ -1388,8 +1404,22 @@ private final class WorkspaceTabBarView: NSView, NSTextFieldDelegate {
                 return event
             }
         }
-        endEditing(commit: true)
-        return event
+        return endEditing(commit: true) ? event : nil
+    }
+
+    private func inlineRenameErrorMessage(for error: ProjectNameNormalizationError) -> String {
+        switch error {
+        case .empty:
+            String(localized: "Enter a Traffic Tab name.")
+        case .containsControlCharacters:
+            String(localized: "Traffic Tab names cannot contain control characters.")
+        case let .tooLong(count):
+            String(
+                localized: "Traffic Tab names are limited to \(ProjectStructuralLimits.nameGraphemeRange.upperBound) characters (received \(count))."
+            )
+        case .notCanonical:
+            String(localized: "The Traffic Tab name is not in canonical Unicode form.")
+        }
     }
 
     @objc private func renameTabFromMenu(_ sender: NSMenuItem) {

--- a/Rockxy/Views/Projects/ProjectPresentation.swift
+++ b/Rockxy/Views/Projects/ProjectPresentation.swift
@@ -167,6 +167,7 @@ struct ProjectNameEditorSheet: View {
         self.context = context
         self.coordinator = coordinator
         _name = State(initialValue: context.initialName)
+        _operationErrorMessage = State(initialValue: nil)
     }
 
     let context: ProjectNameEditorContext
@@ -197,9 +198,12 @@ struct ProjectNameEditorSheet: View {
                     .font(.subheadline.weight(.medium))
                 TextField(String(localized: "For example: Checkout API"), text: $name)
                     .textFieldStyle(.roundedBorder)
-                Text(validationMessage ?? String(localized: "1–80 characters. Names must be unique."))
+                    .onChange(of: name) { _, _ in
+                        operationErrorMessage = nil
+                    }
+                Text(editorMessage)
                     .font(.caption)
-                    .foregroundStyle(validationMessage == nil ? Color.secondary : Color.orange)
+                    .foregroundStyle(hasEditorError ? Color.orange : Color.secondary)
             }
             .padding(18)
 
@@ -225,6 +229,19 @@ struct ProjectNameEditorSheet: View {
 
     @Environment(\.dismiss) private var dismiss
     @State private var name: String
+    @State private var operationErrorMessage: String?
+
+    private var editorMessage: String {
+        validationMessage
+            ?? operationErrorMessage
+            ?? String(
+                localized: "1–\(ProjectStructuralLimits.nameGraphemeRange.upperBound) characters. Names must be unique."
+            )
+    }
+
+    private var hasEditorError: Bool {
+        validationMessage != nil || operationErrorMessage != nil
+    }
 
     private var normalizedName: String? {
         try? ProjectNormalization.normalizedDisplayName(name)
@@ -258,6 +275,8 @@ struct ProjectNameEditorSheet: View {
             coordinator.renameProject(id: id, to: normalizedName)
         }
         guard succeeded else {
+            operationErrorMessage = coordinator.projectOperationErrorMessage
+                ?? String(localized: "The Project could not be updated. Try again.")
             return
         }
         RockxyWorkspaceWindowManager.shared.projectDidChange(coordinator: coordinator)
@@ -529,6 +548,7 @@ struct ProjectManagerSheet: View {
             .buttonStyle(.plain)
             .keyboardShortcut("n", modifiers: [.command, .shift])
             .help(String(localized: "New Project"))
+            .accessibilityLabel(String(localized: "New Project"))
             .disabled(!canCreateProject)
 
             Rectangle()
@@ -552,6 +572,7 @@ struct ProjectManagerSheet: View {
             }
             .buttonStyle(.plain)
             .help(String(localized: "Delete Project"))
+            .accessibilityLabel(String(localized: "Delete Project"))
             .disabled(!canDeleteSelectedProject)
         }
         .frame(
@@ -627,10 +648,8 @@ struct ProjectManagerSheet: View {
     }
 
     private func trafficTabCountText(_ count: Int) -> String {
-        if count == 1 {
-            return String(localized: "1 Traffic Tab")
-        }
-        return String(localized: "\(count) Traffic Tabs")
+        let inflected = AttributedString(localized: "^[\(count) Traffic Tab](inflect: true)")
+        return String(inflected.characters)
     }
 
     private func projectAccessibilityValue(_ project: Project) -> String {

--- a/Rockxy/Views/Projects/ProjectPresentation.swift
+++ b/Rockxy/Views/Projects/ProjectPresentation.swift
@@ -1,7 +1,7 @@
 import AppKit
 import SwiftUI
 
-// MARK: - Project Presentation Models
+// MARK: - ProjectNameEditorContext
 
 struct ProjectNameEditorContext: Identifiable, Equatable {
     enum Mode: Equatable {
@@ -32,14 +32,18 @@ struct ProjectNameEditorContext: Identifiable, Equatable {
     }
 }
 
+// MARK: - ProjectDeletionRequest
+
 struct ProjectDeletionRequest: Identifiable, Equatable {
     let projectID: UUID
     let projectName: String
 
-    var id: UUID { projectID }
+    var id: UUID {
+        projectID
+    }
 }
 
-// MARK: - ProjectToolbarSelectorView
+// MARK: - ProjectToolbarSelectorMetrics
 
 enum ProjectToolbarSelectorMetrics {
     static let minimumWidth: CGFloat = 104
@@ -59,7 +63,11 @@ enum ProjectToolbarSelectorMetrics {
     }
 }
 
+// MARK: - ProjectToolbarSelectorView
+
 struct ProjectToolbarSelectorView: View {
+    // MARK: Internal
+
     @Bindable var coordinator: MainContentCoordinator
 
     var body: some View {
@@ -116,6 +124,8 @@ struct ProjectToolbarSelectorView: View {
                     .foregroundStyle(.secondary)
             }
             .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 5)
             .contentShape(.rect)
         }
         .menuIndicator(.hidden)
@@ -126,6 +136,8 @@ struct ProjectToolbarSelectorView: View {
         .accessibilityLabel(String(localized: "Active Project"))
         .accessibilityValue(coordinator.projectStore.activeProject.name)
     }
+
+    // MARK: Private
 
     private var preferredWidth: CGFloat {
         ProjectToolbarSelectorMetrics.preferredWidth(
@@ -147,7 +159,8 @@ struct ProjectToolbarSelectorView: View {
             "folder.badge.questionmark"
         case .loading:
             "folder"
-        case .idle, .ready:
+        case .idle,
+             .ready:
             "folder.fill"
         }
     }
@@ -163,12 +176,16 @@ struct ProjectToolbarSelectorView: View {
 // MARK: - ProjectNameEditorSheet
 
 struct ProjectNameEditorSheet: View {
+    // MARK: Lifecycle
+
     init(context: ProjectNameEditorContext, coordinator: MainContentCoordinator) {
         self.context = context
         self.coordinator = coordinator
         _name = State(initialValue: context.initialName)
         _operationErrorMessage = State(initialValue: nil)
     }
+
+    // MARK: Internal
 
     let context: ProjectNameEditorContext
     let coordinator: MainContentCoordinator
@@ -219,6 +236,7 @@ struct ProjectNameEditorSheet: View {
                     submit()
                 }
                 .keyboardShortcut(.defaultAction)
+                .rockxyGlassButtonStyle(prominent: true)
                 .disabled(validationMessage != nil)
             }
             .padding(.horizontal, 18)
@@ -226,6 +244,8 @@ struct ProjectNameEditorSheet: View {
         }
         .frame(width: 460)
     }
+
+    // MARK: Private
 
     @Environment(\.dismiss) private var dismiss
     @State private var name: String
@@ -287,10 +307,14 @@ struct ProjectNameEditorSheet: View {
 // MARK: - ProjectManagerSheet
 
 struct ProjectManagerSheet: View {
+    // MARK: Lifecycle
+
     init(coordinator: MainContentCoordinator) {
         self.coordinator = coordinator
         _selection = State(initialValue: coordinator.projectStore.activeProjectID)
     }
+
+    // MARK: Internal
 
     let coordinator: MainContentCoordinator
 
@@ -324,7 +348,9 @@ struct ProjectManagerSheet: View {
             Button(String(localized: "Cancel"), role: .cancel) {}
         } message: { _ in
             Text(
-                String(localized: "This removes the Project, its in-memory traffic history, and its saved Traffic Tab configuration.")
+                String(
+                    localized: "This removes the Project, its in-memory traffic history, and its saved Traffic Tab configuration."
+                )
                     + " "
                     + String(localized: "Manually saved session files, rules, and favorites are not deleted.")
             )
@@ -339,6 +365,8 @@ struct ProjectManagerSheet: View {
             selection = activeProjectID
         }
     }
+
+    // MARK: Private
 
     @Environment(\.dismiss) private var dismiss
     @Environment(\.appUIDisplayMetrics) private var appMetrics
@@ -362,6 +390,23 @@ struct ProjectManagerSheet: View {
 
     private var canExportSelectedProject: Bool {
         canTransitionProjects && selectedProject != nil
+    }
+
+    private var canDeleteSelectedProject: Bool {
+        canTransitionProjects
+            && selectedProject != nil
+            && coordinator.projectStore.projects.count > 1
+    }
+
+    private var deleteConfirmation: Binding<Bool> {
+        Binding(
+            get: { coordinator.projectDeletionRequest != nil },
+            set: {
+                if !$0 {
+                    coordinator.projectDeletionRequest = nil
+                }
+            }
+        )
     }
 
     private var projectSidebar: some View {
@@ -438,8 +483,7 @@ struct ProjectManagerSheet: View {
         .background(Color(nsColor: .windowBackgroundColor))
     }
 
-    @ViewBuilder
-    private var detail: some View {
+    @ViewBuilder private var detail: some View {
         if let project = selectedProject {
             VStack(alignment: .leading, spacing: 0) {
                 HStack(alignment: .center, spacing: toolMetrics.controlSpacing) {
@@ -587,15 +631,11 @@ struct ProjectManagerSheet: View {
         }
     }
 
-    private var canDeleteSelectedProject: Bool {
-        canTransitionProjects
-            && selectedProject != nil
-            && coordinator.projectStore.projects.count > 1
-    }
-
     private var infoBanner: some View {
         Label(
-            String(localized: "Projects save tab names, filters, and layout. Each Project keeps separate in-memory traffic."),
+            String(
+                localized: "Projects save tab names, filters, and layout. Each Project keeps separate in-memory traffic."
+            ),
             systemImage: "info.circle"
         )
         .font(toolMetrics.secondaryFont())
@@ -641,6 +681,7 @@ struct ProjectManagerSheet: View {
                 dismiss()
             }
             .keyboardShortcut(.defaultAction)
+            .rockxyGlassButtonStyle(prominent: true)
         }
         .padding(.horizontal, toolMetrics.contentHorizontalPadding)
         .padding(.vertical, toolMetrics.footerTopPadding)
@@ -658,17 +699,6 @@ struct ProjectManagerSheet: View {
             return String(localized: "\(count), Active Project")
         }
         return count
-    }
-
-    private var deleteConfirmation: Binding<Bool> {
-        Binding(
-            get: { coordinator.projectDeletionRequest != nil },
-            set: {
-                if !$0 {
-                    coordinator.projectDeletionRequest = nil
-                }
-            }
-        )
     }
 
     private func open(_ project: Project) {
@@ -712,6 +742,8 @@ struct ProjectManagerSheet: View {
 // MARK: - ProjectRecoverySheet
 
 struct ProjectRecoverySheet: View {
+    // MARK: Internal
+
     let coordinator: MainContentCoordinator
 
     var body: some View {
@@ -724,7 +756,9 @@ struct ProjectRecoverySheet: View {
                     Text(String(localized: "Projects Could Not Be Loaded"))
                         .font(.headline)
                     Text(
-                        String(localized: "Rockxy kept the existing catalog unchanged and disabled Project edits to avoid overwriting data.")
+                        String(
+                            localized: "Rockxy kept the existing catalog unchanged and disabled Project edits to avoid overwriting data."
+                        )
                     )
                     .foregroundStyle(.secondary)
                     Text(coordinator.projectStore.loadFailureMessage ?? String(localized: "Unknown catalog error"))
@@ -752,6 +786,7 @@ struct ProjectRecoverySheet: View {
                     retry()
                 }
                 .keyboardShortcut(.defaultAction)
+                .rockxyGlassButtonStyle(prominent: true)
             }
             .padding(.horizontal, 20)
             .frame(height: 56)
@@ -769,6 +804,8 @@ struct ProjectRecoverySheet: View {
             )
         }
     }
+
+    // MARK: Private
 
     @State private var confirmsReset = false
 

--- a/Rockxy/Views/Projects/ProjectPresentation.swift
+++ b/Rockxy/Views/Projects/ProjectPresentation.swift
@@ -681,7 +681,7 @@ struct ProjectManagerSheet: View {
                 dismiss()
             }
             .keyboardShortcut(.defaultAction)
-            .rockxyGlassButtonStyle(prominent: true)
+            .rockxyGlassButtonStyle()
         }
         .padding(.horizontal, toolMetrics.contentHorizontalPadding)
         .padding(.vertical, toolMetrics.footerTopPadding)

--- a/Rockxy/Views/RequestList/CenterContentView.swift
+++ b/Rockxy/Views/RequestList/CenterContentView.swift
@@ -70,6 +70,16 @@ struct CenterContentView: View {
                     startPoint: .topLeading,
                     endPoint: .bottomTrailing
                 )
+                RadialGradient(
+                    colors: [
+                        Color.cyan.opacity(Theme.Glass.ambientSecondaryOpacity),
+                        Color.accentColor.opacity(Theme.Glass.ambientSecondaryOpacity * 0.45),
+                        Color.clear,
+                    ],
+                    center: .bottomTrailing,
+                    startRadius: 0,
+                    endRadius: 520
+                )
             }
         }
         .onChange(of: coordinator.selectedTransaction?.id) { _, newID in

--- a/Rockxy/Views/RequestList/CenterContentView.swift
+++ b/Rockxy/Views/RequestList/CenterContentView.swift
@@ -20,63 +20,11 @@ struct CenterContentView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            TrafficCommandBar(coordinator: coordinator, onOpenToolWindow: onOpenToolWindow)
-
-            ProtocolFilterBar(
-                activeFilters: Binding(
-                    get: { coordinator.filterCriteria.activeProtocolFilters },
-                    set: {
-                        coordinator.filterCriteria.activeProtocolFilters = $0
-                        coordinator.recomputeFilteredTransactions()
-                    }
-                )
+            TrafficControlShelf(
+                coordinator: coordinator,
+                advancedRuleCount: advancedRuleCount,
+                onOpenToolWindow: onOpenToolWindow
             )
-
-            SearchFilterBar(
-                searchText: Binding(
-                    get: { coordinator.filterCriteria.searchText },
-                    set: {
-                        coordinator.filterCriteria.searchText = $0
-                        coordinator.recomputeFilteredTransactions()
-                    }
-                ),
-                filterField: Binding(
-                    get: { coordinator.filterCriteria.searchField },
-                    set: {
-                        coordinator.filterCriteria.searchField = $0
-                        coordinator.recomputeFilteredTransactions()
-                    }
-                ),
-                isEnabled: Binding(
-                    get: { coordinator.filterCriteria.isSearchEnabled },
-                    set: {
-                        coordinator.filterCriteria.isSearchEnabled = $0
-                        coordinator.recomputeFilteredTransactions()
-                    }
-                ),
-                isAdvancedFilterVisible: coordinator.isFilterBarVisible,
-                advancedFilterCount: advancedRuleCount,
-                onAddFilter: coordinator.addAdvancedFilterRule,
-                onToggleAdvancedFilters: {
-                    coordinator.isFilterBarVisible.toggle()
-                    coordinator.recomputeFilteredTransactions()
-                }
-            )
-
-            if coordinator.isFilterBarVisible {
-                AdvancedFilterBar(
-                    rules: Binding(
-                        get: { coordinator.filterRules },
-                        set: {
-                            coordinator.filterRules = $0
-                            coordinator.recomputeFilteredTransactions()
-                        }
-                    ),
-                    presetStore: coordinator.filterPresetStore
-                )
-            }
-
-            ActiveFilterSummaryBar(coordinator: coordinator)
 
             inspectorWorkspace
 
@@ -109,6 +57,20 @@ struct CenterContentView: View {
                 },
                 onOpenToolWindow: onOpenToolWindow
             )
+        }
+        .background {
+            ZStack {
+                Color(nsColor: .windowBackgroundColor)
+                LinearGradient(
+                    colors: [
+                        Color.accentColor.opacity(Theme.Glass.ambientAccentOpacity),
+                        Color.cyan.opacity(Theme.Glass.ambientSecondaryOpacity),
+                        Color.clear,
+                    ],
+                    startPoint: .topLeading,
+                    endPoint: .bottomTrailing
+                )
+            }
         }
         .onChange(of: coordinator.selectedTransaction?.id) { _, newID in
             // Only sync single selection to multi-selection IDs when not actively multi-selecting

--- a/Rockxy/Views/RequestList/StatusBarView.swift
+++ b/Rockxy/Views/RequestList/StatusBarView.swift
@@ -252,34 +252,35 @@ enum FooterMutationIndicatorBuilder {
 
 // MARK: - FooterToolingButton
 
-/// Shared capsule launcher rendered identically in the top command bar and the footer. This is the
-/// single visual source of truth for Quick Tools chrome — never fork a top-only variant.
+/// Shared native launcher for the top command bar and footer. Quick Tools are product-specific,
+/// so their names remain visible instead of requiring new users to learn an icon vocabulary.
+/// Native button styles still own bezel, hover, pressed, focused, disabled, and active treatment.
 struct FooterToolingButton: View {
     // MARK: Internal
 
     let descriptor: FooterActionDescriptor
+    var controlSize: ControlSize = .small
     let action: () -> Void
 
     var body: some View {
         Button(action: action) {
             Label(descriptor.title, systemImage: descriptor.systemImage)
-                .modifier(FooterToolingChrome(
-                    isActive: descriptor.isActive,
-                    isEnabled: descriptor.isEnabled,
-                    isHovered: isHovered
-                ))
+                .font(.system(size: metrics.secondaryFontSize, weight: .medium))
+                .lineLimit(1)
+                .fixedSize(horizontal: true, vertical: false)
+                .padding(.horizontal, 2)
         }
-        .buttonStyle(.plain)
+        .controlSize(controlSize)
+        .rockxyGlassButtonStyle(prominent: descriptor.isActive)
         .disabled(!descriptor.isEnabled)
         .help(descriptor.help)
         .accessibilityLabel(descriptor.title)
         .accessibilityValue(descriptor.isActive ? String(localized: "Active") : "")
-        .onHover { isHovered = $0 }
     }
 
     // MARK: Private
 
-    @State private var isHovered = false
+    @Environment(\.appUIDisplayMetrics) private var metrics
 }
 
 // MARK: - FooterMutationIndicatorButton
@@ -296,18 +297,17 @@ private struct FooterMutationIndicatorButton: View {
     let action: () -> Void
 
     var body: some View {
-        Button(action: action) {
-            chip
-        }
-        .buttonStyle(.plain)
+        Button(action: action) { label }
+        .controlSize(.small)
+        .rockxyGlassButtonStyle()
+        .tint(indicatorColor)
         .help(indicator.help)
         .accessibilityLabel(indicator.accessibilityLabel)
-        .onHover { isHovered = $0 }
+        .accessibilityValue(String(localized: "\(indicator.count) active rules"))
     }
 
     // MARK: Private
 
-    @State private var isHovered = false
     @Environment(\.appUIDisplayMetrics) private var metrics
 
     private var indicatorColor: Color {
@@ -320,7 +320,7 @@ private struct FooterMutationIndicatorButton: View {
         }
     }
 
-    private var chip: some View {
+    private var label: some View {
         HStack(spacing: 4) {
             Image(systemName: indicator.systemImage)
             if showsTitle {
@@ -331,9 +331,6 @@ private struct FooterMutationIndicatorButton: View {
         }
         .font(.system(size: metrics.badgeFontSize, weight: .semibold))
         .lineLimit(1)
-        .padding(.horizontal, 7)
-        .padding(.vertical, 2)
-        .rockxyChipStyle(tint: indicatorColor, isActive: true, isHovered: isHovered)
     }
 }
 
@@ -348,7 +345,7 @@ private struct FooterProxyOverrideButton: View {
     let onSwitchOff: () -> Void
 
     var body: some View {
-        FooterToolingButton(descriptor: descriptor) {
+        FooterToolingButton(descriptor: descriptor, controlSize: .regular) {
             showPopover.toggle()
         }
         .popover(isPresented: $showPopover, arrowEdge: .bottom) {
@@ -407,33 +404,6 @@ private struct FooterProxyOverridePopover: View {
     private var statusText: String {
         String(localized: "System Proxy is Overridden by Rockxy (IP=\(proxyHost) Port=\(proxyPort)) (Toggle by: ⌥⌘O)")
     }
-}
-
-// MARK: - FooterToolingChrome
-
-struct FooterToolingChrome: ViewModifier {
-    // MARK: Internal
-
-    let isActive: Bool
-    let isEnabled: Bool
-    let isHovered: Bool
-
-    func body(content: Content) -> some View {
-        content
-            .font(.system(size: metrics.badgeFontSize, weight: .semibold))
-            .lineLimit(1)
-            .padding(.horizontal, 7)
-            .padding(.vertical, 2)
-            .rockxyChipStyle(
-                isActive: isActive,
-                isHovered: isHovered,
-                isEnabled: isEnabled
-            )
-    }
-
-    // MARK: Private
-
-    @Environment(\.appUIDisplayMetrics) private var metrics
 }
 
 // MARK: - StatusBarRequestSummary
@@ -500,11 +470,14 @@ struct StatusBarView: View {
         WorkspaceFooterBar(horizontalPadding: 12) {
             HStack(spacing: 0) {
                 quickTools
+                    .layoutPriority(0)
                 mutationIndicators
-                Spacer(minLength: 24)
+                Spacer(minLength: 12)
                 centerStatus
-                Spacer(minLength: 24)
+                    .layoutPriority(3)
+                Spacer(minLength: 12)
                 rightStats
+                    .layoutPriority(3)
             }
         }
     }
@@ -639,25 +612,38 @@ struct StatusBarView: View {
             }
         }
         .lineLimit(1)
+        .fixedSize(horizontal: true, vertical: false)
     }
 
-    private var quickTools: some View {
-        HStack(spacing: 6) {
-            ForEach(FooterActionDescriptor.toolingActions(
-                isAllowListActive: isAllowListActive,
-                quickTools: quickToolsLayout.footer
-            )) { descriptor in
-                FooterToolingButton(descriptor: descriptor) {
+    @ViewBuilder private var quickTools: some View {
+        let descriptors = FooterActionDescriptor.toolingActions(
+            isAllowListActive: isAllowListActive,
+            quickTools: quickToolsLayout.footer
+        )
+        ViewThatFits(in: .horizontal) {
+            labeledQuickToolsRow(descriptors)
+            quickToolsMenu(descriptors)
+        }
+    }
+
+    private func labeledQuickToolsRow(_ descriptors: [FooterActionDescriptor]) -> some View {
+        HStack(spacing: 4) {
+            ForEach(descriptors) { descriptor in
+                FooterToolingButton(descriptor: descriptor, controlSize: .regular) {
                     performAction(descriptor.id)
                 }
             }
             Button {
                 isCustomizingQuickTools.toggle()
             } label: {
-                Image(systemName: "ellipsis.circle")
+                Image(systemName: "ellipsis")
+                    .frame(width: metrics.chromeBadgeHeight, height: metrics.chromeBadgeHeight)
             }
-            .buttonStyle(.plain)
+            .font(.system(size: metrics.secondaryFontSize, weight: .medium))
+            .controlSize(.regular)
+            .rockxyGlassButtonStyle()
             .help(String(localized: "Customize Quick Tools"))
+            .accessibilityLabel(String(localized: "Customize Quick Tools"))
             .popover(isPresented: $isCustomizingQuickTools, arrowEdge: .bottom) {
                 QuickToolsEditor(
                     layout: quickToolsLayout,
@@ -666,6 +652,45 @@ struct StatusBarView: View {
                     onDone: { isCustomizingQuickTools = false }
                 )
             }
+        }
+        .fixedSize(horizontal: true, vertical: false)
+    }
+
+    private func quickToolsMenu(_ descriptors: [FooterActionDescriptor]) -> some View {
+        Menu {
+            ForEach(descriptors) { descriptor in
+                Button {
+                    performAction(descriptor.id)
+                } label: {
+                    Label(descriptor.title, systemImage: descriptor.systemImage)
+                }
+            }
+            Divider()
+            Button(String(localized: "Customize Quick Tools…")) {
+                DispatchQueue.main.async {
+                    isCustomizingQuickTools = true
+                }
+            }
+        } label: {
+            Label(String(localized: "Quick Tools"), systemImage: "hammer")
+                .font(.system(size: metrics.secondaryFontSize, weight: .medium))
+                .lineLimit(1)
+                .fixedSize(horizontal: true, vertical: false)
+                .padding(.horizontal, 2)
+        }
+        .menuStyle(.button)
+        .menuIndicator(.visible)
+        .controlSize(.regular)
+        .rockxyGlassButtonStyle()
+        .help(String(localized: "Open Quick Tools"))
+        .accessibilityLabel(String(localized: "Quick Tools"))
+        .popover(isPresented: $isCustomizingQuickTools, arrowEdge: .bottom) {
+            QuickToolsEditor(
+                layout: quickToolsLayout,
+                onSave: { quickToolsLayoutRaw = $0.encoded },
+                onReset: { quickToolsLayoutRaw = QuickToolsLayout.default.encoded },
+                onDone: { isCustomizingQuickTools = false }
+            )
         }
     }
 
@@ -694,17 +719,14 @@ struct StatusBarView: View {
                 }
             }
         } label: {
-            Label(
-                "\(indicators.reduce(0) { $0 + $1.count })",
-                systemImage: "bolt.horizontal.circle"
-            )
-            .font(.system(size: metrics.badgeFontSize, weight: .semibold))
-            .padding(.horizontal, 7)
-            .padding(.vertical, 2)
-            .rockxyChipStyle(tint: Color(nsColor: .systemOrange), isActive: true)
+            Label("\(indicators.reduce(0) { $0 + $1.count })", systemImage: "bolt.horizontal.circle")
+                .font(.system(size: metrics.badgeFontSize, weight: .semibold))
         }
-        .menuStyle(.borderlessButton)
+        .menuStyle(.button)
         .menuIndicator(.hidden)
+        .controlSize(.small)
+        .rockxyGlassButtonStyle()
+        .tint(Color(nsColor: .systemOrange))
         .fixedSize()
         .help(String(localized: "Active mutation rules"))
         .accessibilityLabel(String(localized: "Active mutation rules"))
@@ -749,14 +771,20 @@ struct WorkspaceFooterBar<Content: View>: View {
     @ViewBuilder let content: () -> Content
 
     var body: some View {
-        content()
-            .frame(maxWidth: .infinity)
-            .padding(.horizontal, horizontalPadding)
-            .frame(height: metrics.statusBarHeight)
-            .rockxyFunctionalBar()
-            .overlay(alignment: .top) {
-                Divider()
-            }
+        RockxyGlassEffectGroup(spacing: Theme.Glass.footerOuterHorizontalPadding) {
+            content()
+                .frame(maxWidth: .infinity)
+                .padding(.horizontal, horizontalPadding)
+                .frame(height: metrics.statusBarHeight)
+                .rockxyGlassEffect(
+                    in: RoundedRectangle(
+                        cornerRadius: Theme.Glass.footerCornerRadius,
+                        style: .continuous
+                    )
+                )
+        }
+        .padding(.horizontal, Theme.Glass.footerOuterHorizontalPadding)
+        .padding(.vertical, Theme.Glass.footerOuterVerticalPadding)
     }
 
     // MARK: Private

--- a/Rockxy/Views/RequestList/StatusBarView.swift
+++ b/Rockxy/Views/RequestList/StatusBarView.swift
@@ -330,15 +330,10 @@ private struct FooterMutationIndicatorButton: View {
                 .monospacedDigit()
         }
         .font(.system(size: metrics.badgeFontSize, weight: .semibold))
-        .foregroundStyle(indicatorColor)
         .lineLimit(1)
         .padding(.horizontal, 7)
         .padding(.vertical, 2)
-        .background(indicatorColor.opacity(isHovered ? 0.24 : 0.14), in: Capsule())
-        .overlay {
-            Capsule()
-                .stroke(indicatorColor.opacity(isHovered ? 0.55 : 0.32), lineWidth: 0.5)
-        }
+        .rockxyChipStyle(tint: indicatorColor, isActive: true, isHovered: isHovered)
     }
 }
 
@@ -426,27 +421,19 @@ struct FooterToolingChrome: ViewModifier {
     func body(content: Content) -> some View {
         content
             .font(.system(size: metrics.badgeFontSize, weight: .semibold))
-            .foregroundStyle(Color.white)
             .lineLimit(1)
             .padding(.horizontal, 7)
             .padding(.vertical, 2)
-            .background(backgroundColor, in: Capsule())
-            .opacity(isEnabled ? 1 : 0.45)
+            .rockxyChipStyle(
+                isActive: isActive,
+                isHovered: isHovered,
+                isEnabled: isEnabled
+            )
     }
 
     // MARK: Private
 
     @Environment(\.appUIDisplayMetrics) private var metrics
-
-    private var backgroundColor: Color {
-        if isActive {
-            return Color.accentColor
-        }
-        if isHovered, isEnabled {
-            return Color(nsColor: .secondaryLabelColor).opacity(0.86)
-        }
-        return Color(nsColor: .tertiaryLabelColor)
-    }
 }
 
 // MARK: - StatusBarRequestSummary
@@ -712,10 +699,9 @@ struct StatusBarView: View {
                 systemImage: "bolt.horizontal.circle"
             )
             .font(.system(size: metrics.badgeFontSize, weight: .semibold))
-            .foregroundStyle(Color(nsColor: .systemOrange))
             .padding(.horizontal, 7)
             .padding(.vertical, 2)
-            .background(Color(nsColor: .systemOrange).opacity(0.14), in: Capsule())
+            .rockxyChipStyle(tint: Color(nsColor: .systemOrange), isActive: true)
         }
         .menuStyle(.borderlessButton)
         .menuIndicator(.hidden)
@@ -727,11 +713,10 @@ struct StatusBarView: View {
     private func statusPill(_ title: String, color: Color) -> some View {
         Text(title)
             .font(.system(size: metrics.badgeFontSize, weight: .semibold))
-            .foregroundStyle(.white)
             .lineLimit(1)
             .padding(.horizontal, 9)
             .padding(.vertical, 3)
-            .background(color, in: Capsule())
+            .rockxyChipStyle(tint: color, isActive: true)
     }
 
     private func formattedSpeed(_ bytesPerSecond: Int64) -> String {
@@ -768,7 +753,7 @@ struct WorkspaceFooterBar<Content: View>: View {
             .frame(maxWidth: .infinity)
             .padding(.horizontal, horizontalPadding)
             .frame(height: metrics.statusBarHeight)
-            .background(Theme.StatusBar.background)
+            .rockxyFunctionalBar()
             .overlay(alignment: .top) {
                 Divider()
             }

--- a/Rockxy/Views/Rules/AddAllowListRuleSheet.swift
+++ b/Rockxy/Views/Rules/AddAllowListRuleSheet.swift
@@ -98,6 +98,7 @@ struct AddAllowListRuleSheet: View {
                     footerButtonLabel(primaryButtonTitle)
                 }
                 .keyboardShortcut(.defaultAction)
+                .rockxyGlassButtonStyle(prominent: true)
                 .disabled(trimmedURL.isEmpty || validationMessage != nil)
             }
             .padding(.horizontal, toolMetrics.formHorizontalPadding)

--- a/Rockxy/Views/Rules/AllowListWindowView.swift
+++ b/Rockxy/Views/Rules/AllowListWindowView.swift
@@ -582,7 +582,7 @@ struct AllowListWindowView: View {
             }
         }
         .menuIndicator(.hidden)
-        .buttonStyle(.bordered)
+        .rockxyGlassButtonStyle()
         .fixedSize()
     }
 

--- a/Rockxy/Views/Rules/AllowListWindowView.swift
+++ b/Rockxy/Views/Rules/AllowListWindowView.swift
@@ -403,6 +403,7 @@ struct AllowListWindowView: View {
         }
         .padding(.horizontal, toolMetrics.contentHorizontalPadding)
         .padding(.vertical, toolMetrics.headerBottomPadding)
+        .rockxyFunctionalBar()
     }
 
     private var infoBanner: some View {
@@ -460,14 +461,13 @@ struct AllowListWindowView: View {
                     : String(localized: "ALLOW LIST OFF")
             )
             .font(toolMetrics.metadataFont(weight: .semibold))
-            .foregroundStyle(viewModel.isAllowListActive ? Color.white : Color.secondary)
             .padding(.horizontal, 12)
             .padding(.vertical, 4)
-            .background(viewModel.isAllowListActive ? Color.green : Color.secondary.opacity(0.14))
-            .clipShape(Capsule())
+            .rockxyChipStyle(tint: .green, isActive: viewModel.isAllowListActive)
         }
         .padding(.horizontal, toolMetrics.contentHorizontalPadding)
         .padding(.vertical, toolMetrics.footerTopPadding)
+        .rockxyFunctionalBar()
     }
 
     private var footerHint: String {

--- a/Rockxy/Views/Rules/BlockListWindowView.swift
+++ b/Rockxy/Views/Rules/BlockListWindowView.swift
@@ -424,6 +424,7 @@ struct BlockListWindowView: View {
         }
         .padding(.horizontal, toolMetrics.contentHorizontalPadding)
         .padding(.vertical, toolMetrics.headerBottomPadding)
+        .rockxyFunctionalBar()
     }
 
     private var infoBanner: some View {
@@ -470,14 +471,13 @@ struct BlockListWindowView: View {
                     : String(localized: "BLOCK LIST OFF")
             )
             .font(toolMetrics.metadataFont(weight: .semibold))
-            .foregroundStyle(viewModel.isBlockListActive ? Color.white : Color.secondary)
             .padding(.horizontal, 12)
             .padding(.vertical, 4)
-            .background(viewModel.isBlockListActive ? Color.red : Color.secondary.opacity(0.14))
-            .clipShape(Capsule())
+            .rockxyChipStyle(tint: .red, isActive: viewModel.isBlockListActive)
         }
         .padding(.horizontal, toolMetrics.contentHorizontalPadding)
         .padding(.vertical, toolMetrics.footerTopPadding)
+        .rockxyFunctionalBar()
     }
 
     private var footerHint: String {
@@ -994,6 +994,7 @@ private struct AddBlockRuleSheet: View {
                     footerButtonLabel(primaryButtonTitle)
                 }
                 .keyboardShortcut(.defaultAction)
+                .rockxyGlassButtonStyle(prominent: true)
                 .disabled(trimmedPattern.isEmpty)
             }
             .padding(.horizontal, toolMetrics.formHorizontalPadding)

--- a/Rockxy/Views/Rules/BlockListWindowView.swift
+++ b/Rockxy/Views/Rules/BlockListWindowView.swift
@@ -598,7 +598,7 @@ struct BlockListWindowView: View {
             }
         }
         .menuIndicator(.hidden)
-        .buttonStyle(.bordered)
+        .rockxyGlassButtonStyle()
         .fixedSize()
     }
 

--- a/Rockxy/Views/Rules/MapLocalWindowView.swift
+++ b/Rockxy/Views/Rules/MapLocalWindowView.swift
@@ -542,7 +542,7 @@ struct MapLocalWindowView: View {
             }
         }
         .menuIndicator(.hidden)
-        .buttonStyle(.bordered)
+        .rockxyGlassButtonStyle()
         .fixedSize()
     }
 

--- a/Rockxy/Views/Rules/MapLocalWindowView.swift
+++ b/Rockxy/Views/Rules/MapLocalWindowView.swift
@@ -328,6 +328,7 @@ struct MapLocalWindowView: View {
         }
         .padding(.horizontal, toolMetrics.contentHorizontalPadding)
         .padding(.vertical, toolMetrics.headerBottomPadding)
+        .rockxyFunctionalBar()
     }
 
     private var infoBanner: some View {
@@ -452,14 +453,13 @@ struct MapLocalWindowView: View {
                     : String(localized: "MAP LOCAL OFF")
             )
             .font(toolMetrics.metadataFont(weight: .semibold))
-            .foregroundStyle(viewModel.isToolEnabled ? Color.white : Color.secondary)
             .padding(.horizontal, 12)
             .padding(.vertical, 4)
-            .background(viewModel.isToolEnabled ? Color.green : Color.secondary.opacity(0.14))
-            .clipShape(Capsule())
+            .rockxyChipStyle(tint: .green, isActive: viewModel.isToolEnabled)
         }
         .padding(.horizontal, toolMetrics.contentHorizontalPadding)
         .padding(.vertical, toolMetrics.footerTopPadding)
+        .rockxyFunctionalBar()
     }
 
     private var addRemoveControl: some View {
@@ -1066,6 +1066,7 @@ struct MapLocalEditorWindowView: View {
                 )
             }
             .keyboardShortcut(.defaultAction)
+            .rockxyGlassButtonStyle(prominent: true)
             .disabled(!viewModel.isSaveEnabled || isSaving)
         }
         .padding(.horizontal, toolMetrics.formHorizontalPadding)

--- a/Rockxy/Views/Rules/MapRemoteWindowView.swift
+++ b/Rockxy/Views/Rules/MapRemoteWindowView.swift
@@ -334,6 +334,7 @@ struct MapRemoteWindowView: View {
         }
         .padding(.horizontal, toolMetrics.contentHorizontalPadding)
         .padding(.vertical, toolMetrics.headerBottomPadding)
+        .rockxyFunctionalBar()
     }
 
     private var infoBanner: some View {
@@ -479,14 +480,13 @@ struct MapRemoteWindowView: View {
                     : String(localized: "MAP REMOTE OFF")
             )
             .font(toolMetrics.metadataFont(weight: .semibold))
-            .foregroundStyle(viewModel.isToolEnabled ? Color.white : Color.secondary)
             .padding(.horizontal, 12)
             .padding(.vertical, 4)
-            .background(viewModel.isToolEnabled ? Color.green : Color.secondary.opacity(0.14))
-            .clipShape(Capsule())
+            .rockxyChipStyle(tint: .green, isActive: viewModel.isToolEnabled)
         }
         .padding(.horizontal, toolMetrics.contentHorizontalPadding)
         .padding(.vertical, toolMetrics.footerTopPadding)
+        .rockxyFunctionalBar()
     }
 
     private var addRemoveControl: some View {
@@ -1004,6 +1004,7 @@ struct MapRemoteEditorWindowView: View {
                     )
                 }
                 .keyboardShortcut(.defaultAction)
+                .rockxyGlassButtonStyle(prominent: true)
                 .disabled(!viewModel.isSaveEnabled || viewModel.isSaving)
             }
         }

--- a/Rockxy/Views/Rules/MapRemoteWindowView.swift
+++ b/Rockxy/Views/Rules/MapRemoteWindowView.swift
@@ -569,7 +569,7 @@ struct MapRemoteWindowView: View {
             }
         }
         .menuIndicator(.hidden)
-        .buttonStyle(.bordered)
+        .rockxyGlassButtonStyle()
         .fixedSize()
     }
 

--- a/Rockxy/Views/Rules/ModifyHeaderWindowView.swift
+++ b/Rockxy/Views/Rules/ModifyHeaderWindowView.swift
@@ -404,6 +404,7 @@ struct ModifyHeaderWindowView: View {
         }
         .padding(.horizontal, toolMetrics.contentHorizontalPadding)
         .padding(.vertical, toolMetrics.headerBottomPadding)
+        .rockxyFunctionalBar()
     }
 
     @ViewBuilder private var content: some View {
@@ -542,11 +543,9 @@ struct ModifyHeaderWindowView: View {
                     : String(localized: "MODIFY HEADERS OFF")
             )
             .font(toolMetrics.metadataFont(weight: .semibold))
-            .foregroundStyle(viewModel.isToolEnabled ? Color.white : Color.secondary)
             .padding(.horizontal, 12)
             .padding(.vertical, 4)
-            .background(viewModel.isToolEnabled ? Color.green : Color.secondary.opacity(0.14))
-            .clipShape(Capsule())
+            .rockxyChipStyle(tint: .green, isActive: viewModel.isToolEnabled)
             .accessibilityLabel(
                 viewModel.isToolEnabled
                     ? String(localized: "\(viewModel.activeRuleCount) active Modify Header rules")
@@ -555,6 +554,7 @@ struct ModifyHeaderWindowView: View {
         }
         .padding(.horizontal, toolMetrics.contentHorizontalPadding)
         .padding(.vertical, toolMetrics.footerTopPadding)
+        .rockxyFunctionalBar()
     }
 
     @ViewBuilder private var contextMenuItems: some View {
@@ -806,6 +806,7 @@ private struct ModifyHeaderEditSheet: View {
                     )
                 }
                 .keyboardShortcut(.defaultAction)
+                .rockxyGlassButtonStyle(prominent: true)
                 .disabled(!isValid || isSaving)
             }
             .padding(.horizontal, toolMetrics.formHorizontalPadding)

--- a/Rockxy/Views/Rules/NetworkConditionsWindowView.swift
+++ b/Rockxy/Views/Rules/NetworkConditionsWindowView.swift
@@ -994,7 +994,7 @@ struct NetworkConditionsWindowView: View {
             }
         }
         .menuIndicator(.hidden)
-        .buttonStyle(.bordered)
+        .rockxyGlassButtonStyle()
         .fixedSize()
     }
 

--- a/Rockxy/Views/Rules/NetworkConditionsWindowView.swift
+++ b/Rockxy/Views/Rules/NetworkConditionsWindowView.swift
@@ -758,6 +758,7 @@ struct NetworkConditionsWindowView: View {
         }
         .padding(.horizontal, toolMetrics.contentHorizontalPadding)
         .padding(.vertical, toolMetrics.headerBottomPadding)
+        .rockxyFunctionalBar()
     }
 
     private var infoBanner: some View {
@@ -889,14 +890,13 @@ struct NetworkConditionsWindowView: View {
 
             Text(statusCapsuleText)
                 .font(toolMetrics.metadataFont(weight: .semibold))
-                .foregroundStyle(statusCapsuleForeground)
                 .padding(.horizontal, 12)
                 .padding(.vertical, 4)
-                .background(statusCapsuleBackground)
-                .clipShape(Capsule())
+                .rockxyChipStyle(tint: statusCapsuleTint, isActive: statusCapsuleIsActive)
         }
         .padding(.horizontal, toolMetrics.contentHorizontalPadding)
         .padding(.vertical, toolMetrics.footerTopPadding)
+        .rockxyFunctionalBar()
     }
 
     private var addRemoveControl: some View {
@@ -1049,24 +1049,18 @@ struct NetworkConditionsWindowView: View {
         return String(localized: "1 ENABLED")
     }
 
-    private var statusCapsuleForeground: Color {
-        if viewModel.hasMultipleActive, viewModel.isToolEnabled {
-            return .white
-        }
-        if viewModel.activeCount == 1, viewModel.isToolEnabled {
-            return .white
-        }
-        return .secondary
+    private var statusCapsuleIsActive: Bool {
+        viewModel.isToolEnabled && (viewModel.hasMultipleActive || viewModel.activeCount == 1)
     }
 
-    private var statusCapsuleBackground: Color {
+    private var statusCapsuleTint: Color {
         if viewModel.hasMultipleActive, viewModel.isToolEnabled {
             return .orange
         }
         if viewModel.activeCount == 1, viewModel.isToolEnabled {
             return .green
         }
-        return Color.secondary.opacity(0.14)
+        return .secondary
     }
 
     @ViewBuilder
@@ -1218,6 +1212,7 @@ private struct NetworkConditionsEditSheet: View {
                         )
                     }
                     .keyboardShortcut(.defaultAction)
+                    .rockxyGlassButtonStyle(prominent: true)
                     .disabled(!isValid || isSaving)
                 }
             }

--- a/Rockxy/Views/Rules/ProtobufSchemaListWindowView.swift
+++ b/Rockxy/Views/Rules/ProtobufSchemaListWindowView.swift
@@ -118,6 +118,7 @@ struct ProtobufSchemaListWindowView: View {
         .padding(.horizontal, toolMetrics.contentHorizontalPadding)
         .padding(.top, toolMetrics.headerTopPadding)
         .padding(.bottom, toolMetrics.headerBottomPadding)
+        .rockxyFunctionalBar()
     }
 
     private var schemaTable: some View {
@@ -214,6 +215,7 @@ struct ProtobufSchemaListWindowView: View {
         }
         .padding(.horizontal, toolMetrics.contentHorizontalPadding)
         .padding(.vertical, toolMetrics.footerTopPadding)
+        .rockxyFunctionalBar()
     }
 
     private var addRemoveControl: some View {

--- a/Rockxy/Views/Rules/ProtobufSchemaListWindowView.swift
+++ b/Rockxy/Views/Rules/ProtobufSchemaListWindowView.swift
@@ -284,7 +284,7 @@ struct ProtobufSchemaListWindowView: View {
             }
         }
         .menuIndicator(.hidden)
-        .buttonStyle(.bordered)
+        .rockxyGlassButtonStyle()
         .fixedSize()
     }
 

--- a/Rockxy/Views/Rules/ProtobufSettingsWindowView.swift
+++ b/Rockxy/Views/Rules/ProtobufSettingsWindowView.swift
@@ -223,7 +223,7 @@ struct ProtobufSettingsWindowView: View {
             Button(String(localized: "Local Schemas…")) {
                 openWindow(id: "protobufSchemaList")
             }
-            .buttonStyle(.bordered)
+            .rockxyGlassButtonStyle()
             moreMenu
         }
     }
@@ -303,7 +303,7 @@ struct ProtobufSettingsWindowView: View {
             }
         }
         .menuIndicator(.hidden)
-        .buttonStyle(.bordered)
+        .rockxyGlassButtonStyle()
         .fixedSize()
     }
 

--- a/Rockxy/Views/Rules/ProtobufSettingsWindowView.swift
+++ b/Rockxy/Views/Rules/ProtobufSettingsWindowView.swift
@@ -118,6 +118,7 @@ struct ProtobufSettingsWindowView: View {
         .padding(.horizontal, toolMetrics.contentHorizontalPadding)
         .padding(.top, toolMetrics.headerTopPadding)
         .padding(.bottom, toolMetrics.headerBottomPadding)
+        .rockxyFunctionalBar()
     }
 
     private var rulesTable: some View {
@@ -205,6 +206,7 @@ struct ProtobufSettingsWindowView: View {
         }
         .padding(.horizontal, toolMetrics.contentHorizontalPadding)
         .padding(.vertical, toolMetrics.footerTopPadding)
+        .rockxyFunctionalBar()
     }
 
     private var footerLeadingContent: some View {
@@ -688,6 +690,7 @@ private struct ProtobufRuleEditorSheet: View {
                     footerButtonLabel(sessionButtonTitle)
                 }
                 .keyboardShortcut(.defaultAction)
+                .rockxyGlassButtonStyle(prominent: true)
             }
         }
         .padding(.horizontal, toolMetrics.formHorizontalPadding)

--- a/Rockxy/Views/Rules/RuleListView.swift
+++ b/Rockxy/Views/Rules/RuleListView.swift
@@ -79,7 +79,7 @@ struct RuleListView: View {
             } label: {
                 Label(String(localized: "Add Rule"), systemImage: "plus")
             }
-            .buttonStyle(.borderedProminent)
+            .rockxyGlassButtonStyle(prominent: true)
             .controlSize(.small)
 
             Button {
@@ -119,6 +119,7 @@ struct RuleListView: View {
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 8)
+        .rockxyFunctionalBar()
     }
 
     // MARK: - Rule Table
@@ -257,6 +258,7 @@ struct RuleListView: View {
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 8)
+        .rockxyFunctionalBar()
     }
 
     private func actionType(for action: RuleAction) -> RuleActionType {
@@ -489,6 +491,7 @@ private struct RuleEditSheet: View {
                     dismiss()
                 }
                 .keyboardShortcut(.defaultAction)
+                .rockxyGlassButtonStyle(prominent: true)
                 .disabled(!isValid)
             }
             .padding()

--- a/Rockxy/Views/Rules/RuleListView.swift
+++ b/Rockxy/Views/Rules/RuleListView.swift
@@ -79,7 +79,7 @@ struct RuleListView: View {
             } label: {
                 Label(String(localized: "Add Rule"), systemImage: "plus")
             }
-            .rockxyGlassButtonStyle(prominent: true)
+            .rockxyGlassButtonStyle()
             .controlSize(.small)
 
             Button {
@@ -91,7 +91,7 @@ struct RuleListView: View {
             } label: {
                 Label(String(localized: "Remove"), systemImage: "minus")
             }
-            .buttonStyle(.bordered)
+            .rockxyGlassButtonStyle()
             .controlSize(.small)
             .disabled(selectedRuleID == nil)
 
@@ -193,13 +193,13 @@ struct RuleListView: View {
             Button(String(localized: "Import")) {
                 importRules()
             }
-            .buttonStyle(.bordered)
+            .rockxyGlassButtonStyle()
             .controlSize(.small)
 
             Button(String(localized: "Export")) {
                 exportRules()
             }
-            .buttonStyle(.bordered)
+            .rockxyGlassButtonStyle()
             .controlSize(.small)
             .disabled(rules.isEmpty)
 

--- a/Rockxy/Views/Scripting/ScriptEditorWindowView.swift
+++ b/Rockxy/Views/Scripting/ScriptEditorWindowView.swift
@@ -179,6 +179,7 @@ struct ScriptEditorWindowView: View {
         .padding(.horizontal, toolMetrics.contentHorizontalPadding)
         .padding(.top, toolMetrics.headerTopPadding)
         .padding(.bottom, toolMetrics.headerBottomPadding)
+        .rockxyFunctionalBar()
     }
 
     private var testMatchRow: some View {
@@ -342,7 +343,7 @@ struct ScriptEditorWindowView: View {
         }
         .padding(.horizontal, toolMetrics.contentHorizontalPadding)
         .padding(.vertical, toolMetrics.footerTopPadding)
-        .background(Color(nsColor: .controlBackgroundColor))
+        .rockxyFunctionalBar()
     }
 
     private var secondaryActionControls: some View {
@@ -425,7 +426,7 @@ struct ScriptEditorWindowView: View {
             } label: {
                 footerActionLabel(String(localized: "Save & Activate"), weight: .semibold)
             }
-            .buttonStyle(.borderedProminent)
+            .rockxyGlassButtonStyle(prominent: true)
             .keyboardShortcut("s", modifiers: .command)
             .disabled(viewModel.isSaving)
             .fixedSize()

--- a/Rockxy/Views/Scripting/ScriptEditorWindowView.swift
+++ b/Rockxy/Views/Scripting/ScriptEditorWindowView.swift
@@ -354,7 +354,7 @@ struct ScriptEditorWindowView: View {
             } label: {
                 footerActionLabel(String(localized: "Beautify"))
             }
-            .buttonStyle(.bordered)
+            .rockxyGlassButtonStyle()
             .fixedSize()
 
             Button {
@@ -362,7 +362,7 @@ struct ScriptEditorWindowView: View {
             } label: {
                 footerActionLabel(String(localized: "Insert Header Example"))
             }
-            .buttonStyle(.bordered)
+            .rockxyGlassButtonStyle()
             .fixedSize()
         }
     }
@@ -384,7 +384,7 @@ struct ScriptEditorWindowView: View {
                 .frame(minHeight: footerLabelHeight)
         }
         .menuIndicator(.hidden)
-        .buttonStyle(.bordered)
+        .rockxyGlassButtonStyle()
         .fixedSize()
     }
 
@@ -417,7 +417,7 @@ struct ScriptEditorWindowView: View {
             } label: {
                 footerActionLabel(String(localized: "Validate"))
             }
-            .buttonStyle(.bordered)
+            .rockxyGlassButtonStyle()
             .keyboardShortcut("r", modifiers: .command)
             .fixedSize()
 
@@ -487,7 +487,7 @@ struct ScriptEditorWindowView: View {
                 .font(toolMetrics.font(weight: .medium))
                 .frame(minHeight: toolMetrics.formControlHeight)
         }
-        .buttonStyle(.bordered)
+        .rockxyGlassButtonStyle()
         .fixedSize()
 
         let preview = Group {

--- a/Rockxy/Views/Scripting/ScriptingListWindowView.swift
+++ b/Rockxy/Views/Scripting/ScriptingListWindowView.swift
@@ -255,6 +255,7 @@ struct ScriptingListWindowView: View {
         }
         .padding(.horizontal, toolMetrics.contentHorizontalPadding)
         .padding(.vertical, toolMetrics.headerTopPadding)
+        .rockxyFunctionalBar()
     }
 
     // MARK: - Info banner
@@ -398,6 +399,7 @@ struct ScriptingListWindowView: View {
         }
         .padding(.horizontal, toolMetrics.contentHorizontalPadding)
         .padding(.vertical, toolMetrics.footerTopPadding)
+        .rockxyFunctionalBar()
     }
 
     private var addRemoveControl: some View {
@@ -521,29 +523,16 @@ struct ScriptingListWindowView: View {
     private var statusCapsule: some View {
         Text(statusText)
             .font(toolMetrics.secondaryFont(weight: .semibold))
-            .foregroundStyle(.primary)
             .padding(.horizontal, 9)
             .frame(height: toolMetrics.footerControlHeight)
-            .background(statusCapsuleBackground)
-            .clipShape(Capsule())
-            .overlay {
-                Capsule()
-                    .stroke(statusCapsuleStroke, lineWidth: 1)
-            }
+            .rockxyChipStyle(tint: statusCapsuleTint, isActive: viewModel.toolEnabled)
     }
 
-    private var statusCapsuleBackground: Color {
+    private var statusCapsuleTint: Color {
         if !viewModel.toolEnabled {
-            return Color.secondary.opacity(0.1)
+            return .secondary
         }
-        return activeScriptCount == 0 ? Color.orange.opacity(0.12) : Color.green.opacity(0.12)
-    }
-
-    private var statusCapsuleStroke: Color {
-        if !viewModel.toolEnabled {
-            return Color.secondary.opacity(0.25)
-        }
-        return activeScriptCount == 0 ? Color.orange.opacity(0.3) : Color.green.opacity(0.35)
+        return activeScriptCount == 0 ? .orange : .green
     }
 
     private func enabledCell(for row: ScriptListDisplayRow) -> some View {

--- a/Rockxy/Views/Scripting/ScriptingListWindowView.swift
+++ b/Rockxy/Views/Scripting/ScriptingListWindowView.swift
@@ -515,7 +515,7 @@ struct ScriptingListWindowView: View {
             }
         }
         .menuIndicator(.hidden)
-        .buttonStyle(.bordered)
+        .rockxyGlassButtonStyle()
         .frame(minHeight: toolMetrics.footerControlHeight)
         .fixedSize()
     }

--- a/Rockxy/Views/Settings/AddSSLAppDomainSheet.swift
+++ b/Rockxy/Views/Settings/AddSSLAppDomainSheet.swift
@@ -289,6 +289,7 @@ struct AddSSLAppDomainSheet: View {
                 footerButtonLabel(addButtonTitle)
             }
             .keyboardShortcut(.defaultAction)
+            .rockxyGlassButtonStyle(prominent: true)
             .disabled(addButtonDisabled)
         }
         .padding(.horizontal, 16)

--- a/Rockxy/Views/Settings/AddSSLDomainSheet.swift
+++ b/Rockxy/Views/Settings/AddSSLDomainSheet.swift
@@ -111,6 +111,7 @@ struct AddSSLDomainSheet: View {
                     )
                 }
                 .keyboardShortcut(.defaultAction)
+                .rockxyGlassButtonStyle(prominent: true)
                 .disabled(!isValid)
             }
             .padding(.horizontal, 24)

--- a/Rockxy/Views/Settings/AdvancedProxySettingsView.swift
+++ b/Rockxy/Views/Settings/AdvancedProxySettingsView.swift
@@ -326,6 +326,7 @@ struct AdvancedProxySettingsView: View {
         }
         .padding(.horizontal, toolMetrics.contentHorizontalPadding)
         .padding(.vertical, toolMetrics.headerBottomPadding)
+        .rockxyFunctionalBar()
     }
 
     // MARK: - System Routing
@@ -696,6 +697,7 @@ struct AdvancedProxySettingsView: View {
         }
         .padding(.horizontal, toolMetrics.contentHorizontalPadding)
         .padding(.vertical, toolMetrics.footerTopPadding)
+        .rockxyFunctionalBar()
     }
 
     private var restoreDefaultsButton: some View {
@@ -731,6 +733,7 @@ struct AdvancedProxySettingsView: View {
             footerButtonLabel(String(localized: "Apply"))
         }
         .keyboardShortcut(.defaultAction)
+        .rockxyGlassButtonStyle(prominent: true)
         .disabled(!isDirty || !draft.canApply)
     }
 

--- a/Rockxy/Views/Settings/AdvancedSettingsTab.swift
+++ b/Rockxy/Views/Settings/AdvancedSettingsTab.swift
@@ -15,7 +15,7 @@ struct AdvancedSettingsTab: View {
 
     var body: some View {
         SettingsPane {
-            SettingsSectionCard(String(localized: "System Proxy")) {
+            SettingsSection(String(localized: "System Proxy")) {
                 settingsRow(label: String(localized: "Proxy Helper Tool:")) {
                     VStack(alignment: .leading, spacing: 10) {
                         // Zone A: Summary
@@ -175,11 +175,11 @@ struct AdvancedSettingsTab: View {
                 }
             }
 
-            SettingsSectionCard(String(localized: "Software Update")) {
+            SettingsSection(String(localized: "Software Update")) {
                 updatesSection
             }
 
-            SettingsSectionCard(String(localized: "Behavior")) {
+            SettingsSection(String(localized: "Behavior")) {
                 checkboxRow(
                     title: String(localized: "Show alert when quitting Rockxy"),
                     isOn: $showAlertOnQuit
@@ -339,164 +339,152 @@ struct AdvancedSettingsTab: View {
         }
     }
 
+    private var updatesSection: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            VStack(alignment: .leading, spacing: 10) {
+                HStack(alignment: .top, spacing: 12) {
+                    Image(systemName: updater.supportsManualChecks ? "checkmark.shield.fill" : "icloud.slash")
+                        .font(.system(size: max(16, settingsMetrics.bodyFontSize + 3)))
+                        .foregroundStyle(updater.supportsManualChecks ? Color.accentColor : Color.secondary)
+                        .frame(width: 20)
+
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(String(localized: "Update Controls"))
+                            .font(settingsMetrics.font(weight: .medium))
+                        Text(updater.updateAvailabilitySummary)
+                            .font(settingsMetrics.secondaryFont())
+                            .foregroundStyle(.secondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
+
+                Grid(alignment: .leading, horizontalSpacing: 10, verticalSpacing: 6) {
+                    GridRow {
+                        Text(String(localized: "Current:"))
+                            .font(settingsMetrics.secondaryFont())
+                            .foregroundStyle(.secondary)
+                        Text(updater.currentVersionSummary)
+                            .font(settingsMetrics.secondaryFont(monospaced: true))
+                    }
+                    GridRow {
+                        Text(String(localized: "Last Checked:"))
+                            .font(settingsMetrics.secondaryFont())
+                            .foregroundStyle(.secondary)
+                        Text(updater.lastCheckedDescription)
+                            .font(settingsMetrics.secondaryFont())
+                    }
+                }
+            }
+
+            HStack(spacing: 10) {
+                Button(String(localized: "Check for Updates…")) {
+                    updater.checkForUpdates()
+                }
+                .disabled(!updater.canInitiateUpdateCheck)
+
+                Button(String(localized: "Change Logs…")) {
+                    updater.openFullChangelog()
+                }
+
+                if updater.sessionInProgress {
+                    ProgressView()
+                        .controlSize(.small)
+                }
+            }
+
+            Toggle(
+                String(localized: "Automatically check for updates"),
+                isOn: Binding(
+                    get: { updater.automaticallyChecksForUpdates },
+                    set: { updater.setAutomaticallyChecksForUpdates($0) }
+                )
+            )
+            .toggleStyle(.checkbox)
+            .disabled(!updater.supportsAutomaticChecks)
+
+            VStack(alignment: .leading, spacing: 6) {
+                Toggle(
+                    String(localized: "Automatically download updates in the background"),
+                    isOn: Binding(
+                        get: { updater.automaticallyDownloadsUpdates },
+                        set: { updater.setAutomaticallyDownloadsUpdates($0) }
+                    )
+                )
+                .toggleStyle(.checkbox)
+                .disabled(
+                    !updater.supportsAutomaticChecks
+                        || !updater.automaticallyChecksForUpdates
+                        || !updater.allowsAutomaticUpdates
+                )
+
+                Text(
+                    String(
+                        localized: "When enabled, Rockxy downloads signed updates ahead of time so install prompts are faster."
+                    )
+                )
+                .font(settingsMetrics.secondaryFont())
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+            }
+
+            SettingsFieldRow(String(localized: "Check Frequency")) {
+                Picker(
+                    String(localized: "Check Frequency"),
+                    selection: Binding(
+                        get: { UpdateCheckIntervalOption.closest(to: updater.updateCheckInterval) },
+                        set: { updater.setUpdateCheckInterval($0.rawValue) }
+                    )
+                ) {
+                    ForEach(UpdateCheckIntervalOption.allCases) { option in
+                        Text(option.title).tag(option)
+                    }
+                }
+                .pickerStyle(.menu)
+                .labelsHidden()
+                .frame(width: settingsMetrics.menuWidth(180))
+                .disabled(!updater.supportsAutomaticChecks || !updater.automaticallyChecksForUpdates)
+            }
+
+            VStack(alignment: .leading, spacing: 6) {
+                Toggle(
+                    String(localized: "Send anonymous compatibility profile"),
+                    isOn: Binding(
+                        get: { updater.sendsSystemProfile },
+                        set: { updater.setSendsSystemProfile($0) }
+                    )
+                )
+                .toggleStyle(.checkbox)
+                .disabled(!updater.supportsAutomaticChecks)
+
+                Text(
+                    String(
+                        localized: """
+                        This shares basic macOS and hardware compatibility details with Sparkle so Rockxy can match the right update. It does not include captured traffic.
+                        """
+                    )
+                )
+                .font(settingsMetrics.secondaryFont())
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+    }
+
     private func settingsRow(
         label: String,
         @ViewBuilder content: () -> some View
     )
         -> some View
     {
-        HStack(alignment: .top, spacing: 0) {
-            Text(label)
-                .font(settingsMetrics.font(weight: .medium))
-                .frame(width: settingsMetrics.labelWidth, alignment: .trailing)
-                .padding(.trailing, 16)
-                .padding(.top, 2)
+        SettingsFieldRow(label) {
             content()
         }
     }
 
     private func checkboxRow(title: String, isOn: Binding<Bool>) -> some View {
-        HStack {
-            Color.clear.frame(width: settingsMetrics.rowLeading)
+        SettingsIndentedContent {
             Toggle(title, isOn: isOn)
                 .toggleStyle(.checkbox)
-        }
-    }
-
-    private var updatesSection: some View {
-        settingsRow(label: String(localized: "Software Update:")) {
-            VStack(alignment: .leading, spacing: 14) {
-                VStack(alignment: .leading, spacing: 10) {
-                    HStack(alignment: .top, spacing: 12) {
-                        Image(systemName: updater.supportsManualChecks ? "checkmark.shield.fill" : "icloud.slash")
-                            .font(.system(size: max(16, settingsMetrics.bodyFontSize + 3)))
-                            .foregroundStyle(updater.supportsManualChecks ? Color.accentColor : Color.secondary)
-                            .frame(width: 20)
-
-                        VStack(alignment: .leading, spacing: 4) {
-                            Text(String(localized: "Update Controls"))
-                                .font(settingsMetrics.font(weight: .medium))
-                            Text(updater.updateAvailabilitySummary)
-                                .font(settingsMetrics.secondaryFont())
-                                .foregroundStyle(.secondary)
-                                .fixedSize(horizontal: false, vertical: true)
-                        }
-                    }
-
-                    Grid(alignment: .leading, horizontalSpacing: 10, verticalSpacing: 6) {
-                        GridRow {
-                            Text(String(localized: "Current:"))
-                                .font(settingsMetrics.secondaryFont())
-                                .foregroundStyle(.secondary)
-                            Text(updater.currentVersionSummary)
-                                .font(settingsMetrics.secondaryFont(monospaced: true))
-                        }
-                        GridRow {
-                            Text(String(localized: "Last Checked:"))
-                                .font(settingsMetrics.secondaryFont())
-                                .foregroundStyle(.secondary)
-                            Text(updater.lastCheckedDescription)
-                                .font(settingsMetrics.secondaryFont())
-                        }
-                    }
-                }
-
-                HStack(spacing: 10) {
-                    Button(String(localized: "Check for Updates…")) {
-                        updater.checkForUpdates()
-                    }
-                    .disabled(!updater.canInitiateUpdateCheck)
-
-                    Button(String(localized: "Change Logs…")) {
-                        updater.openFullChangelog()
-                    }
-
-                    if updater.sessionInProgress {
-                        ProgressView()
-                            .controlSize(.small)
-                    }
-                }
-
-                Toggle(
-                    String(localized: "Automatically check for updates"),
-                    isOn: Binding(
-                        get: { updater.automaticallyChecksForUpdates },
-                        set: { updater.setAutomaticallyChecksForUpdates($0) }
-                    )
-                )
-                .toggleStyle(.checkbox)
-                .disabled(!updater.supportsAutomaticChecks)
-
-                VStack(alignment: .leading, spacing: 6) {
-                    Toggle(
-                        String(localized: "Automatically download updates in the background"),
-                        isOn: Binding(
-                            get: { updater.automaticallyDownloadsUpdates },
-                            set: { updater.setAutomaticallyDownloadsUpdates($0) }
-                        )
-                    )
-                    .toggleStyle(.checkbox)
-                    .disabled(
-                        !updater.supportsAutomaticChecks
-                            || !updater.automaticallyChecksForUpdates
-                            || !updater.allowsAutomaticUpdates
-                    )
-
-                    Text(
-                        String(
-                            localized: "When enabled, Rockxy downloads signed updates ahead of time so install prompts are faster."
-                        )
-                    )
-                    .font(settingsMetrics.secondaryFont())
-                    .foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
-                }
-
-                HStack(alignment: .top, spacing: 10) {
-                    Text(String(localized: "Check Frequency"))
-                        .font(settingsMetrics.secondaryFont())
-                        .foregroundStyle(.secondary)
-                        .frame(width: settingsMetrics.fieldWidth(120), alignment: .leading)
-
-                    Picker(
-                        String(localized: "Check Frequency"),
-                        selection: Binding(
-                            get: { UpdateCheckIntervalOption.closest(to: updater.updateCheckInterval) },
-                            set: { updater.setUpdateCheckInterval($0.rawValue) }
-                        )
-                    ) {
-                        ForEach(UpdateCheckIntervalOption.allCases) { option in
-                            Text(option.title).tag(option)
-                        }
-                    }
-                    .pickerStyle(.menu)
-                    .frame(width: settingsMetrics.menuWidth(180))
-                    .disabled(!updater.supportsAutomaticChecks || !updater.automaticallyChecksForUpdates)
-                }
-
-                VStack(alignment: .leading, spacing: 6) {
-                    Toggle(
-                        String(localized: "Send anonymous compatibility profile"),
-                        isOn: Binding(
-                            get: { updater.sendsSystemProfile },
-                            set: { updater.setSendsSystemProfile($0) }
-                        )
-                    )
-                    .toggleStyle(.checkbox)
-                    .disabled(!updater.supportsAutomaticChecks)
-
-                    Text(
-                        String(
-                            localized: """
-                            This shares basic macOS and hardware compatibility details with Sparkle so Rockxy can match the right update. It does not include captured traffic.
-                            """
-                        )
-                    )
-                    .font(settingsMetrics.secondaryFont())
-                    .foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
-                }
-            }
         }
     }
 

--- a/Rockxy/Views/Settings/AppearanceSettingsTab.swift
+++ b/Rockxy/Views/Settings/AppearanceSettingsTab.swift
@@ -1,16 +1,18 @@
 import SwiftUI
 
+// MARK: - AppearanceSettingsTab
+
 /// Application-wide appearance and readability settings.
 struct AppearanceSettingsTab: View {
     // MARK: Internal
 
     var body: some View {
         SettingsPane {
-            SettingsSectionCard(String(localized: "App UI")) {
+            SettingsSection(String(localized: "App UI")) {
                 appUISection
             }
 
-            SettingsSectionCard(String(localized: "App Theme")) {
+            SettingsSection(String(localized: "App Theme")) {
                 themeSection
             }
 
@@ -21,6 +23,8 @@ struct AppearanceSettingsTab: View {
     }
 
     // MARK: Private
+
+    @State private var hoveredTheme: AppTheme?
 
     private let settingsManager = AppSettingsManager.shared
 
@@ -36,6 +40,24 @@ struct AppearanceSettingsTab: View {
         SettingsDisplayMetrics(appMetrics: AppUIDisplayMetrics(settings: settingsManager.appUI))
     }
 
+    private var fontSizeBinding: Binding<Int> {
+        Binding(
+            get: { appUI.fontSize },
+            set: { newValue in
+                settingsManager.updateAppUI { $0.fontSize = newValue }
+            }
+        )
+    }
+
+    private var tabWidthBinding: Binding<Int> {
+        Binding(
+            get: { appUI.tabWidth },
+            set: { newValue in
+                settingsManager.updateAppUI { $0.tabWidth = newValue }
+            }
+        )
+    }
+
     private var appUISection: some View {
         VStack(alignment: .leading, spacing: settingsMetrics.sectionContentSpacing) {
             SettingsFieldRow(String(localized: "Font Size:")) {
@@ -45,6 +67,7 @@ struct AppearanceSettingsTab: View {
                     }
                 }
                 .labelsHidden()
+                .pickerStyle(.menu)
                 .frame(width: settingsMetrics.menuWidth(84))
             }
 
@@ -55,6 +78,7 @@ struct AppearanceSettingsTab: View {
                     }
                 }
                 .labelsHidden()
+                .pickerStyle(.menu)
                 .frame(width: settingsMetrics.menuWidth(128))
             }
 
@@ -124,33 +148,6 @@ struct AppearanceSettingsTab: View {
         .font(settingsMetrics.font())
     }
 
-    private var fontSizeBinding: Binding<Int> {
-        Binding(
-            get: { appUI.fontSize },
-            set: { newValue in
-                settingsManager.updateAppUI { $0.fontSize = newValue }
-            }
-        )
-    }
-
-    private var tabWidthBinding: Binding<Int> {
-        Binding(
-            get: { appUI.tabWidth },
-            set: { newValue in
-                settingsManager.updateAppUI { $0.tabWidth = newValue }
-            }
-        )
-    }
-
-    private func appUIToggle(_ keyPath: WritableKeyPath<AppUISettings, Bool>) -> Binding<Bool> {
-        Binding(
-            get: { appUI[keyPath: keyPath] },
-            set: { newValue in
-                settingsManager.updateAppUI { $0[keyPath: keyPath] = newValue }
-            }
-        )
-    }
-
     private func themeOption(_ theme: AppTheme) -> some View {
         Button {
             settingsManager.updateAppTheme(theme)
@@ -171,17 +168,53 @@ struct AppearanceSettingsTab: View {
                 }
                 .frame(minWidth: 82)
             }
+            .padding(10)
+            .background {
+                RoundedRectangle(cornerRadius: 10, style: .continuous)
+                    .fill(themeOptionFill(theme))
+            }
+            .overlay {
+                RoundedRectangle(cornerRadius: 10, style: .continuous)
+                    .stroke(
+                        appTheme == theme ? Color.accentColor.opacity(0.55) : Color.clear,
+                        lineWidth: 1
+                    )
+            }
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+        .onHover { isHovered in
+            hoveredTheme = isHovered ? theme : nil
+        }
         .accessibilityLabel(theme.displayName)
         .accessibilityAddTraits(appTheme == theme ? [.isButton, .isSelected] : .isButton)
+    }
+
+    private func themeOptionFill(_ theme: AppTheme) -> Color {
+        if appTheme == theme {
+            return Color.accentColor.opacity(0.10)
+        }
+        if hoveredTheme == theme {
+            return Color.primary.opacity(0.05)
+        }
+        return .clear
+    }
+
+    private func appUIToggle(_ keyPath: WritableKeyPath<AppUISettings, Bool>) -> Binding<Bool> {
+        Binding(
+            get: { appUI[keyPath: keyPath] },
+            set: { newValue in
+                settingsManager.updateAppUI { $0[keyPath: keyPath] = newValue }
+            }
+        )
     }
 }
 
 // MARK: - ThemePreviewCard
 
 private struct ThemePreviewCard: View {
+    // MARK: Internal
+
     let theme: AppTheme
 
     var body: some View {
@@ -230,9 +263,12 @@ private struct ThemePreviewCard: View {
         }
     }
 
+    // MARK: Private
+
     private var background: Color {
         switch theme {
-        case .system, .light:
+        case .system,
+             .light:
             Color(nsColor: .textBackgroundColor)
         case .dark:
             Color(nsColor: .windowBackgroundColor)

--- a/Rockxy/Views/Settings/AssistantRuntimeSetupSheet.swift
+++ b/Rockxy/Views/Settings/AssistantRuntimeSetupSheet.swift
@@ -227,20 +227,20 @@ struct AssistantRuntimeSetupSheet: View {
                 Button(String(localized: "Done")) {
                     dismiss()
                 }
-                .buttonStyle(.borderedProminent)
                 .keyboardShortcut(.defaultAction)
+                .rockxyGlassButtonStyle(prominent: true)
             case .failed where viewModel.ollamaApplicationURL != nil:
                 Button(String(localized: "Open & Check Again")) {
                     viewModel.retryInstalledOllamaRuntime()
                 }
-                .buttonStyle(.borderedProminent)
                 .keyboardShortcut(.defaultAction)
+                .rockxyGlassButtonStyle(prominent: true)
             default:
                 Button(String(localized: "Install")) {
                     viewModel.installOllamaRuntime()
                 }
-                .buttonStyle(.borderedProminent)
                 .keyboardShortcut(.defaultAction)
+                .rockxyGlassButtonStyle(prominent: true)
                 .disabled(viewModel.runtimeSetupState.isBusy)
             }
         }

--- a/Rockxy/Views/Settings/AssistantSettingsTab.swift
+++ b/Rockxy/Views/Settings/AssistantSettingsTab.swift
@@ -134,6 +134,7 @@ struct AssistantSettingsTab: View {
                 .font(settingsMetrics.secondaryFont())
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
+                .frame(maxWidth: settingsMetrics.fieldWidth(680), alignment: .leading)
 
                 ollamaRuntimeStatus
 
@@ -197,7 +198,7 @@ struct AssistantSettingsTab: View {
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
             }
-            .frame(maxWidth: settingsMetrics.fieldWidth(520), alignment: .leading)
+            .frame(maxWidth: .infinity, alignment: .leading)
         }
     }
 
@@ -213,6 +214,7 @@ struct AssistantSettingsTab: View {
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
             }
+            .layoutPriority(1)
 
             Spacer(minLength: 12)
 
@@ -260,7 +262,7 @@ struct AssistantSettingsTab: View {
                 Button(String(localized: "Download & Use")) {
                     viewModel.installCustomModel()
                 }
-                .rockxyGlassButtonStyle(prominent: true)
+                .rockxyGlassButtonStyle()
                 .disabled(!viewModel.canInstallCustomModel)
             }
             Text(String(localized: "Enter an exact model tag from the Ollama model library."))
@@ -615,8 +617,10 @@ struct AssistantSettingsTab: View {
                         .font(settingsMetrics.metadataFont(monospaced: true))
                         .foregroundStyle(.tertiary)
                 }
+                .layoutPriority(1)
                 Spacer(minLength: 12)
                 modelAction(model)
+                    .fixedSize(horizontal: true, vertical: false)
             }
 
             if viewModel.modelInstallID == model.id {
@@ -654,24 +658,28 @@ struct AssistantSettingsTab: View {
                     .font(settingsMetrics.metadataFont(monospaced: true))
                     .foregroundStyle(.tertiary)
             }
+            .layoutPriority(1)
             Spacer(minLength: 12)
-            if viewModel.isGlobalModel(model.id) {
-                Label(String(localized: "In Use"), systemImage: "checkmark.circle.fill")
-                    .font(settingsMetrics.metadataFont(weight: .medium))
-                    .foregroundStyle(.green)
-            } else {
-                Button(String(localized: "Use Globally")) {
-                    viewModel.useGlobally(model)
+            HStack(spacing: 8) {
+                if viewModel.isGlobalModel(model.id) {
+                    Label(String(localized: "In Use"), systemImage: "checkmark.circle.fill")
+                        .font(settingsMetrics.metadataFont(weight: .medium))
+                        .foregroundStyle(.green)
+                } else {
+                    Button(String(localized: "Use Globally")) {
+                        viewModel.useGlobally(model)
+                    }
+                    .controlSize(.small)
                 }
-                .controlSize(.small)
+                Button(role: .destructive) {
+                    pendingModelRemoval = model
+                } label: {
+                    Image(systemName: "trash")
+                }
+                .help(String(localized: "Remove model from Ollama"))
+                .disabled(viewModel.modelRemovalID != nil || viewModel.modelInstallID != nil)
             }
-            Button(role: .destructive) {
-                pendingModelRemoval = model
-            } label: {
-                Image(systemName: "trash")
-            }
-            .help(String(localized: "Remove model from Ollama"))
-            .disabled(viewModel.modelRemovalID != nil || viewModel.modelInstallID != nil)
+            .fixedSize(horizontal: true, vertical: false)
         }
         .padding(.vertical, 10)
         .overlay(alignment: .bottom) { Divider() }
@@ -694,7 +702,7 @@ struct AssistantSettingsTab: View {
                 viewModel.installAndUse(model)
             }
             .controlSize(.small)
-            .rockxyGlassButtonStyle(prominent: true)
+            .rockxyGlassButtonStyle()
             .disabled(viewModel.modelInstallID != nil)
         }
     }

--- a/Rockxy/Views/Settings/AssistantSettingsTab.swift
+++ b/Rockxy/Views/Settings/AssistantSettingsTab.swift
@@ -10,19 +10,19 @@ struct AssistantSettingsTab: View {
 
     var body: some View {
         SettingsPane {
-            SettingsSectionCard(String(localized: "1. Local Model Setup")) {
+            SettingsSection(String(localized: "1. Local Model Setup")) {
                 globalModelSection
             }
 
-            SettingsSectionCard(String(localized: "2. Provider & Model")) {
+            SettingsSection(String(localized: "2. Provider & Model")) {
                 providerSection
             }
 
-            SettingsSectionCard(String(localized: "3. Connection")) {
+            SettingsSection(String(localized: "3. Connection")) {
                 connectionSection
             }
 
-            SettingsSectionCard(String(localized: "Data Handling")) {
+            SettingsSection(String(localized: "Data Handling")) {
                 privacySection
             }
         }
@@ -35,7 +35,11 @@ struct AssistantSettingsTab: View {
             String(localized: "Remove Local Model?"),
             isPresented: Binding(
                 get: { pendingModelRemoval != nil },
-                set: { if !$0 { pendingModelRemoval = nil } }
+                set: {
+                    if !$0 {
+                        pendingModelRemoval = nil
+                    }
+                }
             )
         ) {
             Button(String(localized: "Cancel"), role: .cancel) {
@@ -101,100 +105,99 @@ struct AssistantSettingsTab: View {
         }
     }
 
-    private var globalModelSection: some View {
-        Group {
-            if let activeID = viewModel.savedConfiguration?.id,
-               !viewModel.savedConfigurations.isEmpty
-            {
-                SettingsFieldRow(String(localized: "Global Default")) {
-                    Picker(String(localized: "Global Default"), selection: Binding(
-                        get: { activeID },
-                        set: viewModel.selectSavedConfiguration
-                    )) {
-                        ForEach(viewModel.savedConfigurations) { configuration in
-                            Text(viewModel.profileLabel(configuration)).tag(configuration.id)
-                        }
+    @ViewBuilder private var globalModelSection: some View {
+        if let activeID = viewModel.savedConfiguration?.id,
+           !viewModel.savedConfigurations.isEmpty
+        {
+            SettingsFieldRow(String(localized: "Global Default")) {
+                Picker(String(localized: "Global Default"), selection: Binding(
+                    get: { activeID },
+                    set: viewModel.selectSavedConfiguration
+                )) {
+                    ForEach(viewModel.savedConfigurations) { configuration in
+                        Text(viewModel.profileLabel(configuration)).tag(configuration.id)
                     }
-                    .labelsHidden()
-                    .frame(width: settingsMetrics.fieldWidth(420))
                 }
+                .labelsHidden()
+                .pickerStyle(.menu)
+                .frame(maxWidth: settingsMetrics.fieldWidth(420))
             }
+        }
 
-            SettingsIndentedContent {
-                VStack(alignment: .leading, spacing: 12) {
-                    Text(
-                        String(
-                            localized: "Run the model on this Mac with no API usage fees. Rockxy checks the local runtime before model and traffic actions."
-                        )
+        SettingsIndentedContent {
+            VStack(alignment: .leading, spacing: 12) {
+                Text(
+                    String(
+                        localized: "Run the model on this Mac with no API usage fees. Rockxy checks the local runtime before model and traffic actions."
                     )
-                    .font(settingsMetrics.secondaryFont())
-                    .foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
+                )
+                .font(settingsMetrics.secondaryFont())
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
 
-                    ollamaRuntimeStatus
+                ollamaRuntimeStatus
 
-                    if viewModel.isOllamaReady {
-                        Text(String(localized: "Installed Models"))
-                            .font(settingsMetrics.secondaryFont(weight: .medium))
+                if viewModel.isOllamaReady {
+                    Text(String(localized: "Installed Models"))
+                        .font(settingsMetrics.secondaryFont(weight: .medium))
 
-                        if viewModel.installedOllamaModels.isEmpty {
-                            Label(
-                                String(localized: "No local models installed yet."),
-                                systemImage: "shippingbox"
-                            )
-                            .font(settingsMetrics.secondaryFont())
-                            .foregroundStyle(.secondary)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                            .padding(12)
-                            .background(
-                                Color(nsColor: .textBackgroundColor).opacity(0.4),
-                                in: RoundedRectangle(cornerRadius: 7)
-                            )
-                        } else {
-                            ForEach(viewModel.installedOllamaModels) { model in
-                                installedModelRow(model)
-                            }
+                    if viewModel.installedOllamaModels.isEmpty {
+                        Label(
+                            String(localized: "No local models installed yet."),
+                            systemImage: "shippingbox"
+                        )
+                        .font(settingsMetrics.secondaryFont())
+                        .foregroundStyle(.secondary)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(12)
+                        .background(
+                            Color(nsColor: .textBackgroundColor).opacity(0.4),
+                            in: RoundedRectangle(cornerRadius: 7)
+                        )
+                    } else {
+                        ForEach(viewModel.installedOllamaModels) { model in
+                            installedModelRow(model)
                         }
-
-                        Text(String(localized: "Curated Local Models"))
-                            .font(settingsMetrics.secondaryFont(weight: .medium))
-
-                        ForEach(AssistantDownloadableModel.recommended) { model in
-                            downloadableModelRow(model)
-                        }
-
-                        customModelDownload
                     }
 
-                    HStack(spacing: 8) {
-                        if viewModel.isRefreshingModelLibrary {
-                            ProgressView().controlSize(.small)
-                        }
-                        Button(String(localized: "Check Again")) {
-                            viewModel.refreshModelLibrary()
+                    Text(String(localized: "Curated Local Models"))
+                        .font(settingsMetrics.secondaryFont(weight: .medium))
+
+                    ForEach(AssistantDownloadableModel.recommended) { model in
+                        downloadableModelRow(model)
+                    }
+
+                    customModelDownload
+                }
+
+                HStack(spacing: 8) {
+                    if viewModel.isRefreshingModelLibrary {
+                        ProgressView().controlSize(.small)
+                    }
+                    Button(String(localized: "Check Again")) {
+                        viewModel.refreshModelLibrary()
+                    }
+                    .controlSize(.small)
+                    .disabled(viewModel.isRefreshingModelLibrary || viewModel.modelInstallID != nil)
+                    if viewModel.isOllamaReady {
+                        Button(String(localized: "Show Models Folder")) {
+                            viewModel.revealOllamaModelsFolder()
                         }
                         .controlSize(.small)
-                        .disabled(viewModel.isRefreshingModelLibrary || viewModel.modelInstallID != nil)
-                        if viewModel.isOllamaReady {
-                            Button(String(localized: "Show Models Folder")) {
-                                viewModel.revealOllamaModelsFolder()
-                            }
-                            .controlSize(.small)
-                        }
                     }
-
-                    Label(
-                        String(
-                            localized: "Model files remain managed by Ollama. Downloads can require several GB of disk and memory; model license terms vary."
-                        ),
-                        systemImage: "externaldrive"
-                    )
-                    .font(settingsMetrics.metadataFont())
-                    .foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
                 }
-                .frame(maxWidth: settingsMetrics.fieldWidth(520), alignment: .leading)
+
+                Label(
+                    String(
+                        localized: "Model files remain managed by Ollama. Downloads can require several GB of disk and memory; model license terms vary."
+                    ),
+                    systemImage: "externaldrive"
+                )
+                .font(settingsMetrics.metadataFont())
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
             }
+            .frame(maxWidth: settingsMetrics.fieldWidth(520), alignment: .leading)
         }
     }
 
@@ -224,17 +227,13 @@ struct AssistantSettingsTab: View {
                         viewModel.prepareRuntimeSetup()
                         isRuntimeSetupPresented = true
                     }
-                        .buttonStyle(.borderedProminent)
-                        .controlSize(.small)
+                    .rockxyGlassButtonStyle(prominent: true)
+                    .controlSize(.small)
                 }
             }
         }
-        .padding(12)
-        .background(Color(nsColor: .textBackgroundColor).opacity(0.55), in: RoundedRectangle(cornerRadius: 7))
-        .overlay {
-            RoundedRectangle(cornerRadius: 7)
-                .stroke(Color(nsColor: .separatorColor).opacity(0.42), lineWidth: 0.5)
-        }
+        .padding(.vertical, 10)
+        .overlay(alignment: .bottom) { Divider() }
     }
 
     @ViewBuilder private var runtimeStatusIcon: some View {
@@ -261,7 +260,7 @@ struct AssistantSettingsTab: View {
                 Button(String(localized: "Download & Use")) {
                     viewModel.installCustomModel()
                 }
-                .buttonStyle(.borderedProminent)
+                .rockxyGlassButtonStyle(prominent: true)
                 .disabled(!viewModel.canInstallCustomModel)
             }
             Text(String(localized: "Enter an exact model tag from the Ollama model library."))
@@ -290,183 +289,183 @@ struct AssistantSettingsTab: View {
         .padding(.top, 2)
     }
 
-    private var providerSection: some View {
-        Group {
-            SettingsFieldRow(String(localized: "Provider")) {
-                Picker(String(localized: "Provider"), selection: Binding(
-                    get: { viewModel.configuration.kind },
-                    set: viewModel.selectProvider
-                )) {
-                    ForEach(AssistantProviderGroup.allCases, id: \.self) { group in
-                        Section(group.title) {
-                            ForEach(AssistantProviderKind.allCases.filter { $0.group == group }) { provider in
-                                Text(providerDisplayTitle(provider))
-                                    .tag(provider)
-                            }
+    @ViewBuilder private var providerSection: some View {
+        SettingsFieldRow(String(localized: "Provider")) {
+            Picker(String(localized: "Provider"), selection: Binding(
+                get: { viewModel.configuration.kind },
+                set: viewModel.selectProvider
+            )) {
+                ForEach(AssistantProviderGroup.allCases, id: \.self) { group in
+                    Section(group.title) {
+                        ForEach(AssistantProviderKind.allCases.filter { $0.group == group }) { provider in
+                            Text(providerDisplayTitle(provider))
+                                .tag(provider)
                         }
                     }
                 }
-                .labelsHidden()
-                .frame(width: settingsMetrics.fieldWidth(420))
             }
+            .labelsHidden()
+            .pickerStyle(.menu)
+            .frame(maxWidth: settingsMetrics.fieldWidth(420))
+        }
 
-            if !viewModel.configuration.kind.isImplemented {
-                SettingsIndentedContent {
-                    Label(
-                        String(
-                            localized: "This provider needs its native adapter. Select OpenAI, Anthropic, Gemini, an OpenAI-compatible endpoint, or Ollama."
-                        ),
-                        systemImage: "hammer"
-                    )
-                    .font(settingsMetrics.secondaryFont())
-                    .foregroundStyle(.orange)
-                }
-            }
-
-            SettingsFieldRow(String(localized: "API Surface")) {
-                Text(viewModel.configuration.kind.apiSurface)
-                    .foregroundStyle(.secondary)
-                    .frame(minHeight: settingsMetrics.controlHeight, alignment: .leading)
-            }
-
-            SettingsFieldRow(String(localized: "Base URL")) {
-                TextField(String(localized: "Provider API base URL"), text: $viewModel.configuration.baseURL)
-                    .textFieldStyle(.roundedBorder)
-                    .frame(width: settingsMetrics.fieldWidth(420))
-                    .frame(minHeight: settingsMetrics.controlHeight)
-                    .disabled(viewModel.configuration.kind.usesFixedEndpoint)
-            }
-
+        if !viewModel.configuration.kind.isImplemented {
             SettingsIndentedContent {
-                endpointSecurityLabel
+                Label(
+                    String(
+                        localized: "This provider needs its native adapter. Select OpenAI, Anthropic, Gemini, an OpenAI-compatible endpoint, or Ollama."
+                    ),
+                    systemImage: "hammer"
+                )
+                .font(settingsMetrics.secondaryFont())
+                .foregroundStyle(.orange)
             }
+        }
 
-            SettingsFieldRow(String(localized: "Model")) {
-                VStack(alignment: .leading, spacing: 6) {
-                    HStack(spacing: 6) {
-                        if viewModel.models.isEmpty {
-                            TextField(String(localized: "Exact model ID"), text: $viewModel.configuration.model)
-                                .textFieldStyle(.roundedBorder)
+        SettingsFieldRow(String(localized: "API Surface")) {
+            Text(viewModel.configuration.kind.apiSurface)
+                .foregroundStyle(.secondary)
+                .frame(minHeight: settingsMetrics.controlHeight, alignment: .leading)
+        }
+
+        SettingsFieldRow(String(localized: "Base URL")) {
+            TextField(String(localized: "Provider API base URL"), text: $viewModel.configuration.baseURL)
+                .textFieldStyle(.roundedBorder)
+                .frame(width: settingsMetrics.fieldWidth(420))
+                .frame(minHeight: settingsMetrics.controlHeight)
+                .disabled(viewModel.configuration.kind.usesFixedEndpoint)
+        }
+
+        SettingsIndentedContent {
+            endpointSecurityLabel
+        }
+
+        SettingsFieldRow(String(localized: "Model")) {
+            VStack(alignment: .leading, spacing: 6) {
+                HStack(spacing: 6) {
+                    if viewModel.models.isEmpty {
+                        TextField(String(localized: "Exact model ID"), text: $viewModel.configuration.model)
+                            .textFieldStyle(.roundedBorder)
+                    } else {
+                        Picker(String(localized: "Available Models"), selection: $viewModel.configuration.model) {
+                            ForEach(viewModel.models) { model in
+                                Text(modelPickerTitle(model)).tag(model.id)
+                            }
+                        }
+                        .labelsHidden()
+                        .pickerStyle(.menu)
+                    }
+
+                    Button {
+                        viewModel.fetchModels()
+                    } label: {
+                        if viewModel.isRefreshingProviderModels {
+                            ProgressView()
+                                .controlSize(.small)
+                                .frame(width: 14, height: 14)
                         } else {
-                            Picker(String(localized: "Available Models"), selection: $viewModel.configuration.model) {
-                                ForEach(viewModel.models) { model in
-                                    Text(modelPickerTitle(model)).tag(model.id)
-                                }
-                            }
-                            .labelsHidden()
+                            Image(systemName: "arrow.clockwise")
                         }
-
-                        Button {
-                            viewModel.fetchModels()
-                        } label: {
-                            if viewModel.isRefreshingProviderModels {
-                                ProgressView()
-                                    .controlSize(.small)
-                                    .frame(width: 14, height: 14)
-                            } else {
-                                Image(systemName: "arrow.clockwise")
-                            }
-                        }
-                        .buttonStyle(.borderless)
-                        .disabled(
-                            viewModel.isBusy
-                                || !viewModel.configuration.kind.isImplemented
-                                || !(viewModel.configuration.kind.capabilities?.modelDiscovery ?? false)
-                        )
-                        .help(String(localized: "Refresh available models"))
-                        .accessibilityLabel(String(localized: "Refresh Available Models"))
                     }
-                    .frame(width: settingsMetrics.fieldWidth(420))
-                    .frame(minHeight: settingsMetrics.controlHeight)
+                    .buttonStyle(.borderless)
+                    .disabled(
+                        viewModel.isBusy
+                            || !viewModel.configuration.kind.isImplemented
+                            || !(viewModel.configuration.kind.capabilities?.modelDiscovery ?? false)
+                    )
+                    .help(String(localized: "Refresh available models"))
+                    .accessibilityLabel(String(localized: "Refresh Available Models"))
+                }
+                .frame(width: settingsMetrics.fieldWidth(420))
+                .frame(minHeight: settingsMetrics.controlHeight)
 
-                    if viewModel.models.isEmpty,
-                       viewModel.configuration.kind.capabilities?.modelDiscovery == true
-                    {
-                        Text(String(localized: "Refresh to discover models available from this provider."))
-                            .font(settingsMetrics.metadataFont())
-                            .foregroundStyle(.secondary)
-                    } else if !viewModel.models.isEmpty {
-                        Text(viewModel.availableModelsDetail)
+                if viewModel.models.isEmpty,
+                   viewModel.configuration.kind.capabilities?.modelDiscovery == true
+                {
+                    Text(String(localized: "Refresh to discover models available from this provider."))
                         .font(settingsMetrics.metadataFont())
                         .foregroundStyle(.secondary)
-                    }
-                }
-            }
-
-            if viewModel.configuration.kind == .ollama {
-                AssistantContextWindowSettingsField(configuration: $viewModel.configuration)
-            }
-
-            SettingsFieldRow(String(localized: "Output Limit")) {
-                VStack(alignment: .leading, spacing: 4) {
-                    HStack(spacing: 8) {
-                        TextField(
-                            String(localized: "Maximum output tokens"),
-                            value: $viewModel.configuration.maxOutputTokens,
-                            format: .number
-                        )
-                        .textFieldStyle(.roundedBorder)
-                        .frame(width: settingsMetrics.fieldWidth(120))
-                        Text(String(localized: "tokens per response"))
-                            .foregroundStyle(.secondary)
-                    }
-                    Text(String(localized: "Rockxy safety range: 1–32,768. The selected model may allow less."))
+                } else if !viewModel.models.isEmpty {
+                    Text(viewModel.availableModelsDetail)
                         .font(settingsMetrics.metadataFont())
                         .foregroundStyle(.secondary)
                 }
+            }
+        }
+
+        if viewModel.configuration.kind == .ollama {
+            AssistantContextWindowSettingsField(configuration: $viewModel.configuration)
+        }
+
+        SettingsFieldRow(String(localized: "Output Limit")) {
+            VStack(alignment: .leading, spacing: 4) {
+                HStack(spacing: 8) {
+                    TextField(
+                        String(localized: "Maximum output tokens"),
+                        value: $viewModel.configuration.maxOutputTokens,
+                        format: .number
+                    )
+                    .textFieldStyle(.roundedBorder)
+                    .frame(width: settingsMetrics.fieldWidth(120))
+                    Text(String(localized: "tokens per response"))
+                        .foregroundStyle(.secondary)
+                }
+                Text(String(localized: "Rockxy safety range: 1–32,768. The selected model may allow less."))
+                    .font(settingsMetrics.metadataFont())
+                    .foregroundStyle(.secondary)
+            }
+            .frame(minHeight: settingsMetrics.controlHeight)
+        }
+
+        if viewModel.configuration.kind == .openAICompatible
+            || viewModel.configuration.kind.group == .china
+        {
+            SettingsFieldRow(String(localized: "Platform / Region")) {
+                TextField(
+                    String(localized: "Optional deployment or region label"),
+                    text: Binding(
+                        get: { viewModel.configuration.region ?? "" },
+                        set: { viewModel.configuration.region = $0.isEmpty ? nil : $0 }
+                    )
+                )
+                .textFieldStyle(.roundedBorder)
+                .frame(width: settingsMetrics.fieldWidth(420))
                 .frame(minHeight: settingsMetrics.controlHeight)
             }
+        }
 
-            if viewModel.configuration.kind == .openAICompatible
-                || viewModel.configuration.kind.group == .china
-            {
-                SettingsFieldRow(String(localized: "Platform / Region")) {
-                    TextField(
-                        String(localized: "Optional deployment or region label"),
-                        text: Binding(
-                            get: { viewModel.configuration.region ?? "" },
-                            set: { viewModel.configuration.region = $0.isEmpty ? nil : $0 }
-                        )
+        if viewModel.configuration.kind != .ollama {
+            SettingsFieldRow(String(localized: "Credential")) {
+                VStack(alignment: .leading, spacing: 6) {
+                    SecureField(
+                        viewModel.hasStoredCredential
+                            ? String(localized: "Saved in Keychain. Enter a new key to replace it.")
+                            : String(localized: "API key"),
+                        text: $viewModel.credentialInput
                     )
                     .textFieldStyle(.roundedBorder)
                     .frame(width: settingsMetrics.fieldWidth(420))
                     .frame(minHeight: settingsMetrics.controlHeight)
-                }
-            }
-
-            if viewModel.configuration.kind != .ollama {
-                SettingsFieldRow(String(localized: "Credential")) {
-                    VStack(alignment: .leading, spacing: 6) {
-                        SecureField(
-                            viewModel.hasStoredCredential
-                                ? String(localized: "Saved in Keychain. Enter a new key to replace it.")
-                                : String(localized: "API key"),
-                            text: $viewModel.credentialInput
-                        )
-                        .textFieldStyle(.roundedBorder)
-                        .frame(width: settingsMetrics.fieldWidth(420))
-                        .frame(minHeight: settingsMetrics.controlHeight)
-                        Label(
-                            viewModel.hasStoredCredential
-                                ? String(localized: "Saved locally in macOS Keychain for this profile")
-                                : String(localized: "No credential saved in settings or Keychain"),
-                            systemImage: viewModel.hasStoredCredential ? "key.fill" : "key"
-                        )
-                        .font(settingsMetrics.metadataFont())
-                        .foregroundStyle(.secondary)
-                        if viewModel.hasStoredCredential {
-                            Button(String(localized: "Remove Credential"), role: .destructive) {
-                                viewModel.removeCredential()
-                            }
-                            .controlSize(.small)
+                    Label(
+                        viewModel.hasStoredCredential
+                            ? String(localized: "Saved locally in macOS Keychain for this profile")
+                            : String(localized: "No credential saved in settings or Keychain"),
+                        systemImage: viewModel.hasStoredCredential ? "key.fill" : "key"
+                    )
+                    .font(settingsMetrics.metadataFont())
+                    .foregroundStyle(.secondary)
+                    if viewModel.hasStoredCredential {
+                        Button(String(localized: "Remove Credential"), role: .destructive) {
+                            viewModel.removeCredential()
                         }
+                        .controlSize(.small)
                     }
                 }
             }
+        }
 
-            SettingsIndentedContent {
-                capabilitySummary
-            }
+        SettingsIndentedContent {
+            capabilitySummary
         }
     }
 
@@ -495,91 +494,107 @@ struct AssistantSettingsTab: View {
         }
     }
 
-    private var connectionSection: some View {
-        Group {
-            SettingsIndentedContent {
-                HStack(spacing: 10) {
-                    Button(String(localized: "Save Configuration")) {
-                        viewModel.save()
-                    }
-                    .buttonStyle(.borderedProminent)
-                    .disabled(viewModel.isBusy || !viewModel.configuration.kind.isImplemented)
+    @ViewBuilder private var connectionSection: some View {
+        SettingsIndentedContent {
+            HStack(spacing: 10) {
+                Button(String(localized: "Save Configuration")) {
+                    viewModel.save()
+                }
+                .rockxyGlassButtonStyle(prominent: true)
+                .disabled(viewModel.isBusy || !viewModel.configuration.kind.isImplemented)
 
-                    Button(String(localized: "Test Connection")) {
-                        viewModel.testConnection()
-                    }
-                    .disabled(viewModel.isBusy || !viewModel.configuration.isComplete)
+                Button(String(localized: "Test Connection")) {
+                    viewModel.testConnection()
+                }
+                .disabled(viewModel.isBusy || !viewModel.configuration.isComplete)
 
-                    if viewModel.isBusy {
-                        ProgressView().controlSize(.small)
-                        Button(String(localized: "Cancel")) {
-                            viewModel.cancelConnection()
-                        }
-                        .controlSize(.small)
+                if viewModel.isBusy {
+                    ProgressView().controlSize(.small)
+                    Button(String(localized: "Cancel")) {
+                        viewModel.cancelConnection()
                     }
+                    .controlSize(.small)
                 }
             }
+        }
 
-            if let status = viewModel.statusMessage {
-                SettingsIndentedContent {
-                    Label(
-                        status,
-                        systemImage: viewModel.hasError ? "exclamationmark.triangle.fill" : "checkmark.circle.fill"
+        if let status = viewModel.statusMessage {
+            SettingsIndentedContent {
+                Label(
+                    status,
+                    systemImage: viewModel.hasError ? "exclamationmark.triangle.fill" : "checkmark.circle.fill"
+                )
+                .font(settingsMetrics.secondaryFont())
+                .foregroundStyle(viewModel.hasError ? .red : .green)
+                .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+
+        accessSection
+
+        SettingsIndentedContent {
+            Button(String(localized: "Remove Provider"), role: .destructive) {
+                viewModel.removeProvider()
+            }
+            .disabled(viewModel.savedConfiguration == nil || viewModel.isBusy)
+        }
+    }
+
+    @ViewBuilder private var privacySection: some View {
+        SettingsIndentedContent {
+            Label(
+                String(
+                    localized: "Sensitive headers, query values, and body fields are redacted before Review Data."
+                ),
+                systemImage: "checkmark.shield.fill"
+            )
+            .foregroundStyle(.green)
+            .fixedSize(horizontal: false, vertical: true)
+        }
+        if viewModel.configuration.kind == .openAI {
+            SettingsIndentedContent {
+                VStack(alignment: .leading, spacing: 5) {
+                    Toggle(
+                        String(localized: "Allow provider response storage"),
+                        isOn: $viewModel.configuration.storeResponses
                     )
-                    .font(settingsMetrics.secondaryFont())
-                    .foregroundStyle(viewModel.hasError ? .red : .green)
-                    .fixedSize(horizontal: false, vertical: true)
+                    .toggleStyle(.checkbox)
+                    Text(String(localized: "When off, Rockxy sends store=false with every Responses API request."))
+                        .font(settingsMetrics.secondaryFont())
+                        .foregroundStyle(.secondary)
                 }
             }
-
-            accessSection
-
+        }
+        SettingsFieldRow(String(localized: "Destination")) {
+            Text(viewModel.configuration.endpointHost)
+                .textSelection(.enabled)
+                .foregroundStyle(.secondary)
+                .frame(minHeight: settingsMetrics.controlHeight, alignment: .leading)
+        }
+        if let documentationURL = viewModel.configuration.kind.documentationURL {
             SettingsIndentedContent {
-                Button(String(localized: "Remove Provider"), role: .destructive) {
-                    viewModel.removeProvider()
-                }
-                .disabled(viewModel.savedConfiguration == nil || viewModel.isBusy)
+                Link(String(localized: "Provider data and API documentation"), destination: documentationURL)
             }
         }
     }
 
-    private var privacySection: some View {
-        Group {
-            SettingsIndentedContent {
-                Label(
-                    String(
-                        localized: "Sensitive headers, query values, and body fields are redacted before Review Data."
-                    ),
-                    systemImage: "checkmark.shield.fill"
-                )
+    @ViewBuilder private var endpointSecurityLabel: some View {
+        switch viewModel.configuration.endpointSecurity {
+        case .encrypted:
+            Label(String(localized: "Encrypted HTTPS connection"), systemImage: "lock.fill")
                 .foregroundStyle(.green)
-                .fixedSize(horizontal: false, vertical: true)
-            }
-            if viewModel.configuration.kind == .openAI {
-                SettingsIndentedContent {
-                    VStack(alignment: .leading, spacing: 5) {
-                        Toggle(
-                            String(localized: "Allow provider response storage"),
-                            isOn: $viewModel.configuration.storeResponses
-                        )
-                        .toggleStyle(.checkbox)
-                        Text(String(localized: "When off, Rockxy sends store=false with every Responses API request."))
-                            .font(settingsMetrics.secondaryFont())
-                            .foregroundStyle(.secondary)
-                    }
-                }
-            }
-            SettingsFieldRow(String(localized: "Destination")) {
-                Text(viewModel.configuration.endpointHost)
-                    .textSelection(.enabled)
-                    .foregroundStyle(.secondary)
-                    .frame(minHeight: settingsMetrics.controlHeight, alignment: .leading)
-            }
-            if let documentationURL = viewModel.configuration.kind.documentationURL {
-                SettingsIndentedContent {
-                    Link(String(localized: "Provider data and API documentation"), destination: documentationURL)
-                }
-            }
+        case .localLoopback:
+            Label(String(localized: "Local-only connection on this Mac"), systemImage: "desktopcomputer")
+                .foregroundStyle(.green)
+        case .insecureRemote:
+            Label(
+                String(localized: "Blocked: remote endpoints must use HTTPS"),
+                systemImage: "exclamationmark.shield.fill"
+            )
+            .foregroundStyle(.red)
+        case .invalid:
+            Label(String(localized: "Enter a valid HTTP or HTTPS base URL"), systemImage: "exclamationmark.triangle")
+                .foregroundStyle(.secondary)
         }
     }
 
@@ -624,12 +639,7 @@ struct AssistantSettingsTab: View {
             }
         }
         .padding(.vertical, 10)
-        .padding(.horizontal, 12)
-        .background(Color(nsColor: .textBackgroundColor).opacity(0.55), in: RoundedRectangle(cornerRadius: 7))
-        .overlay {
-            RoundedRectangle(cornerRadius: 7)
-                .stroke(Color(nsColor: .separatorColor).opacity(0.42), lineWidth: 0.5)
-        }
+        .overlay(alignment: .bottom) { Divider() }
     }
 
     private func installedModelRow(_ model: AssistantModel) -> some View {
@@ -664,12 +674,7 @@ struct AssistantSettingsTab: View {
             .disabled(viewModel.modelRemovalID != nil || viewModel.modelInstallID != nil)
         }
         .padding(.vertical, 10)
-        .padding(.horizontal, 12)
-        .background(Color(nsColor: .textBackgroundColor).opacity(0.55), in: RoundedRectangle(cornerRadius: 7))
-        .overlay {
-            RoundedRectangle(cornerRadius: 7)
-                .stroke(Color(nsColor: .separatorColor).opacity(0.42), lineWidth: 0.5)
-        }
+        .overlay(alignment: .bottom) { Divider() }
     }
 
     @ViewBuilder
@@ -689,7 +694,7 @@ struct AssistantSettingsTab: View {
                 viewModel.installAndUse(model)
             }
             .controlSize(.small)
-            .buttonStyle(.borderedProminent)
+            .rockxyGlassButtonStyle(prominent: true)
             .disabled(viewModel.modelInstallID != nil)
         }
     }
@@ -707,26 +712,6 @@ struct AssistantSettingsTab: View {
             return provider.title
         }
         return String(localized: "Adapter pending for \(provider.title)")
-    }
-
-    @ViewBuilder private var endpointSecurityLabel: some View {
-        switch viewModel.configuration.endpointSecurity {
-        case .encrypted:
-            Label(String(localized: "Encrypted HTTPS connection"), systemImage: "lock.fill")
-                .foregroundStyle(.green)
-        case .localLoopback:
-            Label(String(localized: "Local-only connection on this Mac"), systemImage: "desktopcomputer")
-                .foregroundStyle(.green)
-        case .insecureRemote:
-            Label(
-                String(localized: "Blocked: remote endpoints must use HTTPS"),
-                systemImage: "exclamationmark.shield.fill"
-            )
-            .foregroundStyle(.red)
-        case .invalid:
-            Label(String(localized: "Enter a valid HTTP or HTTPS base URL"), systemImage: "exclamationmark.triangle")
-                .foregroundStyle(.secondary)
-        }
     }
 
     private func modelPickerTitle(_ model: AssistantModel) -> String {
@@ -762,6 +747,8 @@ protocol AssistantSettingsManaging: AnyObject {
     func selectAssistantConfiguration(_ configurationID: UUID)
     func removeAssistantConfiguration(_ configurationID: UUID)
 }
+
+// MARK: - AppSettingsManager + AssistantSettingsManaging
 
 extension AppSettingsManager: AssistantSettingsManaging {}
 
@@ -1157,7 +1144,8 @@ final class AssistantSettingsViewModel {
 
     func retryInstalledOllamaRuntime() {
         guard !runtimeSetupState.isBusy,
-              let applicationURL = ollamaApplicationURL else {
+              let applicationURL = ollamaApplicationURL else
+        {
             return
         }
         runtimeSetupState = .starting
@@ -1388,19 +1376,6 @@ final class AssistantSettingsViewModel {
 
     // MARK: Private
 
-    private let manager: any AssistantSettingsManaging
-    private let credentialStorage: any AssistantCredentialStorage
-    private let runtime: any AssistantProviderRuntimeProtocol
-    private let modelInstaller: any AssistantModelInstallerProtocol
-    private let ollamaRuntime: any OllamaRuntimeChecking
-    private let runtimeInstaller: any AssistantLocalRuntimeInstalling
-    private let applicationOpener: any AssistantRuntimeApplicationOpening
-    @ObservationIgnored private var connectionTask: Task<Void, Never>?
-    @ObservationIgnored private var modelInstallTask: Task<Void, Never>?
-    @ObservationIgnored private var runtimeInstallTask: Task<Void, Never>?
-    private var lastInstalledRuntimeURL: URL?
-    private var connectionGeneration = UUID()
-
     private static var defaultRuntimeInstallDestination: URL {
         let fileManager = FileManager.default
         if let applications = fileManager.urls(for: .applicationDirectory, in: .localDomainMask).first,
@@ -1415,6 +1390,19 @@ final class AssistantSettingsViewModel {
         }
         return fileManager.homeDirectoryForCurrentUser
     }
+
+    private let manager: any AssistantSettingsManaging
+    private let credentialStorage: any AssistantCredentialStorage
+    private let runtime: any AssistantProviderRuntimeProtocol
+    private let modelInstaller: any AssistantModelInstallerProtocol
+    private let ollamaRuntime: any OllamaRuntimeChecking
+    private let runtimeInstaller: any AssistantLocalRuntimeInstalling
+    private let applicationOpener: any AssistantRuntimeApplicationOpening
+    @ObservationIgnored private var connectionTask: Task<Void, Never>?
+    @ObservationIgnored private var modelInstallTask: Task<Void, Never>?
+    @ObservationIgnored private var runtimeInstallTask: Task<Void, Never>?
+    private var lastInstalledRuntimeURL: URL?
+    private var connectionGeneration = UUID()
 
     private var ollamaBaseURL: URL {
         if configuration.kind == .ollama, let endpointURL = configuration.endpointURL {
@@ -1575,7 +1563,8 @@ final class AssistantSettingsViewModel {
         _ operation: @escaping (
             AssistantProviderConfiguration,
             AssistantProviderConnectionToken
-        ) async throws -> Void
+        )
+        async throws -> Void
     ) {
         guard !isBusy else {
             return
@@ -1650,12 +1639,16 @@ final class AssistantSettingsViewModel {
 // MARK: - AssistantProviderConnectionToken
 
 private struct AssistantProviderConnectionToken {
+    // MARK: Lifecycle
+
     init(generation: UUID, configuration: AssistantProviderConfiguration) {
         self.generation = generation
         configurationID = configuration.id
         providerKind = configuration.kind
         baseURL = configuration.baseURL
     }
+
+    // MARK: Internal
 
     let generation: UUID
     let configurationID: UUID

--- a/Rockxy/Views/Settings/BypassProxyListView.swift
+++ b/Rockxy/Views/Settings/BypassProxyListView.swift
@@ -177,6 +177,7 @@ struct BypassProxyListView: View {
         }
         .padding(.horizontal, toolMetrics.contentHorizontalPadding)
         .padding(.vertical, toolMetrics.headerBottomPadding)
+        .rockxyFunctionalBar()
     }
 
     private var behaviorNotice: some View {
@@ -307,16 +308,13 @@ struct BypassProxyListView: View {
 
             Text(activeStatusText)
                 .font(toolMetrics.metadataFont(weight: .semibold))
-                .foregroundStyle(activeCount == 0 ? Color.secondary : Color.blue)
                 .padding(.horizontal, 11)
                 .padding(.vertical, 4)
-                .background(
-                    (activeCount == 0 ? Color.secondary : Color.blue).opacity(0.12)
-                )
-                .clipShape(Capsule())
+                .rockxyChipStyle(tint: .blue, isActive: activeCount > 0)
         }
         .padding(.horizontal, toolMetrics.contentHorizontalPadding)
         .padding(.bottom, toolMetrics.footerBottomPadding)
+        .rockxyFunctionalBar()
     }
 
     private var addRemoveControl: some View {

--- a/Rockxy/Views/Settings/BypassProxySettingsSheet.swift
+++ b/Rockxy/Views/Settings/BypassProxySettingsSheet.swift
@@ -81,6 +81,7 @@ struct BypassProxySettingsSheet: View {
                 }
                 .frame(minWidth: toolMetrics.footerButtonWidth)
                 .keyboardShortcut(.defaultAction)
+                .rockxyGlassButtonStyle(prominent: true)
             }
             .padding(.horizontal, 16)
             .padding(.vertical, 10)

--- a/Rockxy/Views/Settings/CustomHeaderColumnsView.swift
+++ b/Rockxy/Views/Settings/CustomHeaderColumnsView.swift
@@ -417,6 +417,7 @@ struct CustomHeaderColumnsView: View {
         .padding(.horizontal, toolMetrics.contentHorizontalPadding)
         .padding(.top, toolMetrics.headerTopPadding)
         .padding(.bottom, toolMetrics.headerBottomPadding)
+        .rockxyFunctionalBar()
     }
 
     private var infoBanner: some View {
@@ -541,6 +542,7 @@ struct CustomHeaderColumnsView: View {
         .padding(.horizontal, toolMetrics.contentHorizontalPadding)
         .padding(.top, toolMetrics.footerTopPadding)
         .padding(.bottom, toolMetrics.footerBottomPadding)
+        .rockxyFunctionalBar()
     }
 
     private var addRemoveControl: some View {
@@ -769,6 +771,7 @@ private struct AddHeaderColumnSheet: View {
                     footerButtonLabel(String(localized: "Add"))
                 }
                 .keyboardShortcut(.defaultAction)
+                .rockxyGlassButtonStyle(prominent: true)
                 .disabled(!isSubmittable)
             }
             .padding(.horizontal, 24)

--- a/Rockxy/Views/Settings/ExternalProxySettingsView.swift
+++ b/Rockxy/Views/Settings/ExternalProxySettingsView.swift
@@ -85,6 +85,7 @@ struct ExternalProxySettingsView: View {
         }
         .padding(.horizontal, toolMetrics.contentHorizontalPadding)
         .padding(.vertical, toolMetrics.headerBottomPadding)
+        .rockxyFunctionalBar()
     }
 
     private var behaviorNotice: some View {
@@ -457,6 +458,7 @@ struct ExternalProxySettingsView: View {
         }
         .padding(.horizontal, toolMetrics.contentHorizontalPadding)
         .padding(.vertical, toolMetrics.footerTopPadding)
+        .rockxyFunctionalBar()
     }
 
     private var footerActions: some View {
@@ -486,6 +488,7 @@ struct ExternalProxySettingsView: View {
                 footerButtonLabel(String(localized: "Apply"))
             }
             .keyboardShortcut(.defaultAction)
+            .rockxyGlassButtonStyle(prominent: true)
             .disabled(!viewModel.canApply)
         }
     }

--- a/Rockxy/Views/Settings/GeneralSettingsTab.swift
+++ b/Rockxy/Views/Settings/GeneralSettingsTab.swift
@@ -12,11 +12,11 @@ struct GeneralSettingsTab: View {
 
     var body: some View {
         SettingsPane {
-            SettingsSectionCard(String(localized: "Proxy")) {
+            SettingsSection(String(localized: "Proxy")) {
                 generalControlsSection
             }
 
-            SettingsSectionCard(String(localized: "Root CA Certificate")) {
+            SettingsSection(String(localized: "Root CA Certificate")) {
                 certificateSection
 
                 if case let .success(message) = certificateStatus {

--- a/Rockxy/Views/Settings/GitHubSettingsTab.swift
+++ b/Rockxy/Views/Settings/GitHubSettingsTab.swift
@@ -194,7 +194,7 @@ struct GitHubSettingsTab: View {
                         Image(systemName: "questionmark")
                             .font(settingsMetrics.font(weight: .semibold))
                     }
-                    .buttonStyle(.bordered)
+                    .rockxyGlassButtonStyle()
                     .buttonBorderShape(.circle)
                     .controlSize(.small)
                     .help(String(localized: "Open Publish to Gist documentation"))

--- a/Rockxy/Views/Settings/GitHubSettingsTab.swift
+++ b/Rockxy/Views/Settings/GitHubSettingsTab.swift
@@ -8,15 +8,15 @@ struct GitHubSettingsTab: View {
 
     var body: some View {
         SettingsPane {
-            SettingsSectionCard(String(localized: "Account")) {
+            SettingsSection(String(localized: "Account")) {
                 permissionSection
             }
 
-            SettingsSectionCard(String(localized: "Publishing Defaults")) {
+            SettingsSection(String(localized: "Publishing Defaults")) {
                 defaultsSection
             }
 
-            SettingsSectionCard(String(localized: "Access & Help")) {
+            SettingsSection(String(localized: "Access & Help")) {
                 advancedSection
             }
         }
@@ -40,11 +40,30 @@ struct GitHubSettingsTab: View {
     @AppStorage(RockxyIdentity.current.defaultsKey("github.gist.redactSensitiveData"))
     private var redactSensitiveData = true
 
-    @AppStorage(RockxyIdentity.current.defaultsKey("github.gist.openInBrowser"))
-    private var openInBrowser = true
+    @AppStorage(RockxyIdentity.current.defaultsKey("github.gist.openInBrowser")) private var openInBrowser = true
 
     @AppStorage(RockxyIdentity.current.defaultsKey("github.gist.copyURLToClipboard"))
     private var copyURLToClipboard = false
+
+    @Environment(\.appUIDisplayMetrics) private var appMetrics
+
+    private var selectedGistVisibility: GitHubGistVisibility {
+        GitHubGistVisibility(rawValue: gistVisibility) ?? .secret
+    }
+
+    private var gistVisibilityBinding: Binding<GitHubGistVisibility> {
+        Binding(
+            get: { selectedGistVisibility },
+            set: { visibility in
+                gistVisibility = visibility.rawValue
+                AppSettingsManager.shared.updateGitHubGistVisibility(visibility)
+            }
+        )
+    }
+
+    private var settingsMetrics: SettingsDisplayMetrics {
+        SettingsDisplayMetrics(appMetrics: appMetrics)
+    }
 
     private var permissionSection: some View {
         VStack(alignment: .leading, spacing: 22) {
@@ -59,27 +78,12 @@ struct GitHubSettingsTab: View {
 
             alignedRow(label: "") {
                 VStack(alignment: .leading, spacing: 14) {
-                    HStack(spacing: 10) {
-                        Button(String(localized: viewModel.isConnected ? "Reconnect..." : "Authorize...")) {
-                            if viewModel.canUseOAuth {
-                                showDeviceCodeSheet = true
-                            } else {
-                                showPersonalAccessTokenSheet = true
-                            }
+                    ViewThatFits(in: .horizontal) {
+                        HStack(spacing: 10) {
+                            accountActions
                         }
-                        .controlSize(.regular)
-                        .frame(width: settingsMetrics.menuWidth(124))
-
-                        Button(String(localized: "Use Token...")) {
-                            showPersonalAccessTokenSheet = true
-                        }
-                        .controlSize(.regular)
-
-                        if viewModel.isConnected {
-                            Button(String(localized: "Disconnect")) {
-                                viewModel.disconnect()
-                            }
-                            .controlSize(.regular)
+                        VStack(alignment: .leading, spacing: 10) {
+                            accountActions
                         }
                     }
 
@@ -98,10 +102,14 @@ struct GitHubSettingsTab: View {
                     .frame(maxWidth: settingsMetrics.fieldWidth(640), alignment: .leading)
 
                     if !viewModel.canUseOAuth {
-                        Text(String(localized: "OAuth is not configured for this build. Personal access token fallback is available."))
-                            .font(settingsMetrics.secondaryFont())
-                            .foregroundStyle(.secondary)
-                            .fixedSize(horizontal: false, vertical: true)
+                        Text(
+                            String(
+                                localized: "OAuth is not configured for this build. Personal access token fallback is available."
+                            )
+                        )
+                        .font(settingsMetrics.secondaryFont())
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
                     }
                 }
             }
@@ -112,27 +120,35 @@ struct GitHubSettingsTab: View {
         VStack(alignment: .leading, spacing: 20) {
             alignedRow(label: String(localized: "Publish as:")) {
                 VStack(alignment: .leading, spacing: 14) {
-                    radioRow(
-                        title: GitHubGistVisibility.secret.title,
-                        subtitle: GitHubGistVisibility.secret.sharingDescription,
-                        value: .secret
-                    )
-                    radioRow(
-                        title: GitHubGistVisibility.public.title,
-                        subtitle: GitHubGistVisibility.public.sharingDescription,
-                        value: .public
-                    )
+                    Picker(String(localized: "Publish as"), selection: gistVisibilityBinding) {
+                        ForEach(GitHubGistVisibility.allCases, id: \.self) { visibility in
+                            Text(visibility.title).tag(visibility)
+                        }
+                    }
+                    .pickerStyle(.radioGroup)
+                    .labelsHidden()
+
+                    Text(selectedGistVisibility.sharingDescription)
+                        .font(settingsMetrics.secondaryFont())
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
 
                     if GitHubGistVisibility(rawValue: gistVisibility) == .public {
-                        Text(String(localized: "Public Gists are discoverable. Review captured traffic before publishing."))
-                            .font(settingsMetrics.secondaryFont(weight: .medium))
-                            .foregroundStyle(.orange)
-                            .fixedSize(horizontal: false, vertical: true)
+                        Text(
+                            String(
+                                localized: "Public Gists are discoverable. Review captured traffic before publishing."
+                            )
+                        )
+                        .font(settingsMetrics.secondaryFont(weight: .medium))
+                        .foregroundStyle(.orange)
+                        .fixedSize(horizontal: false, vertical: true)
                     }
 
                     checkboxWithHelp(
                         title: String(localized: "Automatic redact sensitive headers"),
-                        subtitle: String(localized: "Authorization, Cookies, Set-Cookies, ... are censored before publishing to Gist."),
+                        subtitle: String(
+                            localized: "Authorization, Cookies, Set-Cookies, ... are censored before publishing to Gist."
+                        ),
                         isOn: $redactSensitiveData,
                         onChange: AppSettingsManager.shared.updateGitHubGistRedactSensitiveData
                     )
@@ -176,55 +192,57 @@ struct GitHubSettingsTab: View {
                         viewModel.openHelp()
                     } label: {
                         Image(systemName: "questionmark")
-                            .font(.system(size: max(18, settingsMetrics.bodyFontSize + 5), weight: .bold))
-                            .frame(width: settingsMetrics.controlHeight + 14, height: settingsMetrics.controlHeight + 14)
+                            .font(settingsMetrics.font(weight: .semibold))
                     }
-                    .buttonStyle(.borderless)
-                    .background(Color(nsColor: .controlBackgroundColor), in: Circle())
+                    .buttonStyle(.bordered)
+                    .buttonBorderShape(.circle)
+                    .controlSize(.small)
                     .help(String(localized: "Open Publish to Gist documentation"))
                 }
             }
         }
     }
 
-    private func alignedRow<Content: View>(
-        label: String,
-        @ViewBuilder content: () -> Content
-    )
-        -> some View
-    {
-        HStack(alignment: .top, spacing: 18) {
-            Text(label)
-                .font(settingsMetrics.font(weight: .medium))
-                .frame(width: settingsMetrics.wideLabelWidth, alignment: .trailing)
-                .padding(.top, 2)
-            content()
+    @ViewBuilder private var accountActions: some View {
+        Button(String(localized: viewModel.isConnected ? "Reconnect..." : "Authorize...")) {
+            if viewModel.canUseOAuth {
+                showDeviceCodeSheet = true
+            } else {
+                showPersonalAccessTokenSheet = true
+            }
+        }
+        .rockxyGlassButtonStyle(prominent: true)
+        .controlSize(.regular)
+
+        Button(String(localized: "Use Token...")) {
+            showPersonalAccessTokenSheet = true
+        }
+        .controlSize(.regular)
+
+        if viewModel.isConnected {
+            Button(String(localized: "Disconnect")) {
+                viewModel.disconnect()
+            }
+            .controlSize(.regular)
         }
     }
 
-    private func radioRow(title: String, subtitle: String, value: GitHubGistVisibility) -> some View {
-        Button {
-            gistVisibility = value.rawValue
-            AppSettingsManager.shared.updateGitHubGistVisibility(value)
-        } label: {
-            VStack(alignment: .leading, spacing: 6) {
-                HStack(spacing: 12) {
-                    Image(systemName: GitHubGistVisibility(rawValue: gistVisibility) == value ? "largecircle.fill.circle" : "circle.fill")
-                        .font(.system(size: max(14, settingsMetrics.bodyFontSize + 1)))
-                        .foregroundStyle(GitHubGistVisibility(rawValue: gistVisibility) == value ? .blue : Color(nsColor: .controlColor))
-                    Text(title)
-                        .font(settingsMetrics.font())
-                        .foregroundStyle(.primary)
-                }
-                Text(subtitle)
-                    .font(settingsMetrics.secondaryFont())
-                    .foregroundStyle(.secondary)
-                    .padding(.leading, 33)
-                    .fixedSize(horizontal: false, vertical: true)
+    @ViewBuilder
+    private func alignedRow(
+        label: String,
+        @ViewBuilder content: () -> some View
+    )
+        -> some View
+    {
+        if label.isEmpty {
+            SettingsIndentedContent {
+                content()
             }
-            .contentShape(Rectangle())
+        } else {
+            SettingsFieldRow(label) {
+                content()
+            }
         }
-        .buttonStyle(.plain)
     }
 
     private func checkboxWithHelp(
@@ -249,12 +267,6 @@ struct GitHubSettingsTab: View {
                     .fixedSize(horizontal: false, vertical: true)
             }
         }
-    }
-
-    @Environment(\.appUIDisplayMetrics) private var appMetrics
-
-    private var settingsMetrics: SettingsDisplayMetrics {
-        SettingsDisplayMetrics(appMetrics: appMetrics)
     }
 }
 
@@ -356,7 +368,8 @@ final class GitHubSettingsViewModel {
         let urlString = switch metadata?.method {
         case .deviceCode:
             "https://github.com/settings/applications"
-        case .personalAccessToken, nil:
+        case .personalAccessToken,
+             nil:
             "https://github.com/settings/tokens"
         }
         if let url = URL(string: urlString) {
@@ -379,8 +392,8 @@ final class GitHubSettingsViewModel {
 // MARK: - PersonalAccessTokenFallbackSheet
 
 private struct PersonalAccessTokenFallbackSheet: View {
-    @Environment(\.dismiss) private var dismiss
-    @Environment(\.appUIDisplayMetrics) private var appMetrics
+    // MARK: Internal
+
     @Bindable var viewModel: GitHubSettingsViewModel
 
     var body: some View {
@@ -422,6 +435,7 @@ private struct PersonalAccessTokenFallbackSheet: View {
                     }
                 }
                 .keyboardShortcut(.defaultAction)
+                .rockxyGlassButtonStyle(prominent: true)
                 .disabled(viewModel.personalAccessToken.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
             }
         }
@@ -429,6 +443,11 @@ private struct PersonalAccessTokenFallbackSheet: View {
         .padding(settingsMetrics.contentPadding)
         .frame(width: settingsMetrics.fieldWidth(430))
     }
+
+    // MARK: Private
+
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.appUIDisplayMetrics) private var appMetrics
 
     private var settingsMetrics: SettingsDisplayMetrics {
         SettingsDisplayMetrics(appMetrics: appMetrics)
@@ -438,12 +457,9 @@ private struct PersonalAccessTokenFallbackSheet: View {
 // MARK: - GitHubDeviceCodeAuthorizationSheet
 
 private struct GitHubDeviceCodeAuthorizationSheet: View {
-    @Environment(\.dismiss) private var dismiss
-    @Environment(\.appUIDisplayMetrics) private var appMetrics
+    // MARK: Internal
+
     @Bindable var viewModel: GitHubSettingsViewModel
-    @State private var deviceCode: GitHubAuthService.DeviceCode?
-    @State private var isLoading = false
-    @State private var errorMessage: String?
 
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
@@ -509,6 +525,18 @@ private struct GitHubDeviceCodeAuthorizationSheet: View {
         }
     }
 
+    // MARK: Private
+
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.appUIDisplayMetrics) private var appMetrics
+    @State private var deviceCode: GitHubAuthService.DeviceCode?
+    @State private var isLoading = false
+    @State private var errorMessage: String?
+
+    private var settingsMetrics: SettingsDisplayMetrics {
+        SettingsDisplayMetrics(appMetrics: appMetrics)
+    }
+
     private func start() async {
         isLoading = true
         defer { isLoading = false }
@@ -533,9 +561,5 @@ private struct GitHubDeviceCodeAuthorizationSheet: View {
         } catch {
             errorMessage = error.localizedDescription
         }
-    }
-
-    private var settingsMetrics: SettingsDisplayMetrics {
-        SettingsDisplayMetrics(appMetrics: appMetrics)
     }
 }

--- a/Rockxy/Views/Settings/MCPSettingsTab.swift
+++ b/Rockxy/Views/Settings/MCPSettingsTab.swift
@@ -11,19 +11,19 @@ struct MCPSettingsTab: View {
 
     var body: some View {
         SettingsPane {
-            SettingsSectionCard(String(localized: "MCP Server")) {
+            SettingsSection(String(localized: "MCP Server")) {
                 mcpServerSection
             }
 
-            SettingsSectionCard(String(localized: "Client Configuration")) {
+            SettingsSection(String(localized: "Client Configuration")) {
                 mcpConfigurationSection
             }
 
-            SettingsSectionCard(String(localized: "Privacy")) {
+            SettingsSection(String(localized: "Privacy")) {
                 privacySection
             }
 
-            SettingsSectionCard(String(localized: "About MCP")) {
+            SettingsSection(String(localized: "About MCP")) {
                 aboutSection
             }
         }

--- a/Rockxy/Views/Settings/PluginDetailView.swift
+++ b/Rockxy/Views/Settings/PluginDetailView.swift
@@ -138,7 +138,7 @@ struct PluginDetailView: View {
                 } label: {
                     Label(String(localized: "Reinstall"), systemImage: "arrow.triangle.2.circlepath")
                 }
-                .rockxyGlassButtonStyle(prominent: true)
+                .rockxyGlassButtonStyle()
             }
 
             if !plugin.isBuiltIn {

--- a/Rockxy/Views/Settings/PluginDetailView.swift
+++ b/Rockxy/Views/Settings/PluginDetailView.swift
@@ -92,9 +92,11 @@ struct PluginDetailView: View {
                         .font(settingsMetrics.secondaryFont(weight: .medium))
                         .padding(.horizontal, 8)
                         .padding(.vertical, 3)
-                        .background(Theme.Plugin.badgeColor(for: type).opacity(0.15))
-                        .foregroundStyle(Theme.Plugin.badgeColor(for: type))
-                        .clipShape(Capsule())
+                        .rockxyChipStyle(
+                            tint: Theme.Plugin.badgeColor(for: type),
+                            isActive: true,
+                            isEnabled: true
+                        )
                 }
             }
 
@@ -105,9 +107,11 @@ struct PluginDetailView: View {
                             .font(settingsMetrics.secondaryFont())
                             .padding(.horizontal, 8)
                             .padding(.vertical, 3)
-                            .background(Color.gray.opacity(0.15))
-                            .foregroundStyle(.secondary)
-                            .clipShape(Capsule())
+                            .rockxyChipStyle(
+                                tint: .secondary,
+                                isActive: true,
+                                isEnabled: true
+                            )
                     }
                 }
             }
@@ -134,7 +138,7 @@ struct PluginDetailView: View {
                 } label: {
                     Label(String(localized: "Reinstall"), systemImage: "arrow.triangle.2.circlepath")
                 }
-                .buttonStyle(.borderedProminent)
+                .rockxyGlassButtonStyle(prominent: true)
             }
 
             if !plugin.isBuiltIn {

--- a/Rockxy/Views/Settings/PluginsSettingsTab.swift
+++ b/Rockxy/Views/Settings/PluginsSettingsTab.swift
@@ -9,11 +9,13 @@ struct PluginsSettingsTab: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            HStack(spacing: 0) {
+            HSplitView {
                 pluginListPanel
-                    .frame(width: settingsMetrics.fieldWidth(240))
-
-                Divider()
+                    .frame(
+                        minWidth: settingsMetrics.fieldWidth(220),
+                        idealWidth: settingsMetrics.fieldWidth(250),
+                        maxWidth: settingsMetrics.fieldWidth(300)
+                    )
 
                 if let plugin = viewModel.selectedPlugin {
                     PluginDetailView(plugin: plugin, viewModel: viewModel)
@@ -58,15 +60,11 @@ struct PluginsSettingsTab: View {
 
     private var pluginListPanel: some View {
         VStack(spacing: 0) {
-            HStack {
-                Image(systemName: "magnifyingglass")
-                    .foregroundStyle(.secondary)
-                TextField(String(localized: "Search Plugins"), text: $viewModel.searchText)
-                    .textFieldStyle(.plain)
-                    .font(settingsMetrics.font())
-                    .frame(minHeight: settingsMetrics.controlHeight)
-            }
-            .padding(8)
+            TextField(String(localized: "Search Plugins"), text: $viewModel.searchText)
+                .textFieldStyle(.roundedBorder)
+                .font(settingsMetrics.font())
+                .frame(minHeight: settingsMetrics.controlHeight)
+                .padding(8)
 
             Divider()
 
@@ -86,16 +84,28 @@ struct PluginsSettingsTab: View {
                 .tag(plugin.id)
                 .listRowInsets(EdgeInsets())
             }
-            .listStyle(.sidebar)
+            .listStyle(.inset)
         }
+        .background(Color(nsColor: .windowBackgroundColor))
     }
 
     private var categoryFilterBar: some View {
-        HStack(spacing: 4) {
-            categoryPill(String(localized: "All"), category: nil)
-            categoryPill(String(localized: "Inspector"), category: .inspector)
-            categoryPill(String(localized: "Exporter"), category: .exporter)
-            categoryPill(String(localized: "Script"), category: .script)
+        ViewThatFits(in: .horizontal) {
+            HStack(spacing: 4) {
+                categoryPill(String(localized: "All"), category: nil)
+                categoryPill(String(localized: "Inspector"), category: .inspector)
+                categoryPill(String(localized: "Exporter"), category: .exporter)
+                categoryPill(String(localized: "Script"), category: .script)
+            }
+
+            Picker(String(localized: "Plugin Category"), selection: $viewModel.selectedCategory) {
+                Text(String(localized: "All")).tag(PluginType?.none)
+                Text(String(localized: "Inspector")).tag(PluginType?.some(.inspector))
+                Text(String(localized: "Exporter")).tag(PluginType?.some(.exporter))
+                Text(String(localized: "Script")).tag(PluginType?.some(.script))
+            }
+            .pickerStyle(.menu)
+            .labelsHidden()
         }
     }
 
@@ -129,6 +139,7 @@ struct PluginsSettingsTab: View {
         }
         .padding(.horizontal, 12)
         .frame(minHeight: settingsMetrics.footerHeight)
+        .rockxyFunctionalBar()
     }
 
     private func categoryPill(_ title: String, category: PluginType?) -> some View {
@@ -140,9 +151,11 @@ struct PluginsSettingsTab: View {
                 .font(settingsMetrics.secondaryFont(weight: isActive ? .semibold : .regular))
                 .padding(.horizontal, 8)
                 .padding(.vertical, 3)
-                .background(isActive ? Color.accentColor.opacity(0.15) : Color.clear)
-                .foregroundStyle(isActive ? Color.accentColor : .secondary)
-                .clipShape(Capsule())
+                .rockxyChipStyle(
+                    tint: .accentColor,
+                    isActive: isActive,
+                    isEnabled: true
+                )
         }
         .buttonStyle(.plain)
     }

--- a/Rockxy/Views/Settings/PreviewerTabSettingsView.swift
+++ b/Rockxy/Views/Settings/PreviewerTabSettingsView.swift
@@ -69,6 +69,7 @@ struct PreviewerTabSettingsView: View {
         }
         .padding(.horizontal, toolMetrics.contentHorizontalPadding)
         .padding(.vertical, toolMetrics.headerBottomPadding)
+        .rockxyFunctionalBar()
     }
 
     private var infoBanner: some View {
@@ -147,6 +148,7 @@ struct PreviewerTabSettingsView: View {
         }
         .padding(.horizontal, toolMetrics.contentHorizontalPadding)
         .padding(.vertical, toolMetrics.footerTopPadding)
+        .rockxyFunctionalBar()
     }
 
     private func centeredToggle(for mode: PreviewRenderMode, panel: PreviewPanel) -> some View {

--- a/Rockxy/Views/Settings/PrivacySettingsTab.swift
+++ b/Rockxy/Views/Settings/PrivacySettingsTab.swift
@@ -3,9 +3,11 @@ import SwiftUI
 
 /// Privacy settings showing honest disclosure about data storage, exports, and telemetry.
 struct PrivacySettingsTab: View {
+    // MARK: Internal
+
     var body: some View {
         SettingsPane {
-            SettingsSectionCard(String(localized: "Data Storage")) {
+            SettingsSection(String(localized: "Data Storage")) {
                 VStack(alignment: .leading, spacing: 12) {
                     Label {
                         VStack(alignment: .leading, spacing: 4) {
@@ -51,7 +53,7 @@ struct PrivacySettingsTab: View {
                 }
             }
 
-            SettingsSectionCard(String(localized: "Exports & Sharing")) {
+            SettingsSection(String(localized: "Exports & Sharing")) {
                 Label {
                     VStack(alignment: .leading, spacing: 4) {
                         Text(String(localized: "Exports Contain Full Traffic Data"))
@@ -74,7 +76,7 @@ struct PrivacySettingsTab: View {
                 }
             }
 
-            SettingsSectionCard(String(localized: "Analytics & Telemetry")) {
+            SettingsSection(String(localized: "Analytics & Telemetry")) {
                 Label {
                     VStack(alignment: .leading, spacing: 4) {
                         HStack {
@@ -85,7 +87,7 @@ struct PrivacySettingsTab: View {
                                 .foregroundStyle(.green)
                                 .padding(.horizontal, 6)
                                 .padding(.vertical, 2)
-                                .background(Color.green.opacity(0.15), in: RoundedRectangle(cornerRadius: 4))
+                                .rockxyChipStyle(tint: .green, isActive: true)
                         }
                         Text(
                             String(
@@ -116,6 +118,8 @@ struct PrivacySettingsTab: View {
         }
         .font(settingsMetrics.font())
     }
+
+    // MARK: Private
 
     @Environment(\.appUIDisplayMetrics) private var appMetrics
 

--- a/Rockxy/Views/Settings/SOCKSProxySettingsView.swift
+++ b/Rockxy/Views/Settings/SOCKSProxySettingsView.swift
@@ -19,6 +19,7 @@ struct SOCKSProxySettingsView: View {
             }
             .padding(.horizontal, toolMetrics.contentHorizontalPadding)
             .padding(.vertical, toolMetrics.headerBottomPadding)
+            .rockxyFunctionalBar()
 
             Divider()
 
@@ -59,9 +60,11 @@ struct SOCKSProxySettingsView: View {
                 }
                 .fixedSize(horizontal: true, vertical: false)
                 .keyboardShortcut(.defaultAction)
+                .rockxyGlassButtonStyle(prominent: true)
             }
             .padding(.horizontal, toolMetrics.contentHorizontalPadding)
             .padding(.vertical, toolMetrics.footerTopPadding)
+            .rockxyFunctionalBar()
         }
         .font(toolMetrics.font())
         .frame(width: toolMetrics.fieldWidth(640), height: 280)

--- a/Rockxy/Views/Settings/SSLProxyingListView.swift
+++ b/Rockxy/Views/Settings/SSLProxyingListView.swift
@@ -208,8 +208,8 @@ struct SSLProxyingListView: View {
         return canInterceptHTTPS ? .green : .orange
     }
 
-    private var statusCapsuleUsesWhiteText: Bool {
-        viewModel.isSSLProxyingEnabled && canInterceptHTTPS && viewModel.enabledDecryptCount > 0
+    private var statusCapsuleIsActive: Bool {
+        viewModel.isSSLProxyingEnabled && viewModel.enabledDecryptCount > 0
     }
 
     private var importConfirmationMessage: String {
@@ -269,6 +269,7 @@ struct SSLProxyingListView: View {
         }
         .padding(.horizontal, toolMetrics.contentHorizontalPadding)
         .padding(.vertical, toolMetrics.headerBottomPadding)
+        .rockxyFunctionalBar()
     }
 
     // MARK: - Info Banner
@@ -409,14 +410,13 @@ struct SSLProxyingListView: View {
 
             Text(statusCapsuleText)
                 .font(toolMetrics.metadataFont(weight: .semibold))
-                .foregroundStyle(statusCapsuleUsesWhiteText ? Color.white : statusCapsuleColor)
                 .padding(.horizontal, 12)
                 .padding(.vertical, 4)
-                .background(statusCapsuleColor.opacity(statusCapsuleUsesWhiteText ? 1 : 0.14))
-                .clipShape(Capsule())
+                .rockxyChipStyle(tint: statusCapsuleColor, isActive: statusCapsuleIsActive)
         }
         .padding(.horizontal, toolMetrics.contentHorizontalPadding)
         .padding(.vertical, toolMetrics.footerTopPadding)
+        .rockxyFunctionalBar()
     }
 
     private var addRemoveControl: some View {

--- a/Rockxy/Views/Settings/SSLProxyingListView.swift
+++ b/Rockxy/Views/Settings/SSLProxyingListView.swift
@@ -551,7 +551,7 @@ struct SSLProxyingListView: View {
             }
         }
         .menuIndicator(.hidden)
-        .buttonStyle(.bordered)
+        .rockxyGlassButtonStyle()
         .fixedSize()
     }
 

--- a/Rockxy/Views/Settings/SettingsSectionComponents.swift
+++ b/Rockxy/Views/Settings/SettingsSectionComponents.swift
@@ -23,11 +23,15 @@ struct SettingsPane<Content: View>: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(Color(nsColor: .windowBackgroundColor))
 
+        #if compiler(>=6.2)
         if #available(macOS 26.0, *) {
             scrollView.scrollEdgeEffectStyle(.soft, for: .vertical)
         } else {
             scrollView
         }
+        #else
+        scrollView
+        #endif
     }
 
     // MARK: Private

--- a/Rockxy/Views/Settings/SettingsSectionComponents.swift
+++ b/Rockxy/Views/Settings/SettingsSectionComponents.swift
@@ -6,26 +6,28 @@ import SwiftUI
 /// Keeping the outer insets here prevents individual categories from drifting
 /// when they are hosted inside the common sidebar/content shell.
 struct SettingsPane<Content: View>: View {
-    // MARK: Lifecycle
-
-    init(@ViewBuilder content: () -> Content) {
-        self.content = content()
-    }
-
     // MARK: Internal
 
-    let content: Content
+    @ViewBuilder let content: Content
 
     var body: some View {
-        ScrollView {
+        let scrollView = ScrollView {
             VStack(alignment: .leading, spacing: settingsMetrics.sectionSpacing) {
                 content
             }
             .padding(.horizontal, settingsMetrics.contentPadding)
             .padding(.vertical, settingsMetrics.paneContentPadding)
+            .frame(maxWidth: settingsMetrics.contentMaxWidth, alignment: .topLeading)
             .frame(maxWidth: .infinity, alignment: .topLeading)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color(nsColor: .windowBackgroundColor))
+
+        if #available(macOS 26.0, *) {
+            scrollView.scrollEdgeEffectStyle(.soft, for: .vertical)
+        } else {
+            scrollView
+        }
     }
 
     // MARK: Private
@@ -37,12 +39,14 @@ struct SettingsPane<Content: View>: View {
     }
 }
 
-// MARK: - SettingsSectionCard
+// MARK: - SettingsSection
 
 /// Shared grouping for dense Settings panes.
-/// A restrained native `GroupBox` — the section title is the group label and
-/// fields align via `SettingsFieldRow` / `SettingsIndentedContent`.
-struct SettingsSectionCard<Content: View>: View {
+/// A flat settings section modeled after Developer Setup. The title establishes
+/// hierarchy while the content remains on the opaque reading plane; adding a
+/// card or glass background here would create a nested surface inside the
+/// window's native Liquid Glass chrome.
+struct SettingsSection<Content: View>: View {
     // MARK: Lifecycle
 
     init(
@@ -59,16 +63,21 @@ struct SettingsSectionCard<Content: View>: View {
     let content: Content
 
     var body: some View {
-        GroupBox {
+        VStack(alignment: .leading, spacing: 10) {
+            Text(title)
+                .font(settingsMetrics.sectionTitleFont())
+                .fixedSize(horizontal: false, vertical: true)
+
             VStack(alignment: .leading, spacing: settingsMetrics.sectionContentSpacing) {
                 content
             }
             .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(.top, 4)
-        } label: {
-            Text(title)
-                .font(settingsMetrics.font(weight: .medium))
+
+            Divider()
+                .padding(.top, 4)
         }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.vertical, 4)
     }
 
     // MARK: Private
@@ -99,16 +108,22 @@ struct SettingsFieldRow<Content: View>: View {
     let content: Content
 
     var body: some View {
-        HStack(alignment: .top, spacing: 0) {
-            Text(label)
-                .font(settingsMetrics.font(weight: .medium))
-                .frame(width: settingsMetrics.labelWidth, alignment: .trailing)
-                .padding(.trailing, 16)
-                .padding(.top, 3)
+        ViewThatFits(in: .horizontal) {
+            HStack(alignment: .firstTextBaseline, spacing: settingsMetrics.fieldSpacing) {
+                fieldLabel
+                    .frame(width: settingsMetrics.labelWidth, alignment: .trailing)
 
-            content
-                .frame(maxWidth: .infinity, alignment: .leading)
+                content
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+
+            VStack(alignment: .leading, spacing: 7) {
+                fieldLabel
+                content
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
         }
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     // MARK: Private
@@ -117,29 +132,23 @@ struct SettingsFieldRow<Content: View>: View {
 
     private var settingsMetrics: SettingsDisplayMetrics {
         SettingsDisplayMetrics(appMetrics: appMetrics)
+    }
+
+    private var fieldLabel: some View {
+        Text(label)
+            .font(settingsMetrics.font(weight: .medium))
+            .foregroundStyle(.secondary)
+            .fixedSize(horizontal: false, vertical: true)
     }
 }
 
 // MARK: - SettingsIndentedContent
 
 struct SettingsIndentedContent<Content: View>: View {
-    // MARK: Internal
-
     @ViewBuilder let content: Content
 
     var body: some View {
-        HStack(alignment: .top, spacing: 0) {
-            Color.clear.frame(width: settingsMetrics.rowLeading)
-            content
-                .frame(maxWidth: .infinity, alignment: .leading)
-        }
-    }
-
-    // MARK: Private
-
-    @Environment(\.appUIDisplayMetrics) private var appMetrics
-
-    private var settingsMetrics: SettingsDisplayMetrics {
-        SettingsDisplayMetrics(appMetrics: appMetrics)
+        content
+            .frame(maxWidth: .infinity, alignment: .leading)
     }
 }

--- a/Rockxy/Views/Settings/SettingsView.swift
+++ b/Rockxy/Views/Settings/SettingsView.swift
@@ -210,11 +210,15 @@ struct SettingsView: View {
         )
         .accessibilityLabel(String(localized: "Settings categories"))
 
+        #if compiler(>=6.2)
         if #available(macOS 26.0, *) {
             list.scrollEdgeEffectStyle(.soft, for: .vertical)
         } else {
             list
         }
+        #else
+        list
+        #endif
     }
 
     /// Keeps panes alive after their first visit so sidebar navigation does not

--- a/Rockxy/Views/Settings/SettingsView.swift
+++ b/Rockxy/Views/Settings/SettingsView.swift
@@ -1,9 +1,8 @@
-import AppKit
 import SwiftUI
 
-// Root settings window using a native macOS sidebar/content layout.
-// The sidebar lists the nine categories; the content column shows a compact
-// pane header followed by the selected category's existing settings pane.
+// Root Settings window using the same native sidebar/detail hierarchy as
+// Developer Setup. macOS owns the title bar, sidebar toggle, and navigation;
+// the detail column stays an opaque, high-contrast configuration surface.
 
 // MARK: - RockxySettingsTab
 
@@ -91,34 +90,44 @@ enum RockxySettingsTab: String, CaseIterable, Identifiable, Hashable {
     }
 }
 
+// MARK: - RockxySettingsSidebarSection
+
+private enum RockxySettingsSidebarSection: String, CaseIterable, Identifiable {
+    case application
+    case integrations
+    case system
+
+    // MARK: Internal
+
+    var id: Self {
+        self
+    }
+
+    var title: String {
+        switch self {
+        case .application: String(localized: "Application")
+        case .integrations: String(localized: "Integrations")
+        case .system: String(localized: "System")
+        }
+    }
+
+    var tabs: [RockxySettingsTab] {
+        switch self {
+        case .application: [.general, .appearance, .privacy]
+        case .integrations: [.assistant, .github, .plugins, .mcp]
+        case .system: [.tools, .advanced]
+        }
+    }
+}
+
 // MARK: - SettingsView
 
 struct SettingsView: View {
     // MARK: Internal
 
     var body: some View {
-        NavigationSplitView(columnVisibility: $columnVisibility) {
-            List(RockxySettingsTab.allCases, selection: selectionBinding) { tab in
-                Label {
-                    Text(tab.title)
-                } icon: {
-                    Image(systemName: tab.symbol)
-                }
-                .font(settingsMetrics.font())
-                .tag(tab)
-            }
-            .listStyle(.sidebar)
-            .safeAreaInset(edge: .top, spacing: 0) {
-                Color.clear
-                    .frame(height: SettingsChromeMetrics.sidebarContentTopInset)
-                    .accessibilityHidden(true)
-            }
-            .navigationSplitViewColumnWidth(
-                min: settingsMetrics.sidebarMinWidth,
-                ideal: settingsMetrics.sidebarIdealWidth,
-                max: settingsMetrics.sidebarMaxWidth
-            )
-            .toolbar(removing: .sidebarToggle)
+        NavigationSplitView {
+            settingsSidebar
         } detail: {
             detailContent(for: selectedTab)
                 .font(settingsMetrics.font())
@@ -128,7 +137,7 @@ struct SettingsView: View {
                     maxHeight: .infinity
                 )
         }
-        .navigationSplitViewStyle(.balanced)
+        .navigationTitle(selectedTab.title)
         .onAppear {
             loadedTabs.insert(selectedTab)
         }
@@ -143,18 +152,12 @@ struct SettingsView: View {
             idealHeight: settingsMetrics.windowIdealHeight,
             maxHeight: .infinity
         )
-        .background {
-            SettingsWindowToolbarInstaller(
-                onToggleSidebar: toggleSidebar
-            )
-        }
     }
 
     // MARK: Private
 
     @AppStorage(RockxySettingsTab.defaultsKey) private var selectedTabID = RockxySettingsTab.general.rawValue
     @Environment(\.appUIDisplayMetrics) private var appMetrics
-    @State private var columnVisibility: NavigationSplitViewVisibility = .all
     @State private var loadedTabs: Set<RockxySettingsTab> = []
 
     private var settingsMetrics: SettingsDisplayMetrics {
@@ -179,20 +182,38 @@ struct SettingsView: View {
         )
     }
 
-    private func toggleSidebar() {
-        withAnimation(.easeInOut(duration: 0.26)) {
-            columnVisibility = columnVisibility == .detailOnly
-                ? .all
-                : .detailOnly
-        }
+    private var loadedPaneTabs: [RockxySettingsTab] {
+        RockxySettingsTab.allCases.filter { loadedTabs.contains($0) || $0 == selectedTab }
     }
 
-    private func detailContent(for tab: RockxySettingsTab) -> some View {
-        VStack(alignment: .leading, spacing: 0) {
-            paneHeader(for: tab)
-            Divider()
-            persistentPaneStack
-                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+    @ViewBuilder private var settingsSidebar: some View {
+        let list = List(selection: selectionBinding) {
+            ForEach(RockxySettingsSidebarSection.allCases) { section in
+                Section(section.title) {
+                    ForEach(section.tabs) { tab in
+                        Label {
+                            Text(tab.title)
+                        } icon: {
+                            Image(systemName: tab.symbol)
+                        }
+                        .font(settingsMetrics.font(weight: selectedTab == tab ? .semibold : .regular))
+                        .tag(tab)
+                    }
+                }
+            }
+        }
+        .listStyle(.sidebar)
+        .navigationSplitViewColumnWidth(
+            min: settingsMetrics.sidebarMinWidth,
+            ideal: settingsMetrics.sidebarIdealWidth,
+            max: settingsMetrics.sidebarMaxWidth
+        )
+        .accessibilityLabel(String(localized: "Settings categories"))
+
+        if #available(macOS 26.0, *) {
+            list.scrollEdgeEffectStyle(.soft, for: .vertical)
+        } else {
+            list
         }
     }
 
@@ -214,22 +235,11 @@ struct SettingsView: View {
         }
     }
 
-    private var loadedPaneTabs: [RockxySettingsTab] {
-        RockxySettingsTab.allCases.filter { loadedTabs.contains($0) || $0 == selectedTab }
-    }
-
-    private func paneHeader(for tab: RockxySettingsTab) -> some View {
-        VStack(alignment: .leading, spacing: settingsMetrics.paneHeaderSpacing) {
-            Text(tab.title)
-                .font(settingsMetrics.font(weight: .semibold))
-            Text(tab.paneDescription)
-                .font(settingsMetrics.secondaryFont())
-                .foregroundStyle(.secondary)
-                .fixedSize(horizontal: false, vertical: true)
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(.horizontal, settingsMetrics.contentPadding)
-        .padding(.vertical, 14)
+    private func detailContent(for tab: RockxySettingsTab) -> some View {
+        persistentPaneStack
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+            .background(Color(nsColor: .windowBackgroundColor))
+            .accessibilityLabel(tab.title)
     }
 
     /// A concrete switch keeps the pane types explicit without type erasure.
@@ -246,183 +256,5 @@ struct SettingsView: View {
         case .mcp: MCPSettingsTab()
         case .advanced: AdvancedSettingsTab()
         }
-    }
-}
-
-// MARK: - SettingsChromeMetrics
-
-private enum SettingsChromeMetrics {
-    static let sidebarContentTopInset: CGFloat = 14
-}
-
-// MARK: - SettingsWindowToolbarInstaller
-
-/// Installs the same native toolbar-item structure as Rockxy's main workspace:
-/// an icon-only sidebar item followed by AppKit's sidebar-tracking separator.
-private struct SettingsWindowToolbarInstaller: NSViewRepresentable {
-    // MARK: Internal
-
-    let onToggleSidebar: () -> Void
-
-    func makeCoordinator() -> Coordinator {
-        Coordinator(onToggleSidebar: onToggleSidebar)
-    }
-
-    func makeNSView(context: Context) -> NSView {
-        let view = NSView()
-        installToolbar(for: view, coordinator: context.coordinator)
-        return view
-    }
-
-    func updateNSView(_ nsView: NSView, context: Context) {
-        context.coordinator.update(onToggleSidebar: onToggleSidebar)
-        installToolbar(for: nsView, coordinator: context.coordinator)
-    }
-
-    static func dismantleNSView(_ nsView: NSView, coordinator: Coordinator) {
-        coordinator.removeToolbar()
-    }
-
-    // MARK: Private
-
-    private func installToolbar(for view: NSView, coordinator: Coordinator) {
-        DispatchQueue.main.async { [weak view, weak coordinator] in
-            guard let window = view?.window,
-                  let coordinator
-            else {
-                return
-            }
-            coordinator.installToolbarIfNeeded(in: window)
-        }
-    }
-
-    // MARK: - Coordinator
-
-    @MainActor
-    final class Coordinator: NSObject {
-        // MARK: Lifecycle
-
-        init(onToggleSidebar: @escaping () -> Void) {
-            toolbar = SettingsWindowToolbar(onToggleSidebar: onToggleSidebar)
-            super.init()
-        }
-
-        // MARK: Internal
-
-        func update(onToggleSidebar: @escaping () -> Void) {
-            toolbar.onToggleSidebar = onToggleSidebar
-        }
-
-        func installToolbarIfNeeded(in window: NSWindow) {
-            guard installedWindow !== window || window.toolbar !== toolbar.managedToolbar else {
-                return
-            }
-
-            if installedWindow !== window {
-                previousToolbar = window.toolbar
-            }
-
-            window.styleMask.insert(.fullSizeContentView)
-            window.titlebarAppearsTransparent = true
-            window.toolbarStyle = .unifiedCompact
-            window.toolbar = toolbar.managedToolbar
-            installedWindow = window
-        }
-
-        func removeToolbar() {
-            if let installedWindow,
-               installedWindow.toolbar === toolbar.managedToolbar
-            {
-                installedWindow.toolbar = previousToolbar
-            }
-            installedWindow = nil
-            previousToolbar = nil
-        }
-
-        // MARK: Private
-
-        private let toolbar: SettingsWindowToolbar
-        private weak var installedWindow: NSWindow?
-        private var previousToolbar: NSToolbar?
-    }
-}
-
-// MARK: - SettingsWindowToolbar
-
-@MainActor
-private final class SettingsWindowToolbar: NSObject, NSToolbarDelegate {
-    // MARK: Lifecycle
-
-    init(onToggleSidebar: @escaping () -> Void) {
-        self.onToggleSidebar = onToggleSidebar
-        managedToolbar = NSToolbar(identifier: Self.toolbarIdentifier)
-        super.init()
-
-        managedToolbar.delegate = self
-        managedToolbar.displayMode = .iconOnly
-        managedToolbar.allowsUserCustomization = false
-        managedToolbar.autosavesConfiguration = false
-    }
-
-    // MARK: Internal
-
-    static let toolbarIdentifier = NSToolbar.Identifier(
-        "\(RockxyIdentity.current.logSubsystem).settings.toolbar"
-    )
-    static let sidebarToggleIdentifier = NSToolbarItem.Identifier(
-        "\(RockxyIdentity.current.logSubsystem).settings.toolbar.toggleSidebar"
-    )
-
-    let managedToolbar: NSToolbar
-    var onToggleSidebar: () -> Void
-
-    func toolbarDefaultItemIdentifiers(
-        _ toolbar: NSToolbar
-    ) -> [NSToolbarItem.Identifier] {
-        [
-            .flexibleSpace,
-            Self.sidebarToggleIdentifier,
-            .sidebarTrackingSeparator,
-            .flexibleSpace,
-        ]
-    }
-
-    func toolbarAllowedItemIdentifiers(
-        _ toolbar: NSToolbar
-    ) -> [NSToolbarItem.Identifier] {
-        toolbarDefaultItemIdentifiers(toolbar)
-    }
-
-    func toolbar(
-        _ toolbar: NSToolbar,
-        itemForItemIdentifier itemIdentifier: NSToolbarItem.Identifier,
-        willBeInsertedIntoToolbar flag: Bool
-    ) -> NSToolbarItem? {
-        guard itemIdentifier == Self.sidebarToggleIdentifier else {
-            return nil
-        }
-
-        let label = String(localized: "Toggle Settings Sidebar")
-        let item = NSToolbarItem(itemIdentifier: itemIdentifier)
-        item.label = label
-        item.paletteLabel = label
-        item.toolTip = label
-        item.target = self
-        item.action = #selector(toggleSidebar(_:))
-        item.image = NSImage(
-            systemSymbolName: "sidebar.leading",
-            accessibilityDescription: label
-        )
-        // Keep the native toolbar item icon-only at rest. A bordered item adds
-        // a persistent bezel that visually overlaps the sidebar's rounded edge.
-        item.isBordered = false
-        return item
-    }
-
-    // MARK: Private
-
-    @objc
-    private func toggleSidebar(_ sender: Any?) {
-        onToggleSidebar()
     }
 }

--- a/Rockxy/Views/Settings/SettingsWindowScene.swift
+++ b/Rockxy/Views/Settings/SettingsWindowScene.swift
@@ -1,0 +1,36 @@
+import SwiftUI
+
+// MARK: - SettingsWindowScene
+
+/// Settings deliberately uses the same normal utility-window contract as
+/// Developer Setup. A SwiftUI `Settings` scene places the automatic sidebar
+/// toggle inside the content region; the normal `Window` scene lets macOS keep
+/// that toggle in the unified title bar where it belongs.
+struct SettingsWindowScene: Scene {
+    // MARK: Internal
+
+    var body: some Scene {
+        settingsWindow
+    }
+
+    // MARK: Private
+
+    private var settingsWindow: some Scene {
+        let base = Window(String(localized: "Settings"), id: "settings") {
+            AppUIDisplayMetricsProvider {
+                SettingsView()
+            }
+        }
+        .commandsRemoved()
+        .defaultSize(width: 1_000, height: 640)
+        .defaultPosition(.center)
+        .windowToolbarStyle(.unified(showsTitle: true))
+        .windowResizability(.contentMinSize)
+
+        if #available(macOS 15.0, *) {
+            return base.restorationBehavior(.disabled)
+        } else {
+            return base
+        }
+    }
+}

--- a/Rockxy/Views/Settings/ToolsSettingsTab.swift
+++ b/Rockxy/Views/Settings/ToolsSettingsTab.swift
@@ -12,7 +12,7 @@ struct ToolsSettingsTab: View {
 
     var body: some View {
         SettingsPane {
-            SettingsSectionCard(String(localized: "Request Behavior")) {
+            SettingsSection(String(localized: "Request Behavior")) {
                 SettingsIndentedContent {
                     Toggle(
                         String(localized: "Disable caching (No-Cache headers)"),

--- a/Rockxy/Views/Sidebar/AddFavoriteView.swift
+++ b/Rockxy/Views/Sidebar/AddFavoriteView.swift
@@ -189,6 +189,7 @@ struct AddFavoriteView: View {
                 isPresented = false
             }
             .keyboardShortcut(.defaultAction)
+            .rockxyGlassButtonStyle(prominent: true)
             .disabled(selectedItem == nil || isAddDisabledByQuota)
         }
     }

--- a/Rockxy/Views/Sidebar/FocusSetEditorSheet.swift
+++ b/Rockxy/Views/Sidebar/FocusSetEditorSheet.swift
@@ -216,6 +216,7 @@ struct FocusSetEditorSheet: View {
                 dismiss()
             }
             .keyboardShortcut(.defaultAction)
+            .rockxyGlassButtonStyle(prominent: true)
             .disabled(trimmedName.isEmpty || draft.ruleCount == 0)
         }
         .padding(.horizontal, 18)

--- a/Rockxy/Views/Sidebar/NoiseControlManagerSheet.swift
+++ b/Rockxy/Views/Sidebar/NoiseControlManagerSheet.swift
@@ -238,6 +238,7 @@ struct NoiseControlManagerSheet: View {
             .disabled(allSources.isEmpty)
             Button(String(localized: "Done")) { dismiss() }
                 .keyboardShortcut(.defaultAction)
+                .rockxyGlassButtonStyle(prominent: true)
         }
         .padding(.horizontal, 18)
         .frame(height: 52)

--- a/Rockxy/Views/Sidebar/NoiseControlManagerSheet.swift
+++ b/Rockxy/Views/Sidebar/NoiseControlManagerSheet.swift
@@ -238,7 +238,7 @@ struct NoiseControlManagerSheet: View {
             .disabled(allSources.isEmpty)
             Button(String(localized: "Done")) { dismiss() }
                 .keyboardShortcut(.defaultAction)
-                .rockxyGlassButtonStyle(prominent: true)
+                .rockxyGlassButtonStyle()
         }
         .padding(.horizontal, 18)
         .frame(height: 52)

--- a/Rockxy/Views/Sidebar/SidebarBottomBar.swift
+++ b/Rockxy/Views/Sidebar/SidebarBottomBar.swift
@@ -6,6 +6,8 @@ import SwiftUI
 // MARK: - SidebarBottomBar
 
 struct SidebarBottomBar: View {
+    // MARK: Internal
+
     @Binding var filterText: String
     @Binding var isAddFavoritePresented: Bool
 
@@ -48,9 +50,9 @@ struct SidebarBottomBar: View {
         }
         .padding(.horizontal, 8)
         .padding(.vertical, 4)
-        .background(Color.clear)
-        .overlay(alignment: .top) { Divider() }
     }
+
+    // MARK: Private
 
     @Environment(\.appUIDisplayMetrics) private var metrics
 }

--- a/Rockxy/Views/Sidebar/SidebarBottomBar.swift
+++ b/Rockxy/Views/Sidebar/SidebarBottomBar.swift
@@ -1,7 +1,8 @@
+import AppKit
 import SwiftUI
 
-// Bottom toolbar for the sidebar, providing a filter text field and an add-favorite button.
-// Mirrors the compact bottom-bar pattern used in Finder and Proxyman sidebars.
+// Bottom toolbar for the sidebar, providing a native filter field and an add-favorite button.
+// Mirrors Xcode's navigator control bar: the add action stands apart from the expanding search field.
 
 // MARK: - SidebarBottomBar
 
@@ -12,47 +13,94 @@ struct SidebarBottomBar: View {
     @Binding var isAddFavoritePresented: Bool
 
     var body: some View {
-        HStack(spacing: 6) {
+        HStack(spacing: 8) {
             Button {
                 isAddFavoritePresented = true
             } label: {
                 Image(systemName: "plus")
-                    .font(.system(size: metrics.fontSize))
+                    .font(.system(size: metrics.sidebarIconFontSize))
+                    .frame(width: 24, height: 28)
+                    .contentShape(Rectangle())
             }
             .buttonStyle(.borderless)
+            .accessibilityLabel(String(localized: "Add favorite app or domain"))
             .help(String(localized: "Add favorite app or domain"))
 
-            HStack(spacing: 4) {
-                Image(systemName: "line.3.horizontal.decrease.circle")
-                    .font(.system(size: metrics.secondaryFontSize))
-                    .foregroundStyle(.secondary)
-                TextField(
-                    String(localized: "Filter (\u{2318}\u{21E7}F)"),
-                    text: $filterText
-                )
-                .textFieldStyle(.plain)
-                .font(metrics.swiftUIFont())
-                if !filterText.isEmpty {
-                    Button {
-                        filterText = ""
-                    } label: {
-                        Image(systemName: "xmark.circle.fill")
-                            .font(.system(size: metrics.badgeFontSize))
-                            .foregroundStyle(.secondary)
-                    }
-                    .buttonStyle(.borderless)
-                }
-            }
-            .padding(.horizontal, 6)
-            .padding(.vertical, 3)
-            .background(Color(nsColor: .quaternaryLabelColor).opacity(0.5))
-            .clipShape(RoundedRectangle(cornerRadius: 6))
+            NativeSidebarSearchField(
+                text: $filterText,
+                fontSize: metrics.sidebarNavigationFontSize
+            )
+            .frame(maxWidth: .infinity, minHeight: 28)
         }
         .padding(.horizontal, 8)
-        .padding(.vertical, 4)
+        .padding(.vertical, 6)
     }
 
     // MARK: Private
 
     @Environment(\.appUIDisplayMetrics) private var metrics
+}
+
+// MARK: - NativeSidebarSearchField
+
+private struct NativeSidebarSearchField: NSViewRepresentable {
+    // MARK: Internal
+
+    @Binding var text: String
+    let fontSize: CGFloat
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(text: $text)
+    }
+
+    func makeNSView(context: Context) -> NSSearchField {
+        let searchField = NSSearchField()
+        searchField.placeholderString = String(localized: "Filter")
+        searchField.toolTip = String(localized: "Filter sidebar items")
+        searchField.controlSize = .regular
+        searchField.focusRingType = .exterior
+        searchField.sendsWholeSearchString = false
+        searchField.sendsSearchStringImmediately = true
+        searchField.delegate = context.coordinator
+        searchField.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        searchField.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        searchField.setAccessibilityLabel(String(localized: "Filter sidebar"))
+        configure(searchField)
+        return searchField
+    }
+
+    func updateNSView(_ searchField: NSSearchField, context: Context) {
+        context.coordinator.text = $text
+        if searchField.stringValue != text {
+            searchField.stringValue = text
+        }
+        configure(searchField)
+    }
+
+    // MARK: Private
+
+    private func configure(_ searchField: NSSearchField) {
+        searchField.font = .systemFont(ofSize: fontSize)
+        guard let searchCell = searchField.cell as? NSSearchFieldCell else { return }
+        searchCell.searchButtonCell?.image = NSImage(
+            systemSymbolName: "line.3.horizontal.decrease.circle",
+            accessibilityDescription: String(localized: "Filter")
+        )
+    }
+
+    // MARK: - Coordinator
+
+    @MainActor
+    final class Coordinator: NSObject, NSSearchFieldDelegate {
+        var text: Binding<String>
+
+        init(text: Binding<String>) {
+            self.text = text
+        }
+
+        func controlTextDidChange(_ notification: Notification) {
+            guard let searchField = notification.object as? NSSearchField else { return }
+            text.wrappedValue = searchField.stringValue
+        }
+    }
 }

--- a/Rockxy/Views/Sidebar/SidebarView.swift
+++ b/Rockxy/Views/Sidebar/SidebarView.swift
@@ -136,32 +136,7 @@ struct SidebarView: View {
     let coordinator: MainContentCoordinator
 
     var body: some View {
-        VStack(spacing: 0) {
-            Picker(String(localized: "Navigator"), selection: navigatorModeBinding) {
-                ForEach(FocusNavigatorMode.allCases) { mode in
-                    Text(mode.title).tag(mode)
-                }
-            }
-            .workspaceModeSwitcherStyle()
-
-            Divider()
-
-            Group {
-                switch coordinator.focusNavigatorMode {
-                case .browse:
-                    browseList
-                case .focus:
-                    focusList
-                case .library:
-                    libraryList
-                }
-            }
-
-            SidebarBottomBar(
-                filterText: $sidebarFilterText,
-                isAddFavoritePresented: $isAddFavoritePresented
-            )
-        }
+        navigatorChrome
         .sheet(isPresented: $isAddFavoritePresented) {
             AddFavoriteView(
                 coordinator: coordinator,
@@ -204,6 +179,56 @@ struct SidebarView: View {
     @State private var expandedAppNames: Set<String> = []
     @State private var expandedDomainNodeIDs: Set<String> = []
     @Environment(\.appUIDisplayMetrics) private var metrics
+
+    @ViewBuilder
+    private var navigatorChrome: some View {
+        if #available(macOS 26.0, *) {
+            navigatorList
+                .scrollEdgeEffectStyle(.soft, for: .vertical)
+                .safeAreaBar(edge: .top, spacing: 0) {
+                    navigatorPicker
+                }
+                .safeAreaBar(edge: .bottom, spacing: 0) {
+                    sidebarBottomBar
+                }
+        } else {
+            VStack(spacing: 0) {
+                navigatorPicker
+                Divider()
+                navigatorList
+                Divider()
+                sidebarBottomBar
+            }
+        }
+    }
+
+    private var navigatorPicker: some View {
+        Picker(String(localized: "Navigator"), selection: navigatorModeBinding) {
+            ForEach(FocusNavigatorMode.allCases) { mode in
+                Text(mode.title).tag(mode)
+            }
+        }
+        .workspaceModeSwitcherStyle()
+    }
+
+    @ViewBuilder
+    private var navigatorList: some View {
+        switch coordinator.focusNavigatorMode {
+        case .browse:
+            browseList
+        case .focus:
+            focusList
+        case .library:
+            libraryList
+        }
+    }
+
+    private var sidebarBottomBar: some View {
+        SidebarBottomBar(
+            filterText: $sidebarFilterText,
+            isAddFavoritePresented: $isAddFavoritePresented
+        )
+    }
 
     private var sidebarBinding: Binding<SidebarItem?> {
         Binding(

--- a/Rockxy/Views/Sidebar/SidebarView.swift
+++ b/Rockxy/Views/Sidebar/SidebarView.swift
@@ -203,11 +203,17 @@ struct SidebarView: View {
     }
 
     private var navigatorPicker: some View {
-        Picker(String(localized: "Navigator"), selection: navigatorModeBinding) {
-            ForEach(FocusNavigatorMode.allCases) { mode in
-                Text(mode.title).tag(mode)
-            }
-        }
+        WorkspaceModeSegmentedControl(
+            selection: navigatorModeBinding,
+            segments: FocusNavigatorMode.allCases.map { mode in
+                WorkspaceModeSegment(
+                    value: mode,
+                    title: mode.title,
+                    systemImage: mode.systemImage
+                )
+            },
+            accessibilityLabel: String(localized: "Navigator")
+        )
         .workspaceModeSwitcherStyle()
     }
 
@@ -404,7 +410,7 @@ struct SidebarView: View {
                         .font(.caption.weight(.medium))
                 }
             }
-            .buttonStyle(.bordered)
+            .rockxyGlassButtonStyle()
             .controlSize(.small)
             .foregroundStyle(.secondary)
             .help(actionLabel)

--- a/Rockxy/Views/Sidebar/SidebarView.swift
+++ b/Rockxy/Views/Sidebar/SidebarView.swift
@@ -182,6 +182,7 @@ struct SidebarView: View {
 
     @ViewBuilder
     private var navigatorChrome: some View {
+        #if compiler(>=6.2)
         if #available(macOS 26.0, *) {
             navigatorList
                 .scrollEdgeEffectStyle(.soft, for: .vertical)
@@ -192,13 +193,20 @@ struct SidebarView: View {
                     sidebarBottomBar
                 }
         } else {
-            VStack(spacing: 0) {
-                navigatorPicker
-                Divider()
-                navigatorList
-                Divider()
-                sidebarBottomBar
-            }
+            legacyNavigatorChrome
+        }
+        #else
+        legacyNavigatorChrome
+        #endif
+    }
+
+    private var legacyNavigatorChrome: some View {
+        VStack(spacing: 0) {
+            navigatorPicker
+            Divider()
+            navigatorList
+            Divider()
+            sidebarBottomBar
         }
     }
 

--- a/Rockxy/Views/Toolbar/ActiveFilterSummaryBar.swift
+++ b/Rockxy/Views/Toolbar/ActiveFilterSummaryBar.swift
@@ -11,6 +11,7 @@ struct ActiveFilterSummaryBar: View {
     // MARK: Internal
 
     let coordinator: MainContentCoordinator
+    var isEmbeddedInControlShelf = false
 
     var body: some View {
         if hasActiveFilters {
@@ -88,46 +89,6 @@ struct ActiveFilterSummaryBar: View {
                         }
                     }
 
-                    if coordinator.filterCriteria.isSearchEnabled,
-                       !coordinator.filterCriteria.searchText.isEmpty
-                    {
-                        let field = coordinator.filterCriteria.searchField.displayName
-                        let text = coordinator.filterCriteria.searchText
-                        FilterChip(
-                            label: "\(field): \(text)",
-                            onRemove: {
-                                coordinator.filterCriteria.searchText = ""
-                                coordinator.recomputeFilteredTransactions()
-                            }
-                        )
-                    }
-
-                    ForEach(
-                        ProtocolFilterSelection.summaryFilters(in: coordinator.filterCriteria.activeProtocolFilters),
-                        id: \.self
-                    ) { filter in
-                        FilterChip(
-                            label: filter.displayName,
-                            onRemove: {
-                                coordinator.filterCriteria.activeProtocolFilters.remove(filter)
-                                coordinator.recomputeFilteredTransactions()
-                            }
-                        )
-                    }
-
-                    if coordinator.isFilterBarVisible,
-                       coordinator.filterRules.contains(where: { $0.isEnabled && !$0.value.isEmpty })
-                    {
-                        let count = coordinator.filterRules.filter { $0.isEnabled && !$0.value.isEmpty }.count
-                        FilterChip(
-                            label: String(localized: "\(count) rules active"),
-                            onRemove: {
-                                coordinator.isFilterBarVisible = false
-                                coordinator.recomputeFilteredTransactions()
-                            }
-                        )
-                    }
-
                     Button(String(localized: "Clear All")) {
                         coordinator.clearAllWorkspaceFilters()
                     }
@@ -138,8 +99,16 @@ struct ActiveFilterSummaryBar: View {
                 .padding(.horizontal, 8)
             }
             .frame(height: metrics.filterBarHeight)
-            .background(Color(nsColor: .controlBackgroundColor).opacity(0.5))
-            .overlay(alignment: .bottom) { Divider() }
+            .background {
+                if !isEmbeddedInControlShelf {
+                    Color(nsColor: .controlBackgroundColor).opacity(0.5)
+                }
+            }
+            .overlay(alignment: .bottom) {
+                if !isEmbeddedInControlShelf {
+                    Divider()
+                }
+            }
         }
     }
 
@@ -157,10 +126,6 @@ struct ActiveFilterSummaryBar: View {
             || coordinator.filterCriteria.sidebarScope == .saved
             || coordinator.filterCriteria.sidebarScope == .pinned
             || coordinator.filterCriteria.sidebarScope == .notes
-            || (coordinator.filterCriteria.isSearchEnabled && !coordinator.filterCriteria.searchText.isEmpty)
-            || !coordinator.filterCriteria.activeProtocolFilters.isEmpty
-            || (coordinator.isFilterBarVisible
-                && coordinator.filterRules.contains(where: { $0.isEnabled && !$0.value.isEmpty }))
     }
 }
 
@@ -168,6 +133,8 @@ struct ActiveFilterSummaryBar: View {
 
 /// Removable pill displaying a single active filter with an X button.
 private struct FilterChip: View {
+    // MARK: Internal
+
     let label: String
     let onRemove: () -> Void
 
@@ -186,15 +153,10 @@ private struct FilterChip: View {
         }
         .padding(.horizontal, 8)
         .padding(.vertical, 3)
-        .background(
-            RoundedRectangle(cornerRadius: 4)
-                .fill(Color(nsColor: .controlBackgroundColor))
-                .overlay(
-                    RoundedRectangle(cornerRadius: 4)
-                        .strokeBorder(Color(nsColor: .separatorColor), lineWidth: 0.5)
-                )
-        )
+        .rockxyChipStyle(isActive: true)
     }
+
+    // MARK: Private
 
     @Environment(\.appUIDisplayMetrics) private var metrics
 }

--- a/Rockxy/Views/Toolbar/AdvancedFilterBar.swift
+++ b/Rockxy/Views/Toolbar/AdvancedFilterBar.swift
@@ -150,7 +150,7 @@ struct AdvancedFilterBar: View {
                 Image(systemName: "minus")
                     .font(.system(size: metrics.controlFontSize, weight: .medium))
             }
-            .buttonStyle(.bordered)
+            .rockxyGlassButtonStyle()
             .controlSize(.small)
 
             Button {
@@ -159,7 +159,7 @@ struct AdvancedFilterBar: View {
                 Image(systemName: "plus")
                     .font(.system(size: metrics.controlFontSize, weight: .medium))
             }
-            .buttonStyle(.bordered)
+            .rockxyGlassButtonStyle()
             .controlSize(.small)
 
             if isFirst {

--- a/Rockxy/Views/Toolbar/AdvancedFilterBar.swift
+++ b/Rockxy/Views/Toolbar/AdvancedFilterBar.swift
@@ -14,6 +14,7 @@ struct AdvancedFilterBar: View {
 
     var presetStore: FilterPresetStore
     var onSave: () -> Void = {}
+    var isEmbeddedInControlShelf = false
 
     var body: some View {
         VStack(spacing: 0) {
@@ -22,11 +23,30 @@ struct AdvancedFilterBar: View {
             }
             shortcutsHint
         }
-        .background(Color(nsColor: .windowBackgroundColor))
-        .overlay(alignment: .bottom) { Divider() }
+        .background {
+            if !isEmbeddedInControlShelf {
+                Color(nsColor: .windowBackgroundColor)
+            }
+        }
+        .overlay(alignment: .bottom) {
+            if !isEmbeddedInControlShelf {
+                Divider()
+            }
+        }
     }
 
     // MARK: Private
+
+    private static let advancedFields: [FilterField] = [
+        .url, .method, .statusCode, .requestHeader, .responseHeader, .requestBody,
+        .responseBody, .clientApp, .domain, .contentType, .queryString, .cookies,
+        .comment, .color,
+    ]
+
+    private static let enableToggleWidth: CGFloat = 22
+    private static let connectorWidth: CGFloat = 76
+
+    @Environment(\.appUIDisplayMetrics) private var metrics
 
     private var shortcutsHint: some View {
         HStack(spacing: 12) {
@@ -42,6 +62,45 @@ struct AdvancedFilterBar: View {
         .foregroundStyle(Color(nsColor: .tertiaryLabelColor))
         .padding(.horizontal, 12)
         .padding(.vertical, 6)
+    }
+
+    private var presetMenu: some View {
+        Menu {
+            Button {
+                _ = presetStore.saveGeneratedPreset(rules: rules)
+                onSave()
+            } label: {
+                Label(String(localized: "Save Current Filter"), systemImage: "square.and.arrow.down")
+            }
+            .disabled(FilterRuleEvaluator.activeRules(in: rules, isFilterBarVisible: true).isEmpty)
+
+            if !presetStore.presets.isEmpty {
+                Divider()
+                ForEach(presetStore.presets) { preset in
+                    Button {
+                        rules = preset.rules.isEmpty ? [FilterRule()] : preset.rules
+                    } label: {
+                        Label(preset.name, systemImage: "line.3.horizontal.decrease.circle")
+                    }
+                }
+
+                Divider()
+                Menu(String(localized: "Delete Preset")) {
+                    ForEach(presetStore.presets) { preset in
+                        Button(role: .destructive) {
+                            presetStore.deletePreset(id: preset.id)
+                        } label: {
+                            Text(preset.name)
+                        }
+                    }
+                }
+            }
+        } label: {
+            Label(String(localized: "Presets"), systemImage: "chevron.down")
+                .labelStyle(.titleAndIcon)
+        }
+        .menuStyle(.borderlessButton)
+        .controlSize(.small)
     }
 
     private func filterRow(at index: Int, isFirst: Bool) -> some View {
@@ -124,55 +183,5 @@ struct AdvancedFilterBar: View {
             return
         }
         rules.remove(at: index)
-    }
-
-    private static let advancedFields: [FilterField] = [
-        .url, .method, .statusCode, .requestHeader, .responseHeader, .requestBody,
-        .responseBody, .clientApp, .domain, .contentType, .queryString, .cookies,
-        .comment, .color,
-    ]
-
-    private static let enableToggleWidth: CGFloat = 22
-    private static let connectorWidth: CGFloat = 76
-
-    @Environment(\.appUIDisplayMetrics) private var metrics
-
-    private var presetMenu: some View {
-        Menu {
-            Button {
-                _ = presetStore.saveGeneratedPreset(rules: rules)
-                onSave()
-            } label: {
-                Label(String(localized: "Save Current Filter"), systemImage: "square.and.arrow.down")
-            }
-            .disabled(FilterRuleEvaluator.activeRules(in: rules, isFilterBarVisible: true).isEmpty)
-
-            if !presetStore.presets.isEmpty {
-                Divider()
-                ForEach(presetStore.presets) { preset in
-                    Button {
-                        rules = preset.rules.isEmpty ? [FilterRule()] : preset.rules
-                    } label: {
-                        Label(preset.name, systemImage: "line.3.horizontal.decrease.circle")
-                    }
-                }
-
-                Divider()
-                Menu(String(localized: "Delete Preset")) {
-                    ForEach(presetStore.presets) { preset in
-                        Button(role: .destructive) {
-                            presetStore.deletePreset(id: preset.id)
-                        } label: {
-                            Text(preset.name)
-                        }
-                    }
-                }
-            }
-        } label: {
-            Label(String(localized: "Presets"), systemImage: "chevron.down")
-                .labelStyle(.titleAndIcon)
-        }
-        .menuStyle(.borderlessButton)
-        .controlSize(.small)
     }
 }

--- a/Rockxy/Views/Toolbar/FilterPillButton.swift
+++ b/Rockxy/Views/Toolbar/FilterPillButton.swift
@@ -7,30 +7,29 @@ import SwiftUI
 /// Compact toggle-style pill button used in the protocol filter bar. Renders with themed
 /// active/inactive colors from `Theme.FilterPill`.
 struct FilterPillButton: View {
+    // MARK: Internal
+
     let title: String
     let isActive: Bool
     let action: () -> Void
 
     var body: some View {
         Button(action: action) {
-            Text(title)
-                .font(.system(size: metrics.secondaryFontSize, weight: isActive ? .semibold : .regular))
-                .foregroundStyle(
-                    isActive
-                        ? Theme.FilterPill.activeForeground
-                        : Theme.FilterPill.inactiveForeground
-                )
-                .padding(.horizontal, 8)
-                .padding(.vertical, max(3, (metrics.fontSize - 10) / 3))
-                .background(
-                    isActive
-                        ? Theme.FilterPill.activeBackground
-                        : Theme.FilterPill.inactiveBackground
-                )
-                .cornerRadius(4)
+            pillLabel
         }
         .buttonStyle(.borderless)
     }
 
+    // MARK: Private
+
     @Environment(\.appUIDisplayMetrics) private var metrics
+
+    private var pillLabel: some View {
+        Text(title)
+            .font(.system(size: metrics.secondaryFontSize, weight: isActive ? .semibold : .regular))
+            .foregroundStyle(isActive ? Theme.FilterPill.activeForeground : Theme.FilterPill.inactiveForeground)
+            .padding(.horizontal, 9)
+            .padding(.vertical, max(3, (metrics.fontSize - 10) / 3))
+            .rockxyChipStyle(isActive: isActive)
+    }
 }

--- a/Rockxy/Views/Toolbar/ProtocolFilterBar.swift
+++ b/Rockxy/Views/Toolbar/ProtocolFilterBar.swift
@@ -16,6 +16,8 @@ struct ProtocolFilterBar: View {
 
     @Binding var activeFilters: Set<ProtocolFilter>
 
+    var isEmbeddedInControlShelf = false
+
     var body: some View {
         // Widest tier first; `ViewThatFits` keeps the first that fits. Tier 5 (`.all` + overflow +
         // icon Clear All) is the always-fitting fallback. Kept in sync with `inlinePillTiers`.
@@ -29,8 +31,16 @@ struct ProtocolFilterBar: View {
         }
         .padding(.horizontal, Theme.Layout.contentPadding)
         .padding(.vertical, max(4, (metrics.fontSize - 10) / 3))
-        .background(Color(nsColor: .windowBackgroundColor))
-        .overlay(alignment: .bottom) { Divider() }
+        .background {
+            if !isEmbeddedInControlShelf {
+                Color(nsColor: .windowBackgroundColor)
+            }
+        }
+        .overlay(alignment: .bottom) {
+            if !isEmbeddedInControlShelf {
+                Divider()
+            }
+        }
         .fixedSize(horizontal: false, vertical: true)
     }
 

--- a/Rockxy/Views/Toolbar/ProxyStatusIndicator.swift
+++ b/Rockxy/Views/Toolbar/ProxyStatusIndicator.swift
@@ -10,9 +10,6 @@ import SwiftUI
 struct ProxyStatusIndicator: View {
     // MARK: Internal
 
-    @Environment(\.colorScheme) private var colorScheme
-    @Environment(\.appUIDisplayMetrics) private var metrics
-
     let displayState: ProxyDisplayState
     let listenAddress: String
     let port: Int
@@ -66,7 +63,7 @@ struct ProxyStatusIndicator: View {
             }
         }
         .frame(height: metrics.chromeControlHeight)
-        .contentShape(Rectangle())
+        .contentShape(Capsule(style: .continuous))
         .popover(isPresented: $showPopover) {
             ProxyStatusPopover(
                 displayState: displayState,
@@ -84,20 +81,9 @@ struct ProxyStatusIndicator: View {
 
     private enum ProxyStatusChromeMetrics {
         static let horizontalPadding: CGFloat = 14
-        static let strokeWidth: CGFloat = 0.75
     }
 
-    private var statusDot: some View {
-        Circle()
-            .fill(statusColor)
-            .frame(width: metrics.chromeStatusDotSize, height: metrics.chromeStatusDotSize)
-            .shadow(
-                color: statusShadowColor,
-                radius: 4,
-                x: 0,
-                y: 0
-            )
-    }
+    @Environment(\.appUIDisplayMetrics) private var metrics
 
     private var statusColor: Color {
         switch displayState {
@@ -148,7 +134,18 @@ struct ProxyStatusIndicator: View {
         return captureContext.joined(separator: "\n")
     }
 
-    @ViewBuilder
+    private var statusDot: some View {
+        Circle()
+            .fill(statusColor)
+            .frame(width: metrics.chromeStatusDotSize, height: metrics.chromeStatusDotSize)
+            .shadow(
+                color: statusShadowColor,
+                radius: 4,
+                x: 0,
+                y: 0
+            )
+    }
+
     private func updateStatus(_ summary: AppUpdater.UpdateStatusSummary) -> some View {
         Button(action: openUpdates) {
             ViewThatFits(in: .horizontal) {
@@ -169,24 +166,9 @@ struct ProxyStatusIndicator: View {
     private func updateBadge(_ title: String) -> some View {
         Text(title)
             .font(.system(size: metrics.chromeBadgeFontSize, weight: .semibold))
-            .foregroundStyle(.white)
             .lineLimit(1)
             .padding(.horizontal, 9)
             .frame(height: metrics.chromeBadgeHeight)
-            .background {
-                Capsule(style: .continuous).fill(updateBadgeBackground)
-            }
-            .overlay {
-                Capsule(style: .continuous).strokeBorder(updateBadgeStroke, lineWidth: ProxyStatusChromeMetrics.strokeWidth)
-            }
-            .contentShape(Capsule(style: .continuous))
-    }
-
-    private var updateBadgeBackground: Color {
-        Color(nsColor: .systemGray).opacity(colorScheme == .dark ? 0.62 : 0.82)
-    }
-
-    private var updateBadgeStroke: Color {
-        Color.primary.opacity(colorScheme == .dark ? 0.10 : 0.06)
+            .rockxyChipStyle(isActive: true)
     }
 }

--- a/Rockxy/Views/Toolbar/SearchFilterBar.swift
+++ b/Rockxy/Views/Toolbar/SearchFilterBar.swift
@@ -90,7 +90,7 @@ struct SearchFilterBar: View {
                     Image(systemName: "plus")
                 }
             }
-            .buttonStyle(.bordered)
+            .rockxyGlassButtonStyle()
             .controlSize(.small)
             .help(String(localized: "Add a compound filter rule"))
             .accessibilityLabel(String(localized: "Add Filter"))
@@ -106,7 +106,7 @@ struct SearchFilterBar: View {
                         .font(.caption2)
                 }
             }
-            .buttonStyle(.bordered)
+            .rockxyGlassButtonStyle()
             .controlSize(.small)
             .help(isAdvancedFilterVisible
                 ? String(localized: "Hide compound filters")

--- a/Rockxy/Views/Toolbar/SearchFilterBar.swift
+++ b/Rockxy/Views/Toolbar/SearchFilterBar.swift
@@ -16,6 +16,7 @@ struct SearchFilterBar: View {
     let advancedFilterCount: Int
     let onAddFilter: () -> Void
     let onToggleAdvancedFilters: () -> Void
+    var isEmbeddedInControlShelf = false
 
     var body: some View {
         // Widest tier first; `ViewThatFits` keeps the first that fits. The search field carries a
@@ -28,8 +29,16 @@ struct SearchFilterBar: View {
         }
         .padding(.horizontal, 8)
         .padding(.vertical, max(4, (metrics.fontSize - 10) / 3))
-        .background(Color(nsColor: .windowBackgroundColor))
-        .overlay(alignment: .bottom) { Divider() }
+        .background {
+            if !isEmbeddedInControlShelf {
+                Color(nsColor: .windowBackgroundColor)
+            }
+        }
+        .overlay(alignment: .bottom) {
+            if !isEmbeddedInControlShelf {
+                Divider()
+            }
+        }
         .onReceive(NotificationCenter.default.publisher(for: .focusMainSearchField)) { _ in
             isEnabled = true
             isSearchFocused = true
@@ -97,7 +106,7 @@ struct SearchFilterBar: View {
                         .font(.caption2)
                 }
             }
-            .buttonStyle(.borderless)
+            .buttonStyle(.bordered)
             .controlSize(.small)
             .help(isAdvancedFilterVisible
                 ? String(localized: "Hide compound filters")

--- a/Rockxy/Views/Toolbar/SystemProxyWarningBanner.swift
+++ b/Rockxy/Views/Toolbar/SystemProxyWarningBanner.swift
@@ -27,7 +27,7 @@ struct SystemProxyWarningBanner: View {
             if let primaryActionTitle, let onPrimaryAction {
                 Button(primaryActionTitle, action: onPrimaryAction)
                     .font(.system(size: metrics.chromeBadgeFontSize))
-                    .buttonStyle(.bordered)
+                    .rockxyGlassButtonStyle()
                     .controlSize(.small)
             }
 

--- a/Rockxy/Views/Toolbar/TrafficCommandBar.swift
+++ b/Rockxy/Views/Toolbar/TrafficCommandBar.swift
@@ -259,7 +259,7 @@ struct TrafficCommandBar: View {
         } label: {
             commandLabel(title: presentation.title, systemImage: presentation.systemImage)
         }
-        .buttonStyle(.bordered)
+        .rockxyGlassButtonStyle()
         .controlSize(.small)
         .disabled(!presentation.isEnabled)
         .help(presentation.help)
@@ -291,7 +291,7 @@ struct TrafficCommandBar: View {
         } label: {
             commandLabel(title: descriptor.title, systemImage: descriptor.systemImage)
         }
-        .buttonStyle(.bordered)
+        .rockxyGlassButtonStyle()
         .controlSize(.small)
         .disabled(!descriptor.isEnabled)
         .help(descriptor.help)
@@ -306,7 +306,7 @@ struct TrafficCommandBar: View {
             commandLabel(title: descriptor.title, systemImage: descriptor.systemImage)
                 .foregroundStyle(.primary)
         }
-        .buttonStyle(.bordered)
+        .rockxyGlassButtonStyle()
         .controlSize(.small)
         .overlay {
             if descriptor.isActive {

--- a/Rockxy/Views/Toolbar/TrafficCommandBar.swift
+++ b/Rockxy/Views/Toolbar/TrafficCommandBar.swift
@@ -155,14 +155,24 @@ struct TrafficCommandBar: View {
 
     let coordinator: MainContentCoordinator
     var onOpenToolWindow: (String) -> Void = { _ in }
+    var isEmbeddedInControlShelf = false
+    var showsQuickTools = true
 
     var body: some View {
         commandRow
             .padding(.horizontal, Theme.Layout.contentPadding)
             .padding(.vertical, max(4, (metrics.fontSize - 10) / 3))
-            .background(Color(nsColor: .windowBackgroundColor))
-            .overlay(alignment: .bottom) { Divider() }
-            .fixedSize(horizontal: false, vertical: true)
+            .background {
+                if !isEmbeddedInControlShelf {
+                    Color(nsColor: .windowBackgroundColor)
+                }
+            }
+            .overlay(alignment: .bottom) {
+                if !isEmbeddedInControlShelf {
+                    Divider()
+                }
+            }
+            .fixedSize(horizontal: isEmbeddedInControlShelf, vertical: true)
             .task { persistResolvedQuickToolsLayoutIfNeeded() }
     }
 
@@ -224,22 +234,17 @@ struct TrafficCommandBar: View {
         )
     }
 
-    private var followLiveBinding: Binding<Bool> {
-        Binding(
-            get: { coordinator.isFollowingLiveTraffic },
-            set: { coordinator.setFollowingLiveTraffic($0) }
-        )
-    }
-
     private var commandRow: some View {
         HStack(spacing: 8) {
             recordingButton
             clearSessionButton
             commandDivider
             followLiveButton
-            responsiveQuickToolsGroup
+            if showsQuickTools {
+                responsiveQuickToolsGroup
+            }
 
-            Spacer(minLength: 12)
+            Spacer(minLength: showsQuickTools ? 12 : 4)
             moreActionsMenu
         }
     }
@@ -252,10 +257,7 @@ struct TrafficCommandBar: View {
         return Button {
             actions.toggleRecording()
         } label: {
-            Label(presentation.title, systemImage: presentation.systemImage)
-                .font(.system(size: metrics.secondaryFontSize))
-                .lineLimit(1)
-                .fixedSize(horizontal: true, vertical: false)
+            commandLabel(title: presentation.title, systemImage: presentation.systemImage)
         }
         .buttonStyle(.bordered)
         .controlSize(.small)
@@ -287,10 +289,7 @@ struct TrafficCommandBar: View {
         return Button {
             actions.clearSession()
         } label: {
-            Label(descriptor.title, systemImage: descriptor.systemImage)
-                .font(.system(size: metrics.secondaryFontSize))
-                .lineLimit(1)
-                .fixedSize(horizontal: true, vertical: false)
+            commandLabel(title: descriptor.title, systemImage: descriptor.systemImage)
         }
         .buttonStyle(.bordered)
         .controlSize(.small)
@@ -301,15 +300,21 @@ struct TrafficCommandBar: View {
 
     private var followLiveButton: some View {
         let descriptor = TrafficCommandDescriptor.followLive(isActive: coordinator.isFollowingLiveTraffic)
-        return Toggle(isOn: followLiveBinding) {
-            Label(descriptor.title, systemImage: descriptor.systemImage)
-                .font(.system(size: metrics.secondaryFontSize))
-                .lineLimit(1)
-                .fixedSize(horizontal: true, vertical: false)
+        return Button {
+            coordinator.setFollowingLiveTraffic(!coordinator.isFollowingLiveTraffic)
+        } label: {
+            commandLabel(title: descriptor.title, systemImage: descriptor.systemImage)
+                .foregroundStyle(.primary)
         }
-        .toggleStyle(.button)
         .buttonStyle(.bordered)
         .controlSize(.small)
+        .overlay {
+            if descriptor.isActive {
+                Capsule(style: .continuous)
+                    .strokeBorder(Color.accentColor.opacity(Theme.Glass.activeStrokeOpacity), lineWidth: 1)
+                    .allowsHitTesting(false)
+            }
+        }
         .help(descriptor.help)
         .accessibilityLabel(descriptor.title)
         .accessibilityValue(descriptor.isActive ? String(localized: "On") : String(localized: "Off"))
@@ -494,6 +499,20 @@ struct TrafficCommandBar: View {
         Divider()
             .frame(height: 16)
             .padding(.horizontal, 4)
+    }
+
+    @ViewBuilder
+    private func commandLabel(title: String, systemImage: String) -> some View {
+        if isEmbeddedInControlShelf {
+            Image(systemName: systemImage)
+                .font(.system(size: metrics.controlFontSize, weight: .medium))
+                .frame(width: metrics.filterBarHeight, height: metrics.filterBarHeight)
+        } else {
+            Label(title, systemImage: systemImage)
+                .font(.system(size: metrics.secondaryFontSize))
+                .lineLimit(1)
+                .fixedSize(horizontal: true, vertical: false)
+        }
     }
 
     private func quickToolsRow(_ descriptors: [FooterActionDescriptor]) -> some View {

--- a/Rockxy/Views/Toolbar/TrafficControlShelf.swift
+++ b/Rockxy/Views/Toolbar/TrafficControlShelf.swift
@@ -1,0 +1,156 @@
+import SwiftUI
+
+// MARK: - TrafficControlShelf
+
+/// The top-level functional layer for traffic commands and filtering.
+///
+/// Liquid Glass belongs to this shared navigation/control surface, while the request table below
+/// remains an opaque, high-density content layer. Child controls deliberately avoid their own
+/// glass backgrounds so the shelf never becomes glass-on-glass.
+struct TrafficControlShelf: View {
+    // MARK: Internal
+
+    let coordinator: MainContentCoordinator
+    let advancedRuleCount: Int
+    let onOpenToolWindow: (String) -> Void
+
+    var body: some View {
+        RockxyGlassEffectGroup(spacing: Theme.Glass.shelfSectionSpacing) {
+            VStack(spacing: Theme.Glass.shelfSectionSpacing) {
+                ViewThatFits(in: .horizontal) {
+                    HStack(spacing: Theme.Layout.controlSpacing) {
+                        trafficCommandBar
+
+                        Divider()
+                            .frame(height: 22)
+
+                        searchFilterBar
+                            .layoutPriority(1)
+                    }
+
+                    VStack(spacing: Theme.Glass.shelfSectionSpacing) {
+                        trafficCommandBar
+                        shelfSeparator
+                        searchFilterBar
+                    }
+                }
+
+                shelfSeparator
+
+                ProtocolFilterBar(
+                    activeFilters: Binding(
+                        get: { coordinator.filterCriteria.activeProtocolFilters },
+                        set: {
+                            coordinator.filterCriteria.activeProtocolFilters = $0
+                            coordinator.recomputeFilteredTransactions()
+                        }
+                    ),
+                    isEmbeddedInControlShelf: true
+                )
+
+                if coordinator.isFilterBarVisible {
+                    shelfSeparator
+
+                    AdvancedFilterBar(
+                        rules: Binding(
+                            get: { coordinator.filterRules },
+                            set: {
+                                coordinator.filterRules = $0
+                                coordinator.recomputeFilteredTransactions()
+                            }
+                        ),
+                        presetStore: coordinator.filterPresetStore,
+                        isEmbeddedInControlShelf: true
+                    )
+                    .transition(.move(edge: .top).combined(with: .opacity))
+                }
+
+                ActiveFilterSummaryBar(
+                    coordinator: coordinator,
+                    isEmbeddedInControlShelf: true
+                )
+            }
+            .padding(Theme.Glass.shelfInset)
+            .rockxyGlassEffect(
+                in: RoundedRectangle(
+                    cornerRadius: Theme.Glass.shelfCornerRadius,
+                    style: .continuous
+                )
+            )
+            .overlay {
+                RoundedRectangle(
+                    cornerRadius: Theme.Glass.shelfCornerRadius,
+                    style: .continuous
+                )
+                .strokeBorder(
+                    Color.primary.opacity(Theme.Glass.shelfStrokeOpacity),
+                    lineWidth: 0.75
+                )
+                .allowsHitTesting(false)
+            }
+            .shadow(
+                color: Color.black.opacity(Theme.Glass.shelfShadowOpacity),
+                radius: Theme.Glass.shelfShadowRadius,
+                x: 0,
+                y: Theme.Glass.shelfShadowY
+            )
+        }
+        .padding(.horizontal, Theme.Glass.shelfOuterPadding)
+        .padding(.top, Theme.Glass.shelfOuterPadding)
+        .padding(.bottom, Theme.Glass.shelfOuterPadding - 2)
+        .fixedSize(horizontal: false, vertical: true)
+    }
+
+    // MARK: Private
+
+    private var shelfSeparator: some View {
+        Divider()
+            .opacity(Theme.Glass.separatorOpacity)
+            .padding(.horizontal, Theme.Layout.contentPadding)
+    }
+
+    private var trafficCommandBar: some View {
+        TrafficCommandBar(
+            coordinator: coordinator,
+            onOpenToolWindow: onOpenToolWindow,
+            isEmbeddedInControlShelf: true,
+            showsQuickTools: false
+        )
+    }
+
+    private var searchFilterBar: some View {
+        SearchFilterBar(
+            searchText: Binding(
+                get: { coordinator.filterCriteria.searchText },
+                set: {
+                    coordinator.filterCriteria.searchText = $0
+                    coordinator.recomputeFilteredTransactions()
+                }
+            ),
+            filterField: Binding(
+                get: { coordinator.filterCriteria.searchField },
+                set: {
+                    coordinator.filterCriteria.searchField = $0
+                    coordinator.recomputeFilteredTransactions()
+                }
+            ),
+            isEnabled: Binding(
+                get: { coordinator.filterCriteria.isSearchEnabled },
+                set: {
+                    coordinator.filterCriteria.isSearchEnabled = $0
+                    coordinator.recomputeFilteredTransactions()
+                }
+            ),
+            isAdvancedFilterVisible: coordinator.isFilterBarVisible,
+            advancedFilterCount: advancedRuleCount,
+            onAddFilter: coordinator.addAdvancedFilterRule,
+            onToggleAdvancedFilters: {
+                withAnimation(.easeInOut(duration: 0.18)) {
+                    coordinator.isFilterBarVisible.toggle()
+                }
+                coordinator.recomputeFilteredTransactions()
+            },
+            isEmbeddedInControlShelf: true
+        )
+    }
+}

--- a/Rockxy/Views/Toolbar/TrafficControlShelf.swift
+++ b/Rockxy/Views/Toolbar/TrafficControlShelf.swift
@@ -5,8 +5,9 @@ import SwiftUI
 /// The top-level functional layer for traffic commands and filtering.
 ///
 /// Liquid Glass belongs to this shared navigation/control surface, while the request table below
-/// remains an opaque, high-density content layer. Child controls deliberately avoid their own
-/// glass backgrounds so the shelf never becomes glass-on-glass.
+/// remains an opaque, high-density content layer. Every native and custom glass control lives in
+/// one `GlassEffectContainer`, giving nearby elements a shared sampling region instead of painting
+/// opaque capsules over the functional layer.
 struct TrafficControlShelf: View {
     // MARK: Internal
 
@@ -17,96 +18,102 @@ struct TrafficControlShelf: View {
     var body: some View {
         RockxyGlassEffectGroup(spacing: Theme.Glass.shelfSectionSpacing) {
             VStack(spacing: Theme.Glass.shelfSectionSpacing) {
-                ViewThatFits(in: .horizontal) {
-                    HStack(spacing: Theme.Layout.controlSpacing) {
-                        trafficCommandBar
+                shelfSurface {
+                    ViewThatFits(in: .horizontal) {
+                        HStack(spacing: Theme.Layout.controlSpacing) {
+                            trafficCommandBar
 
-                        Divider()
-                            .frame(height: 22)
+                            Divider()
+                                .frame(height: 22)
 
-                        searchFilterBar
-                            .layoutPriority(1)
-                    }
+                            searchFilterBar
+                                .layoutPriority(1)
+                        }
 
-                    VStack(spacing: Theme.Glass.shelfSectionSpacing) {
-                        trafficCommandBar
-                        shelfSeparator
-                        searchFilterBar
+                        VStack(spacing: 0) {
+                            trafficCommandBar
+                            Divider()
+                                .opacity(Theme.Glass.separatorOpacity)
+                            searchFilterBar
+                        }
                     }
                 }
 
-                shelfSeparator
-
-                ProtocolFilterBar(
-                    activeFilters: Binding(
-                        get: { coordinator.filterCriteria.activeProtocolFilters },
-                        set: {
-                            coordinator.filterCriteria.activeProtocolFilters = $0
-                            coordinator.recomputeFilteredTransactions()
-                        }
-                    ),
-                    isEmbeddedInControlShelf: true
-                )
-
-                if coordinator.isFilterBarVisible {
-                    shelfSeparator
-
-                    AdvancedFilterBar(
-                        rules: Binding(
-                            get: { coordinator.filterRules },
+                shelfSurface {
+                    ProtocolFilterBar(
+                        activeFilters: Binding(
+                            get: { coordinator.filterCriteria.activeProtocolFilters },
                             set: {
-                                coordinator.filterRules = $0
+                                coordinator.filterCriteria.activeProtocolFilters = $0
                                 coordinator.recomputeFilteredTransactions()
                             }
                         ),
-                        presetStore: coordinator.filterPresetStore,
                         isEmbeddedInControlShelf: true
                     )
+                }
+
+                if coordinator.isFilterBarVisible {
+                    shelfSurface {
+                        AdvancedFilterBar(
+                            rules: Binding(
+                                get: { coordinator.filterRules },
+                                set: {
+                                    coordinator.filterRules = $0
+                                    coordinator.recomputeFilteredTransactions()
+                                }
+                            ),
+                            presetStore: coordinator.filterPresetStore,
+                            isEmbeddedInControlShelf: true
+                        )
+                    }
                     .transition(.move(edge: .top).combined(with: .opacity))
                 }
 
-                ActiveFilterSummaryBar(
-                    coordinator: coordinator,
-                    isEmbeddedInControlShelf: true
-                )
+                if hasActiveFilterSummary {
+                    shelfSurface {
+                        ActiveFilterSummaryBar(
+                            coordinator: coordinator,
+                            isEmbeddedInControlShelf: true
+                        )
+                    }
+                    .transition(.move(edge: .top).combined(with: .opacity))
+                }
             }
-            .padding(Theme.Glass.shelfInset)
+        }
+        .padding(.horizontal, Theme.Glass.shelfOuterPadding)
+        .padding(.top, Theme.Glass.shelfOuterPadding)
+        .padding(.bottom, 4)
+        .animation(.easeInOut(duration: 0.18), value: coordinator.isFilterBarVisible)
+        .animation(.easeInOut(duration: 0.18), value: hasActiveFilterSummary)
+        .fixedSize(horizontal: false, vertical: true)
+    }
+
+    // MARK: Private
+
+    private var hasActiveFilterSummary: Bool {
+        coordinator.activeWorkspace.activeTrafficSignal != nil
+            || coordinator.activeWorkspace.activeFocusSet != nil
+            || !coordinator.activeWorkspace.mutedTrafficSources.isEmpty
+            || coordinator.filterCriteria.sidebarDomain != nil
+            || coordinator.filterCriteria.sidebarPathPrefix != nil
+            || coordinator.filterCriteria.sidebarApp != nil
+            || coordinator.filterCriteria.sidebarScope == .saved
+            || coordinator.filterCriteria.sidebarScope == .pinned
+            || coordinator.filterCriteria.sidebarScope == .notes
+    }
+
+    private func shelfSurface<Content: View>(
+        @ViewBuilder content: () -> Content
+    )
+        -> some View
+    {
+        content()
             .rockxyGlassEffect(
                 in: RoundedRectangle(
                     cornerRadius: Theme.Glass.shelfCornerRadius,
                     style: .continuous
                 )
             )
-            .overlay {
-                RoundedRectangle(
-                    cornerRadius: Theme.Glass.shelfCornerRadius,
-                    style: .continuous
-                )
-                .strokeBorder(
-                    Color.primary.opacity(Theme.Glass.shelfStrokeOpacity),
-                    lineWidth: 0.75
-                )
-                .allowsHitTesting(false)
-            }
-            .shadow(
-                color: Color.black.opacity(Theme.Glass.shelfShadowOpacity),
-                radius: Theme.Glass.shelfShadowRadius,
-                x: 0,
-                y: Theme.Glass.shelfShadowY
-            )
-        }
-        .padding(.horizontal, Theme.Glass.shelfOuterPadding)
-        .padding(.top, Theme.Glass.shelfOuterPadding)
-        .padding(.bottom, Theme.Glass.shelfOuterPadding - 2)
-        .fixedSize(horizontal: false, vertical: true)
-    }
-
-    // MARK: Private
-
-    private var shelfSeparator: some View {
-        Divider()
-            .opacity(Theme.Glass.separatorOpacity)
-            .padding(.horizontal, Theme.Layout.contentPadding)
     }
 
     private var trafficCommandBar: some View {

--- a/Rockxy/Views/Toolbar/TrafficQuickTools.swift
+++ b/Rockxy/Views/Toolbar/TrafficQuickTools.swift
@@ -242,6 +242,7 @@ struct QuickToolsEditor: View {
                     onDone()
                 }
                 .keyboardShortcut(.defaultAction)
+                .rockxyGlassButtonStyle(prominent: true)
             }
         }
         .padding(16)

--- a/Rockxy/Views/Toolbar/TrafficQuickTools.swift
+++ b/Rockxy/Views/Toolbar/TrafficQuickTools.swift
@@ -2,8 +2,8 @@ import SwiftUI
 
 // Shared Quick Tools system: one seven-tool catalog and one persisted layout own both the
 // top `TrafficCommandBar` (3 slots) and the footer `StatusBarView` (4 slots). Both regions render
-// the same `FooterToolingButton` capsule so there is no top-only styling. `proxyOverride` stays a
-// separate dynamic footer control and is never part of this layout.
+// the same labeled native `FooterToolingButton`, preserving discoverability without a separate
+// top-only style. `proxyOverride` stays a dynamic footer control outside this layout.
 
 // MARK: - FooterActionKind + Quick Tools
 
@@ -242,7 +242,7 @@ struct QuickToolsEditor: View {
                     onDone()
                 }
                 .keyboardShortcut(.defaultAction)
-                .rockxyGlassButtonStyle(prominent: true)
+                .rockxyGlassButtonStyle()
             }
         }
         .padding(16)

--- a/Rockxy/Views/Updates/SoftwareUpdatePanelView.swift
+++ b/Rockxy/Views/Updates/SoftwareUpdatePanelView.swift
@@ -247,7 +247,7 @@ struct SoftwareUpdatePanelView: View {
     private var appIcon: some View {
         Image(nsImage: AppIconProvider.appIcon)
             .resizable()
-            .aspectRatio(contentMode: .fit)
+            .scaledToFit()
             .frame(width: appIconSize, height: appIconSize)
             .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
     }
@@ -272,6 +272,7 @@ struct SoftwareUpdatePanelView: View {
         }
         .padding(.horizontal, 28)
         .padding(.vertical, 14)
+        .rockxyFunctionalBar()
     }
 
     @ViewBuilder private var footerLeadingContent: some View {
@@ -333,6 +334,7 @@ struct SoftwareUpdatePanelView: View {
                             performAvailablePrimaryAction(context)
                         }
                         .keyboardShortcut(.defaultAction)
+                        .rockxyGlassButtonStyle(prominent: true)
                         .controlSize(.large)
                     }
                 }
@@ -353,6 +355,7 @@ struct SoftwareUpdatePanelView: View {
                     performAvailablePrimaryAction(context)
                 }
                 .keyboardShortcut(.defaultAction)
+                .rockxyGlassButtonStyle(prominent: true)
                 .controlSize(.large)
             }
 
@@ -383,6 +386,7 @@ struct SoftwareUpdatePanelView: View {
                         controller.chooseInstall()
                     }
                     .keyboardShortcut(.defaultAction)
+                    .rockxyGlassButtonStyle(prominent: true)
                     .controlSize(.large)
                 }
             } else {
@@ -399,6 +403,7 @@ struct SoftwareUpdatePanelView: View {
                     controller.chooseInstall()
                 }
                 .keyboardShortcut(.defaultAction)
+                .rockxyGlassButtonStyle(prominent: true)
                 .controlSize(.large)
             }
 
@@ -419,6 +424,7 @@ struct SoftwareUpdatePanelView: View {
                 controller.acknowledgeAndDismiss()
             }
             .keyboardShortcut(.defaultAction)
+            .rockxyGlassButtonStyle(prominent: true)
             .controlSize(.large)
 
         case .error:
@@ -431,6 +437,7 @@ struct SoftwareUpdatePanelView: View {
                 controller.acknowledgeAndDismiss()
             }
             .keyboardShortcut(.defaultAction)
+            .rockxyGlassButtonStyle(prominent: true)
             .controlSize(.large)
 
         case .hidden:

--- a/Rockxy/Views/Welcome/WelcomeView.swift
+++ b/Rockxy/Views/Welcome/WelcomeView.swift
@@ -327,7 +327,6 @@ struct WelcomeView: View {
             .rockxyGlassButtonStyle(prominent: true)
             .controlSize(.large)
             .keyboardShortcut(.defaultAction)
-            .rockxyGlassButtonStyle(prominent: true)
             .disabled(!viewModel.canGetStarted || viewModel.isBusy)
         }
     }

--- a/Rockxy/Views/Welcome/WelcomeView.swift
+++ b/Rockxy/Views/Welcome/WelcomeView.swift
@@ -317,15 +317,17 @@ struct WelcomeView: View {
                 Button(String(localized: "Debug My App…")) {
                     finish(openDeveloperSetup: true)
                 }
+                .rockxyGlassButtonStyle()
                 .controlSize(.large)
             }
 
             Button(String(localized: "Get Started")) {
                 finish(openDeveloperSetup: false)
             }
-            .buttonStyle(.borderedProminent)
+            .rockxyGlassButtonStyle(prominent: true)
             .controlSize(.large)
             .keyboardShortcut(.defaultAction)
+            .rockxyGlassButtonStyle(prominent: true)
             .disabled(!viewModel.canGetStarted || viewModel.isBusy)
         }
     }

--- a/RockxyTests/Core/Storage/ProjectCatalogRepositoryTests.swift
+++ b/RockxyTests/Core/Storage/ProjectCatalogRepositoryTests.swift
@@ -300,6 +300,23 @@ struct ProjectCatalogRepositoryTests {
         #expect(try Data(contentsOf: sentinel) == Data("keep".utf8))
     }
 
+    @Test("reset preserves an existing recovery backup when the live catalog is non-regular")
+    func resetKeepsRecoveryBackupWhenLiveCatalogIsInvalid() async throws {
+        let repo = makeRepo()
+        try FileManager.default.createDirectory(at: repo.directoryURL, withIntermediateDirectories: true)
+        let backupURL = repo.directoryURL.appendingPathComponent(ProjectCatalogRepository.recoveryBackupFileName)
+        let recoveryData = Data("previous recovery".utf8)
+        try recoveryData.write(to: backupURL)
+        try FileManager.default.createDirectory(at: repo.fileURL, withIntermediateDirectories: true)
+
+        await #expect(throws: ProjectCatalogRepositoryError.notRegularFile) {
+            try await repo.reset()
+        }
+
+        #expect(try Data(contentsOf: backupURL) == recoveryData)
+        #expect(FileManager.default.fileExists(atPath: repo.fileURL.path))
+    }
+
     @Test("reset refuses to recursively remove a non-regular recovery node")
     func resetPreservesNonRegularRecoveryNode() async throws {
         let repo = makeRepo()

--- a/RockxyTests/Models/Projects/ProjectNormalizationTests.swift
+++ b/RockxyTests/Models/Projects/ProjectNormalizationTests.swift
@@ -35,6 +35,12 @@ struct ProjectNormalizationTests {
         #expect(throws: ProjectNameNormalizationError.containsControlCharacters) {
             _ = try ProjectNormalization.normalizedDisplayName("Stag\u{0007}ing")
         }
+        #expect(throws: ProjectNameNormalizationError.containsControlCharacters) {
+            _ = try ProjectNormalization.normalizedDisplayName("Stag\u{2028}ing")
+        }
+        #expect(throws: ProjectNameNormalizationError.containsControlCharacters) {
+            _ = try ProjectNormalization.normalizedDisplayName("Stag\u{2029}ing")
+        }
     }
 
     @Test("rejects unsafe invisible and directional formatting characters")

--- a/RockxyTests/Models/Projects/ProjectStoreTests.swift
+++ b/RockxyTests/Models/Projects/ProjectStoreTests.swift
@@ -603,9 +603,7 @@ struct ProjectStoreTests {
         let store = ProjectStore(repository: repo, now: { Self.fixedDate })
         await store.loadPersistedCatalog()
         _ = try store.createProject(name: "Staging")
-        for _ in 0 ..< 1_000 where store.persistenceStatus != .saved {
-            await Task.yield()
-        }
+        await store.waitForPendingPersistence()
         #expect(await repo.lastSaved?.revision == 2)
         #expect(store.persistenceStatus == .saved)
     }
@@ -616,9 +614,7 @@ struct ProjectStoreTests {
         let store = ProjectStore(repository: repo, now: { Self.fixedDate })
         await store.loadPersistedCatalog()
         _ = try store.createProject(name: "Staging")
-        for _ in 0 ..< 1_000 where store.persistenceStatus == .saving || store.persistenceStatus == .idle {
-            await Task.yield()
-        }
+        await store.waitForPendingPersistence()
         #expect(store.persistenceStatus == .failed(String(describing: FakeError.boom)))
     }
 
@@ -705,9 +701,7 @@ private actor FakeCatalogRepository: ProjectCatalogPersisting {
 
     func reset() async throws -> ProjectCatalog {
         resetCount += 1
-        let fresh = ProjectCatalog.makeDefault(now: Date(timeIntervalSince1970: 1_000_000))
-        savedCatalogs.append(fresh)
-        return fresh
+        return ProjectCatalog.makeDefault(now: Date(timeIntervalSince1970: 1_000_000))
     }
 
     // MARK: Private

--- a/RockxyTests/Models/UI/ExportScopeTests.swift
+++ b/RockxyTests/Models/UI/ExportScopeTests.swift
@@ -130,7 +130,7 @@ struct ExportScopeTests {
         let source = try readProjectFile("Rockxy/Views/Export/ExportScopeSheet.swift")
 
         #expect(source.contains(".pickerStyle(.radioGroup)"))
-        #expect(source.contains(".buttonStyle(.bordered)"))
+        #expect(source.contains(".rockxyGlassButtonStyle()"))
         #expect(source.contains(".rockxyGlassButtonStyle(prominent: true)"))
         #expect(source.contains(".keyboardShortcut(.cancelAction)"))
         #expect(source.contains(".keyboardShortcut(.defaultAction)"))

--- a/RockxyTests/Models/UI/ExportScopeTests.swift
+++ b/RockxyTests/Models/UI/ExportScopeTests.swift
@@ -131,7 +131,7 @@ struct ExportScopeTests {
 
         #expect(source.contains(".pickerStyle(.radioGroup)"))
         #expect(source.contains(".buttonStyle(.bordered)"))
-        #expect(source.contains(".buttonStyle(.borderedProminent)"))
+        #expect(source.contains(".rockxyGlassButtonStyle(prominent: true)"))
         #expect(source.contains(".keyboardShortcut(.cancelAction)"))
         #expect(source.contains(".keyboardShortcut(.defaultAction)"))
         #expect(source.contains("ToolWindowDisplayMetrics"))

--- a/RockxyTests/Models/UI/FocusNavigatorStateTests.swift
+++ b/RockxyTests/Models/UI/FocusNavigatorStateTests.swift
@@ -3,6 +3,16 @@ import Foundation
 import Testing
 
 struct FocusNavigatorStateTests {
+    @Test("Navigator modes expose distinct native symbols and localized help titles")
+    func navigatorModePresentation() {
+        let modes = FocusNavigatorMode.allCases
+
+        #expect(Set(modes.map(\.title)).count == modes.count)
+        #expect(modes.allSatisfy { !$0.title.isEmpty })
+        #expect(Set(modes.map(\.systemImage)).count == modes.count)
+        #expect(modes.allSatisfy { !$0.systemImage.isEmpty })
+    }
+
     @Test("Errors include HTTP failures but exclude redirects and intentional blocks")
     func errorSignalMatching() {
         let clientError = TestFixtures.makeTransaction(statusCode: 404)

--- a/RockxyTests/Models/UI/WorkspaceStoreTests.swift
+++ b/RockxyTests/Models/UI/WorkspaceStoreTests.swift
@@ -28,6 +28,24 @@ struct WorkspaceStoreTests {
         #expect(ws.isClosable == true)
     }
 
+    @Test("Create workspace canonicalizes its title")
+    func createWorkspaceCanonicalizesTitle() {
+        let store = WorkspaceStore()
+        let workspace = store.createWorkspace(title: "  Cafe\u{0301}  ")
+
+        #expect(workspace.title == "Café")
+    }
+
+    @Test("Create workspace rejects an invalid title without changing tabs")
+    func createWorkspaceRejectsInvalidTitle() {
+        let store = WorkspaceStore()
+        let active = store.activeWorkspace
+        let returned = store.createWorkspace(title: "Bad\nTitle")
+
+        #expect(returned.id == active.id)
+        #expect(store.workspaces.count == 1)
+    }
+
     @Test("Create workspace with filter sets initial filter")
     func createWithFilter() {
         let store = WorkspaceStore()
@@ -251,6 +269,20 @@ struct WorkspaceStoreTests {
         #expect(store.activeWorkspaceID == copy.id)
     }
 
+    @Test("Duplicate keeps its generated title within the structural bound")
+    func duplicateWorkspaceBoundsGeneratedTitle() throws {
+        let store = WorkspaceStore()
+        let maximumTitle = String(
+            repeating: "a",
+            count: ProjectStructuralLimits.nameGraphemeRange.upperBound
+        )
+        let original = store.createWorkspace(title: maximumTitle)
+        let copy = try #require(store.duplicateWorkspace(id: original.id))
+
+        #expect(copy.title.count <= ProjectStructuralLimits.nameGraphemeRange.upperBound)
+        #expect(copy.title.hasSuffix(" Copy"))
+    }
+
     @Test("Duplicate inserts after source workspace")
     func duplicatePosition() throws {
         let store = WorkspaceStore()
@@ -289,11 +321,23 @@ struct WorkspaceStoreTests {
         #expect(ws.title == "New Name")
     }
 
+    @Test("Rename canonicalizes valid titles and rejects invalid titles")
+    func renameEnforcesTitleBoundary() {
+        let store = WorkspaceStore()
+        let workspace = store.createWorkspace(title: "Original")
+
+        store.renameWorkspace(id: workspace.id, to: "  Cafe\u{0301}  ")
+        #expect(workspace.title == "Café")
+
+        store.renameWorkspace(id: workspace.id, to: String(repeating: "x", count: 81))
+        #expect(workspace.title == "Café")
+    }
+
     @Test("Rename with invalid ID does nothing")
     func renameInvalid() {
         let store = WorkspaceStore()
         store.renameWorkspace(id: UUID(), to: "Ghost")
-        #expect(store.workspaces[0].title == String(localized: "All Traffic"))
+        #expect(store.workspaces[0].title == ProjectStructuralLimits.defaultTabTitle)
     }
 
     // MARK: - Active Workspace Computed Properties

--- a/RockxyTests/Theme/LiquidGlassRenderingPolicyTests.swift
+++ b/RockxyTests/Theme/LiquidGlassRenderingPolicyTests.swift
@@ -1,5 +1,7 @@
-@testable import Rockxy
+import AppKit
 import Foundation
+@testable import Rockxy
+import SwiftUI
 import Testing
 
 // Pure-policy tests for `LiquidGlassRenderingPolicy`. Every branch of the resolver is exercised
@@ -81,18 +83,119 @@ struct LiquidGlassRenderingPolicyTests {
             increaseContrast: true
         ) == .opaqueColor)
     }
+
+    @Test("Every live appearance input changes the native glass identity")
+    func glassIdentityTracksAppearanceInputs() {
+        let light = LiquidGlassAppearanceIdentity(
+            isDark: false,
+            reduceTransparency: false,
+            increaseContrast: false
+        )
+
+        #expect(light != LiquidGlassAppearanceIdentity(
+            isDark: true,
+            reduceTransparency: false,
+            increaseContrast: false
+        ))
+        #expect(light != LiquidGlassAppearanceIdentity(
+            isDark: false,
+            reduceTransparency: true,
+            increaseContrast: false
+        ))
+        #expect(light != LiquidGlassAppearanceIdentity(
+            isDark: false,
+            reduceTransparency: false,
+            increaseContrast: true
+        ))
+        #expect(light == LiquidGlassAppearanceIdentity(
+            isDark: false,
+            reduceTransparency: false,
+            increaseContrast: false
+        ))
+    }
+}
+
+// MARK: - AppThemeApplierTests
+
+struct AppThemeApplierTests {
+    @Test("App themes resolve independently from the macOS appearance")
+    func appThemePresentationScheme() {
+        #expect(AppTheme.system.resolvedColorScheme(inheriting: .dark) == .dark)
+        #expect(AppTheme.system.resolvedColorScheme(inheriting: .light) == .light)
+        #expect(AppTheme.light.resolvedColorScheme(inheriting: .dark) == .light)
+        #expect(AppTheme.dark.resolvedColorScheme(inheriting: .light) == .dark)
+    }
+
+    @MainActor
+    @Test("Theme transitions refresh existing native toolbar controls")
+    func themeTransitionRefreshesExistingToolbarControls() throws {
+        let lightAppearance = try #require(NSAppearance(named: .aqua))
+        let staleDarkAppearance = try #require(NSAppearance(named: .darkAqua))
+        let window = NSWindow()
+        let container = NSView()
+        let control = NSSegmentedControl(
+            labels: ["Overview", "Guide"],
+            trackingMode: .selectOne,
+            target: nil,
+            action: nil
+        )
+
+        window.contentView = container
+        container.addSubview(control)
+        window.appearance = lightAppearance
+        control.appearance = staleDarkAppearance
+
+        #expect(control.effectiveAppearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua)
+
+        AppThemeApplier.refreshToolbarView(control, appearance: lightAppearance)
+
+        #expect(control.effectiveAppearance.bestMatch(from: [.aqua, .darkAqua]) == .aqua)
+    }
+
+    @MainActor
+    @Test("System theme clears explicit toolbar appearance")
+    func systemThemeRestoresToolbarInheritance() throws {
+        let lightAppearance = try #require(NSAppearance(named: .aqua))
+        let staleDarkAppearance = try #require(NSAppearance(named: .darkAqua))
+        let window = NSWindow()
+        let container = NSView()
+        let control = NSButton(title: "Set Up…", target: nil, action: nil)
+
+        window.contentView = container
+        container.addSubview(control)
+        window.appearance = lightAppearance
+        control.appearance = staleDarkAppearance
+
+        AppThemeApplier.refreshToolbarView(control, appearance: nil)
+
+        #expect(control.appearance == nil)
+        #expect(control.effectiveAppearance.bestMatch(from: [.aqua, .darkAqua]) == .aqua)
+    }
 }
 
 // MARK: - LiquidGlassPresentationContractTests
 
 struct LiquidGlassPresentationContractTests {
-    @Test("Primary actions use the availability-safe native glass family")
-    func primaryActionsUseGlassButtonStyle() throws {
+    @Test("Every scene provider propagates theme into SwiftUI-hosted toolbar chrome")
+    func sceneProviderPropagatesTheme() throws {
+        let source = try readProjectFile("Rockxy/Models/UI/AppUIDisplayMetrics.swift")
+
+        #expect(source.contains(".environment("))
+        #expect(source.contains("\\.colorScheme,"))
+        #expect(source.contains(
+            "settingsManager.appTheme.resolvedColorScheme(inheriting: inheritedColorScheme)"
+        ))
+    }
+
+    @Test("Visible action buttons use the availability-safe native glass family")
+    func actionButtonsUseGlassButtonStyle() throws {
         let sources = try viewSources()
         let joined = sources.values.joined(separator: "\n")
 
         #expect(!joined.contains(".buttonStyle(.borderedProminent)"))
+        #expect(!joined.contains(".buttonStyle(.bordered)"))
         #expect(joined.components(separatedBy: ".rockxyGlassButtonStyle(prominent: true)").count > 20)
+        #expect(joined.components(separatedBy: ".rockxyGlassButtonStyle()").count > 30)
     }
 
     @Test("Shared semantic chips own active footer and filter state")
@@ -128,13 +231,34 @@ struct LiquidGlassPresentationContractTests {
         #expect(source.contains(".rockxyChipStyle(isActive: isActive)"))
     }
 
-    @Test("Toast geometry and shadow stay tokenized")
+    @Test("Toast geometry uses the native glass effect without a painted shadow")
     func toastUsesSharedGlassTokens() throws {
         let source = try readProjectFile("Rockxy/Views/Common/ToastView.swift")
 
         #expect(source.contains("Theme.Glass.toastCornerRadius"))
-        #expect(source.contains("Theme.Glass.toastShadowRadius"))
         #expect(source.contains(".rockxyGlassEffect("))
+        #expect(!source.contains(".shadow("))
+    }
+
+    @Test("Workspace and feature bars use native floating Liquid Glass surfaces")
+    func functionalLayersUseNativeGlassSurfaces() throws {
+        let glassSource = try readProjectFile("Rockxy/Theme/LiquidGlass.swift")
+        let shelfSource = try readProjectFile("Rockxy/Views/Toolbar/TrafficControlShelf.swift")
+        let footerSource = try readProjectFile("Rockxy/Views/RequestList/StatusBarView.swift")
+
+        #expect(glassSource.contains("RockxyFunctionalBarModifier"))
+        #expect(glassSource.contains("RockxyGlassButtonStyleModifier"))
+        #expect(glassSource.contains("LiquidGlassAppearanceIdentity"))
+        #expect(glassSource.components(separatedBy: ".id(appearanceIdentity)").count >= 5)
+        #expect(glassSource.contains("Theme.Glass.functionalBarHorizontalInset"))
+        #expect(!glassSource.contains("func rockxyFunctionalBar() -> some View {\n        background(.bar)"))
+        #expect(shelfSource.contains("RockxyGlassEffectGroup"))
+        #expect(!shelfSource.contains("shelfTint"))
+        #expect(!shelfSource.contains(".strokeBorder("))
+        #expect(!shelfSource.contains(".shadow("))
+        #expect(shelfSource.components(separatedBy: "shelfSurface {").count >= 4)
+        #expect(footerSource.contains("Theme.Glass.footerCornerRadius"))
+        #expect(footerSource.contains("RockxyGlassEffectGroup"))
     }
 
     private func viewSources() throws -> [String: String] {

--- a/RockxyTests/Theme/LiquidGlassRenderingPolicyTests.swift
+++ b/RockxyTests/Theme/LiquidGlassRenderingPolicyTests.swift
@@ -1,0 +1,167 @@
+@testable import Rockxy
+import Foundation
+import Testing
+
+// Pure-policy tests for `LiquidGlassRenderingPolicy`. Every branch of the resolver is exercised
+// directly through its inputs — no snapshots, and no mutation of system accessibility settings.
+
+// MARK: - LiquidGlassRenderingPolicyTests
+
+struct LiquidGlassRenderingPolicyTests {
+    // MARK: - Liquid Glass
+
+    @Test("Liquid Glass is chosen only when available and no accessibility preference forces opacity")
+    func liquidGlassWhenAvailableAndNoOpacityRequired() {
+        #expect(LiquidGlassRenderingPolicy.resolve(
+            liquidGlassAvailable: true,
+            reduceTransparency: false,
+            increaseContrast: false
+        ) == .liquidGlass)
+    }
+
+    // MARK: - System material
+
+    @Test("System material is chosen on older systems when accessibility does not require opacity")
+    func systemMaterialWhenUnavailableAndNoOpacityRequired() {
+        #expect(LiquidGlassRenderingPolicy.resolve(
+            liquidGlassAvailable: false,
+            reduceTransparency: false,
+            increaseContrast: false
+        ) == .systemMaterial)
+    }
+
+    // MARK: - Opaque color (accessibility wins)
+
+    @Test("Reduce Transparency forces opaque even when Liquid Glass is available")
+    func opaqueWhenReduceTransparencyAndAvailable() {
+        #expect(LiquidGlassRenderingPolicy.resolve(
+            liquidGlassAvailable: true,
+            reduceTransparency: true,
+            increaseContrast: false
+        ) == .opaqueColor)
+    }
+
+    @Test("Increase Contrast forces opaque even when Liquid Glass is available")
+    func opaqueWhenIncreaseContrastAndAvailable() {
+        #expect(LiquidGlassRenderingPolicy.resolve(
+            liquidGlassAvailable: true,
+            reduceTransparency: false,
+            increaseContrast: true
+        ) == .opaqueColor)
+    }
+
+    @Test("Reduce Transparency forces opaque on older systems instead of system material")
+    func opaqueWhenReduceTransparencyAndUnavailable() {
+        #expect(LiquidGlassRenderingPolicy.resolve(
+            liquidGlassAvailable: false,
+            reduceTransparency: true,
+            increaseContrast: false
+        ) == .opaqueColor)
+    }
+
+    @Test("Increase Contrast forces opaque on older systems instead of system material")
+    func opaqueWhenIncreaseContrastAndUnavailable() {
+        #expect(LiquidGlassRenderingPolicy.resolve(
+            liquidGlassAvailable: false,
+            reduceTransparency: false,
+            increaseContrast: true
+        ) == .opaqueColor)
+    }
+
+    @Test("Both accessibility preferences together resolve to opaque regardless of availability")
+    func opaqueWhenBothAccessibilityPreferencesRegardlessOfAvailability() {
+        #expect(LiquidGlassRenderingPolicy.resolve(
+            liquidGlassAvailable: true,
+            reduceTransparency: true,
+            increaseContrast: true
+        ) == .opaqueColor)
+        #expect(LiquidGlassRenderingPolicy.resolve(
+            liquidGlassAvailable: false,
+            reduceTransparency: true,
+            increaseContrast: true
+        ) == .opaqueColor)
+    }
+}
+
+// MARK: - LiquidGlassPresentationContractTests
+
+struct LiquidGlassPresentationContractTests {
+    @Test("Primary actions use the availability-safe native glass family")
+    func primaryActionsUseGlassButtonStyle() throws {
+        let sources = try viewSources()
+        let joined = sources.values.joined(separator: "\n")
+
+        #expect(!joined.contains(".buttonStyle(.borderedProminent)"))
+        #expect(joined.components(separatedBy: ".rockxyGlassButtonStyle(prominent: true)").count > 20)
+    }
+
+    @Test("Shared semantic chips own active footer and filter state")
+    func sharedSemanticChipsOwnActiveState() throws {
+        let requiredFiles = [
+            "Rockxy/Views/Toolbar/FilterPillButton.swift",
+            "Rockxy/Views/Toolbar/ActiveFilterSummaryBar.swift",
+            "Rockxy/Views/RequestList/StatusBarView.swift",
+            "Rockxy/Views/Rules/MapLocalWindowView.swift",
+            "Rockxy/Views/Rules/MapRemoteWindowView.swift",
+            "Rockxy/Views/Rules/BlockListWindowView.swift",
+            "Rockxy/Views/Rules/AllowListWindowView.swift",
+            "Rockxy/Views/Rules/ModifyHeaderWindowView.swift",
+            "Rockxy/Views/Rules/NetworkConditionsWindowView.swift",
+            "Rockxy/Views/Breakpoint/BreakpointRulesWindowView.swift",
+            "Rockxy/Views/Scripting/ScriptingListWindowView.swift",
+            "Rockxy/Views/Settings/SSLProxyingListView.swift",
+            "Rockxy/Views/Settings/BypassProxyListView.swift",
+        ]
+
+        for file in requiredFiles {
+            let source = try readProjectFile(file)
+            #expect(source.contains(".rockxyChipStyle("), "Missing shared semantic chip in \(file)")
+        }
+    }
+
+    @Test("Protocol filter pills always emit their readable label")
+    func protocolFilterPillsEmitLabels() throws {
+        let source = try readProjectFile("Rockxy/Views/Toolbar/FilterPillButton.swift")
+
+        #expect(source.contains("Text(title)"))
+        #expect(!source.contains("let label = Text(title)"))
+        #expect(source.contains(".rockxyChipStyle(isActive: isActive)"))
+    }
+
+    @Test("Toast geometry and shadow stay tokenized")
+    func toastUsesSharedGlassTokens() throws {
+        let source = try readProjectFile("Rockxy/Views/Common/ToastView.swift")
+
+        #expect(source.contains("Theme.Glass.toastCornerRadius"))
+        #expect(source.contains("Theme.Glass.toastShadowRadius"))
+        #expect(source.contains(".rockxyGlassEffect("))
+    }
+
+    private func viewSources() throws -> [String: String] {
+        let viewsURL = projectRoot().appendingPathComponent("Rockxy/Views", isDirectory: true)
+        let enumerator = try #require(FileManager.default.enumerator(
+            at: viewsURL,
+            includingPropertiesForKeys: nil
+        ))
+        var result: [String: String] = [:]
+        for case let url as URL in enumerator where url.pathExtension == "swift" {
+            result[url.path] = try String(contentsOf: url, encoding: .utf8)
+        }
+        return result
+    }
+
+    private func readProjectFile(_ relativePath: String) throws -> String {
+        try String(
+            contentsOf: projectRoot().appendingPathComponent(relativePath),
+            encoding: .utf8
+        )
+    }
+
+    private func projectRoot() -> URL {
+        var url = URL(fileURLWithPath: #filePath)
+        while url.lastPathComponent != "RockxyTests", url.path != "/" {
+            url.deleteLastPathComponent()
+        }
+        return url.deletingLastPathComponent()
+    }
+}

--- a/RockxyTests/Theme/LiquidGlassRenderingPolicyTests.swift
+++ b/RockxyTests/Theme/LiquidGlassRenderingPolicyTests.swift
@@ -176,6 +176,23 @@ struct AppThemeApplierTests {
 // MARK: - LiquidGlassPresentationContractTests
 
 struct LiquidGlassPresentationContractTests {
+    @Test("macOS 26-only presentation APIs stay compatible with the CI compiler")
+    func nativePresentationAPIsAreCompilerGated() throws {
+        let requiredFiles = [
+            "Rockxy/Theme/LiquidGlass.swift",
+            "Rockxy/Views/DeveloperSetup/DeveloperSetupAutomaticWindowView.swift",
+            "Rockxy/Views/DeveloperSetup/DeveloperSetupManualWindowView.swift",
+            "Rockxy/Views/Settings/SettingsSectionComponents.swift",
+            "Rockxy/Views/Settings/SettingsView.swift",
+            "Rockxy/Views/Sidebar/SidebarView.swift",
+        ]
+
+        for file in requiredFiles {
+            let source = try readProjectFile(file)
+            #expect(source.contains("#if compiler(>=6.2)"), "Missing compiler gate in \(file)")
+        }
+    }
+
     @Test("Every scene provider propagates theme into SwiftUI-hosted toolbar chrome")
     func sceneProviderPropagatesTheme() throws {
         let source = try readProjectFile("Rockxy/Models/UI/AppUIDisplayMetrics.swift")

--- a/RockxyTests/ViewModels/DeveloperSetupNativeStructureTests.swift
+++ b/RockxyTests/ViewModels/DeveloperSetupNativeStructureTests.swift
@@ -108,6 +108,8 @@ struct DeveloperSetupNativeStructureTests {
             #expect(source.contains("ScrollView"))
             #expect(source.contains("minWidth:"))
             #expect(source.contains("setupMetrics.font"))
+            #expect(source.contains(".safeAreaBar(edge: .top, spacing: 0)"))
+            #expect(source.contains(".safeAreaBar(edge: .bottom, spacing: 0)"))
             #expect(source.contains(".font(.system") == false)
             // Fixed content-size framing forbids resize; must not be present.
             #expect(source.contains(".frame(width: 780, height: 540)") == false)

--- a/RockxyTests/Views/Export/GistPublishConfirmationSheetTests.swift
+++ b/RockxyTests/Views/Export/GistPublishConfirmationSheetTests.swift
@@ -134,7 +134,7 @@ struct GistPublishConfirmationSheetTests {
         #expect(source.contains("Publishing"))
         #expect(source.contains("guard !isPublishing else {"))
         #expect(source.contains(".disabled(isPublishing)"))
-        #expect(source.contains(".buttonStyle(.borderedProminent)"))
+        #expect(source.contains(".rockxyGlassButtonStyle(prominent: true)"))
 
         // Failure re-enables controls and shows an inline error.
         #expect(source.contains("errorMessage = error.localizedDescription"))

--- a/RockxyTests/Views/FocusSidebarPresentationTests.swift
+++ b/RockxyTests/Views/FocusSidebarPresentationTests.swift
@@ -13,7 +13,7 @@ struct FocusSidebarPresentationTests {
 
         #expect(source.contains("actionLabel: String(localized: \"Create Focus Set\")"))
         #expect(source.contains("actionLabel: String(localized: \"Configure Noise Control\")"))
-        #expect(source.contains(".buttonStyle(.bordered)"))
+        #expect(source.contains(".rockxyGlassButtonStyle()"))
         #expect(source.contains(".controlSize(.small)"))
         #expect(source.contains(".accessibilityLabel(actionLabel)"))
     }
@@ -35,6 +35,38 @@ struct FocusSidebarPresentationTests {
         #expect(source.contains(".safeAreaBar(edge: .bottom, spacing: 0)"))
         #expect(!source.contains(".rockxyGlassEffect"))
         #expect(!bottomBar.contains(".rockxyGlassEffect"))
+    }
+
+    @Test("Sidebar filter uses an expanding native Xcode-style search control")
+    func sidebarFilterUsesNativeSearchControl() throws {
+        let source = try readProjectFile("Rockxy/Views/Sidebar/SidebarBottomBar.swift")
+
+        #expect(source.contains("NSSearchField()"))
+        #expect(source.contains("searchField.sendsSearchStringImmediately = true"))
+        #expect(source.contains("func controlTextDidChange"))
+        #expect(source.contains("searchField.placeholderString = String(localized: \"Filter\")"))
+        #expect(source.contains("systemSymbolName: \"line.3.horizontal.decrease.circle\""))
+        #expect(source.contains(".frame(maxWidth: .infinity, minHeight: 28)"))
+        #expect(!source.contains("TextField("))
+        #expect(!source.contains(".background(Color(nsColor: .quaternaryLabelColor)"))
+        #expect(!source.contains(".clipShape(RoundedRectangle"))
+        #expect(!source.contains("Filter (\\u{2318}\\u{21E7}F)"))
+    }
+
+    @Test("Navigator modes use Xcode-style native icon segments")
+    func navigatorModesUseNativeIconSegments() throws {
+        let sidebar = try readProjectFile("Rockxy/Views/Sidebar/SidebarView.swift")
+        let shared = try readProjectFile("Rockxy/Views/Common/UtilitySegmentedHeader.swift")
+
+        #expect(sidebar.contains("WorkspaceModeSegmentedControl("))
+        #expect(sidebar.contains("segments: FocusNavigatorMode.allCases.map"))
+        #expect(shared.contains("NSSegmentedControl"))
+        #expect(shared.contains("control.segmentStyle = .capsule"))
+        #expect(shared.contains("selectedSegmentBezelColor = .controlAccentColor"))
+        #expect(shared.contains("accessibilityDescription: segment.title"))
+        #expect(shared.contains("control.setToolTip(segment.title, forSegment: index)"))
+        #expect(shared.contains("final class EqualWidthSegmentedControl"))
+        #expect(!sidebar.contains("Text(mode.title).tag(mode)"))
     }
 
     // MARK: Private

--- a/RockxyTests/Views/FocusSidebarPresentationTests.swift
+++ b/RockxyTests/Views/FocusSidebarPresentationTests.swift
@@ -5,6 +5,8 @@ import Testing
 // MARK: - FocusSidebarPresentationTests
 
 struct FocusSidebarPresentationTests {
+    // MARK: Internal
+
     @Test("Focus section actions use visible native buttons")
     func focusSectionActionsUseVisibleNativeButtons() throws {
         let source = try readProjectFile("Rockxy/Views/Sidebar/SidebarView.swift")
@@ -21,6 +23,21 @@ struct FocusSidebarPresentationTests {
         #expect(SidebarDisclosureDefaults.appsExpanded)
         #expect(SidebarDisclosureDefaults.domainsExpanded)
     }
+
+    @Test("Sidebar delegates modern glass bars to the system")
+    func sidebarUsesSystemOwnedLiquidGlassBars() throws {
+        let source = try readProjectFile("Rockxy/Views/Sidebar/SidebarView.swift")
+        let bottomBar = try readProjectFile("Rockxy/Views/Sidebar/SidebarBottomBar.swift")
+
+        #expect(source.contains("if #available(macOS 26.0, *)"))
+        #expect(source.contains(".scrollEdgeEffectStyle(.soft, for: .vertical)"))
+        #expect(source.contains(".safeAreaBar(edge: .top, spacing: 0)"))
+        #expect(source.contains(".safeAreaBar(edge: .bottom, spacing: 0)"))
+        #expect(!source.contains(".rockxyGlassEffect"))
+        #expect(!bottomBar.contains(".rockxyGlassEffect"))
+    }
+
+    // MARK: Private
 
     private func readProjectFile(_ relativePath: String) throws -> String {
         var url = URL(fileURLWithPath: #filePath)

--- a/RockxyTests/Views/Import/ImportReviewSheetTests.swift
+++ b/RockxyTests/Views/Import/ImportReviewSheetTests.swift
@@ -191,7 +191,7 @@ struct ImportReviewSheetTests {
 
         // Native controls, no custom plain destructive button.
         #expect(source.contains(".buttonStyle(.bordered)"))
-        #expect(source.contains(".buttonStyle(.borderedProminent)"))
+        #expect(source.contains(".rockxyGlassButtonStyle(prominent: true)"))
         #expect(source.contains("Button(role: .destructive)"))
         #expect(source.contains("exclamationmark.triangle.fill"))
         #expect(!source.contains(".buttonStyle(.plain)"))

--- a/RockxyTests/Views/Import/ImportReviewSheetTests.swift
+++ b/RockxyTests/Views/Import/ImportReviewSheetTests.swift
@@ -190,7 +190,7 @@ struct ImportReviewSheetTests {
         let source = try readProjectFile("Rockxy/Views/Import/ImportReviewSheet.swift")
 
         // Native controls, no custom plain destructive button.
-        #expect(source.contains(".buttonStyle(.bordered)"))
+        #expect(source.contains(".rockxyGlassButtonStyle()"))
         #expect(source.contains(".rockxyGlassButtonStyle(prominent: true)"))
         #expect(source.contains("Button(role: .destructive)"))
         #expect(source.contains("exclamationmark.triangle.fill"))

--- a/RockxyTests/Views/Inspector/ContextDockPresentationTests.swift
+++ b/RockxyTests/Views/Inspector/ContextDockPresentationTests.swift
@@ -474,11 +474,14 @@ struct ContextDockInvestigationReportTests {
     @Test("Mode switcher shows Details / AI Assistant, not Context / Investigate")
     func modeSwitcherUsesRestoredLabels() throws {
         let dock = try readProjectFile("Rockxy/Views/Inspector/ContextDockView.swift")
+        let dockHeader = try #require(dock.components(separatedBy: "Divider()").first)
         #expect(dock.contains("Text(String(localized: \"Details\")).tag(ContextDockTab.details)"))
         #expect(dock.contains("Text(String(localized: \"AI Assistant\")).tag(ContextDockTab.aiAssistant)"))
         #expect(!dock.contains("Text(String(localized: \"Context\")).tag"))
         #expect(!dock.contains("Text(String(localized: \"Investigate\")).tag"))
         #expect(dock.contains("Picker(String(localized: \"Inspector\")"))
+        #expect(dockHeader.contains(".workspaceModeSwitcherStyle()"))
+        #expect(!dockHeader.contains(".rockxyFunctionalBar()"))
         #expect(dock.contains(".accessibilityLabel(String(localized: \"Inspector\"))"))
         // Stable internal enum cases are unchanged.
         #expect(dock.contains("ContextDockTab.details"))

--- a/RockxyTests/Views/Inspector/ContextDockPresentationTests.swift
+++ b/RockxyTests/Views/Inspector/ContextDockPresentationTests.swift
@@ -452,7 +452,7 @@ struct ContextDockInvestigationReportTests {
         #expect(dock.contains("Text(recipe.title)"))
         #expect(dock.contains(".lineLimit(2)"))
         #expect(dock.contains("HStack(spacing: 6)"))
-        #expect(dock.contains(".buttonStyle(.bordered)"))
+        #expect(dock.contains(".rockxyGlassButtonStyle()"))
         #expect(dock.contains(".controlSize(.small)"))
         #expect(!dock.contains("Color(nsColor: .controlBackgroundColor), in: RoundedRectangle(cornerRadius: 8)"))
         #expect(!dock.contains("RoundedRectangle(cornerRadius: 8)"))
@@ -471,15 +471,17 @@ struct ContextDockInvestigationReportTests {
         #expect(DebugAssistantRecipe.allCases.last == .prepareBugReport)
     }
 
-    @Test("Mode switcher shows Details / AI Assistant, not Context / Investigate")
-    func modeSwitcherUsesRestoredLabels() throws {
+    @Test("Mode switcher exposes Details and AI Assistant as native icon segments")
+    func modeSwitcherUsesNativeIconSegments() throws {
         let dock = try readProjectFile("Rockxy/Views/Inspector/ContextDockView.swift")
         let dockHeader = try #require(dock.components(separatedBy: "Divider()").first)
-        #expect(dock.contains("Text(String(localized: \"Details\")).tag(ContextDockTab.details)"))
-        #expect(dock.contains("Text(String(localized: \"AI Assistant\")).tag(ContextDockTab.aiAssistant)"))
-        #expect(!dock.contains("Text(String(localized: \"Context\")).tag"))
-        #expect(!dock.contains("Text(String(localized: \"Investigate\")).tag"))
-        #expect(dock.contains("Picker(String(localized: \"Inspector\")"))
+        #expect(dock.contains("title: String(localized: \"Details\")"))
+        #expect(dock.contains("systemImage: \"doc.text.magnifyingglass\""))
+        #expect(dock.contains("title: String(localized: \"AI Assistant\")"))
+        #expect(dock.contains("systemImage: \"sparkles\""))
+        #expect(dock.components(separatedBy: "WorkspaceModeSegment(").count == 3)
+        #expect(dock.contains("WorkspaceModeSegmentedControl("))
+        #expect(dock.contains("accessibilityLabel: String(localized: \"Inspector\")"))
         #expect(dockHeader.contains(".workspaceModeSwitcherStyle()"))
         #expect(!dockHeader.contains(".rockxyFunctionalBar()"))
         #expect(dock.contains(".accessibilityLabel(String(localized: \"Inspector\"))"))

--- a/RockxyTests/Views/Main/FooterActionDescriptorTests.swift
+++ b/RockxyTests/Views/Main/FooterActionDescriptorTests.swift
@@ -110,6 +110,37 @@ struct FooterActionDescriptorTests {
         #expect(FooterActionKind.networkConditions.toolWindowID == "networkConditions")
         #expect(FooterActionKind.proxyOverride.toolWindowID == nil)
     }
+
+    @Test("Quick Tools stay labeled while Customize remains compact and accessible")
+    func quickToolsUseLabeledNativeGlassControls() throws {
+        let source = try readProjectFile("Rockxy/Views/RequestList/StatusBarView.swift")
+
+        #expect(source.contains("Label(descriptor.title, systemImage: descriptor.systemImage)"))
+        #expect(source.contains(".rockxyGlassButtonStyle(prominent: descriptor.isActive)"))
+        #expect(source.contains("Label(String(localized: \"Quick Tools\"), systemImage: \"hammer\")"))
+        #expect(source.contains("Image(systemName: \"ellipsis\")"))
+        #expect(!source.contains("Label(String(localized: \"Customize\"), systemImage: \"ellipsis\")"))
+        #expect(!source.contains("showsCustomizeTitle"))
+        #expect(source.contains("quickTools\n                    .layoutPriority(0)"))
+        #expect(source.contains("centerStatus\n                    .layoutPriority(3)"))
+        #expect(source.contains("rightStats\n                    .layoutPriority(3)"))
+        #expect(source.contains("ViewThatFits(in: .horizontal)"))
+        #expect(source.contains(".accessibilityLabel(String(localized: \"Customize Quick Tools\"))"))
+        #expect(!source.contains("struct FooterToolIconLabel"))
+        #expect(!source.contains("struct FooterToolingChrome"))
+        #expect(!source.contains("FooterToolingChrome("))
+    }
+
+    // MARK: Private
+
+    private func readProjectFile(_ relativePath: String) throws -> String {
+        var url = URL(fileURLWithPath: #filePath)
+        while url.lastPathComponent != "RockxyTests", url.path != "/" {
+            url.deleteLastPathComponent()
+        }
+        url.deleteLastPathComponent()
+        return try String(contentsOf: url.appendingPathComponent(relativePath), encoding: .utf8)
+    }
 }
 
 // MARK: - QuickToolsLayoutTests

--- a/RockxyTests/Views/Main/HistoryRetentionTests.swift
+++ b/RockxyTests/Views/Main/HistoryRetentionTests.swift
@@ -73,6 +73,27 @@ struct HistoryRetentionTests {
         #expect(coordinator.observedDomainsByApp[String(localized: "Unknown")]?.count == 20)
     }
 
+    @Test("Saturated capture evicts with headroom instead of rebuilding every batch")
+    @MainActor
+    func saturatedCaptureUsesEvictionHeadroom() {
+        let coordinator = MainContentCoordinator(policy: SmallHistoryPolicy())
+        coordinator.isRecording = true
+        coordinator.processActiveProjectTestBatch((0 ..< 10).map {
+            TestFixtures.makeTransaction(url: "https://example.com/\($0)")
+        })
+
+        coordinator.processActiveProjectTestBatch([
+            TestFixtures.makeTransaction(url: "https://example.com/10"),
+        ])
+        #expect(coordinator.transactions.count == 9)
+
+        coordinator.processActiveProjectTestBatch([
+            TestFixtures.makeTransaction(url: "https://example.com/11"),
+        ])
+        #expect(coordinator.transactions.count == 10)
+        #expect(coordinator.activeWorkspace.lastDeriveWasAppendOnly)
+    }
+
     @Test("Follow Live selects the newest request that survives the active view")
     @MainActor
     func followLiveSelectsNewestVisibleRequest() {

--- a/RockxyTests/Views/Main/NativeWorkspaceSplitViewTests.swift
+++ b/RockxyTests/Views/Main/NativeWorkspaceSplitViewTests.swift
@@ -130,6 +130,36 @@ struct NativeWorkspaceSplitViewTests {
         #expect(window.toolbarStyle == .unified)
     }
 
+    @Test("Project changes and late scene updates cannot duplicate the selector")
+    func projectChangesDoNotRenderAWindowTitle() {
+        let coordinator = MainContentCoordinator()
+        let window = NSWindow()
+        let manager = RockxyWorkspaceWindowManager.shared
+        window.title = RockxyIdentity.current.displayName
+
+        manager.registerPrimaryWindow(window, coordinator: coordinator)
+        defer {
+            manager.handleWindowWillClose(window)
+        }
+
+        #expect(window.title == RockxyIdentity.current.displayName)
+        #expect(window.titleVisibility == .hidden)
+
+        // Simulate the old Project-title assignment followed by a delayed SwiftUI
+        // reconciliation. The window manager owns a persistent invariant instead
+        // of repairing only the synchronous Project-switch callback.
+        window.title = "New Project 3"
+        window.titleVisibility = .visible
+
+        #expect(window.title == RockxyIdentity.current.displayName)
+        #expect(window.titleVisibility == .hidden)
+
+        manager.projectDidChange(coordinator: coordinator)
+
+        #expect(window.title == RockxyIdentity.current.displayName)
+        #expect(window.titleVisibility == .hidden)
+    }
+
     @Test("Main toolbar places the sidebar toggle before its tracking separator")
     func nativeSidebarToolbarChrome() {
         let controller = makeController(sidebarPresented: true, inspectorPresented: true)

--- a/RockxyTests/Views/Main/NativeWorkspaceSplitViewTests.swift
+++ b/RockxyTests/Views/Main/NativeWorkspaceSplitViewTests.swift
@@ -127,6 +127,7 @@ struct NativeWorkspaceSplitViewTests {
         #expect(window.styleMask.contains(.fullSizeContentView))
         #expect(window.titlebarAppearsTransparent)
         #expect(window.titleVisibility == .hidden)
+        #expect(window.toolbarStyle == .unified)
     }
 
     @Test("Main toolbar places the sidebar toggle before its tracking separator")

--- a/RockxyTests/Views/Main/NearbyTransferImportTests.swift
+++ b/RockxyTests/Views/Main/NearbyTransferImportTests.swift
@@ -57,4 +57,52 @@ struct NearbyTransferImportTests {
         #expect(coordinator.activeWorkspace.filteredTransactions.count == 1)
         #expect(coordinator.activeWorkspace.filteredTransactions.first?.request.host == "ios.example.com")
     }
+
+    @Test("Import never reintroduces transactions evicted by the live-history cap")
+    func importFiltersOnlyRetainedTransactions() async throws {
+        let coordinator = MainContentCoordinator(policy: SingleEntryHistoryPolicy())
+        let timestamp = ISO8601DateFormatter().string(from: Date())
+        let transferred = (0 ..< 3).map { index in
+            RockxyNearbyTransferSession.Transaction(
+                id: UUID().uuidString,
+                timestamp: timestamp,
+                request: .init(
+                    method: "GET",
+                    url: "https://ios.example.com/\(index)",
+                    headers: [:],
+                    body: nil,
+                    statusCode: nil,
+                    contentType: nil
+                ),
+                response: nil,
+                timing: nil,
+                clientApp: "Example iOS App"
+            )
+        }
+        let session = RockxyNearbyTransferSession(
+            version: "1",
+            metadata: .init(
+                title: "Bounded Import",
+                createdAt: timestamp,
+                appVersion: "1.0",
+                deviceName: "iPhone"
+            ),
+            transactions: transferred
+        )
+
+        try await coordinator.importNearbyTransfer(session, deviceName: "iPhone")
+
+        let retainedIDs = Set(coordinator.transactions.map(\.id))
+        #expect(coordinator.transactions.count == 1)
+        #expect(coordinator.activeWorkspace.filteredTransactions.count == 1)
+        #expect(coordinator.activeWorkspace.filteredTransactions.allSatisfy { retainedIDs.contains($0.id) })
+    }
+}
+
+private struct SingleEntryHistoryPolicy: AppPolicy {
+    let maxWorkspaceTabs = 8
+    let maxDomainFavorites = 5
+    let maxActiveRulesPerTool = 10
+    let maxEnabledScripts = 10
+    let maxLiveHistoryEntries = 1
 }

--- a/RockxyTests/Views/Main/ProjectCoordinationTests.swift
+++ b/RockxyTests/Views/Main/ProjectCoordinationTests.swift
@@ -347,6 +347,25 @@ struct ProjectCoordinationTests {
         #expect(coordinator.logEntries.first?.correlatedTransactionId == alphaTransaction.id)
     }
 
+    @Test("project switching advances live sequence numbers beyond persisted favorites")
+    func projectSwitchAccountsForFavoriteSequences() async {
+        let (catalog, alpha, beta) = Self.twoProjectCatalog()
+        let coordinator = MainContentCoordinator(
+            projectCatalogRepository: FakeProjectRepo(loadResult: .success(catalog))
+        )
+        await coordinator.hydrateProjectsOnLaunch()
+        let favorite = TestFixtures.makeTransaction(url: "https://favorite.example.com")
+        favorite.sequenceNumber = 100
+        coordinator.persistedFavorites = [favorite]
+
+        #expect(coordinator.switchToProject(id: beta.id))
+        #expect(coordinator.switchToProject(id: alpha.id))
+        let fresh = TestFixtures.makeTransaction(url: "https://alpha.example.com/fresh")
+        coordinator.processActiveProjectTestBatch([fresh])
+
+        #expect(fresh.sequenceNumber == 101)
+    }
+
     @Test("live traffic history is capped independently for every bounded Project")
     func perProjectHistoryIsBounded() async {
         let (catalog, alpha, beta) = Self.twoProjectCatalog()

--- a/RockxyTests/Views/ScriptEditorWindowReadabilityTests.swift
+++ b/RockxyTests/Views/ScriptEditorWindowReadabilityTests.swift
@@ -50,7 +50,7 @@ struct ScriptEditorWindowReadabilityTests {
 
         // Save & Activate is the clear primary action with a truthful (label-free) shortcut.
         #expect(source.contains("footerActionLabel(String(localized: \"Save & Activate\"), weight: .semibold)"))
-        #expect(source.contains(".buttonStyle(.borderedProminent)"))
+        #expect(source.contains(".rockxyGlassButtonStyle(prominent: true)"))
         #expect(!source.contains("Save & Activate ⌘S"))
         #expect(source.contains(#".keyboardShortcut("s", modifiers: .command)"#))
         #expect(source.contains(#".keyboardShortcut("r", modifiers: .command)"#))

--- a/RockxyTests/Views/SettingsWindowReadabilityTests.swift
+++ b/RockxyTests/Views/SettingsWindowReadabilityTests.swift
@@ -180,6 +180,17 @@ struct SettingsWindowReadabilityTests {
         #expect(!pluginsSource.contains(".padding(.horizontal, settingsMetrics.contentPadding)"))
     }
 
+    @Test("Assistant local model library uses the available Settings width")
+    func assistantModelLibraryUsesAvailableWidth() throws {
+        let source = try readProjectFile("Rockxy/Views/Settings/AssistantSettingsTab.swift")
+
+        #expect(source.contains(".frame(maxWidth: settingsMetrics.fieldWidth(680), alignment: .leading)"))
+        #expect(source.contains(".frame(maxWidth: .infinity, alignment: .leading)"))
+        #expect(source.components(separatedBy: "settingsMetrics.fieldWidth(520)").count - 1 == 1)
+        #expect(source.components(separatedBy: ".layoutPriority(1)").count - 1 >= 3)
+        #expect(source.contains("modelAction(model)\n                    .fixedSize(horizontal: true, vertical: false)"))
+    }
+
     @Test("MCP configuration remains readable without wrapping long paths")
     func mcpConfigurationUsesScrollableCodeSurface() throws {
         let source = try readProjectFile("Rockxy/Views/Settings/MCPSettingsTab.swift")

--- a/RockxyTests/Views/SettingsWindowReadabilityTests.swift
+++ b/RockxyTests/Views/SettingsWindowReadabilityTests.swift
@@ -58,52 +58,34 @@ struct SettingsWindowReadabilityTests {
         #expect(defaults.string(forKey: RockxySettingsTab.defaultsKey) == "general")
     }
 
-    @Test("Settings shell is a resizable native sidebar/content window")
+    @Test("Settings shell clones the native Developer Setup window contract")
     func settingsShellIsResizableNativeSidebarContentWindow() throws {
         let source = try readProjectFile("Rockxy/Views/Settings/SettingsView.swift")
         let appSource = try readProjectFile("Rockxy/RockxyApp.swift")
+        let sceneSource = try readProjectFile("Rockxy/Views/Settings/SettingsWindowScene.swift")
 
-        // NavigationSplitView owns the columns. Rockxy removes the system
-        // toggle because Settings can otherwise host it in a second toolbar row.
-        #expect(source.contains("NavigationSplitView(columnVisibility: $columnVisibility)"))
-        #expect(source.contains("List(RockxySettingsTab.allCases, selection: selectionBinding)"))
+        // Settings uses the same fully native split-view structure as Developer
+        // Setup. The system owns its sidebar toggle and unified title bar.
+        #expect(source.contains("NavigationSplitView {"))
+        #expect(source.contains("List(selection: selectionBinding)"))
         #expect(source.contains("Binding<RockxySettingsTab?>"))
+        #expect(source.contains("RockxySettingsSidebarSection.allCases"))
+        #expect(source.contains("Section(section.title)"))
         #expect(source.contains("min: settingsMetrics.sidebarMinWidth"))
         #expect(source.contains("ideal: settingsMetrics.sidebarIdealWidth"))
         #expect(source.contains("max: settingsMetrics.sidebarMaxWidth"))
-        #expect(source.contains(".navigationSplitViewStyle(.balanced)"))
-        #expect(source.contains(".toolbar(removing: .sidebarToggle)"))
-        #expect(!source.contains("titlebarContentInset"))
-
-        // Settings uses a real AppKit toolbar item followed by a
-        // sidebar-tracking separator. It stays unbordered so the native glyph
-        // does not gain a capsule that overlaps the rounded sidebar edge.
-        #expect(source.contains(
-            "@State private var columnVisibility: NavigationSplitViewVisibility = .all"
-        ))
-        #expect(source.contains("SettingsChromeMetrics.sidebarContentTopInset"))
-        #expect(source.contains(".safeAreaInset(edge: .top, spacing: 0)"))
-        #expect(source.contains("static let sidebarContentTopInset: CGFloat = 14"))
-        #expect(source.contains("SettingsWindowToolbarInstaller("))
-        #expect(source.contains("SettingsWindowToolbar: NSObject, NSToolbarDelegate"))
-        #expect(source.contains("managedToolbar = NSToolbar(identifier: Self.toolbarIdentifier)"))
-        #expect(source.contains("window.styleMask.insert(.fullSizeContentView)"))
-        #expect(source.contains("window.toolbarStyle = .unifiedCompact"))
-        #expect(source.contains("withAnimation(.easeInOut(duration: 0.26))"))
-        #expect(source.contains(".sidebarTrackingSeparator"))
-        #expect(source.contains("let item = NSToolbarItem(itemIdentifier: itemIdentifier)"))
-        #expect(source.contains("systemSymbolName: \"sidebar.leading\""))
-        #expect(source.contains("item.target = self"))
-        #expect(source.contains("item.action = #selector(toggleSidebar(_:))"))
-        #expect(source.contains("item.isBordered = false"))
-        #expect(!source.contains("item.isBordered = true"))
-        #expect(!source.contains("toolbarControlDownwardOffset"))
-        #expect(!source.contains("button.layer?.setAffineTransform("))
-        #expect(source.contains("columnVisibility == .detailOnly"))
+        #expect(source.contains(".navigationTitle(selectedTab.title)"))
+        #expect(source.contains(".scrollEdgeEffectStyle(.soft, for: .vertical)"))
+        #expect(!source.contains("settingsToolbarContent"))
+        #expect(!source.contains("Settings Category"))
+        #expect(!source.contains("ToolbarItem(placement: .principal)"))
+        #expect(!source.contains(".safeAreaBar(edge: .top"))
+        #expect(!source.contains("SettingsWindowToolbarInstaller"))
+        #expect(!source.contains("NSToolbarDelegate"))
 
         // Font scaling belongs to pane content. Applying it at the split root
         // also scales native toolbar controls and can create a second toolbar row.
-        #expect(source.contains(".font(settingsMetrics.font())\n                .tag(tab)"))
+        #expect(source.contains(".font(settingsMetrics.font(weight: selectedTab == tab ? .semibold : .regular))"))
         #expect(!source.contains(".listStyle(.sidebar)\n            .font(settingsMetrics.font())"))
         #expect(source.contains("detailContent(for: selectedTab)\n                .font(settingsMetrics.font())"))
 
@@ -118,9 +100,9 @@ struct SettingsWindowReadabilityTests {
         #expect(source.contains("switch tab {"))
         #expect(!source.contains("AnyView"))
 
-        // One compact native pane header precedes the selected pane.
-        #expect(source.contains("private func paneHeader(for tab: RockxySettingsTab)"))
-        #expect(source.contains("tab.paneDescription"))
+        // Category title belongs to native navigation chrome, not to a second
+        // picker or hand-built bar floating above every pane.
+        #expect(!source.contains("private func paneHeader(for tab: RockxySettingsTab)"))
 
         // The fixed 820x600 shell is gone; geometry is adaptive and resizable.
         #expect(!source.contains(".frame(width: settingsMetrics.windowWidth, height: settingsMetrics.windowHeight)"))
@@ -129,10 +111,18 @@ struct SettingsWindowReadabilityTests {
         #expect(source.contains("minHeight: settingsMetrics.windowMinHeight"))
         #expect(source.contains("maxWidth: .infinity"))
 
-        // The Settings scene inherits Appearance metrics and resizes to content min size.
-        #expect(appSource.contains("Settings {\n            AppUIDisplayMetricsProvider"))
-        #expect(appSource.contains(".windowResizability(.contentMinSize)"))
-        #expect(appSource.contains(".windowToolbarStyle(.unifiedCompact)"))
+        // Settings is a normal Window scene just like Developer Setup. This is
+        // what keeps the automatic sidebar toggle inside the unified title bar.
+        #expect(appSource.contains("SettingsWindowScene()"))
+        #expect(appSource.contains("CommandGroup(replacing: .appSettings)"))
+        #expect(appSource.contains("openWindow(id: \"settings\")"))
+        #expect(!appSource.contains("Settings {"))
+        #expect(sceneSource.contains("struct SettingsWindowScene: Scene"))
+        #expect(sceneSource.contains("Window(String(localized: \"Settings\"), id: \"settings\")"))
+        #expect(sceneSource.contains(".defaultSize(width: 1_000, height: 640)"))
+        #expect(sceneSource.contains(".defaultPosition(.center)"))
+        #expect(sceneSource.contains(".windowResizability(.contentMinSize)"))
+        #expect(sceneSource.contains(".windowToolbarStyle(.unified(showsTitle: true))"))
     }
 
     @Test("Settings panes share one outer layout contract")
@@ -141,6 +131,12 @@ struct SettingsWindowReadabilityTests {
         #expect(componentSource.contains("struct SettingsPane<Content: View>: View"))
         #expect(componentSource.contains(".padding(.horizontal, settingsMetrics.contentPadding)"))
         #expect(componentSource.contains(".padding(.vertical, settingsMetrics.paneContentPadding)"))
+        #expect(componentSource.contains("settingsMetrics.contentMaxWidth"))
+        #expect(componentSource.contains("Color(nsColor: .windowBackgroundColor)"))
+        #expect(componentSource.contains("ViewThatFits(in: .horizontal)"))
+        #expect(componentSource.contains("settingsMetrics.fieldSpacing"))
+        #expect(!componentSource.contains("GroupBox"))
+        #expect(!componentSource.contains("Color.clear.frame(width: settingsMetrics.rowLeading)"))
 
         let standardPanePaths = [
             "Rockxy/Views/Settings/GeneralSettingsTab.swift",
@@ -167,11 +163,20 @@ struct SettingsWindowReadabilityTests {
         let appearanceSource = try readProjectFile("Rockxy/Views/Settings/AppearanceSettingsTab.swift")
         #expect(!appearanceSource.contains(".padding(.horizontal, 18)"))
 
-        // Plugins intentionally keeps a full-bleed master/detail surface; it
-        // still lives under the same shell header and does not add outer insets.
+        let advancedSource = try readProjectFile("Rockxy/Views/Settings/AdvancedSettingsTab.swift")
+        #expect(!advancedSource.contains("settingsRow(label: String(localized: \"Software Update:\"))"))
+        #expect(advancedSource.contains("SettingsFieldRow(String(localized: \"Check Frequency\"))"))
+        #expect(advancedSource.contains(".labelsHidden()"))
+
+        // Plugins intentionally keeps a full-bleed master/detail surface with
+        // a native resizable content split and a compact menu fallback.
         let pluginsSource = try readProjectFile("Rockxy/Views/Settings/PluginsSettingsTab.swift")
         #expect(pluginsSource.contains("VStack(spacing: 0)"))
         #expect(pluginsSource.contains("pluginListPanel"))
+        #expect(pluginsSource.contains("HSplitView"))
+        #expect(pluginsSource.contains("ViewThatFits(in: .horizontal)"))
+        #expect(pluginsSource.contains(".pickerStyle(.menu)"))
+        #expect(pluginsSource.contains(".listStyle(.inset)"))
         #expect(!pluginsSource.contains(".padding(.horizontal, settingsMetrics.contentPadding)"))
     }
 
@@ -179,7 +184,7 @@ struct SettingsWindowReadabilityTests {
     func mcpConfigurationUsesScrollableCodeSurface() throws {
         let source = try readProjectFile("Rockxy/Views/Settings/MCPSettingsTab.swift")
 
-        #expect(source.contains("SettingsSectionCard(String(localized: \"Client Configuration\"))"))
+        #expect(source.contains("SettingsSection(String(localized: \"Client Configuration\"))"))
         #expect(source.contains("ScrollView(.horizontal)"))
         #expect(source.contains(".fixedSize(horizontal: true, vertical: true)"))
         #expect(source.contains(".textSelection(.enabled)"))

--- a/RockxyTests/Views/ToolWindowReadabilityTests.swift
+++ b/RockxyTests/Views/ToolWindowReadabilityTests.swift
@@ -153,14 +153,12 @@ struct ToolWindowReadabilityTests {
     @Test("Assistant dock follows Appearance typography and keeps protocol summaries monospaced")
     func assistantDockUsesDisplayMetrics() throws {
         let source = try readProjectFile("Rockxy/Views/Inspector/ContextDockView.swift")
-        let sidebarSource = try readProjectFile("Rockxy/Views/Sidebar/SidebarView.swift")
-        let switcherStyleSource = try readProjectFile("Rockxy/Views/Common/UtilitySegmentedHeader.swift")
 
         #expect(source.contains("@Environment(\\.appUIDisplayMetrics)"))
         // UI/prose uses explicit proportional .system(size:) roles derived from Appearance metrics,
         // no longer routed through swiftUIFont (which could force all prose monospaced). Technical
-        // data (request summaries, model IDs) stays explicitly monospaced. Restored switcher labels
-        // (Details / AI Assistant) are asserted in ContextDockPresentationTests.
+        // data (request summaries, model IDs) stays explicitly monospaced. The native icon switcher
+        // keeps Details / AI Assistant in help and accessibility labels.
         #expect(!source.contains("swiftUIFont"))
         #expect(source.contains("assistantFont(appMetrics."))
         #expect(source.contains("monospaced: true"))
@@ -170,12 +168,6 @@ struct ToolWindowReadabilityTests {
         #expect(!source.contains(".disabled(isBusy || primaryTransaction == nil)"))
         #expect(!source.contains(".disabled(conversationIsEmpty && !isBusy)"))
         #expect(source.contains("Ask Rockxy AI Assistant…"))
-        #expect(source.contains("ContextDetailsView(coordinator: coordinator)"))
-        #expect(source.contains("AIAssistantDockView("))
-        #expect(source.contains(".workspaceModeSwitcherStyle()"))
-        #expect(sidebarSource.contains(".workspaceModeSwitcherStyle()"))
-        #expect(switcherStyleSource.contains(".controlSize(.regular)"))
-        #expect(switcherStyleSource.contains("metrics.workspaceTabFontSize"))
     }
 
     @Test("Assistant dock uses a compact native hierarchy with progressive disclosure")

--- a/RockxyTests/Views/ToolWindowReadabilityTests.swift
+++ b/RockxyTests/Views/ToolWindowReadabilityTests.swift
@@ -80,12 +80,12 @@ struct ToolWindowReadabilityTests {
             labelWidth: CGFloat,
             controlHeight: CGFloat
         )] = [
-            (10, 196, 896, 500, 160, 24),
-            (12, 196, 896, 500, 160, 24),
-            (13, 196, 896, 500, 160, 25),
-            (14, 202, 902, 500, 168, 26),
-            (20, 238, 970, 502, 216, 32),
-            (28, 286, 1_082, 550, 280, 40),
+            (10, 200, 820, 560, 136, 24),
+            (12, 200, 820, 560, 136, 24),
+            (13, 200, 820, 560, 136, 25),
+            (14, 200, 820, 560, 142, 26),
+            (20, 230, 886, 560, 178, 32),
+            (28, 270, 990, 570, 226, 40),
         ]
         // swiftlint:enable large_tuple
 
@@ -100,18 +100,18 @@ struct ToolWindowReadabilityTests {
 
             // Adaptive, bounded window geometry replaces the pinned 820x600 shell.
             #expect(metrics.sidebarMinWidth == item.sidebarMin)
-            #expect(metrics.sidebarIdealWidth == item.sidebarMin)
-            #expect(metrics.sidebarMaxWidth == item.sidebarMin + 96)
-            #expect(metrics.contentMinWidth == item.minWidth - item.sidebarMin)
+            #expect(metrics.sidebarIdealWidth == max(220, item.sidebarMin))
+            #expect(metrics.sidebarMaxWidth == max(280, max(220, item.sidebarMin) + 60))
+            #expect(metrics.contentMinWidth == max(600, CGFloat(item.fontSize) * 8 + 496))
             #expect(metrics.windowMinWidth == item.minWidth)
-            #expect(metrics.windowIdealWidth == item.minWidth + 132)
+            #expect(metrics.windowIdealWidth == max(1_000, item.minWidth + 140))
             #expect(metrics.windowMinHeight == item.minHeight)
             #expect(metrics.windowIdealHeight == item.minHeight + 96)
 
             // Field labels/indents adapt with font size (identical at the 13pt default).
             #expect(metrics.labelWidth == item.labelWidth)
             #expect(metrics.wideLabelWidth == item.labelWidth + 22)
-            #expect(metrics.rowLeading == item.labelWidth + 16)
+            #expect(metrics.rowLeading == item.labelWidth + 14)
             #expect(metrics.controlHeight == item.controlHeight)
             #expect(metrics.fieldWidth(200) >= 200)
             #expect(metrics.menuWidth(120) >= 120)
@@ -121,9 +121,13 @@ struct ToolWindowReadabilityTests {
     @Test("Settings scene and tabs use display metrics")
     func settingsSceneAndTabsUseDisplayMetrics() throws {
         let appSource = try readProjectFile("Rockxy/RockxyApp.swift")
+        let sceneSource = try readProjectFile("Rockxy/Views/Settings/SettingsWindowScene.swift")
+        #expect(appSource.contains("SettingsWindowScene()"))
+        #expect(sceneSource.contains("struct SettingsWindowScene: Scene"))
+        #expect(sceneSource.contains("Window(String(localized: \"Settings\"), id: \"settings\")"))
         #expect(
-            appSource.contains("Settings {\n            AppUIDisplayMetricsProvider"),
-            "Settings scene must inherit Appearance display metrics"
+            sceneSource.contains("AppUIDisplayMetricsProvider {\n                SettingsView()"),
+            "Settings window must inherit Appearance display metrics"
         )
 
         let files = [
@@ -229,7 +233,7 @@ struct ToolWindowReadabilityTests {
         let source = try readProjectFile("Rockxy/Views/Settings/AssistantSettingsTab.swift")
         let components = try readProjectFile("Rockxy/Views/Settings/SettingsSectionComponents.swift")
 
-        #expect(source.components(separatedBy: "SettingsSectionCard(").count - 1 == 4)
+        #expect(source.components(separatedBy: "SettingsSection(").count - 1 == 4)
         #expect(source.contains("SettingsFieldRow"))
         #expect(source.contains("SettingsIndentedContent"))
         #expect(source.contains("1. Local Model Setup"))
@@ -242,11 +246,13 @@ struct ToolWindowReadabilityTests {
         #expect(!source.contains("Button(String(localized: \"Fetch Models\"))"))
         #expect(!source.contains("LazyVGrid("))
         #expect(components.contains("SettingsDisplayMetrics"))
-        // SettingsSectionCard is a restrained native GroupBox, and field rows/indents
-        // adapt with the Appearance font size instead of a fixed inset card.
-        #expect(components.contains("GroupBox"))
+        // Settings sections share Developer Setup's flat hierarchy and rows
+        // reflow instead of preserving an artificial fixed label gutter.
+        #expect(!components.contains("GroupBox"))
+        #expect(components.contains("ViewThatFits(in: .horizontal)"))
         #expect(components.contains("settingsMetrics.labelWidth"))
-        #expect(components.contains("settingsMetrics.rowLeading"))
+        #expect(components.contains("settingsMetrics.fieldSpacing"))
+        #expect(!components.contains("Color.clear.frame(width: settingsMetrics.rowLeading)"))
         #expect(!components.contains("separatorColor).opacity(0.62)"))
     }
 
@@ -395,7 +401,7 @@ struct ToolWindowReadabilityTests {
         #expect(!windowSource.contains("arrow.up.left.and.arrow.down.right"))
 
         // Primary Send action keeps a clear loading state and honest disabled logic.
-        #expect(windowSource.contains(".buttonStyle(.borderedProminent)"))
+        #expect(windowSource.contains(".rockxyGlassButtonStyle(prominent: true)"))
         #expect(windowSource.contains("cancelActiveSend"))
         #expect(windowSource.contains(#".keyboardShortcut(".", modifiers: .command)"#))
         #expect(windowSource.contains("viewModel.url.isEmpty || viewModel.isUnsupportedForReplay"))
@@ -1007,7 +1013,7 @@ struct ToolWindowReadabilityTests {
 
         // Info banner + status capsule + native empty state.
         #expect(source.contains(#"Image(systemName: "pause.circle")"#))
-        #expect(source.contains(".clipShape(Capsule())"))
+        #expect(source.contains(".rockxyChipStyle("))
         #expect(source.contains("ACTIVE"))
         #expect(source.contains("BREAKPOINTS OFF"))
         #expect(source.contains("ContentUnavailableView"))
@@ -1204,7 +1210,7 @@ struct ToolWindowReadabilityTests {
         // Status capsule + semantic card surfaces.
         #expect(source.contains("SCRIPTING OFF"))
         #expect(source.contains("ACTIVE"))
-        #expect(source.contains(".clipShape(Capsule())"))
+        #expect(source.contains(".rockxyChipStyle("))
         #expect(source.contains("Color(nsColor: .textBackgroundColor)"))
         #expect(source.contains("RoundedRectangle(cornerRadius: 6)"))
         #expect(source.contains(".stroke(Color(nsColor: .separatorColor), lineWidth: 1)"))

--- a/docs/design-specs/main-window.md
+++ b/docs/design-specs/main-window.md
@@ -58,11 +58,11 @@ The primary application window — a 3-column developer debugging interface foll
 
 | Control | Icon (SF Symbol) | States | Shortcut | Priority |
 |---------|-----------------|--------|----------|----------|
+| Project Selector | `folder.fill` | Active Project menu | — | High |
 | Start/Stop | `play.fill` / `stop.fill` | Toggle | ⌘⇧R / ⌘. | High |
-| Record | `record.circle` / `record.circle.fill` | Toggle, red when active | ⌘⇧E | High |
-| Clear | `trash` | Enabled when sessions > 0 | ⌘K | Medium |
-| Inspector | `rectangle.split.1x2` | Toggle visibility | — | Medium |
-| Orientation | `rectangle.split.2x1` | Toggle H/V split | — | Low |
+| Developer Hub | `command` | Opens tool launcher | — | Medium |
+| Bottom Inspector | `rectangle.split.1x2` | Toggle visibility | — | Medium |
+| Context Dock | `sidebar.trailing` | Toggle visibility | — | Medium |
 
 ### Project Selector (Leading)
 - Appears immediately after the sidebar tracking separator.

--- a/docs/features/workspaces.mdx
+++ b/docs/features/workspaces.mdx
@@ -7,8 +7,8 @@ description: "Project-owned tabs that present one Project capture through indepe
 
 A Traffic Tab is an independent view onto its Project's traffic history. Each tab keeps its own filters and inspector layout, but every tab in that Project reads the **same underlying Project capture**. Switching tabs never changes where traffic is recorded.
 
-<Frame caption="Multiple workspace tabs in the main window">
-  <img src="/images/features/DemoMultipleTabWorkingSpace.png" alt="Workspace tabs" />
+<Frame caption="Multiple Traffic Tabs in the main window">
+  <img src="/images/features/DemoMultipleTabWorkingSpace.png" alt="Traffic Tabs" />
 </Frame>
 
 ## Why Traffic Tabs
@@ -30,8 +30,8 @@ Per-tab runtime state:
 - Sidebar selection (domain, app, or favorite)
 - Inspector tab and layout (right / bottom / hidden)
 - Selected request and selected log entry
-- Per-workspace sort descriptors
-- Per-workspace domain tree, app nodes, and grouping index
+- Per-Traffic-Tab sort descriptors
+- Per-Traffic-Tab domain tree, app nodes, and grouping index
 
 Shared by the Traffic Tabs inside one Project:
 
@@ -74,11 +74,11 @@ Keep your default **All Traffic** tab unchanged. In a second tab, set a filter r
 
 ### Replay and compare
 
-When focusing on a specific app or domain, use the sidebar context menu **Open in New Tab** to spawn a fresh workspace filtered to that source. The replayed flow then lands next to its source request rather than buried in the global list.
+When focusing on a specific app or domain, use the sidebar context menu **Open in New Tab** to create a fresh Traffic Tab filtered to that source. The replayed flow then lands next to its source request rather than buried in the global list.
 
 ## Per-tab sort
 
-Sorting is a workspace preference, not a window preference. Sort the **Errors** tab by `Duration ↓` to surface the worst offenders, leave the default tab sorted by `Time ↑`, and the two views stay independent. Sorts persist across `Clear Session` so you do not have to re-pick every time.
+Sorting is a Traffic Tab preference, not a window preference. Sort the **Errors** tab by `Duration ↓` to surface the worst offenders, leave the default tab sorted by `Time ↑`, and the two views stay independent. Sorts persist across `Clear Session` so you do not have to re-pick every time.
 
 ## Eviction and per-tab views
 
@@ -95,7 +95,7 @@ When a Project's in-memory history reaches its configured cap, its oldest entrie
 
 <CardGroup cols={2}>
   <Card title="Keyboard Shortcuts" icon="keyboard" href="/customization/keyboard-shortcuts">
-    All workspace and inspector shortcuts in one table.
+    All Traffic Tab and inspector shortcuts in one table.
   </Card>
   <Card title="Sessions and Export" icon="floppy-disk" href="/features/sessions">
     Save, load, and export the active Project's captured traffic.


### PR DESCRIPTION
## Summary

- Establish a shared native Liquid Glass rendering policy with semantic glass styles, macOS availability handling, accessibility fallbacks, and consistent theme propagation.
- Refine the main workspace toolbar, filters, sidebar, footer, inspectors, Settings, Developer Setup, rule tools, scripting, certificates, import/export, and supporting windows with adaptive native surfaces.
- Fix duplicate project title presentation, footer overflow, compressed AI Assistant settings, active toolbar contrast, and stale Light/Dark appearance during live theme transitions.
- Expand regression coverage for Liquid Glass contracts, focus navigation, footer actions, workspace structure, Settings readability, inspectors, and tool-window presentation.

## Why

The previous interface mixed default control bezels, painted material layers, and toolbar hosts that could retain stale appearance state. This produced inconsistent tones, clipped controls, duplicated project labels, and Developer Setup controls that remained dark after switching Rockxy to Light mode.

This change centralizes the presentation policy and gives each functional surface a consistent native hierarchy while preserving macOS resizing, focus, accessibility, and fallback behavior.

## Impact

- Interactive controls use native glass sampling surfaces on supported macOS versions.
- Reduce Transparency and Increase Contrast continue to receive readable fallback treatments.
- Light, Dark, and System theme changes propagate through SwiftUI content and AppKit toolbar hosts without reopening windows.
- Compact layouts preserve primary status information by collapsing secondary actions and using adaptive controls.

This PR is stacked on #278. Its project lifecycle commit is temporarily included in the comparison with `develop` and will drop out after #278 is merged.

## Related issues

Refs #10

## Validation

- `swiftlint lint --strict` — passed with 0 violations across 547 Swift files.
- Focused theme, Liquid Glass, and Developer Setup test suites — passed.
- `scripts/run-rockxy.sh` — built, launched, and verified the exact manual-run artifact.
- Foreground UI audit on macOS Dark with Rockxy Dark → Light — Developer Setup toolbar, setup menu, and inspector control updated consistently while the window remained open.
- Full macOS test suite — all suites passed except the unchanged `BreakpointManagerTests.notifiesOncePerNonEmptyLifetime()` concurrency-sensitive test; the failing test passed when rerun in isolation.