### PR TITLE
fix: harden recovery and settings presentation

### DIFF
--- a/Rockxy/Core/Storage/ProjectCatalogRepository.swift
+++ b/Rockxy/Core/Storage/ProjectCatalogRepository.swift
@@ -285,16 +285,25 @@ actor ProjectCatalogRepository: ProjectCatalogPersisting {
         guard type == .typeRegular || type == .typeSymbolicLink else {
             throw ProjectCatalogRepositoryError.notRegularFile
         }
-        if let recoveryType = fileType(at: recoveryBackupURL) {
+        let recoveryType = fileType(at: recoveryBackupURL)
+        if let recoveryType {
             guard recoveryType == .typeRegular || recoveryType == .typeSymbolicLink else {
                 throw ProjectCatalogRepositoryError.notRegularFile
             }
-            try fileManager.removeItem(at: recoveryBackupURL)
         }
         if type == .typeSymbolicLink {
-            // Explicit reset may remove the link itself, but never follows it.
+            // Explicit reset may remove the live link itself, but never follows it.
+            // Keep a prior regular recovery file because this path cannot create
+            // a replacement from the unsafe live node. A recovery symlink is not
+            // usable evidence and can be removed without following its target.
+            if recoveryType == .typeSymbolicLink {
+                try fileManager.removeItem(at: recoveryBackupURL)
+            }
             try fileManager.removeItem(at: fileURL)
             return
+        }
+        if recoveryType != nil {
+            try fileManager.removeItem(at: recoveryBackupURL)
         }
         let attributes = try fileManager.attributesOfItem(atPath: fileURL.path)
         if let size = attributes[.size] as? Int, size > Self.maxCatalogByteSize {

--- a/Rockxy/Views/Settings/GitHubSettingsTab.swift
+++ b/Rockxy/Views/Settings/GitHubSettingsTab.swift
@@ -204,7 +204,11 @@ struct GitHubSettingsTab: View {
     }
 
     @ViewBuilder private var accountActions: some View {
-        Button(String(localized: viewModel.isConnected ? "Reconnect..." : "Authorize...")) {
+        Button(
+            viewModel.isConnected
+                ? String(localized: "Reconnect...")
+                : String(localized: "Authorize...")
+        ) {
             if viewModel.canUseOAuth {
                 showDeviceCodeSheet = true
             } else {

--- a/Rockxy/Views/Settings/SettingsSectionComponents.swift
+++ b/Rockxy/Views/Settings/SettingsSectionComponents.swift
@@ -154,5 +154,14 @@ struct SettingsIndentedContent<Content: View>: View {
     var body: some View {
         content
             .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.leading, settingsMetrics.rowLeading)
+    }
+
+    // MARK: Private
+
+    @Environment(\.appUIDisplayMetrics) private var appMetrics
+
+    private var settingsMetrics: SettingsDisplayMetrics {
+        SettingsDisplayMetrics(appMetrics: appMetrics)
     }
 }

--- a/RockxyTests/Core/Storage/ProjectCatalogRepositoryTests.swift
+++ b/RockxyTests/Core/Storage/ProjectCatalogRepositoryTests.swift
@@ -286,6 +286,27 @@ struct ProjectCatalogRepositoryTests {
         try reloaded.validate()
     }
 
+    @Test("reset preserves an existing recovery backup when discarding a live symlink")
+    func resetKeepsRecoveryBackupWhenLiveCatalogIsSymlink() async throws {
+        let repo = makeRepo()
+        try FileManager.default.createDirectory(at: repo.directoryURL, withIntermediateDirectories: true)
+        let backupURL = repo.directoryURL.appendingPathComponent(ProjectCatalogRepository.recoveryBackupFileName)
+        let recoveryData = Data("previous recovery".utf8)
+        try recoveryData.write(to: backupURL)
+
+        let secret = repo.directoryURL.appendingPathComponent("secret.json")
+        let secretData = Data("secret".utf8)
+        try secretData.write(to: secret)
+        try FileManager.default.createSymbolicLink(at: repo.fileURL, withDestinationURL: secret)
+
+        let fresh = try await repo.reset()
+        let reloaded = try await repo.load()
+
+        #expect(try Data(contentsOf: backupURL) == recoveryData)
+        #expect(try Data(contentsOf: secret) == secretData)
+        #expect(reloaded == fresh)
+    }
+
     @Test("reset refuses to recursively remove a non-regular catalog node")
     func resetPreservesNonRegularCatalogNode() async throws {
         let repo = makeRepo()

--- a/RockxyTests/Views/SettingsWindowReadabilityTests.swift
+++ b/RockxyTests/Views/SettingsWindowReadabilityTests.swift
@@ -137,6 +137,12 @@ struct SettingsWindowReadabilityTests {
         #expect(componentSource.contains("settingsMetrics.fieldSpacing"))
         #expect(!componentSource.contains("GroupBox"))
         #expect(!componentSource.contains("Color.clear.frame(width: settingsMetrics.rowLeading)"))
+        #expect(componentSource.contains(".padding(.leading, settingsMetrics.rowLeading)"))
+
+        let githubSource = try readProjectFile("Rockxy/Views/Settings/GitHubSettingsTab.swift")
+        #expect(githubSource.contains("? String(localized: \"Reconnect...\")"))
+        #expect(githubSource.contains(": String(localized: \"Authorize...\")"))
+        #expect(!githubSource.contains("String(localized: viewModel.isConnected ?"))
 
         let standardPanePaths = [
             "Rockxy/Views/Settings/GeneralSettingsTab.swift",

--- a/docs/design-specs/main-window.md
+++ b/docs/design-specs/main-window.md
@@ -51,7 +51,7 @@ The primary application window — a 3-column developer debugging interface foll
 
 ### Layout
 ```
-[Sidebar] │ [📁 Active Project ▾]     {● Listening on 127.0.0.1:9090}     [▶ Start/Stop] [Inspector] [Context Dock]
+[Sidebar] │ [📁 Active Project ▾]     {● Listening on 127.0.0.1:9090}     [▶ Start/Stop] [Developer Hub] [Bottom Inspector] [Context Dock]
 ```
 
 ### Controls
@@ -75,7 +75,7 @@ The primary application window — a 3-column developer debugging interface foll
 - Font: `.systemFont(ofSize: 12)`, `NSColor.secondaryLabelColor`
 
 ### Styling
-- Button style: `.borderless`
+- Button style: native bordered `NSToolbarItem` controls in the unified toolbar, with the shared glass-control treatment used by SwiftUI toolbar fallbacks
 - Icon size: 16pt SF Symbols
 - Button spacing: 4pt
 - Separator: SwiftUI `Divider()` between action groups


### PR DESCRIPTION
## Summary

- preserve an existing regular recovery backup when resetting a symlinked project catalog
- restore metrics-driven settings content alignment and use extractable static localization keys
- align the main-window design specification with the native unified toolbar
- add regression coverage for catalog recovery and settings source contracts

## Why

Promotion review identified a recovery edge case that could discard the last usable backup, plus presentation and localization contracts that had drifted from the implementation.

## Impact

Project catalog reset remains symlink-safe without sacrificing an existing recovery file. Settings rows retain native column alignment, account actions remain localizable, and the design specification matches the shipped toolbar structure.

## Related issues

Refs #10
Follow-up to #281

## Validation

- swiftlint lint --strict
- xcodebuild -project Rockxy.xcodeproj -scheme Rockxy -destination platform=macOS -only-testing:RockxyTests/ProjectCatalogRepositoryTests -only-testing:RockxyTests/SettingsWindowReadabilityTests test
- git diff --check