### PR TITLE
fix(ui): refine Focus Set and Noise Control sheets

### DIFF
--- a/Rockxy/Views/Common/NativeWorkspaceWindowChrome.swift
+++ b/Rockxy/Views/Common/NativeWorkspaceWindowChrome.swift
@@ -336,7 +336,6 @@ final class NativeWorkspaceToolbar: NSObject, NSToolbarDelegate {
             action: #selector(toggleSidebar(_:))
         )
         item.isBordered = true
-        item.isNavigational = true
         item.toolTip = String(localized: "Show or hide the Source List")
         return item
     }

--- a/Rockxy/Views/Sidebar/FocusSetEditorSheet.swift
+++ b/Rockxy/Views/Sidebar/FocusSetEditorSheet.swift
@@ -31,12 +31,13 @@ struct FocusSetEditorSheet: View {
     var body: some View {
         VStack(spacing: 0) {
             sheetHeader
-            Divider()
             editorContent
-            Divider()
             actionBar
         }
-        .frame(width: 600, height: 570)
+        .font(toolMetrics.font())
+        .frame(width: max(640, toolMetrics.fieldWidth(640)), height: 600)
+        .background(Color(nsColor: .windowBackgroundColor))
+        .accessibilityIdentifier("focusSetEditor.sheet")
         .onChange(of: draft.suggestedName) { _, suggestedName in
             guard isCreating, usesSuggestedName else {
                 return
@@ -53,6 +54,7 @@ struct FocusSetEditorSheet: View {
 
     // MARK: Private
 
+    @Environment(\.appUIDisplayMetrics) private var appMetrics
     @Environment(\.dismiss) private var dismiss
     @State private var draft: FocusSet
     @State private var usesSuggestedName: Bool
@@ -63,54 +65,62 @@ struct FocusSetEditorSheet: View {
         draft.name.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
+    private var toolMetrics: ToolWindowDisplayMetrics {
+        ToolWindowDisplayMetrics(appMetrics: appMetrics)
+    }
+
     private var matchCount: Int {
         transactions.count { !$0.isTLSFailure && draft.matches($0) }
     }
 
     private var matchSummary: String {
         if draft.ruleCount == 0 {
-            return String(localized: "Add at least one include or exclude condition")
+            return String(localized: "Add an include or exclude condition to preview matches")
         }
-        return String(localized: "\(matchCount) matching requests")
+        return matchCount == 1
+            ? String(localized: "1 matching request")
+            : String(localized: "\(matchCount) matching requests")
     }
 
     private var sheetHeader: some View {
-        HStack(spacing: 10) {
-            Image(systemName: "scope")
-                .font(.title2)
-                .foregroundStyle(Color.accentColor)
-                .frame(width: 28)
-            VStack(alignment: .leading, spacing: 1) {
+        HStack(alignment: .center, spacing: toolMetrics.headerSpacing) {
+            VStack(alignment: .leading, spacing: 3) {
                 Text(isCreating
                     ? String(localized: "Create Focus Set")
                     : String(localized: "Edit Focus Set"))
-                    .font(.headline)
-                Text(String(localized: "Show only the traffic that matters for this task."))
-                    .font(.caption)
+                    .font(toolMetrics.font(weight: .medium))
+                Text(String(localized: "Save a reusable view of the traffic relevant to one task."))
+                    .font(toolMetrics.secondaryFont())
                     .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
             }
             Spacer()
         }
-        .padding(.horizontal, 18)
-        .frame(height: 58)
+        .padding(.horizontal, toolMetrics.contentHorizontalPadding)
+        .padding(.top, toolMetrics.headerTopPadding)
+        .padding(.bottom, toolMetrics.headerBottomPadding)
+        .rockxyFunctionalBar()
     }
 
     private var editorContent: some View {
         ScrollView {
-            VStack(alignment: .leading, spacing: 16) {
+            VStack(alignment: .leading, spacing: 18) {
                 nameField
+
+                Divider()
 
                 conditionGroup(
                     title: String(localized: "Include"),
-                    description: String(localized: "Traffic must match every condition you fill in.")
+                    description: String(
+                        localized: "A request must match every condition you set. Empty fields match any value."
+                    )
                 ) {
                     applicationCondition
                     conditionDivider
                     suggestionCondition(
                         title: String(localized: "Domain"),
-                        icon: "globe",
                         placeholder: String(localized: "Any domain"),
-                        hint: String(localized: "Matches this domain and its subdomains, for example api.example.com."),
+                        hint: String(localized: "Matches this domain and its subdomains, such as api.example.com."),
                         pickerTitle: String(localized: "Choose Captured Domain"),
                         searchPrompt: String(localized: "Search captured domains"),
                         emptySelectionTitle: String(localized: "Any Domain"),
@@ -121,10 +131,9 @@ struct FocusSetEditorSheet: View {
                     conditionDivider
                     suggestionCondition(
                         title: String(localized: "Path Prefix"),
-                        icon: "point.topleft.down.to.point.bottomright.curvepath",
                         placeholder: String(localized: "Any path"),
                         hint: String(
-                            localized: "Matches URL paths that begin with this value, for example /v1/orders."
+                            localized: "Matches URL paths that begin with this value, such as /v1/orders."
                         ),
                         pickerTitle: String(localized: "Choose Captured Path"),
                         searchPrompt: String(localized: "Search captured paths"),
@@ -135,17 +144,18 @@ struct FocusSetEditorSheet: View {
                     )
                 }
 
+                Divider()
+
                 conditionGroup(
                     title: String(localized: "Exclude"),
                     description: String(
-                        localized: "Matching traffic is removed after the include conditions are applied."
+                        localized: "Matching requests are hidden after the include conditions are applied."
                     )
                 ) {
                     suggestionCondition(
                         title: String(localized: "Domain"),
-                        icon: "globe.badge.xmark",
                         placeholder: String(localized: "No excluded domain"),
-                        hint: String(localized: "Removes this domain and its subdomains from the Focus Set."),
+                        hint: String(localized: "Hides this domain and its subdomains from the Focus Set."),
                         pickerTitle: String(localized: "Choose Excluded Domain"),
                         searchPrompt: String(localized: "Search captured domains"),
                         emptySelectionTitle: String(localized: "No Excluded Domain"),
@@ -156,9 +166,8 @@ struct FocusSetEditorSheet: View {
                     conditionDivider
                     suggestionCondition(
                         title: String(localized: "Path Prefix"),
-                        icon: "point.topleft.down.to.point.bottomright.curvepath",
                         placeholder: String(localized: "No excluded path"),
-                        hint: String(localized: "Removes URL paths that begin with this value from the Focus Set."),
+                        hint: String(localized: "Hides URL paths that begin with this value from the Focus Set."),
                         pickerTitle: String(localized: "Choose Excluded Path"),
                         searchPrompt: String(localized: "Search captured paths"),
                         emptySelectionTitle: String(localized: "No Excluded Path"),
@@ -168,26 +177,38 @@ struct FocusSetEditorSheet: View {
                     )
                 }
             }
-            .padding(18)
+            .padding(.horizontal, 24)
+            .padding(.vertical, 20)
             .frame(maxWidth: .infinity, alignment: .topLeading)
         }
         .controlSize(.regular)
+        .background(Color(nsColor: .windowBackgroundColor))
     }
 
     private var nameField: some View {
-        HStack(alignment: .firstTextBaseline, spacing: 12) {
-            Text(String(localized: "Name"))
-                .foregroundStyle(.secondary)
-                .frame(width: 92, alignment: .trailing)
-            TextField(String(localized: "For example: Checkout API"), text: $draft.name)
-                .textFieldStyle(.roundedBorder)
+        VStack(alignment: .leading, spacing: 7) {
+            conditionRow(title: String(localized: "Name")) {
+                TextField(String(localized: "For example: Checkout API"), text: $draft.name)
+                    .textFieldStyle(.roundedBorder)
+                    .frame(height: toolMetrics.formControlHeight)
+                    .accessibilityIdentifier("focusSetEditor.name")
+            }
+
+            Text(
+                String(
+                    localized: "Focus Sets are available in every Project. Saving applies this set to the current Traffic Tab."
+                )
+            )
+            .font(toolMetrics.secondaryFont())
+            .foregroundStyle(.secondary)
+            .fixedSize(horizontal: false, vertical: true)
+            .padding(.leading, toolMetrics.formLabelWidth + toolMetrics.controlSpacing)
         }
     }
 
     private var applicationCondition: some View {
         conditionRow(
             title: String(localized: "Application"),
-            icon: "app",
             hint: String(localized: "Only includes traffic captured from the selected application.")
         ) {
             CapturedApplicationSelectionField(
@@ -199,17 +220,18 @@ struct FocusSetEditorSheet: View {
 
     private var conditionDivider: some View {
         Divider()
-            .padding(.leading, 104)
+            .padding(.leading, toolMetrics.formLabelWidth + toolMetrics.controlSpacing)
     }
 
     private var actionBar: some View {
-        HStack(spacing: 10) {
+        HStack(spacing: toolMetrics.controlSpacing) {
             Label(matchSummary, systemImage: "line.3.horizontal.decrease.circle")
-                .font(.caption)
+                .font(toolMetrics.secondaryFont())
                 .foregroundStyle(matchCount == 0 ? Color.orange : Color.secondary)
             Spacer()
             Button(String(localized: "Cancel"), role: .cancel) { dismiss() }
                 .keyboardShortcut(.cancelAction)
+                .rockxyGlassButtonStyle()
             Button(isCreating ? String(localized: "Create") : String(localized: "Save")) {
                 draft.name = trimmedName
                 onSave(draft)
@@ -219,8 +241,9 @@ struct FocusSetEditorSheet: View {
             .rockxyGlassButtonStyle(prominent: true)
             .disabled(trimmedName.isEmpty || draft.ruleCount == 0)
         }
-        .padding(.horizontal, 18)
-        .frame(height: 52)
+        .padding(.horizontal, toolMetrics.contentHorizontalPadding)
+        .padding(.vertical, toolMetrics.footerTopPadding)
+        .rockxyFunctionalBar()
     }
 
     private func conditionGroup(
@@ -230,31 +253,24 @@ struct FocusSetEditorSheet: View {
     )
         -> some View
     {
-        VStack(alignment: .leading, spacing: 7) {
-            VStack(alignment: .leading, spacing: 1) {
+        VStack(alignment: .leading, spacing: 12) {
+            VStack(alignment: .leading, spacing: 3) {
                 Text(title)
-                    .font(.subheadline.weight(.semibold))
+                    .font(toolMetrics.font(weight: .semibold))
                 Text(description)
-                    .font(.caption)
+                    .font(toolMetrics.secondaryFont())
                     .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
             }
 
-            VStack(spacing: 10) {
+            VStack(spacing: 12) {
                 content()
-            }
-            .padding(12)
-            .background(Color(nsColor: .controlBackgroundColor).opacity(0.55))
-            .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
-            .overlay {
-                RoundedRectangle(cornerRadius: 8, style: .continuous)
-                    .stroke(Color(nsColor: .separatorColor), lineWidth: 0.5)
             }
         }
     }
 
     private func suggestionCondition(
         title: String,
-        icon: String,
         placeholder: String,
         hint: String,
         pickerTitle: String,
@@ -266,7 +282,7 @@ struct FocusSetEditorSheet: View {
     )
         -> some View
     {
-        conditionRow(title: title, icon: icon, hint: hint) {
+        conditionRow(title: title, hint: hint) {
             CapturedTextSuggestionField(
                 text: text,
                 placeholder: placeholder,
@@ -281,22 +297,24 @@ struct FocusSetEditorSheet: View {
 
     private func conditionRow(
         title: String,
-        icon: String,
-        hint: String,
+        hint: String? = nil,
         @ViewBuilder content: () -> some View
     )
         -> some View
     {
         HStack(alignment: .top, spacing: 12) {
-            Label(title, systemImage: icon)
+            Text(title)
+                .font(toolMetrics.font(weight: .medium))
                 .foregroundStyle(.secondary)
-                .frame(width: 92, alignment: .trailing)
+                .frame(width: toolMetrics.formLabelWidth, alignment: .trailing)
             VStack(alignment: .leading, spacing: 3) {
                 content()
-                Text(hint)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
+                if let hint {
+                    Text(hint)
+                        .font(toolMetrics.secondaryFont())
+                        .foregroundStyle(.tertiary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
         }

--- a/Rockxy/Views/Sidebar/NoiseControlManagerSheet.swift
+++ b/Rockxy/Views/Sidebar/NoiseControlManagerSheet.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 // MARK: - NoiseControlManagerSheet
 
-/// Workspace-scoped manager for traffic that should stay captured but remain out of the working set.
+/// Traffic Tab-scoped manager for traffic that should stay captured but remain out of the working set.
 struct NoiseControlManagerSheet: View {
     // MARK: Lifecycle
 
@@ -18,22 +18,28 @@ struct NoiseControlManagerSheet: View {
     var body: some View {
         VStack(spacing: 0) {
             sheetHeader
-            Divider()
             managerContent
-            Divider()
             actionBar
         }
-        .frame(width: 600, height: 570)
+        .font(toolMetrics.font())
+        .frame(width: max(680, toolMetrics.fieldWidth(680)), height: 590)
+        .background(Color(nsColor: .windowBackgroundColor))
+        .accessibilityIdentifier("noiseControl.sheet")
     }
 
     // MARK: Private
 
+    @Environment(\.appUIDisplayMetrics) private var appMetrics
     @Environment(\.dismiss) private var dismiss
     @State private var sourceKind: CapturedValueKind = .domain
     @State private var sourceDraft = ""
     @State private var searchText = ""
 
     private let suggestions: FocusSetEditorSuggestions
+
+    private var toolMetrics: ToolWindowDisplayMetrics {
+        ToolWindowDisplayMetrics(appMetrics: appMetrics)
+    }
 
     private var allSources: [MutedTrafficSource] {
         coordinator.activeWorkspace.mutedTrafficSources.sorted {
@@ -119,202 +125,217 @@ struct NoiseControlManagerSheet: View {
     }
 
     private var sheetHeader: some View {
-        HStack(spacing: 10) {
-            Image(systemName: "eye.slash")
-                .font(.title2)
-                .foregroundStyle(Color.accentColor)
-                .frame(width: 28)
-            VStack(alignment: .leading, spacing: 1) {
+        HStack(alignment: .center, spacing: toolMetrics.headerSpacing) {
+            VStack(alignment: .leading, spacing: 3) {
                 Text(String(localized: "Noise Control"))
-                    .font(.headline)
-                Text(String(localized: "Hide matching traffic in this workspace without stopping capture."))
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+                    .font(toolMetrics.font(weight: .medium))
+                Text(
+                    String(
+                        localized: "Hide recurring traffic from the current Traffic Tab. Capture continues and no requests are deleted."
+                    )
+                )
+                .font(toolMetrics.secondaryFont())
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
             }
-            Spacer()
+
+            Spacer(minLength: 20)
+
+            TextField(String(localized: "Filter muted sources"), text: $searchText)
+                .textFieldStyle(.roundedBorder)
+                .frame(width: toolMetrics.fieldWidth(210), height: toolMetrics.formControlHeight)
+                .accessibilityLabel(String(localized: "Filter muted sources"))
+                .accessibilityIdentifier("noiseControl.filter")
         }
-        .padding(.horizontal, 18)
-        .frame(height: 58)
+        .padding(.horizontal, toolMetrics.contentHorizontalPadding)
+        .padding(.top, toolMetrics.headerTopPadding)
+        .padding(.bottom, toolMetrics.headerBottomPadding)
+        .rockxyFunctionalBar()
     }
 
     private var managerContent: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: 16) {
-                addSourceGroup
-                mutedSourcesGroup
+        VStack(alignment: .leading, spacing: 0) {
+            addSourceGroup
+
+            Divider()
+
+            VStack(alignment: .leading, spacing: toolMetrics.controlSpacing) {
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(String(localized: "Muted Sources"))
+                        .font(toolMetrics.font(weight: .semibold))
+                    Text(String(localized: "Muted sources apply regardless of the active Focus Set."))
+                        .font(toolMetrics.secondaryFont())
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                mutedSourcesTable
             }
-            .padding(18)
-            .frame(maxWidth: .infinity, alignment: .topLeading)
+            .padding(.horizontal, 24)
+            .padding(.top, 16)
+            .padding(.bottom, 12)
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         }
         .controlSize(.regular)
+        .background(Color(nsColor: .windowBackgroundColor))
     }
 
     private var addSourceGroup: some View {
-        conditionGroup(
-            title: String(localized: "Mute Source"),
-            description: String(localized: "Hide matching traffic throughout this workspace. Capture continues.")
-        ) {
-            conditionRow(title: String(localized: "Source Type"), icon: "slider.horizontal.3") {
-                Picker(String(localized: "Source Type"), selection: $sourceKind) {
-                    Text(String(localized: "Domain")).tag(CapturedValueKind.domain)
-                    Text(String(localized: "Path Prefix")).tag(CapturedValueKind.path)
-                }
-                .pickerStyle(.segmented)
-                .labelsHidden()
+        VStack(alignment: .leading, spacing: 12) {
+            VStack(alignment: .leading, spacing: 3) {
+                Text(String(localized: "Mute a Source"))
+                    .font(toolMetrics.font(weight: .semibold))
+                Text(String(localized: "Choose a captured domain or path, or enter a pattern."))
+                    .font(toolMetrics.secondaryFont())
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
             }
 
-            conditionDivider
-
-            conditionRow(title: String(localized: "Pattern"), icon: sourceKind.systemImage) {
-                HStack(alignment: .top, spacing: 8) {
-                    CapturedTextSuggestionField(
-                        text: $sourceDraft,
-                        placeholder: sourcePlaceholder,
-                        pickerTitle: sourcePickerTitle,
-                        searchPrompt: sourceSearchPrompt,
-                        emptySelectionTitle: String(localized: "No Selection"),
-                        suggestions: currentSuggestions,
-                        kind: sourceKind,
-                        requestsInitialFocus: true
-                    )
-                    Button(String(localized: "Mute"), action: addSource)
-                        .keyboardShortcut(.return, modifiers: [.command])
-                        .disabled(validationMessage != nil)
+            VStack(spacing: 10) {
+                conditionRow(title: String(localized: "Type")) {
+                    Picker(String(localized: "Source Type"), selection: $sourceKind) {
+                        Text(String(localized: "Domain")).tag(CapturedValueKind.domain)
+                        Text(String(localized: "Path Prefix")).tag(CapturedValueKind.path)
+                    }
+                    .pickerStyle(.segmented)
+                    .labelsHidden()
+                    .frame(width: toolMetrics.fieldWidth(250))
                 }
 
-                Text(sourceMessage)
-                    .font(.caption)
-                    .foregroundStyle(isSourceMessageError ? Color.orange : Color.secondary)
+                conditionRow(title: String(localized: "Pattern")) {
+                    HStack(alignment: .top, spacing: 8) {
+                        CapturedTextSuggestionField(
+                            text: $sourceDraft,
+                            placeholder: sourcePlaceholder,
+                            pickerTitle: sourcePickerTitle,
+                            searchPrompt: sourceSearchPrompt,
+                            emptySelectionTitle: String(localized: "No Selection"),
+                            suggestions: currentSuggestions,
+                            kind: sourceKind,
+                            requestsInitialFocus: true
+                        )
+                        Button(String(localized: "Mute"), action: addSource)
+                            .keyboardShortcut(.return, modifiers: [.command])
+                            .rockxyGlassButtonStyle()
+                            .disabled(validationMessage != nil)
+                    }
+
+                    Text(sourceMessage)
+                        .font(toolMetrics.secondaryFont())
+                        .foregroundStyle(
+                            isSourceMessageError ? Color.red : Color(nsColor: .tertiaryLabelColor)
+                        )
+                        .fixedSize(horizontal: false, vertical: true)
+                }
             }
         }
+        .padding(.horizontal, 24)
+        .padding(.top, 18)
+        .padding(.bottom, 16)
         .onChange(of: sourceKind) { _, _ in
             sourceDraft = ""
         }
     }
 
-    private var mutedSourcesGroup: some View {
-        conditionGroup(
-            title: String(localized: "Muted Sources"),
-            description: String(
-                localized: "Focus Set exclusions apply only inside that Focus Set; these rules apply regardless of the active Focus Set."
-            )
-        ) {
-            conditionRow(title: String(localized: "Filter"), icon: "magnifyingglass") {
-                TextField(String(localized: "Filter muted sources"), text: $searchText)
-                    .textFieldStyle(.roundedBorder)
-            }
-
-            conditionDivider
-
-            if filteredSources.isEmpty {
-                Text(searchText.isEmpty
-                    ? String(localized: "No muted sources. Add a domain or path prefix above.")
-                    : String(localized: "No muted sources match this filter."))
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .frame(maxWidth: .infinity, minHeight: 64, alignment: .center)
-            } else {
-                LazyVStack(spacing: 0) {
-                    ForEach(filteredSources) { source in
-                        sourceRow(source)
-                        if source.id != filteredSources.last?.id {
-                            Divider().padding(.leading, 30)
-                        }
-                    }
+    private var mutedSourcesTable: some View {
+        Table(filteredSources) {
+            TableColumn(String(localized: "Source")) { source in
+                HStack(spacing: 7) {
+                    Image(systemName: source.systemImage)
+                        .font(toolMetrics.metadataFont())
+                        .foregroundStyle(.secondary)
+                    Text(source.title)
+                        .font(toolMetrics.font(monospaced: true))
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                        .help(source.title)
                 }
             }
+            .width(min: 190, ideal: 250)
+
+            TableColumn(String(localized: "Type")) { source in
+                Text(sourceKindLabel(source))
+                    .foregroundStyle(.secondary)
+            }
+            .width(min: 130, ideal: 150)
+
+            TableColumn(String(localized: "Matches")) { source in
+                Text("\(coordinator.mutedTransactionCount(for: source))")
+                    .font(toolMetrics.font(monospaced: true))
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .trailing)
+            }
+            .width(60)
+
+            TableColumn("") { source in
+                Button {
+                    coordinator.unmuteTrafficSource(source)
+                } label: {
+                    Image(systemName: "minus.circle")
+                }
+                .buttonStyle(.borderless)
+                .help(String(localized: "Unmute \(source.title)"))
+                .accessibilityLabel(String(localized: "Unmute \(source.title)"))
+                .frame(maxWidth: .infinity, alignment: .center)
+            }
+            .width(32)
+        }
+        .overlay {
+            if filteredSources.isEmpty {
+                ContentUnavailableView(
+                    searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                        ? String(localized: "No Muted Sources")
+                        : String(localized: "No Matching Sources"),
+                    systemImage: searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                        ? "eye.slash"
+                        : "magnifyingglass",
+                    description: Text(
+                        searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                            ? String(localized: "Mute a domain or path prefix to keep recurring traffic out of this Traffic Tab.")
+                            : String(localized: "Try a different domain or path prefix.")
+                    )
+                )
+            }
+        }
+        .background(Color(nsColor: .textBackgroundColor))
+        .clipShape(RoundedRectangle(cornerRadius: 6))
+        .overlay {
+            RoundedRectangle(cornerRadius: 6)
+                .stroke(Color(nsColor: .separatorColor), lineWidth: 1)
         }
     }
 
     private var actionBar: some View {
-        HStack(spacing: 10) {
-            Label(String(localized: "\(allSources.count) muted sources"), systemImage: "eye.slash")
-                .font(.caption)
+        HStack(spacing: toolMetrics.controlSpacing) {
+            Label(mutedSourceCountLabel, systemImage: "eye.slash")
+                .font(toolMetrics.secondaryFont())
                 .foregroundStyle(.secondary)
             Spacer()
             Button(String(localized: "Unmute All"), role: .destructive) {
                 coordinator.unmuteAllTrafficSources()
             }
+            .rockxyGlassButtonStyle()
             .disabled(allSources.isEmpty)
             Button(String(localized: "Done")) { dismiss() }
                 .keyboardShortcut(.defaultAction)
-                .rockxyGlassButtonStyle()
+                .rockxyGlassButtonStyle(prominent: true)
         }
-        .padding(.horizontal, 18)
-        .frame(height: 52)
-    }
-
-    private var conditionDivider: some View {
-        Divider()
-            .padding(.leading, 104)
-    }
-
-    private func sourceRow(_ source: MutedTrafficSource) -> some View {
-        HStack(spacing: 9) {
-            Image(systemName: source.systemImage)
-                .foregroundStyle(.secondary)
-                .frame(width: 18)
-            VStack(alignment: .leading, spacing: 1) {
-                Text(source.title)
-                    .font(.body.monospaced())
-                    .lineLimit(1)
-                    .truncationMode(.middle)
-                    .help(source.title)
-                Text(sourceKindLabel(source))
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            }
-            Spacer(minLength: 8)
-            Text(String(localized: "\(coordinator.mutedTransactionCount(for: source)) matches"))
-                .font(.caption.monospacedDigit())
-                .foregroundStyle(.secondary)
-            Button(String(localized: "Unmute")) {
-                coordinator.unmuteTrafficSource(source)
-            }
-        }
-        .padding(.vertical, 8)
-    }
-
-    private func conditionGroup(
-        title: String,
-        description: String,
-        @ViewBuilder content: () -> some View
-    )
-        -> some View
-    {
-        VStack(alignment: .leading, spacing: 7) {
-            VStack(alignment: .leading, spacing: 1) {
-                Text(title)
-                    .font(.subheadline.weight(.semibold))
-                Text(description)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            }
-
-            VStack(spacing: 10) {
-                content()
-            }
-            .padding(12)
-            .background(Color(nsColor: .controlBackgroundColor).opacity(0.55))
-            .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
-            .overlay {
-                RoundedRectangle(cornerRadius: 8, style: .continuous)
-                    .stroke(Color(nsColor: .separatorColor), lineWidth: 0.5)
-            }
-        }
+        .padding(.horizontal, toolMetrics.contentHorizontalPadding)
+        .padding(.vertical, toolMetrics.footerTopPadding)
+        .rockxyFunctionalBar()
     }
 
     private func conditionRow(
         title: String,
-        icon: String,
         @ViewBuilder content: () -> some View
     )
         -> some View
     {
         HStack(alignment: .top, spacing: 12) {
-            Label(title, systemImage: icon)
+            Text(title)
+                .font(toolMetrics.font(weight: .medium))
                 .foregroundStyle(.secondary)
-                .frame(width: 92, alignment: .trailing)
+                .frame(width: toolMetrics.formLabelWidth, alignment: .trailing)
             VStack(alignment: .leading, spacing: 3) {
                 content()
             }
@@ -329,6 +350,12 @@ struct NoiseControlManagerSheet: View {
         case .pathPrefix:
             String(localized: "Path prefix")
         }
+    }
+
+    private var mutedSourceCountLabel: String {
+        allSources.count == 1
+            ? String(localized: "1 muted source")
+            : String(localized: "\(allSources.count) muted sources")
     }
 
     private func addSource() {

--- a/RockxyTests/Views/FocusSidebarPresentationTests.swift
+++ b/RockxyTests/Views/FocusSidebarPresentationTests.swift
@@ -18,6 +18,36 @@ struct FocusSidebarPresentationTests {
         #expect(source.contains(".accessibilityLabel(actionLabel)"))
     }
 
+    @Test("Focus and Noise sheets use Rockxy's native glass hierarchy")
+    func focusSheetsUseNativeGlassHierarchy() throws {
+        let focus = try readProjectFile("Rockxy/Views/Sidebar/FocusSetEditorSheet.swift")
+        let noise = try readProjectFile("Rockxy/Views/Sidebar/NoiseControlManagerSheet.swift")
+
+        #expect(focus.components(separatedBy: ".rockxyFunctionalBar()").count == 3)
+        #expect(noise.components(separatedBy: ".rockxyFunctionalBar()").count == 3)
+        #expect(focus.contains(".rockxyGlassButtonStyle(prominent: true)"))
+        #expect(noise.contains(".rockxyGlassButtonStyle(prominent: true)"))
+        #expect(noise.contains("Table(filteredSources)"))
+        #expect(noise.contains("Color(nsColor: .textBackgroundColor)"))
+        #expect(!focus.contains("controlBackgroundColor).opacity(0.55)"))
+        #expect(!noise.contains("controlBackgroundColor).opacity(0.55)"))
+        #expect(!focus.contains("Image(systemName: \"scope\")"))
+        #expect(!noise.contains("Image(systemName: \"eye.slash\")\n                .font(.title2)"))
+    }
+
+    @Test("Focus and Noise sheet copy matches Project and Traffic Tab ownership")
+    func focusSheetsUseCurrentProductTerminology() throws {
+        let focus = try readProjectFile("Rockxy/Views/Sidebar/FocusSetEditorSheet.swift")
+        let noise = try readProjectFile("Rockxy/Views/Sidebar/NoiseControlManagerSheet.swift")
+
+        #expect(focus.contains("Focus Sets are available in every Project"))
+        #expect(focus.contains("current Traffic Tab"))
+        #expect(noise.contains("current Traffic Tab"))
+        #expect(noise.contains("no requests are deleted"))
+        #expect(noise.contains("regardless of the active Focus Set"))
+        #expect(!noise.contains("this workspace"))
+    }
+
     @Test("Browse reveals captured apps and domains without extra disclosure clicks")
     func browseGroupsStartExpanded() {
         #expect(SidebarDisclosureDefaults.appsExpanded)

--- a/RockxyTests/Views/Main/NativeWorkspaceSplitViewTests.swift
+++ b/RockxyTests/Views/Main/NativeWorkspaceSplitViewTests.swift
@@ -160,7 +160,7 @@ struct NativeWorkspaceSplitViewTests {
         #expect(window.titleVisibility == .hidden)
     }
 
-    @Test("Main toolbar places the sidebar toggle before its tracking separator")
+    @Test("Main toolbar keeps the sidebar toggle inside the leading pane before its tracking separator")
     func nativeSidebarToolbarChrome() {
         let controller = makeController(sidebarPresented: true, inspectorPresented: true)
         let coordinator = MainContentCoordinator()
@@ -200,6 +200,9 @@ struct NativeWorkspaceSplitViewTests {
                 toolbar.managedToolbar.items[trackingSeparatorIndex]
                     is NSTrackingSeparatorToolbarItem
             )
+        }
+        if let toggleIndex {
+            #expect(!toolbar.managedToolbar.items[toggleIndex].isNavigational)
         }
         if let projectSelectorIndex,
            let selectorView = toolbar.managedToolbar.items[projectSelectorIndex].view


### PR DESCRIPTION
## Summary

- Rebuild the Focus Set editor and Noise Control manager with native macOS hierarchy, Rockxy terminology, and scoped Liquid Glass chrome.
- Present muted sources in a native table with clear search, empty, mute, unmute, and count states.
- Restore the Source List toggle to its original position inside the leading pane and protect the placement with regression coverage.

## Why

The Focus and Noise sheets used card-heavy presentation and ambiguous ownership copy that did not match the rest of Rockxy. The customizable toolbar also moved the Source List toggle out of the sidebar title-bar region.

## Impact

- Focus Set definitions remain app-wide while applying a set remains Traffic Tab-scoped.
- Noise Control remains Traffic Tab-scoped and continues capturing without deleting requests.
- Filtering and capture behavior are unchanged; this PR refines presentation, terminology, accessibility, and toolbar placement.

## Related issues

Refs #10

## Validation

- swiftlint lint --strict
- FocusSidebarPresentationTests
- NativeWorkspaceSplitViewTests
- Debug build
- Isolated dark and light runtime QA for both sheets
- Isolated sidebar collapse and restore QA