### PR TITLE
docs(localization): formalize global translation contributions

### DIFF
--- a/.github/ISSUE_TEMPLATE/4-Translation_Improvement.md
+++ b/.github/ISSUE_TEMPLATE/4-Translation_Improvement.md
@@ -1,0 +1,35 @@
+---
+name: Translation Improvement
+about: Report wording that is inaccurate, unnatural, culturally inappropriate, or truncated.
+labels: 'enhancement'
+---
+
+## Language
+
+<!-- Include the language and locale when known, for example German (de) or Brazilian Portuguese (pt-BR). -->
+
+- Language:
+- Locale:
+
+## Location
+
+<!-- Where does the text appear? Include the screen, dialog, setting, or action that reveals it. -->
+
+- Rockxy version:
+- Screen or workflow:
+
+## Current Text
+
+<!-- Paste the current localized text exactly as shown. -->
+
+## Suggested Text
+
+<!-- Paste the wording you recommend. -->
+
+## Why This Is Better
+
+<!-- Explain the meaning, tone, cultural issue, technical terminology, or layout problem. Native-speaker context, a platform terminology reference, or a screenshot is useful evidence when relevant. -->
+
+## Screenshot or Reference
+
+<!-- Optional. Remove private URLs, headers, credentials, tokens, request bodies, and other captured traffic before attaching a screenshot. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,12 +9,22 @@
 -
 -
 
+## Localization (if applicable)
+<!-- For translation work, include the language/locale, affected screen or catalog key, and why the proposed wording is better. A screenshot or terminology reference is useful when relevant. Write "Not applicable" for non-localization PRs. -->
+
+- Language / locale:
+- Affected UI or catalog key:
+- Verification / rationale:
+
 ## Checklist
+
+<!-- Mark non-applicable items in the PR description. Translation-only PRs do not need Swift tests, lint, formatting, or a changelog entry unless Swift code, English source strings, or product behavior also changed. -->
 
 - [ ] Tests added or updated
 - [ ] `CHANGELOG.md` updated under `[Unreleased]` (skip for unreleased-only fixes)
 - [ ] Docs updated in `docs/` if the change affects user-facing behavior
 - [ ] User-facing strings localized with `String(localized:)`
+- [ ] If string catalogs changed: placeholders and non-translatable technical details are unchanged
 - [ ] If string catalogs changed: `python3 .github/tools/validate_xcstrings.py` passes (see `docs/development/localization.mdx`)
 - [ ] No SwiftLint / SwiftFormat violations (`swiftlint lint --strict && swiftformat .`)
 - [ ] If this PR touches helper packaging, release scripts, or platform compatibility claims, Intel + Apple Silicon validation was updated or re-run

--- a/.github/tools/tests/test_validate_xcstrings.py
+++ b/.github/tools/tests/test_validate_xcstrings.py
@@ -1,0 +1,87 @@
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+
+VALIDATOR_PATH = Path(__file__).resolve().parents[1] / "validate_xcstrings.py"
+SPEC = importlib.util.spec_from_file_location("validate_xcstrings", VALIDATOR_PATH)
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError(f"Cannot load validator from {VALIDATOR_PATH}")
+VALIDATOR = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(VALIDATOR)
+
+
+def catalog_with(localizations: dict[str, str]) -> dict:
+    return {
+        "sourceLanguage": "en",
+        "strings": {
+            "Start Proxy": {
+                "localizations": {
+                    language: {"stringUnit": {"state": "translated", "value": value}}
+                    for language, value in localizations.items()
+                }
+            }
+        },
+        "version": "1.0",
+    }
+
+
+class LanguageDiscoveryTests(unittest.TestCase):
+    def write_catalog(self, directory: Path, name: str, localizations: dict[str, str]) -> Path:
+        path = directory / name
+        path.write_text(json.dumps(catalog_with(localizations)), encoding="utf-8")
+        return path
+
+    def test_discovers_union_of_locales_and_keeps_shipped_baseline(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            app = self.write_catalog(root, "Localizable.xcstrings", {"de": "Proxy starten"})
+            info = self.write_catalog(root, "InfoPlist.xcstrings", {"fr": "Demarrer le proxy"})
+
+            self.assertEqual(VALIDATOR.discover_languages([app, info]), ["de", "fr", "zh-Hans"])
+
+    def test_union_requires_new_locale_in_every_catalog(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            app = self.write_catalog(
+                root,
+                "Localizable.xcstrings",
+                {"de": "Proxy starten", "zh-Hans": "Start Proxy"},
+            )
+            info = self.write_catalog(root, "InfoPlist.xcstrings", {"zh-Hans": "Start Proxy"})
+
+            required = VALIDATOR.required_languages("all", [app, info])
+            errors = VALIDATOR.validate_catalog(info, required)
+
+            self.assertTrue(any("missing de translation" in error for error in errors))
+
+    def test_explicit_locale_list_is_trimmed_sorted_and_deduplicated(self) -> None:
+        self.assertEqual(VALIDATOR.required_languages(" de,zh-Hans,de ", []), ["de", "zh-Hans"])
+
+    def test_reads_quoted_and_unquoted_project_regions(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            project = Path(temporary_directory) / "project.pbxproj"
+            project.write_text(
+                'knownRegions = (\n en,\n Base,\n de,\n "pt-BR",\n);\n',
+                encoding="utf-8",
+            )
+
+            self.assertEqual(VALIDATOR.project_languages(project), ["de", "pt-BR"])
+
+    def test_reports_catalog_and_project_locale_mismatches(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            catalog = self.write_catalog(root, "Localizable.xcstrings", {"de": "Proxy starten"})
+            project = root / "project.pbxproj"
+            project.write_text('knownRegions = (\n en,\n Base,\n fr,\n);\n', encoding="utf-8")
+
+            errors = VALIDATOR.validate_project_languages([catalog], project)
+
+            self.assertTrue(any("'de' is present in catalogs" in error for error in errors))
+            self.assertTrue(any("'fr' is missing from the catalogs" in error for error in errors))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/tools/validate_xcstrings.py
+++ b/.github/tools/validate_xcstrings.py
@@ -6,17 +6,19 @@ canonical catalogs):
 
   * the file is valid JSON with sourceLanguage == "en";
   * every translatable entry has a non-empty translation for each required
-    language (default: zh-Hans) -- this is the coverage gate;
+    language (default: every locale discovered across the canonical catalogs,
+    plus the shipped zh-Hans baseline) -- this is the coverage gate;
   * no translation value is empty or whitespace-only;
   * printf-style placeholders and positional arguments match between the
     source string and each translation (placeholder parity);
+  * locales in the canonical catalogs match the Xcode project's knownRegions;
   * when `xcrun xcstringstool` is available, each catalog compiles cleanly.
 
 The script needs no third-party packages and no secrets, so it is safe to run
 on untrusted fork pull requests. Exit code is non-zero if any check fails.
 
 Usage:
-    python3 .github/tools/validate_xcstrings.py [--require zh-Hans[,de,...]] [catalog ...]
+    python3 .github/tools/validate_xcstrings.py [--require all|zh-Hans[,de,...]] [catalog ...]
 """
 
 from __future__ import annotations
@@ -39,6 +41,8 @@ DEFAULT_CATALOGS = [
     "Rockxy/Localizable.xcstrings",
     "Rockxy/InfoPlist.xcstrings",
 ]
+BASELINE_LANGUAGES = {"zh-Hans"}
+DEFAULT_PROJECT_FILE = Path("Rockxy.xcodeproj/project.pbxproj")
 
 
 def placeholder_multiset(text: str) -> list[str]:
@@ -94,6 +98,88 @@ def source_units(key: str, entry: dict) -> dict[tuple[str, ...], str]:
 
 def is_translatable(entry: dict) -> bool:
     return entry.get("shouldTranslate", True) is not False
+
+
+def catalog_languages(paths: list[Path]) -> list[str]:
+    """Return the union of translated locales across all readable catalogs.
+
+    Invalid files are left to validate_catalog(), which reports actionable errors.
+    """
+    languages: set[str] = set()
+    for path in paths:
+        try:
+            catalog = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+
+        source_language = catalog.get("sourceLanguage")
+        strings = catalog.get("strings")
+        if not isinstance(strings, dict):
+            continue
+        for entry in strings.values():
+            if not isinstance(entry, dict) or not is_translatable(entry):
+                continue
+            localizations = entry.get("localizations")
+            if not isinstance(localizations, dict):
+                continue
+            languages.update(
+                language
+                for language in localizations
+                if isinstance(language, str) and language and language != source_language
+            )
+    return sorted(languages)
+
+
+def discover_languages(paths: list[Path]) -> list[str]:
+    """Return every catalog locale plus the shipped baseline.
+
+    The baseline prevents a pull request from bypassing coverage by deleting the
+    only shipped translation from both catalogs. Taking the union means a locale
+    added to just one catalog becomes required in every catalog in the same run.
+    """
+    return sorted(set(catalog_languages(paths)) | BASELINE_LANGUAGES)
+
+
+def project_languages(path: Path) -> list[str]:
+    """Read translatable locale identifiers from the Xcode knownRegions block."""
+    text = path.read_text(encoding="utf-8")
+    match = re.search(r"\bknownRegions\s*=\s*\((.*?)\);", text, re.DOTALL)
+    if match is None:
+        raise ValueError("missing knownRegions block")
+
+    languages: set[str] = set()
+    for raw_line in match.group(1).splitlines():
+        token = raw_line.split("/*", 1)[0].strip().rstrip(",").strip()
+        if not token:
+            continue
+        if token.startswith('"') and token.endswith('"'):
+            token = json.loads(token)
+        if token not in {"Base", "en"}:
+            languages.add(token)
+    return sorted(languages)
+
+
+def validate_project_languages(paths: list[Path], project_path: Path) -> list[str]:
+    """Require the canonical catalogs and Xcode project to declare the same locales."""
+    try:
+        regions = set(project_languages(project_path))
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        return [f"{project_path}: cannot read knownRegions ({exc})"]
+
+    locales = set(catalog_languages(paths))
+    errors: list[str] = []
+    for language in sorted(locales - regions):
+        errors.append(f"{project_path}: locale {language!r} is present in catalogs but missing from knownRegions")
+    for language in sorted(regions - locales):
+        errors.append(f"{project_path}: knownRegions locale {language!r} is missing from the catalogs")
+    return errors
+
+
+def required_languages(value: str, paths: list[Path]) -> list[str]:
+    """Resolve the --require option into a stable, de-duplicated locale list."""
+    if value.strip().lower() == "all":
+        return discover_languages(paths)
+    return sorted({language.strip() for language in value.split(",") if language.strip()})
 
 
 def validate_catalog(path: Path, required: list[str]) -> list[str]:
@@ -188,8 +274,11 @@ def main() -> int:
     parser = argparse.ArgumentParser(description="Validate Rockxy .xcstrings catalogs.")
     parser.add_argument(
         "--require",
-        default="zh-Hans",
-        help="Comma-separated languages that must be fully translated (default: zh-Hans).",
+        default="all",
+        help=(
+            "Comma-separated languages that must be fully translated, or 'all' to discover every locale "
+            "across the catalogs (default: all)."
+        ),
     )
     parser.add_argument(
         "--no-compile",
@@ -199,12 +288,17 @@ def main() -> int:
     parser.add_argument("catalogs", nargs="*", default=DEFAULT_CATALOGS)
     args = parser.parse_args()
 
-    required = [lang.strip() for lang in args.require.split(",") if lang.strip()]
     catalogs = args.catalogs or DEFAULT_CATALOGS
+    catalog_paths = [Path(name) for name in catalogs]
+    required = required_languages(args.require, catalog_paths)
+
+    if not required:
+        parser.error("--require must contain at least one locale or 'all'")
 
     all_errors: list[str] = []
-    for name in catalogs:
-        path = Path(name)
+    if catalogs == DEFAULT_CATALOGS:
+        all_errors.extend(validate_project_languages(catalog_paths, DEFAULT_PROJECT_FILE))
+    for path in catalog_paths:
         if not path.exists():
             all_errors.append(f"{path}: catalog not found")
             continue

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,9 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # immutable commit
         with:
           persist-credentials: false
-      - name: Validate string catalogs (JSON, zh-Hans coverage, placeholder parity, compile)
+      - name: Test localization validator
+        run: python3 -m unittest discover -s .github/tools/tests -p 'test_validate_xcstrings.py'
+      - name: Validate string catalogs (JSON, locale coverage, project regions, placeholders, compile)
         run: python3 .github/tools/validate_xcstrings.py
 
   lint:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,14 +77,41 @@ Before opening, check:
 - [ ] No SwiftLint/SwiftFormat violations
 - [ ] If the change touches helper packaging, release scripts, or platform compatibility claims, Intel + Apple Silicon validation was updated or re-run
 
+Mark checklist items that do not apply in the PR description. A translation-only
+PR does not need Swift tests, SwiftLint, SwiftFormat, or a changelog entry unless it
+also changes Swift code, English source strings, or product behavior.
+
 ## Translations
 
 Rockxy ships native Xcode String Catalogs (`Rockxy/Localizable.xcstrings` and
 `Rockxy/InfoPlist.xcstrings`); the Git-tracked catalogs are canonical and there is
 an app-language picker under **Settings › Appearance › Language**. **System Default**
 follows the macOS language; choosing another bundled language updates Rockxy
-immediately. To add or improve a language, edit the catalogs in Xcode, preserve every
-placeholder and plural/format token, then validate before pushing:
+immediately.
+
+There are three useful ways to contribute:
+
+1. **Report wording:** use the
+   [Translation Improvement issue template](https://github.com/RockxyApp/Rockxy/issues/new?template=4-Translation_Improvement.md)
+   if you know better wording but do not want to edit the catalogs.
+2. **Repair a translation:** a focused PR may update only the affected localized
+   value. Small repairs can be made in GitHub or any text editor; Xcode is optional.
+3. **Add a language:** use Xcode to add the locale to both catalogs, translate all
+   translatable entries, and verify the changed UI in the app.
+
+For a repair, include the locale, affected screen, proposed wording, and a short
+reason the wording is better. Useful evidence can be native-speaker knowledge, a
+platform terminology reference, a screenshot showing context or truncation, or a
+clear explanation of the technical meaning. Do not include private captured traffic
+in screenshots.
+
+Keep non-translatable details unchanged: placeholders, protocol names, header
+names, URLs, file extensions, MIME types, code fragments, product names, and
+keyboard shortcuts. Machine translation may help with a draft, but bulk-generated
+translations must be reviewed by someone fluent in the target language before the
+PR is marked ready.
+
+Preserve every placeholder and plural/format token, then validate before pushing:
 
 ```bash
 python3 .github/tools/validate_xcstrings.py
@@ -92,7 +119,8 @@ python3 .github/tools/validate_xcstrings.py
 
 A maintainer reviews every `.xcstrings` change; this gates review, not authorship.
 See [`docs/development/localization.mdx`](docs/development/localization.mdx) for the
-full workflow, catalog hygiene, and placeholder rules.
+complete GitHub/text-editor workflow, Xcode workflow, language identifiers, runtime
+checks, catalog hygiene, and placeholder rules.
 
 ## Project Layout
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,13 @@
   <a href="https://trendshift.io/repositories/26380?utm_source=trendshift-badge&amp;utm_medium=badge&amp;utm_campaign=badge-trendshift-26380" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/trendshift/repositories/26380/daily?language=Swift" alt="RockxyApp/Rockxy | Trendshift" width="250" height="55" /></a>
 </p>
 
+> [!TIP]
+> Translation improvements are welcome in every language. Found wording that is
+> awkward, inaccurate, culturally inappropriate, truncated, or too literal? Open
+> a [translation issue](https://github.com/RockxyApp/Rockxy/issues/new?template=4-Translation_Improvement.md)
+> or send a focused PR. Small repairs can be made without Xcode. See the
+> [localization guide](docs/development/localization.mdx) for both repair and new-language workflows.
+
 > [!IMPORTANT]
 > This repository contains the public Rockxy Community source edition under
 > AGPL-3.0-or-later. Builds made solely from this repository are AGPL builds.

--- a/RockxyTests/Localization/StringCatalogCoverageTests.swift
+++ b/RockxyTests/Localization/StringCatalogCoverageTests.swift
@@ -13,8 +13,6 @@ import Testing
 struct StringCatalogCoverageTests {
     // MARK: Internal
 
-    static let requiredLanguages = ["zh-Hans"]
-
     @Test("Localizable.xcstrings is well-formed and fully covered")
     func localizableCatalog() throws {
         try validateCatalog(named: "Localizable.xcstrings")
@@ -35,6 +33,28 @@ struct StringCatalogCoverageTests {
             .deletingLastPathComponent() // <repo>/
             .appendingPathComponent("Rockxy")
             .appendingPathComponent(fileName)
+    }
+
+    private static func requiredLanguages() throws -> [String] {
+        var languages: Set = ["zh-Hans"]
+        for fileName in ["Localizable.xcstrings", "InfoPlist.xcstrings"] {
+            let data = try Data(contentsOf: catalogURL(fileName))
+            let root = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+            let catalog = try #require(root, "\(fileName): not a JSON object")
+            let sourceLanguage = catalog["sourceLanguage"] as? String
+            let strings = try #require(catalog["strings"] as? [String: Any], "\(fileName): missing strings object")
+
+            for rawEntry in strings.values {
+                guard let entry = rawEntry as? [String: Any],
+                      entry["shouldTranslate"] as? Bool != false,
+                      let localizations = entry["localizations"] as? [String: Any] else
+                {
+                    continue
+                }
+                languages.formUnion(localizations.keys.filter { $0 != sourceLanguage })
+            }
+        }
+        return languages.sorted()
     }
 
     private static func sourceUnits(key: String, entry: [String: Any]) -> [String: String] {
@@ -105,6 +125,7 @@ struct StringCatalogCoverageTests {
         #expect(catalog["sourceLanguage"] as? String == "en", "\(fileName): sourceLanguage must be en")
 
         let strings = try #require(catalog["strings"] as? [String: Any], "\(fileName): missing strings object")
+        let requiredLanguages = try Self.requiredLanguages()
 
         for (key, rawEntry) in strings {
             guard let entry = rawEntry as? [String: Any] else {
@@ -117,7 +138,7 @@ struct StringCatalogCoverageTests {
             let localizations = entry["localizations"] as? [String: Any] ?? [:]
             let expectedUnits = Self.sourceUnits(key: key, entry: entry)
 
-            for language in Self.requiredLanguages {
+            for language in requiredLanguages {
                 guard let node = localizations[language] as? [String: Any] else {
                     Issue.record("\(fileName): \(key) missing \(language) translation")
                     continue

--- a/docs/development/localization.mdx
+++ b/docs/development/localization.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Localization"
-description: "How Rockxy is localized, how to add or improve a language, and the catalog hygiene rules contributors must follow"
+description: "How to report, repair, test, and contribute Rockxy translations or add a new language"
 ---
 
 Rockxy uses native Xcode **String Catalogs** (`.xcstrings`). The catalogs checked
@@ -21,8 +21,24 @@ automatically.
 | `Rockxy/InfoPlist.xcstrings` | `Info.plist` user-facing text (e.g. the Local Network usage prompt) |
 
 The source language is **English (`en`)**. The first shipped translation is
-**Simplified Chinese (`zh-Hans`)**. `knownRegions` in `Rockxy.xcodeproj/project.pbxproj`
-lists every language the project builds.
+**Simplified Chinese (`zh-Hans`)**. `knownRegions` in
+`Rockxy.xcodeproj/project.pbxproj` lists every language the project builds.
+
+## What contributions are welcome
+
+Rockxy accepts localization contributions for every language, including:
+
+- inaccurate, unnatural, overly literal, or culturally inappropriate wording,
+- text that is too long, clipped, or unclear in its actual UI context,
+- incorrect technical terminology or inconsistent wording,
+- missing translator context and corrections to the English source,
+- complete translations for a new language.
+
+You do not need to be a programmer or have Xcode to report or repair a small
+translation. If you prefer not to edit a catalog, open a
+[Translation Improvement issue](https://github.com/RockxyApp/Rockxy/issues/new?template=4-Translation_Improvement.md)
+with the language, where the text appears, the current wording, your proposed
+wording, and why it is better.
 
 ## Writing localizable code
 
@@ -57,20 +73,82 @@ Rules that keep extraction clean and translations safe:
 - **Comments are for translators.** Add a `comment` to any catalog entry whose
   meaning is ambiguous out of context, and to flag tokens that must stay verbatim.
 
-## Adding or improving a language
+## Translation principles
+
+- **Translate meaning in context.** Prefer natural product language in the target
+  language over word-for-word English structure.
+- **Preserve technical meaning.** A polished sentence that changes how a proxy,
+  certificate, rule, or destructive action behaves is not an acceptable translation.
+- **Keep the UI concise.** Match the tone of a native macOS application and check
+  that labels, buttons, menus, tables, and settings do not truncate.
+- **Be consistent.** Reuse established translations for the same action or concept.
+- **Review generated drafts.** Machine translation may be used as a starting point,
+  but do not submit bulk-generated catalog output without fluent human review.
+- **Protect user data.** Redact private URLs, headers, credentials, tokens, request
+  bodies, and captured traffic from screenshots or examples.
+
+## Repairing an existing translation
+
+Translation repair PRs are welcome, including PRs that change only one phrase. A
+small, focused correction is easier to review and does not need unrelated catalog
+entries, Swift tests, SwiftLint, SwiftFormat, or a changelog entry.
+
+### Without Xcode
+
+For a small repair, GitHub's web editor or any UTF-8 text editor is enough:
+
+1. Fork the repository and create a branch from `develop`.
+2. Search `Rockxy/Localizable.xcstrings` or `Rockxy/InfoPlist.xcstrings` for the
+   exact text currently shown in the app.
+3. In that entry's `localizations` object, change only the `value` for your locale.
+   Do not rename the English key, reorder the whole file, or reformat unrelated JSON.
+4. Run `python3 .github/tools/validate_xcstrings.py --no-compile`. This needs only
+   Python 3 and works without Xcode on macOS, Linux, and Windows (where the command
+   may be `python` instead of `python3`).
+5. Open a PR against `develop` and complete the localization section of the PR
+   template.
+
+### With Xcode
+
+1. Open `Rockxy.xcodeproj` and select the affected `.xcstrings` catalog.
+2. Filter by the target language or search for the English key/current translation.
+3. Edit only the affected localized value and review every variation shown by Xcode.
+4. Run the validator and verify the changed UI in Rockxy.
+5. Open a focused PR against `develop`.
+
+For either workflow, include the locale, affected screen or catalog key, and a
+short reason the wording is better. Useful evidence can be native-speaker knowledge,
+a platform terminology reference, a screenshot showing context or truncation, or a
+clear explanation of the technical meaning. A public citation is helpful when one
+exists, but it is not required for ordinary native-language corrections.
+
+If the English source is wrong, say so explicitly. Changing an English key can
+affect every locale, so update the impacted translations or keep the source change
+in a separate PR that can receive broader review.
+
+## Adding a new language
 
 Anyone may contribute a language through a normal reviewed pull request:
 
-1. Open `Rockxy/Localizable.xcstrings` (and `InfoPlist.xcstrings`) in Xcode.
-2. Add your language from the catalog's **+** control, or edit an existing one.
-3. Translate every entry. Preserve, exactly:
+1. Choose the standard locale identifier used by Apple, such as `de`, `fr`, `ja`,
+   `ko`, `zh-Hant`, or `pt-BR`. Use a region-specific locale only when the wording
+   genuinely differs from the base language.
+2. Open `Rockxy/Localizable.xcstrings` and `Rockxy/InfoPlist.xcstrings` in Xcode.
+3. Add the same language to **both catalogs** from the catalog's **+** control.
+   Confirm Xcode also added the locale to `knownRegions` in
+   `Rockxy.xcodeproj/project.pbxproj`.
+4. Translate every translatable entry. Preserve, exactly:
    - placeholders and their **order** (`%@`, `%lld`, positional `%1$@` / `%2$lld`),
    - plural / device variations,
    - leading/trailing whitespace and newlines,
    - Markdown and HTML fragments,
    - keyboard notation, file extensions, and technical/product terms.
-4. Run the validator (below) until it is clean.
-5. Open a PR against `develop`. A maintainer reviews every `.xcstrings` change
+5. Run `python3 .github/tools/validate_xcstrings.py --require <locale>` until it
+   is clean. The default validator also discovers and checks every locale present
+   in either catalog.
+6. Build Rockxy, select the new language under **Settings › Appearance › Language**,
+   and inspect the important surfaces listed below.
+7. Open a PR against `develop`. A maintainer reviews every `.xcstrings` change
    (see `.github/CODEOWNERS`) — this protects placeholder integrity and the shared
    English source, and does **not** block your contribution.
 
@@ -78,26 +156,62 @@ Translations may land as a first pass and be refined later, but a language shoul
 not be advertised as supported until its **runtime coverage is complete** — every
 translatable entry has a non-empty value.
 
+## What must remain unchanged
+
+Unless the term has an established localized product spelling, preserve these
+exactly:
+
+- placeholders and their order (`%@`, `%lld`, `%1$@`, `%2$lld`),
+- protocol and product names (`HTTP`, `HTTPS`, `WebSocket`, `GraphQL`, `MCP`,
+  `Rockxy`),
+- header names, MIME types, URLs, routes, file extensions, and code fragments,
+- keyboard notation and shortcuts,
+- Markdown/HTML structure, intentional whitespace, and newlines.
+
+If a technical token must move to make the sentence natural, use positional
+placeholders so its semantic argument order remains unambiguous; do not change the
+placeholder's conversion type.
+
+## Runtime review
+
+Catalog validation proves structure and placeholder safety, but it cannot judge
+language quality or layout. Before marking a new-language PR ready, select the
+language in Rockxy and review at least:
+
+- onboarding and permission dialogs,
+- **Settings**, including **Appearance › Language**,
+- the main capture toolbar, traffic list, filters, and empty states,
+- request/response inspectors and error messages,
+- rules, breakpoints, certificate, import/export, and destructive confirmations,
+- menus, tooltips, keyboard shortcuts, and `Info.plist` permission prompts.
+
+Look for clipping, overlapping controls, untranslated English, incorrect plural or
+format substitutions, and wording that changes the action's meaning. Attach focused,
+redacted screenshots to the PR when a reviewer cannot infer the UI context from the
+catalog key alone.
+
 ## Validation
 
-Run the deterministic validator before pushing. It needs no secrets and no Xcode
-project, so it runs the same way locally and in CI:
+Run the deterministic validator before pushing. It needs no secrets or third-party
+packages, so it runs the same way locally and in CI:
 
 ```bash
-# Validate the default catalogs, requiring full zh-Hans coverage
+# Validate both catalogs and every locale discovered in either catalog
 python3 .github/tools/validate_xcstrings.py
 
-# Check a different language (or several)
+# Require a specific language (or several) explicitly
 python3 .github/tools/validate_xcstrings.py --require zh-Hans,de
 
 # Skip the optional xcstringstool compile (e.g. on a non-macOS machine)
 python3 .github/tools/validate_xcstrings.py --no-compile
 ```
 
-The validator checks: valid JSON, `sourceLanguage == en`, full coverage for the
-required languages, no empty values, and placeholder parity between the source and
-every translation. When Xcode's toolchain is available it also compiles each catalog
-with `xcrun xcstringstool compile`. You can compile a catalog by hand too:
+The validator checks: valid JSON, `sourceLanguage == en`, matching locale coverage
+across both catalogs, full coverage for every discovered or explicitly required
+language, parity with the Xcode project's `knownRegions`, no empty values, variation
+parity, and placeholder parity between the source and every translation. When
+Xcode's toolchain is available it also compiles each catalog with
+`xcrun xcstringstool compile`. You can compile a catalog by hand too:
 
 ```bash
 xcrun xcstringstool compile --output-directory /tmp/xcstrings Rockxy/Localizable.xcstrings


### PR DESCRIPTION
## Summary

- add a dedicated translation feedback issue template and localization fields to the pull request template
- document focused translation repairs, no-Xcode contributions, new-language setup, evidence expectations, runtime review, and screenshot privacy
- make localization validation discover every contributed locale, require parity across both catalogs and Xcode known regions, and keep the shipped Simplified Chinese baseline protected
- add validator unit tests and run them in the fork-safe localization CI job

## Why

Rockxy now reaches users across more languages, but contributors need a clear path for both small wording repairs and complete new-language support. The public workflow should welcome non-programmers, capture enough context for accurate review, and provide deterministic checks that scale beyond the first translated locale.

## Impact

Translation contributors can report or repair wording without Xcode, while new-language pull requests receive automatic coverage, placeholder, variation, catalog, project-region, and compile checks. This pull request does not change current translations or application runtime behavior.

## Related issues

No directly related issue. The repository issue audit found #289, but its Simplified Chinese support request was completed by earlier localization work and this pull request does not implement that acceptance criterion.

## Validation

- `python3 -m unittest discover -s .github/tools/tests -p 'test_validate_xcstrings.py'`
- `python3 .github/tools/validate_xcstrings.py`
- `python3 .github/tools/validate_xcstrings.py --no-compile`
- `swiftformat --lint RockxyTests/Localization/StringCatalogCoverageTests.swift`
- `swiftlint lint --strict RockxyTests/Localization/StringCatalogCoverageTests.swift`
- `xcodebuild -project Rockxy.xcodeproj -scheme Rockxy -destination 'platform=macOS' -only-testing:RockxyTests/StringCatalogCoverageTests test`
