### PR TITLE
feat: add native workspace toolbar customization

### DIFF
--- a/Rockxy/Views/Common/NativeWorkspaceWindowChrome.swift
+++ b/Rockxy/Views/Common/NativeWorkspaceWindowChrome.swift
@@ -64,30 +64,28 @@ final class NativeWorkspaceToolbar: NSObject, NSToolbarDelegate {
 
     init(
         splitViewController: NativeWorkspaceSplitViewController,
-        configuration: NativeWorkspaceToolbarConfiguration
+        configuration: NativeWorkspaceToolbarConfiguration,
+        toolbarIdentifier: NSToolbar.Identifier? = nil,
+        autosavesConfiguration: Bool = true
     ) {
         self.splitViewController = splitViewController
         coordinator = configuration.coordinator
         onOpenDeveloperHub = configuration.onOpenDeveloperHub
         onToggleProxy = configuration.onToggleProxy
-        managedToolbar = NSToolbar(identifier: Self.toolbarIdentifier)
+        managedToolbar = NSToolbar(identifier: toolbarIdentifier ?? Self.toolbarIdentifier)
         super.init()
 
         managedToolbar.delegate = self
         managedToolbar.displayMode = .iconOnly
-        managedToolbar.allowsUserCustomization = false
-        managedToolbar.autosavesConfiguration = false
+        managedToolbar.allowsUserCustomization = true
+        managedToolbar.autosavesConfiguration = autosavesConfiguration
         managedToolbar.centeredItemIdentifiers = [Self.proxyStatusIdentifier]
-    }
-
-    deinit {
-        observationTask?.cancel()
     }
 
     // MARK: Internal
 
     static let toolbarIdentifier = NSToolbar.Identifier(
-        "\(RockxyIdentity.current.logSubsystem).main.toolbar"
+        "\(RockxyIdentity.current.logSubsystem).main.toolbar.customizable.v1"
     )
     static let sidebarToggleIdentifier = NSToolbarItem.Identifier(
         "\(RockxyIdentity.current.logSubsystem).toolbar.toggleSidebar"
@@ -101,81 +99,148 @@ final class NativeWorkspaceToolbar: NSObject, NSToolbarDelegate {
     static let projectSelectorIdentifier = NSToolbarItem.Identifier(
         "\(RockxyIdentity.current.logSubsystem).toolbar.projectSelector"
     )
-    static let actionGroupIdentifier = NSToolbarItem.Identifier(
-        "\(RockxyIdentity.current.logSubsystem).toolbar.actions"
+    static let proxyToggleIdentifier = NSToolbarItem.Identifier(
+        "\(RockxyIdentity.current.logSubsystem).toolbar.toggleProxy"
     )
+    static let developerHubIdentifier = NSToolbarItem.Identifier(
+        "\(RockxyIdentity.current.logSubsystem).toolbar.developerHub"
+    )
+    static let bottomInspectorIdentifier = NSToolbarItem.Identifier(
+        "\(RockxyIdentity.current.logSubsystem).toolbar.bottomInspector"
+    )
+    static let contextDockIdentifier = NSToolbarItem.Identifier(
+        "\(RockxyIdentity.current.logSubsystem).toolbar.contextDock"
+    )
+
+    static let defaultItemIdentifiers: [NSToolbarItem.Identifier] = [
+        .flexibleSpace,
+        sidebarToggleIdentifier,
+        sidebarTrackingSeparatorIdentifier,
+        projectSelectorIdentifier,
+        .flexibleSpace,
+        proxyStatusIdentifier,
+        .flexibleSpace,
+        proxyToggleIdentifier,
+        developerHubIdentifier,
+        bottomInspectorIdentifier,
+        contextDockIdentifier,
+    ]
+
+    static let allowedItemIdentifiers: [NSToolbarItem.Identifier] = [
+        sidebarToggleIdentifier,
+        sidebarTrackingSeparatorIdentifier,
+        projectSelectorIdentifier,
+        proxyStatusIdentifier,
+        proxyToggleIdentifier,
+        developerHubIdentifier,
+        bottomInspectorIdentifier,
+        contextDockIdentifier,
+        .space,
+        .flexibleSpace,
+    ]
+
+    static let userCustomizableItemIdentifiers: [NSToolbarItem.Identifier] = [
+        sidebarToggleIdentifier,
+        projectSelectorIdentifier,
+        proxyStatusIdentifier,
+        proxyToggleIdentifier,
+        developerHubIdentifier,
+        bottomInspectorIdentifier,
+        contextDockIdentifier,
+    ]
 
     let managedToolbar: NSToolbar
 
-    func startObservingState() {
-        syncActionItems()
-        observationTask?.cancel()
-        observationTask = Task { [weak self, weak coordinator] in
-            guard let coordinator else {
+    /// Opens AppKit's standard toolbar customization palette for the frontmost
+    /// Rockxy workspace window after transient menu windows have closed.
+    static func presentCustomizationPalette(preferredWindow: NSWindow? = nil) {
+        DispatchQueue.main.async {
+            let candidateWindows = [NSApp.keyWindow, NSApp.mainWindow].compactMap { $0 }
+                + NSApp.orderedWindows
+            guard let toolbar = customizationToolbar(
+                preferredWindow: preferredWindow,
+                fallbackWindows: candidateWindows
+            ),
+                !toolbar.customizationPaletteIsRunning else
+            {
                 return
             }
-            while !Task.isCancelled {
-                await withCheckedContinuation { continuation in
-                    withObservationTracking {
-                        _ = coordinator.isProxyRunning
-                        _ = coordinator.hasPayloadInspectorSelection
-                    } onChange: {
-                        continuation.resume()
-                    }
-                }
-                guard !Task.isCancelled else {
-                    return
-                }
-
-                // Observation can resume while SwiftUI is still reconciling one of the
-                // toolbar's hosted views. Mutating NSToolbarItem geometry in that turn can
-                // make AppKit re-enter NSHostingView layout and leave a newly opened tool
-                // window with a skipped (blank) content pass. Give the current render turn
-                // back to SwiftUI before updating AppKit-owned toolbar items.
-                await Task.yield()
-                guard !Task.isCancelled else {
-                    return
-                }
-                self?.syncActionItems()
-            }
+            toolbar.runCustomizationPalette(nil)
         }
+    }
+
+    static func customizationToolbar(
+        preferredWindow: NSWindow?,
+        fallbackWindows: [NSWindow]
+    )
+        -> NSToolbar?
+    {
+        let windows = [preferredWindow].compactMap { $0 } + fallbackWindows
+        return windows.lazy
+            .compactMap(\.toolbar)
+            .first {
+                $0.identifier == toolbarIdentifier && $0.allowsUserCustomization
+            }
+    }
+
+    func startObservingState() {
+        syncActionItems()
+        guard !isObservingState else {
+            return
+        }
+        isObservingState = true
+        armObservation()
     }
 
     func toolbarDefaultItemIdentifiers(
         _ toolbar: NSToolbar
-    ) -> [NSToolbarItem.Identifier] {
-        [
-            .flexibleSpace,
-            Self.sidebarToggleIdentifier,
-            Self.sidebarTrackingSeparatorIdentifier,
-            Self.projectSelectorIdentifier,
-            .flexibleSpace,
-            Self.proxyStatusIdentifier,
-            .flexibleSpace,
-            Self.actionGroupIdentifier,
-        ]
+    )
+        -> [NSToolbarItem.Identifier]
+    {
+        Self.defaultItemIdentifiers
     }
 
     func toolbarAllowedItemIdentifiers(
         _ toolbar: NSToolbar
-    ) -> [NSToolbarItem.Identifier] {
-        toolbarDefaultItemIdentifiers(toolbar)
+    )
+        -> [NSToolbarItem.Identifier]
+    {
+        Self.allowedItemIdentifiers
+    }
+
+    func toolbarImmovableItemIdentifiers(
+        _ toolbar: NSToolbar
+    )
+        -> Set<NSToolbarItem.Identifier>
+    {
+        [Self.sidebarTrackingSeparatorIdentifier]
     }
 
     func toolbar(
         _ toolbar: NSToolbar,
         itemForItemIdentifier itemIdentifier: NSToolbarItem.Identifier,
         willBeInsertedIntoToolbar flag: Bool
-    ) -> NSToolbarItem? {
+    )
+        -> NSToolbarItem?
+    {
         switch itemIdentifier {
         case Self.sidebarToggleIdentifier:
             return makeSidebarToggleItem()
         case Self.sidebarTrackingSeparatorIdentifier:
-            return NSTrackingSeparatorToolbarItem(
+            guard let splitView = splitViewController?.splitView else {
+                return nil
+            }
+            let item = NSTrackingSeparatorToolbarItem(
                 identifier: Self.sidebarTrackingSeparatorIdentifier,
-                splitView: splitViewController.splitView,
+                splitView: splitView,
                 dividerIndex: 0
             )
+            item.label = String(localized: "Source List Divider")
+            // The tracking separator has only a narrow preview cell in AppKit's draggable
+            // default-set row. Keep its descriptive toolbar label, but use a compact palette
+            // label so it does not collide with Flexible Space and Project labels.
+            item.paletteLabel = String(localized: "Divider")
+            return item
         case Self.projectSelectorIdentifier:
             let item = hostingItem(
                 identifier: itemIdentifier,
@@ -186,14 +251,23 @@ final class NativeWorkspaceToolbar: NSObject, NSToolbarDelegate {
             item.visibilityPriority = .high
             return item
         case Self.proxyStatusIdentifier:
-            return hostingItem(
+            let item = hostingItem(
                 identifier: itemIdentifier,
                 rootView: AnyView(
                     ProxyToolbarStatusView(coordinator: coordinator)
                 )
             )
-        case Self.actionGroupIdentifier:
-            return makeActionGroup()
+            item.label = String(localized: "Proxy Status")
+            item.paletteLabel = item.label
+            return item
+        case Self.proxyToggleIdentifier:
+            return makeProxyToggleItem()
+        case Self.developerHubIdentifier:
+            return makeDeveloperHubItem()
+        case Self.bottomInspectorIdentifier:
+            return makeBottomInspectorItem()
+        case Self.contextDockIdentifier:
+            return makeContextDockItem()
         default:
             return nil
         }
@@ -201,93 +275,137 @@ final class NativeWorkspaceToolbar: NSObject, NSToolbarDelegate {
 
     // MARK: Private
 
-    private let splitViewController: NativeWorkspaceSplitViewController
+    private weak var splitViewController: NativeWorkspaceSplitViewController?
     private let coordinator: MainContentCoordinator
     private let onOpenDeveloperHub: () -> Void
     private let onToggleProxy: () -> Void
-    private var hostingControllers: [
-        NSToolbarItem.Identifier: NSHostingController<AnyView>
-    ] = [:]
-    private var observationTask: Task<Void, Never>?
-    private weak var proxyToggleItem: NSToolbarItem?
-    private weak var bottomInspectorItem: NSToolbarItem?
+    private var isObservingState = false
+
+    private var proxyToolTip: String {
+        coordinator.isProxyRunning
+            ? String(localized: "Stop proxy")
+            : String(localized: "Start proxy")
+    }
+
+    private var bottomInspectorToolTip: String {
+        guard coordinator.canToggleBottomInspector else {
+            return String(localized: "Select a request to use the bottom inspector")
+        }
+        return coordinator.isBottomInspectorEffectivelyPresented
+            ? String(localized: "Hide Bottom Inspector")
+            : String(localized: "Show Bottom Inspector")
+    }
+
+    private var contextDockToolTip: String {
+        coordinator.isContextDockVisible
+            ? String(localized: "Hide Context Dock")
+            : String(localized: "Show Context Dock")
+    }
+
+    /// Arms a single-shot observation of the coordinator's toolbar-relevant state and re-arms
+    /// after each change. `withObservationTracking` fires `onChange` exactly once, so the handler
+    /// re-registers itself. Both the handler and its follow-up task capture `self` weakly, so a
+    /// deallocated toolbar simply stops re-arming — nothing keeps the coordinator alive.
+    private func armObservation() {
+        withObservationTracking {
+            _ = coordinator.isProxyRunning
+            _ = coordinator.hasPayloadInspectorSelection
+            _ = coordinator.isBottomInspectorEffectivelyPresented
+            _ = coordinator.isContextDockVisible
+        } onChange: { [weak self] in
+            // `onChange` runs inside the mutating turn. Hop to a fresh main-actor turn and yield
+            // before touching AppKit-owned toolbar items: mutating NSToolbarItem geometry while
+            // SwiftUI is still reconciling a hosted view can re-enter NSHostingView layout and
+            // leave a newly opened tool window with a skipped (blank) content pass.
+            Task { @MainActor [weak self] in
+                await Task.yield()
+                guard let self else {
+                    return
+                }
+                self.syncActionItems()
+                self.armObservation()
+            }
+        }
+    }
 
     private func makeSidebarToggleItem() -> NSToolbarItem {
         let item = imageItem(
             identifier: Self.sidebarToggleIdentifier,
-            label: String(localized: "Toggle Source List"),
+            label: String(localized: "Source List"),
             systemImage: "sidebar.leading",
             action: #selector(toggleSidebar(_:))
         )
         item.isBordered = true
+        item.isNavigational = true
+        item.toolTip = String(localized: "Show or hide the Source List")
         return item
     }
 
-    private func makeActionGroup() -> NSToolbarItemGroup {
-        let proxyItem = imageItem(
-            identifier: NSToolbarItem.Identifier(
-                "\(Self.actionGroupIdentifier.rawValue).proxy"
-            ),
+    private func makeProxyToggleItem() -> NSToolbarItem {
+        let item = imageItem(
+            identifier: Self.proxyToggleIdentifier,
             label: coordinator.isProxyRunning
                 ? String(localized: "Stop")
                 : String(localized: "Start"),
+            paletteLabel: String(localized: "Start or Stop Proxy"),
             systemImage: coordinator.isProxyRunning ? "stop.fill" : "play.fill",
             action: #selector(toggleProxy(_:))
         )
-        proxyToggleItem = proxyItem
+        item.possibleLabels = [String(localized: "Start"), String(localized: "Stop")]
+        item.visibilityPriority = .high
+        item.toolTip = proxyToolTip
+        return item
+    }
 
-        let developerHubItem = imageItem(
-            identifier: NSToolbarItem.Identifier(
-                "\(Self.actionGroupIdentifier.rawValue).developerHub"
-            ),
-            label: String(localized: "Dev Hub"),
+    private func makeDeveloperHubItem() -> NSToolbarItem {
+        imageItem(
+            identifier: Self.developerHubIdentifier,
+            label: String(localized: "Developer Hub"),
             systemImage: "command",
             action: #selector(openDeveloperHub(_:))
         )
-        let bottomInspectorItem = imageItem(
-            identifier: NSToolbarItem.Identifier(
-                "\(Self.actionGroupIdentifier.rawValue).bottomInspector"
-            ),
+    }
+
+    private func makeBottomInspectorItem() -> NSToolbarItem {
+        let item = imageItem(
+            identifier: Self.bottomInspectorIdentifier,
             label: String(localized: "Bottom Inspector"),
             systemImage: "rectangle.split.1x2",
             action: #selector(toggleBottomInspector(_:))
         )
-        bottomInspectorItem.isEnabled = coordinator.canToggleBottomInspector
-        bottomInspectorItem.toolTip = bottomInspectorToolTip
-        self.bottomInspectorItem = bottomInspectorItem
-        let contextDockItem = imageItem(
-            identifier: NSToolbarItem.Identifier(
-                "\(Self.actionGroupIdentifier.rawValue).contextDock"
-            ),
+        item.isEnabled = coordinator.canToggleBottomInspector
+        item.toolTip = bottomInspectorToolTip
+        return item
+    }
+
+    private func makeContextDockItem() -> NSToolbarItem {
+        let item = imageItem(
+            identifier: Self.contextDockIdentifier,
             label: String(localized: "Context Dock"),
             systemImage: "sidebar.trailing",
             action: #selector(toggleContextDock(_:))
         )
-
-        let group = NSToolbarItemGroup(itemIdentifier: Self.actionGroupIdentifier)
-        group.label = String(localized: "Workspace Actions")
-        group.paletteLabel = group.label
-        group.subitems = [
-            proxyItem,
-            developerHubItem,
-            bottomInspectorItem,
-            contextDockItem,
-        ]
-        return group
+        item.toolTip = contextDockToolTip
+        return item
     }
 
     private func imageItem(
         identifier: NSToolbarItem.Identifier,
         label: String,
+        paletteLabel: String? = nil,
         systemImage: String,
         action: Selector
-    ) -> NSToolbarItem {
+    )
+        -> NSToolbarItem
+    {
         let item = NSToolbarItem(itemIdentifier: identifier)
         item.label = label
-        item.paletteLabel = label
+        item.paletteLabel = paletteLabel ?? label
         item.toolTip = label
         item.target = self
         item.action = action
+        item.autovalidates = false
+        item.isBordered = true
         item.image = NSImage(
             systemSymbolName: systemImage,
             accessibilityDescription: label
@@ -298,41 +416,51 @@ final class NativeWorkspaceToolbar: NSObject, NSToolbarDelegate {
     private func hostingItem(
         identifier: NSToolbarItem.Identifier,
         rootView: AnyView
-    ) -> NSToolbarItem {
+    )
+        -> NSToolbarItem
+    {
         let controller = NSHostingController(rootView: rootView)
         controller.sizingOptions = [.intrinsicContentSize]
-        hostingControllers[identifier] = controller
 
         let item = NSToolbarItem(itemIdentifier: identifier)
         item.view = controller.view
         item.visibilityPriority = .high
+        objc_setAssociatedObject(
+            item,
+            &NativeWorkspaceToolbarHostingAssociation.key,
+            controller,
+            .OBJC_ASSOCIATION_RETAIN_NONATOMIC
+        )
         return item
     }
 
     private func syncActionItems() {
         let isRunning = coordinator.isProxyRunning
         let label = isRunning ? String(localized: "Stop") : String(localized: "Start")
+        let proxyToggleItem = toolbarItem(identifier: Self.proxyToggleIdentifier)
         proxyToggleItem?.label = label
-        proxyToggleItem?.paletteLabel = label
-        proxyToggleItem?.toolTip = isRunning
-            ? String(localized: "Stop proxy")
-            : String(localized: "Start proxy")
+        proxyToggleItem?.toolTip = proxyToolTip
         proxyToggleItem?.image = NSImage(
             systemSymbolName: isRunning ? "stop.fill" : "play.fill",
             accessibilityDescription: label
         )
+
+        let bottomInspectorItem = toolbarItem(identifier: Self.bottomInspectorIdentifier)
         bottomInspectorItem?.isEnabled = coordinator.canToggleBottomInspector
         bottomInspectorItem?.toolTip = bottomInspectorToolTip
+
+        toolbarItem(identifier: Self.contextDockIdentifier)?.toolTip = contextDockToolTip
     }
 
-    private var bottomInspectorToolTip: String {
-        coordinator.canToggleBottomInspector
-            ? String(localized: "Show or hide the bottom inspector panel")
-            : String(localized: "Select a request to use the bottom inspector")
+    private func toolbarItem(identifier: NSToolbarItem.Identifier) -> NSToolbarItem? {
+        managedToolbar.items.first { $0.itemIdentifier == identifier }
     }
 
     @objc
     private func toggleSidebar(_ sender: Any?) {
+        guard let splitViewController else {
+            return
+        }
         splitViewController.setSidebarPresented(
             !splitViewController.isSidebarPresented,
             animated: true
@@ -381,7 +509,8 @@ extension NativeWorkspaceSplitViewController {
         configuration: NativeWorkspaceToolbarConfiguration
     ) {
         if let nativeToolbar,
-           window.toolbar === nativeToolbar.managedToolbar {
+           window.toolbar === nativeToolbar.managedToolbar
+        {
             return
         }
 
@@ -389,6 +518,13 @@ extension NativeWorkspaceSplitViewController {
             splitViewController: self,
             configuration: configuration
         )
+        attachNativeToolbar(toolbar, to: window)
+    }
+
+    /// Installs a pre-built toolbar as this controller's owned toolbar. The controller strongly
+    /// retains the toolbar through its associated object while the toolbar holds only a weak
+    /// reference back, so releasing the controller deallocates both.
+    func attachNativeToolbar(_ toolbar: NativeWorkspaceToolbar, to window: NSWindow) {
         nativeToolbar = toolbar
         window.toolbar = toolbar.managedToolbar
         toolbar.startObservingState()
@@ -415,5 +551,11 @@ extension NativeWorkspaceSplitViewController {
 // MARK: - NativeWorkspaceToolbarAssociation
 
 private enum NativeWorkspaceToolbarAssociation {
+    static var key: UInt8 = 0
+}
+
+// MARK: - NativeWorkspaceToolbarHostingAssociation
+
+private enum NativeWorkspaceToolbarHostingAssociation {
     static var key: UInt8 = 0
 }

--- a/Rockxy/Views/Toolbar/ProtocolFilterBar.swift
+++ b/Rockxy/Views/Toolbar/ProtocolFilterBar.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 
 // Renders the protocol filter bar interface for toolbar controls and filtering.
@@ -42,11 +43,16 @@ struct ProtocolFilterBar: View {
             }
         }
         .fixedSize(horizontal: false, vertical: true)
+        .background {
+            ToolbarCustomizationWindowReader(reference: customizationWindowReference)
+                .frame(width: 0, height: 0)
+        }
     }
 
     // MARK: Private
 
     @Environment(\.appUIDisplayMetrics) private var metrics
+    @State private var customizationWindowReference = ToolbarCustomizationWindowReference()
 
     private var hasActiveFilters: Bool {
         !activeFilters.isEmpty
@@ -104,6 +110,12 @@ struct ProtocolFilterBar: View {
             overflowSection(String(localized: "Protocol"), ProtocolFilterSelection.protocolFilters, visiblePills)
             overflowSection(String(localized: "Content"), ProtocolFilterSelection.contentTypeFilters, visiblePills)
             overflowStatusSection(visiblePills)
+            Divider()
+            Button(String(localized: "Customize Toolbar…")) {
+                NativeWorkspaceToolbar.presentCustomizationPalette(
+                    preferredWindow: customizationWindowReference.window
+                )
+            }
         } label: {
             Image(systemName: hasHidden ? "ellipsis.circle.fill" : "ellipsis.circle")
                 .font(.system(size: metrics.secondaryFontSize))
@@ -178,5 +190,41 @@ struct ProtocolFilterBar: View {
             get: { ProtocolFilterSelection.isSelected(filter, in: activeFilters) },
             set: { _ in activeFilters = ProtocolFilterSelection.toggling(filter, in: activeFilters) }
         )
+    }
+}
+
+// MARK: - ToolbarCustomizationWindowReader
+
+@MainActor
+private final class ToolbarCustomizationWindowReference {
+    weak var window: NSWindow?
+}
+
+private struct ToolbarCustomizationWindowReader: NSViewRepresentable {
+    let reference: ToolbarCustomizationWindowReference
+
+    func makeNSView(context: Context) -> ToolbarCustomizationWindowAnchor {
+        let view = ToolbarCustomizationWindowAnchor()
+        view.reference = reference
+        return view
+    }
+
+    func updateNSView(_ nsView: ToolbarCustomizationWindowAnchor, context: Context) {
+        nsView.reference = reference
+        nsView.captureWindow()
+    }
+}
+
+@MainActor
+private final class ToolbarCustomizationWindowAnchor: NSView {
+    weak var reference: ToolbarCustomizationWindowReference?
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        captureWindow()
+    }
+
+    func captureWindow() {
+        reference?.window = window
     }
 }

--- a/RockxyTests/Views/Main/NativeWorkspaceSplitViewTests.swift
+++ b/RockxyTests/Views/Main/NativeWorkspaceSplitViewTests.swift
@@ -169,7 +169,9 @@ struct NativeWorkspaceSplitViewTests {
             configuration: NativeWorkspaceToolbarConfiguration(
                 coordinator: coordinator,
                 onOpenDeveloperHub: {}
-            )
+            ),
+            toolbarIdentifier: uniqueToolbarIdentifier(),
+            autosavesConfiguration: false
         )
         let window = NSWindow(contentViewController: controller)
 
@@ -214,6 +216,256 @@ struct NativeWorkspaceSplitViewTests {
         }
     }
 
+    @Test("Main toolbar supports and persists native user customization")
+    func nativeToolbarCustomizationConfiguration() {
+        // The autosave contract is verified under a unique identifier so the shared production
+        // toolbar preferences are never written. The default initializer opts into autosaving.
+        let autosaveIdentifier = uniqueToolbarIdentifier()
+        let autosavingToolbar = NativeWorkspaceToolbar(
+            splitViewController: makeController(sidebarPresented: true, inspectorPresented: true),
+            configuration: NativeWorkspaceToolbarConfiguration(
+                coordinator: MainContentCoordinator(),
+                onOpenDeveloperHub: {}
+            ),
+            toolbarIdentifier: autosaveIdentifier
+        )
+        #expect(autosavingToolbar.managedToolbar.autosavesConfiguration)
+        autosavingToolbar.managedToolbar.autosavesConfiguration = false
+        removeToolbarConfigurationDefaults(autosaveIdentifier)
+
+        // `customizationToolbar` matches by the production identifier, so the customization contract
+        // is exercised with a non-autosaving toolbar that carries that identifier. Autosave is off,
+        // so nothing is written to the production preferences.
+        let controller = makeController(sidebarPresented: true, inspectorPresented: true)
+        let toolbar = NativeWorkspaceToolbar(
+            splitViewController: controller,
+            configuration: NativeWorkspaceToolbarConfiguration(
+                coordinator: MainContentCoordinator(),
+                onOpenDeveloperHub: {}
+            ),
+            toolbarIdentifier: NativeWorkspaceToolbar.toolbarIdentifier,
+            autosavesConfiguration: false
+        )
+        let window = NSWindow(contentViewController: controller)
+        window.toolbar = toolbar.managedToolbar
+
+        #expect(toolbar.managedToolbar.allowsUserCustomization)
+        #expect(!toolbar.managedToolbar.autosavesConfiguration)
+
+        let defaults = toolbar.toolbarDefaultItemIdentifiers(toolbar.managedToolbar)
+        let allowed = toolbar.toolbarAllowedItemIdentifiers(toolbar.managedToolbar)
+        let immovable = toolbar.toolbarImmovableItemIdentifiers(toolbar.managedToolbar)
+
+        #expect(defaults == NativeWorkspaceToolbar.defaultItemIdentifiers)
+        #expect(allowed == NativeWorkspaceToolbar.allowedItemIdentifiers)
+        #expect(Set(allowed).count == allowed.count)
+        #expect(Set(defaults).isSubset(of: Set(allowed)))
+        #expect(allowed.contains(.space))
+        #expect(allowed.contains(.flexibleSpace))
+        #expect(Set(NativeWorkspaceToolbar.userCustomizableItemIdentifiers).isSubset(of: Set(allowed)))
+        #expect(immovable == [NativeWorkspaceToolbar.sidebarTrackingSeparatorIdentifier])
+
+        let preferredWindow = window
+        let fallbackWindow = NSWindow()
+        let fallbackToolbar = NSToolbar(identifier: NativeWorkspaceToolbar.toolbarIdentifier)
+        fallbackToolbar.allowsUserCustomization = true
+        fallbackWindow.toolbar = fallbackToolbar
+
+        #expect(NativeWorkspaceToolbar.customizationToolbar(
+            preferredWindow: preferredWindow,
+            fallbackWindows: [fallbackWindow]
+        ) === toolbar.managedToolbar)
+
+        let unrelatedWindow = NSWindow()
+        unrelatedWindow.toolbar = NSToolbar(identifier: "unrelated.toolbar")
+        #expect(NativeWorkspaceToolbar.customizationToolbar(
+            preferredWindow: unrelatedWindow,
+            fallbackWindows: [fallbackWindow]
+        ) === fallbackToolbar)
+    }
+
+    @Test("Every customizable toolbar option has a complete native palette representation")
+    func customizableToolbarItemCatalogIsComplete() throws {
+        let controller = makeController(sidebarPresented: true, inspectorPresented: true)
+        let toolbar = NativeWorkspaceToolbar(
+            splitViewController: controller,
+            configuration: NativeWorkspaceToolbarConfiguration(
+                coordinator: MainContentCoordinator(),
+                onOpenDeveloperHub: {}
+            ),
+            toolbarIdentifier: uniqueToolbarIdentifier(),
+            autosavesConfiguration: false
+        )
+
+        for identifier in NativeWorkspaceToolbar.userCustomizableItemIdentifiers {
+            let item = try #require(toolbar.toolbar(
+                toolbar.managedToolbar,
+                itemForItemIdentifier: identifier,
+                willBeInsertedIntoToolbar: false
+            ))
+            #expect(!item.label.isEmpty)
+            #expect(!item.paletteLabel.isEmpty)
+            #expect(item.image != nil || item.view != nil)
+        }
+    }
+
+    @Test("Tracking separator uses a compact default-set palette label")
+    func trackingSeparatorPaletteLabelIsCompact() throws {
+        let controller = makeController(sidebarPresented: true, inspectorPresented: true)
+        let toolbar = NativeWorkspaceToolbar(
+            splitViewController: controller,
+            configuration: NativeWorkspaceToolbarConfiguration(
+                coordinator: MainContentCoordinator(),
+                onOpenDeveloperHub: {}
+            ),
+            toolbarIdentifier: uniqueToolbarIdentifier(),
+            autosavesConfiguration: false
+        )
+
+        let separator = try #require(toolbar.toolbar(
+            toolbar.managedToolbar,
+            itemForItemIdentifier: NativeWorkspaceToolbar.sidebarTrackingSeparatorIdentifier,
+            willBeInsertedIntoToolbar: false
+        ))
+
+        #expect(separator.label == String(localized: "Source List Divider"))
+        #expect(separator.paletteLabel == String(localized: "Divider"))
+    }
+
+    @Test("Optional toolbar items can be removed and restored independently")
+    func customizableToolbarItemsRoundTrip() throws {
+        let controller = makeController(sidebarPresented: true, inspectorPresented: true)
+        let toolbar = NativeWorkspaceToolbar(
+            splitViewController: controller,
+            configuration: NativeWorkspaceToolbarConfiguration(
+                coordinator: MainContentCoordinator(),
+                onOpenDeveloperHub: {}
+            ),
+            toolbarIdentifier: uniqueToolbarIdentifier(),
+            autosavesConfiguration: false
+        )
+        let window = NSWindow(contentViewController: controller)
+        window.toolbar = toolbar.managedToolbar
+
+        for identifier in NativeWorkspaceToolbar.userCustomizableItemIdentifiers {
+            let index = try #require(toolbar.managedToolbar.items.firstIndex {
+                $0.itemIdentifier == identifier
+            })
+            toolbar.managedToolbar.removeItem(at: index)
+            #expect(!toolbar.managedToolbar.items.contains { $0.itemIdentifier == identifier })
+
+            toolbar.managedToolbar.insertItem(withItemIdentifier: identifier, at: index)
+            let restored = try #require(toolbar.managedToolbar.items.first {
+                $0.itemIdentifier == identifier
+            })
+            #expect(!restored.paletteLabel.isEmpty)
+        }
+
+        #expect(toolbar.managedToolbar.items.contains {
+            $0.itemIdentifier == NativeWorkspaceToolbar.sidebarTrackingSeparatorIdentifier
+        })
+
+        // Proxy Status is the toolbar's centered item; removing and re-adding items must not
+        // drop it from the centered set.
+        #expect(toolbar.managedToolbar.centeredItemIdentifiers.contains(
+            NativeWorkspaceToolbar.proxyStatusIdentifier
+        ))
+    }
+
+    @Test("Releasing a workspace controller deallocates the controller and its toolbar")
+    func toolbarReleaseDeallocatesControllerAndToolbar() async {
+        weak var weakController: NativeWorkspaceSplitViewController?
+        weak var weakToolbar: NativeWorkspaceToolbar?
+
+        do {
+            let controller = makeController(sidebarPresented: true, inspectorPresented: true)
+            let toolbar = NativeWorkspaceToolbar(
+                splitViewController: controller,
+                configuration: NativeWorkspaceToolbarConfiguration(
+                    coordinator: MainContentCoordinator(),
+                    onOpenDeveloperHub: {}
+                ),
+                toolbarIdentifier: uniqueToolbarIdentifier(),
+                autosavesConfiguration: false
+            )
+            // A bare window (no contentViewController) is used deliberately: if AppKit retains the
+            // window past this scope it only keeps the NSToolbar alive, never the controller, so the
+            // deallocation assertions below stay reliable.
+            let window = NSWindow()
+            // The controller strongly owns the toolbar (associated object) while the toolbar keeps
+            // only a weak reference back, so this mirrors the production ownership graph.
+            controller.attachNativeToolbar(toolbar, to: window)
+
+            weakController = controller
+            weakToolbar = toolbar
+            #expect(weakController != nil)
+            #expect(weakToolbar != nil)
+        }
+
+        // Drain any observation follow-up task scheduled during startObservingState().
+        await Task.yield()
+
+        #expect(weakController == nil)
+        #expect(weakToolbar == nil)
+    }
+
+    @Test("Workspace windows with the same toolbar identity share customization")
+    func customizableToolbarConfigurationSynchronizesAcrossWindows() async throws {
+        let identifier = uniqueToolbarIdentifier()
+        let firstController = makeController(sidebarPresented: true, inspectorPresented: true)
+        let secondController = makeController(sidebarPresented: true, inspectorPresented: true)
+        let firstToolbar = NativeWorkspaceToolbar(
+            splitViewController: firstController,
+            configuration: NativeWorkspaceToolbarConfiguration(
+                coordinator: MainContentCoordinator(),
+                onOpenDeveloperHub: {}
+            ),
+            toolbarIdentifier: identifier,
+            autosavesConfiguration: false
+        )
+        let secondToolbar = NativeWorkspaceToolbar(
+            splitViewController: secondController,
+            configuration: NativeWorkspaceToolbarConfiguration(
+                coordinator: MainContentCoordinator(),
+                onOpenDeveloperHub: {}
+            ),
+            toolbarIdentifier: identifier,
+            autosavesConfiguration: false
+        )
+        let firstWindow = NSWindow(contentViewController: firstController)
+        let secondWindow = NSWindow(contentViewController: secondController)
+        firstWindow.toolbar = firstToolbar.managedToolbar
+        secondWindow.toolbar = secondToolbar.managedToolbar
+
+        let removedIdentifier = NativeWorkspaceToolbar.developerHubIdentifier
+        let removedIndex = try #require(firstToolbar.managedToolbar.items.firstIndex {
+            $0.itemIdentifier == removedIdentifier
+        })
+        firstToolbar.managedToolbar.removeItem(at: removedIndex)
+
+        for _ in 0 ..< 6 where secondToolbar.managedToolbar.items.contains(where: {
+            $0.itemIdentifier == removedIdentifier
+        }) {
+            await Task.yield()
+        }
+        #expect(!secondToolbar.managedToolbar.items.contains {
+            $0.itemIdentifier == removedIdentifier
+        })
+
+        firstToolbar.managedToolbar.insertItem(
+            withItemIdentifier: removedIdentifier,
+            at: removedIndex
+        )
+        for _ in 0 ..< 6 where !secondToolbar.managedToolbar.items.contains(where: {
+            $0.itemIdentifier == removedIdentifier
+        }) {
+            await Task.yield()
+        }
+        #expect(secondToolbar.managedToolbar.items.contains {
+            $0.itemIdentifier == removedIdentifier
+        })
+    }
+
     @Test("Native toolbar toggle collapses and restores the sidebar split item")
     func nativeToolbarTogglesSidebar() {
         let controller = makeController(sidebarPresented: true, inspectorPresented: true)
@@ -222,7 +474,9 @@ struct NativeWorkspaceSplitViewTests {
             configuration: NativeWorkspaceToolbarConfiguration(
                 coordinator: MainContentCoordinator(),
                 onOpenDeveloperHub: {}
-            )
+            ),
+            toolbarIdentifier: uniqueToolbarIdentifier(),
+            autosavesConfiguration: false
         )
         let window = NSWindow(contentViewController: controller)
         window.toolbar = toolbar.managedToolbar
@@ -256,7 +510,9 @@ struct NativeWorkspaceSplitViewTests {
                     #expect(actionDispatchReturned)
                     openCount += 1
                 }
-            )
+            ),
+            toolbarIdentifier: uniqueToolbarIdentifier(),
+            autosavesConfiguration: false
         )
         let window = NSWindow(contentViewController: controller)
         window.toolbar = toolbar.managedToolbar
@@ -267,11 +523,8 @@ struct NativeWorkspaceSplitViewTests {
         // Developer Hub action is dispatched from the native toolbar.
         coordinator.isProxyRunning = true
 
-        let actionGroup = try #require(toolbar.managedToolbar.items.first {
-            $0.itemIdentifier == NativeWorkspaceToolbar.actionGroupIdentifier
-        } as? NSToolbarItemGroup)
-        let developerHubItem = try #require(actionGroup.subitems.first {
-            $0.itemIdentifier.rawValue.hasSuffix(".developerHub")
+        let developerHubItem = try #require(toolbar.managedToolbar.items.first {
+            $0.itemIdentifier == NativeWorkspaceToolbar.developerHubIdentifier
         })
         let action = try #require(developerHubItem.action)
 
@@ -279,7 +532,7 @@ struct NativeWorkspaceSplitViewTests {
         #expect(openCount == 0)
         actionDispatchReturned = true
 
-        for _ in 0..<4 where openCount == 0 {
+        for _ in 0 ..< 4 where openCount == 0 {
             await Task.yield()
         }
         #expect(openCount == 1)
@@ -299,16 +552,15 @@ struct NativeWorkspaceSplitViewTests {
                     #expect(actionDispatchReturned)
                     toggleCount += 1
                 }
-            )
+            ),
+            toolbarIdentifier: uniqueToolbarIdentifier(),
+            autosavesConfiguration: false
         )
         let window = NSWindow(contentViewController: controller)
         window.toolbar = toolbar.managedToolbar
 
-        let actionGroup = try #require(toolbar.managedToolbar.items.first {
-            $0.itemIdentifier == NativeWorkspaceToolbar.actionGroupIdentifier
-        } as? NSToolbarItemGroup)
-        let proxyItem = try #require(actionGroup.subitems.first {
-            $0.itemIdentifier.rawValue.hasSuffix(".proxy")
+        let proxyItem = try #require(toolbar.managedToolbar.items.first {
+            $0.itemIdentifier == NativeWorkspaceToolbar.proxyToggleIdentifier
         })
         let action = try #require(proxyItem.action)
 
@@ -316,10 +568,96 @@ struct NativeWorkspaceSplitViewTests {
         #expect(toggleCount == 0)
         actionDispatchReturned = true
 
-        for _ in 0..<4 where toggleCount == 0 {
+        for _ in 0 ..< 4 where toggleCount == 0 {
             await Task.yield()
         }
         #expect(toggleCount == 1)
+    }
+
+    @Test("Dynamic toolbar state survives palette creation and item re-addition")
+    func customizableToolbarDynamicStateRemainsLive() async throws {
+        let controller = makeController(sidebarPresented: true, inspectorPresented: true)
+        let coordinator = MainContentCoordinator()
+        let toolbar = NativeWorkspaceToolbar(
+            splitViewController: controller,
+            configuration: NativeWorkspaceToolbarConfiguration(
+                coordinator: coordinator,
+                onOpenDeveloperHub: {}
+            ),
+            toolbarIdentifier: uniqueToolbarIdentifier(),
+            autosavesConfiguration: false
+        )
+        let window = NSWindow(contentViewController: controller)
+        window.toolbar = toolbar.managedToolbar
+        toolbar.startObservingState()
+        await Task.yield()
+
+        let activeProxyItem = try #require(toolbar.managedToolbar.items.first {
+            $0.itemIdentifier == NativeWorkspaceToolbar.proxyToggleIdentifier
+        })
+        #expect(activeProxyItem.label == String(localized: "Start"))
+        #expect(activeProxyItem.paletteLabel == String(localized: "Start or Stop Proxy"))
+
+        // AppKit asks for separate item instances while constructing the palette.
+        // That must not replace the live toolbar instance tracked by state updates.
+        _ = toolbar.toolbar(
+            toolbar.managedToolbar,
+            itemForItemIdentifier: NativeWorkspaceToolbar.proxyToggleIdentifier,
+            willBeInsertedIntoToolbar: false
+        )
+        coordinator.isProxyRunning = true
+        for _ in 0 ..< 6 where activeProxyItem.label != String(localized: "Stop") {
+            await Task.yield()
+        }
+        #expect(activeProxyItem.label == String(localized: "Stop"))
+        #expect(activeProxyItem.paletteLabel == String(localized: "Start or Stop Proxy"))
+
+        let proxyIndex = try #require(toolbar.managedToolbar.items.firstIndex {
+            $0.itemIdentifier == NativeWorkspaceToolbar.proxyToggleIdentifier
+        })
+        toolbar.managedToolbar.removeItem(at: proxyIndex)
+        toolbar.managedToolbar.insertItem(
+            withItemIdentifier: NativeWorkspaceToolbar.proxyToggleIdentifier,
+            at: proxyIndex
+        )
+        let restoredProxyItem = try #require(toolbar.managedToolbar.items.first {
+            $0.itemIdentifier == NativeWorkspaceToolbar.proxyToggleIdentifier
+        })
+        #expect(restoredProxyItem.label == String(localized: "Stop"))
+        #expect(restoredProxyItem.paletteLabel == String(localized: "Start or Stop Proxy"))
+
+        coordinator.isProxyRunning = false
+        for _ in 0 ..< 6 where restoredProxyItem.label != String(localized: "Start") {
+            await Task.yield()
+        }
+        #expect(restoredProxyItem.label == String(localized: "Start"))
+
+        let transaction = TestFixtures.makeTransaction()
+        coordinator.selectedTransaction = transaction
+        coordinator.selectedTransactionIDs = [transaction.id]
+        let bottomItem = try #require(toolbar.managedToolbar.items.first {
+            $0.itemIdentifier == NativeWorkspaceToolbar.bottomInspectorIdentifier
+        })
+        for _ in 0 ..< 6 where !bottomItem.isEnabled {
+            await Task.yield()
+        }
+        #expect(bottomItem.isEnabled)
+        #expect(bottomItem.toolTip == String(localized: "Hide Bottom Inspector"))
+
+        let contextItem = try #require(toolbar.managedToolbar.items.first {
+            $0.itemIdentifier == NativeWorkspaceToolbar.contextDockIdentifier
+        })
+        let initialContextVisibility = coordinator.isContextDockVisible
+        let action = try #require(contextItem.action)
+        NSApp.sendAction(action, to: contextItem.target, from: contextItem)
+        let expectedContextToolTip = initialContextVisibility
+            ? String(localized: "Show Context Dock")
+            : String(localized: "Hide Context Dock")
+        for _ in 0 ..< 6 where contextItem.toolTip != expectedContextToolTip {
+            await Task.yield()
+        }
+        #expect(coordinator.isContextDockVisible != initialContextVisibility)
+        #expect(contextItem.toolTip == expectedContextToolTip)
     }
 
     // MARK: - Project selector sizing metrics
@@ -646,6 +984,10 @@ struct NativeWorkspaceSplitViewTests {
         "NativeWorkspaceSplitViewTests-\(UUID().uuidString)"
     }
 
+    private func uniqueToolbarIdentifier() -> NSToolbar.Identifier {
+        NSToolbar.Identifier("NativeWorkspaceSplitViewTests.Toolbar.\(UUID().uuidString)")
+    }
+
     private func expectNonNegativeArrangedGeometry(_ controller: NativeWorkspaceSplitViewController) {
         for item in controller.splitViewItems {
             let frame = item.viewController.view.frame
@@ -658,5 +1000,9 @@ struct NativeWorkspaceSplitViewTests {
 
     private func removeSplitViewAutosaveDefaults(_ autosaveName: String) {
         UserDefaults.standard.removeObject(forKey: "NSSplitView Subview Frames \(autosaveName)")
+    }
+
+    private func removeToolbarConfigurationDefaults(_ identifier: NSToolbar.Identifier) {
+        UserDefaults.standard.removeObject(forKey: "NSToolbar Configuration \(identifier)")
     }
 }

--- a/docs/design-specs/main-window.md
+++ b/docs/design-specs/main-window.md
@@ -59,7 +59,7 @@ The primary application window — a 3-column developer debugging interface foll
 | Control | Icon (SF Symbol) | States | Shortcut | Priority |
 |---------|-----------------|--------|----------|----------|
 | Project Selector | `folder.fill` | Active Project menu | — | High |
-| Start/Stop | `play.fill` / `stop.fill` | Toggle | ⌘⇧R / ⌘. | High |
+| Start/Stop | `play.fill` / `stop.fill` | Toggle | — / ⌘. | High |
 | Developer Hub | `command` | Opens tool launcher | — | Medium |
 | Bottom Inspector | `rectangle.split.1x2` | Toggle visibility | — | Medium |
 | Context Dock | `sidebar.trailing` | Toggle visibility | — | Medium |
@@ -80,6 +80,33 @@ The primary application window — a 3-column developer debugging interface foll
 - Button spacing: 4pt
 - Separator: SwiftUI `Divider()` between action groups
 - Tooltips on all buttons via `.help()` modifier
+
+### Customization Flow
+- Entry point: `Customize Toolbar…` at the bottom of the protocol-filter ellipsis menu.
+- Uses the standard AppKit toolbar customization palette, including Icon and Text display modes,
+  fixed/flexible spaces, Done, and the draggable default set.
+- User-customizable items: Source List, Project, Proxy Status, Start or Stop Proxy, Developer Hub,
+  Bottom Inspector, and Context Dock.
+- The source-list tracking separator is structural and immovable so the unified titlebar continues
+  to align with the three-pane split even when the Source List button is removed. AppKit documents
+  immovable items as un-draggable and non-removable, so the separator cannot be dragged out or
+  reordered from the customization palette.
+- Removing a toolbar item never removes the underlying command: proxy, Project, panel, Source List,
+  and Developer Hub actions remain available from the app menus or the traffic control shelf; Proxy
+  Status is informational only.
+- Proxy Status is registered as the toolbar's centered item, so when present it stays visually
+  centered regardless of the surrounding item order — removing and re-adding it, or reordering its
+  neighbors, does not move it out of the centered set.
+- The Icon and Text display modes only change how AppKit's own image/label items render. The custom
+  hosted items (Project selector, Proxy Status) supply their own SwiftUI content via `NSHostingController`,
+  so they keep their native rendered view across every display mode rather than collapsing to a
+  system label or icon.
+- The customized order, visibility, and display mode autosave under a versioned toolbar identity and
+  are reused whenever AppKit recreates the main workspace toolbar. Toolbar instances sharing that
+  identity synchronize changes immediately.
+- Dynamic toolbar items keep live behavior after removal and re-addition: Start/Stop follows proxy
+  state, Bottom Inspector follows selection and panel visibility, and Context Dock tooltips follow
+  its visible state.
 
 ---
 


### PR DESCRIPTION
## Summary

- Add a Customize Toolbar… entry to the protocol-filter overflow menu and open the native AppKit palette for the originating workspace window.
- Make workspace toolbar controls individually addable, removable, and reorderable, with fixed and flexible spaces available.
- Persist toolbar order, visibility, and display mode across workspace windows while keeping dynamic action state live.
- Keep structural titlebar alignment intact and use a compact divider label in the draggable default-set preview.

## Why

The workspace toolbar had a fixed layout even though different debugging workflows prioritize different controls. Native customization lets users tailor the toolbar without removing the underlying menu commands or compromising the three-pane window structure.

## Impact

- Source List, Project, Proxy Status, Start or Stop Proxy, Developer Hub, Bottom Inspector, and Context Dock can be removed and restored independently.
- The source-list tracking separator remains immovable, and Proxy Status remains centered when present.
- Toolbar instances sharing the versioned identifier synchronize customization and restore it on subsequent windows.
- Lifecycle and palette-isolation coverage protects against retained controllers and test writes to production toolbar preferences.

## Related issues

No direct matching issue was found in the repository audit.

## Validation

- swiftlint lint --strict
- xcodebuild -project Rockxy.xcodeproj -scheme Rockxy -destination platform=macOS -only-testing:RockxyTests/NativeWorkspaceSplitViewTests test
- xcodebuild -project Rockxy.xcodeproj -scheme Rockxy -configuration Debug build
- git diff --check