### PR TITLE
fix(diff): prevent side-by-side layout overflow

### DIFF
--- a/Rockxy/Views/Diff/DiffViewerView.swift
+++ b/Rockxy/Views/Diff/DiffViewerView.swift
@@ -85,6 +85,7 @@ struct DiffViewerView: View {
         .padding(.horizontal, 8)
         .padding(.vertical, 5)
         .background(.quaternary.opacity(0.3))
+        .fixedSize(horizontal: false, vertical: true)
     }
 
     // MARK: - Text Paste Mode
@@ -178,7 +179,9 @@ struct DiffViewerView: View {
 
     private func sideBySideView(_ result: DiffResult) -> some View {
         GeometryReader { geometry in
-            ScrollView([.horizontal, .vertical]) {
+            let paneWidth = max(320, (geometry.size.width - 1) / 2)
+
+            ScrollView(.vertical) {
                 LazyVStack(alignment: .leading, spacing: 0) {
                     ForEach(result.sections) { section in
                         sectionHeader(section.title)
@@ -186,15 +189,17 @@ struct DiffViewerView: View {
                         ForEach(rows) { row in
                             HStack(spacing: 0) {
                                 sideBySideCell(row.left)
-                                    .frame(minWidth: max(320, (geometry.size.width - 1) / 2))
+                                    .frame(width: paneWidth, alignment: .leading)
+                                    .clipped()
                                 Divider()
                                 sideBySideCell(row.right)
-                                    .frame(minWidth: max(320, (geometry.size.width - 1) / 2))
+                                    .frame(width: paneWidth, alignment: .leading)
+                                    .clipped()
                             }
                         }
                     }
                 }
-                .frame(minWidth: geometry.size.width, alignment: .leading)
+                .frame(width: max(641, geometry.size.width), alignment: .leading)
             }
         }
     }
@@ -202,7 +207,7 @@ struct DiffViewerView: View {
     @ViewBuilder
     private func sideBySideCell(_ line: DiffLine?) -> some View {
         if let line {
-            diffLineRow(line)
+            diffLineRow(line, allowsHorizontalOverflow: false)
                 .frame(maxWidth: .infinity, alignment: .leading)
         } else {
             Color.clear
@@ -220,7 +225,7 @@ struct DiffViewerView: View {
                     ForEach(result.sections) { section in
                         sectionHeader(section.title)
                         ForEach(section.lines) { line in
-                            diffLineRow(line)
+                            diffLineRow(line, allowsHorizontalOverflow: true)
                         }
                     }
                 }
@@ -241,7 +246,7 @@ struct DiffViewerView: View {
             .background(.quaternary.opacity(0.2))
     }
 
-    private func diffLineRow(_ line: DiffLine) -> some View {
+    private func diffLineRow(_ line: DiffLine, allowsHorizontalOverflow: Bool) -> some View {
         HStack(spacing: 0) {
             Text("\(line.lineNumber)")
                 .font(toolMetrics.metadataFont(monospaced: true))
@@ -258,7 +263,8 @@ struct DiffViewerView: View {
                 .font(toolMetrics.secondaryFont(monospaced: true))
                 .foregroundStyle(contentColor(for: line.type))
                 .lineLimit(1)
-                .fixedSize(horizontal: true, vertical: false)
+                .truncationMode(.tail)
+                .fixedSize(horizontal: allowsHorizontalOverflow, vertical: false)
                 .frame(maxWidth: .infinity, alignment: .leading)
         }
         .padding(.vertical, 1)

--- a/RockxyTests/Views/ToolWindowReadabilityTests.swift
+++ b/RockxyTests/Views/ToolWindowReadabilityTests.swift
@@ -358,6 +358,10 @@ struct ToolWindowReadabilityTests {
 
         #expect(viewerSource.contains("GeometryReader"))
         #expect(viewerSource.contains("ScrollView([.horizontal, .vertical])"))
+        #expect(viewerSource.contains("ScrollView(.vertical)"))
+        #expect(viewerSource.contains(".fixedSize(horizontal: false, vertical: true)"))
+        #expect(viewerSource.contains(".frame(width: paneWidth, alignment: .leading)"))
+        #expect(viewerSource.contains(".fixedSize(horizontal: allowsHorizontalOverflow, vertical: false)"))
         #expect(viewerSource.contains("case .textReady"))
         #expect(viewerSource.contains("comparisonContent(showsIdentity: false)"))
         #expect(viewerSource.contains("Left text"))


### PR DESCRIPTION
## Summary

- Keep the captured transaction identity row sized to its content.
- Constrain side-by-side diff cells to equal pane widths so long lines cannot cross the center divider.
- Preserve horizontal overflow behavior in Unified mode while truncating wide Side by Side content.
- Add focused layout regression guards for the Diff workspace.

## Why

The Left and Right identity row could absorb excess vertical space, leaving a large empty area above and below its content. Long request or body lines also retained their intrinsic width and rendered over the opposing pane, making realistic comparisons difficult to read.

## Impact

This keeps the Diff workspace dense and readable for captured and freeform comparisons without changing diff computation, candidate assignment, state, or export behavior.

## Related issues

Refs #19

## Validation

- `swiftlint lint --strict --quiet`
- `xcodebuild -quiet -project Rockxy.xcodeproj -scheme Rockxy -destination platform=macOS -only-testing:RockxyTests/ToolWindowReadabilityTests -only-testing:RockxyTests/DiffEngineTests -only-testing:RockxyTests/DiffFormatterTests -only-testing:RockxyTests/DiffViewModelTests test`
- Manually verified the Debug build with long GraphQL comparison lines; each side remains clipped to its pane with a clear center divider.