### PR TITLE
fix: preserve recovery before size validation

### DIFF
--- a/Rockxy/Core/Storage/ProjectCatalogRepository.swift
+++ b/Rockxy/Core/Storage/ProjectCatalogRepository.swift
@@ -302,12 +302,12 @@ actor ProjectCatalogRepository: ProjectCatalogPersisting {
             try fileManager.removeItem(at: fileURL)
             return
         }
-        if recoveryType != nil {
-            try fileManager.removeItem(at: recoveryBackupURL)
-        }
         let attributes = try fileManager.attributesOfItem(atPath: fileURL.path)
         if let size = attributes[.size] as? Int, size > Self.maxCatalogByteSize {
             throw ProjectCatalogRepositoryError.fileTooLarge(bytes: size)
+        }
+        if recoveryType != nil {
+            try fileManager.removeItem(at: recoveryBackupURL)
         }
         try fileManager.moveItem(at: fileURL, to: recoveryBackupURL)
         try fileManager.setAttributes([.posixPermissions: 0o600], ofItemAtPath: recoveryBackupURL.path)

--- a/RockxyTests/Core/Storage/ProjectCatalogRepositoryTests.swift
+++ b/RockxyTests/Core/Storage/ProjectCatalogRepositoryTests.swift
@@ -338,6 +338,24 @@ struct ProjectCatalogRepositoryTests {
         #expect(FileManager.default.fileExists(atPath: repo.fileURL.path))
     }
 
+    @Test("reset preserves an existing recovery backup when the live catalog is oversized")
+    func resetKeepsRecoveryBackupWhenLiveCatalogIsOversized() async throws {
+        let repo = makeRepo()
+        try FileManager.default.createDirectory(at: repo.directoryURL, withIntermediateDirectories: true)
+        let backupURL = repo.directoryURL.appendingPathComponent(ProjectCatalogRepository.recoveryBackupFileName)
+        let recoveryData = Data("previous recovery".utf8)
+        try recoveryData.write(to: backupURL)
+        let oversized = Data(repeating: 0x20, count: ProjectCatalogRepository.maxCatalogByteSize + 1)
+        try oversized.write(to: repo.fileURL)
+
+        await #expect(throws: ProjectCatalogRepositoryError.fileTooLarge(bytes: oversized.count)) {
+            try await repo.reset()
+        }
+
+        #expect(try Data(contentsOf: backupURL) == recoveryData)
+        #expect(try Data(contentsOf: repo.fileURL) == oversized)
+    }
+
     @Test("reset refuses to recursively remove a non-regular recovery node")
     func resetPreservesNonRegularRecoveryNode() async throws {
         let repo = makeRepo()


### PR DESCRIPTION
## Summary

- validate the live catalog size before replacing an existing recovery backup
- preserve both the prior recovery file and oversized live catalog when reset is rejected
- add regression coverage for the oversized-catalog recovery path

## Why

Promotion review identified an ordering issue where reset could remove the last usable recovery backup before rejecting an oversized live catalog.

## Impact

Failed reset attempts remain non-destructive: the existing recovery copy stays available, and the oversized live file remains untouched for diagnosis or manual recovery.

## Related issues

Follow-up to #281

## Validation

- swiftlint lint --strict
- xcodebuild -project Rockxy.xcodeproj -scheme Rockxy -destination platform=macOS -only-testing:RockxyTests/ProjectCatalogRepositoryTests test
- git diff --check