### PR TITLE
fix(breakpoints): stabilize promotion checks

### DIFF
--- a/Rockxy/Core/RuleEngine/BreakpointManager.swift
+++ b/Rockxy/Core/RuleEngine/BreakpointManager.swift
@@ -90,7 +90,7 @@ final class BreakpointManager {
                 // Auto-raise the queue window once per burst: notify only on the
                 // empty → non-empty transition, not on every subsequent hit.
                 if wasEmpty {
-                    NotificationCenter.default.post(name: .breakpointHit, object: nil)
+                    NotificationCenter.default.post(name: .breakpointHit, object: self)
                 }
             }
         } onCancel: {

--- a/Rockxy/Models/UI/KeyboardShortcutReference.swift
+++ b/Rockxy/Models/UI/KeyboardShortcutReference.swift
@@ -93,7 +93,7 @@ enum KeyboardShortcutCatalog {
             row("compose.reset", "Compose", "Reset to a fresh request", "⌘0", "Compose window", nil, nil),
         ]),
         KeyboardShortcutSection(id: "breakpointQueue", title: "Breakpoint Queue", shortcuts: [
-            row("breakpoint.execute", "Breakpoint Queue", "Execute the selected paused item", "⌘↩", "Selected paused item", nil, nil),
+            row("breakpoint.execute", "Breakpoint Queue", "Apply changes and continue the selected paused item", "⌘↩", "Selected paused item", nil, nil),
             row("breakpoint.abort", "Breakpoint Queue", "Abort the selected paused item", "⌘.", "Selected paused item", nil, nil),
             row("breakpoint.close", "Breakpoint Queue", "Close the queue window; queued items remain paused", "Esc", "Breakpoint Queue window", nil, "Paused item stays queued."),
             row("breakpoint.previous", "Breakpoint Queue", "Move to the previous or next queued item", "⌘[", "Breakpoint Queue selection", nil, nil),
@@ -110,7 +110,7 @@ enum KeyboardShortcutCatalog {
             row("rules.breakpoint.duplicate", "Breakpoint Rules", "Duplicate the selected rule", "⌘D", "Breakpoint Rules window", nil, nil),
             row("rules.breakpoint.delete", "Breakpoint Rules", "Delete the selected rule", "⌘⌫", "Breakpoint Rules window", nil, nil),
             row("rules.breakpoint.filter", "Breakpoint Rules", "Focus the rules search field", "⌘F", "Breakpoint Rules window", nil, nil),
-            row("rules.templates", "Breakpoint Rules", "Open Breakpoint Templates from Breakpoint Rules", "⌘T", "Breakpoint Rules window", nil, nil),
+            row("rules.templates", "Breakpoint Rules", "Open Breakpoint Templates", "⌘T", "Breakpoint Rules window", nil, nil),
             row("rules.new", "Other Rules Windows", "New rule", "⌘N", "Focused non-Breakpoint rules window", nil, nil),
             row("rules.newFolder", "Other Rules Windows", "New folder", "⇧⌘N", "Map Local and Scripting lists", nil, "Unavailable in rule windows without folder support."),
             row("rules.edit", "Other Rules Windows", "Edit selected rule", "⌘E", "Focused non-Breakpoint rules list", nil, nil),

--- a/RockxyTests/Breakpoint/BreakpointPhaseGTests.swift
+++ b/RockxyTests/Breakpoint/BreakpointPhaseGTests.swift
@@ -10,10 +10,14 @@ struct BreakpointPhaseGTests {
     func threeConcurrentMatchesProduceThreeQueueItems() async throws {
         let manager = BreakpointManager()
         let harness = BreakpointTestHarness(manager: manager, ruleEngine: RuleEngine())
-        let tasks = (1...3).map { index in
-            Task { await manager.enqueueAndWait(.test(url: "https://httpbin.org/get?id=\(index)")) }
+        var tasks: [Task<(BreakpointDecision, BreakpointRequestData), Never>] = []
+        for index in 1...3 {
+            let task = Task {
+                await manager.enqueueAndWait(.test(url: "https://httpbin.org/get?id=\(index)"))
+            }
+            tasks.append(task)
+            try await waitForQueueCount(index, manager: manager)
         }
-        try await waitForQueueCount(3, manager: manager)
         #expect(manager.pausedItems.count == 3)
         let ids = Set(manager.pausedItems.map(\.id))
         #expect(ids.count == 3)

--- a/RockxyTests/Breakpoint/BreakpointTestHarness.swift
+++ b/RockxyTests/Breakpoint/BreakpointTestHarness.swift
@@ -112,7 +112,10 @@ actor BreakpointTestHarness {
         }
         return try await withThrowingTaskGroup(of: PausedBreakpointItem.self) { group in
             group.addTask { [manager] in
-                for await _ in NotificationCenter.default.notifications(named: .breakpointHit) {
+                for await notification in NotificationCenter.default.notifications(named: .breakpointHit) {
+                    guard notification.object as AnyObject? === manager else {
+                        continue
+                    }
                     if let item = await MainActor.run(body: { manager.pausedItems.first }) {
                         return item
                     }

--- a/RockxyTests/Core/RuleEngine/BreakpointManagerTests.swift
+++ b/RockxyTests/Core/RuleEngine/BreakpointManagerTests.swift
@@ -163,7 +163,7 @@ struct BreakpointManagerTests {
         let counter = NotificationCounter()
         let token = NotificationCenter.default.addObserver(
             forName: .breakpointHit,
-            object: nil,
+            object: manager,
             queue: nil
         ) { _ in
             counter.increment()

--- a/RockxyTests/Keyboard/KeyboardShortcutTests.swift
+++ b/RockxyTests/Keyboard/KeyboardShortcutTests.swift
@@ -48,7 +48,7 @@ struct KeyboardShortcutTests {
     @Test("KS_FOCUS_03 Breakpoint Queue documents execute without an extra click")
     func breakpointQueueExecuteFocusIsDocumented() throws {
         let reference = try Self.documentation(named: "keyboard-shortcuts.md")
-        #expect(reference.contains("Execute the selected paused item"))
+        #expect(reference.contains("Apply changes and continue the selected paused item"))
         #expect(reference.contains("`⌘↩`"))
     }
 


### PR DESCRIPTION
## Summary

- scope breakpoint queue notifications to the manager that produced them so parallel test configurations do not observe unrelated queue bursts
- register concurrent paused items deterministically before asserting queue state
- align the keyboard shortcut catalog with the public Breakpoint Queue documentation

## Root Cause

The promotion test plan runs multiple configurations concurrently. Breakpoint tests were observing process-wide notifications without identifying the originating manager, while the concurrent queue test used one shared wall-clock deadline. The shortcut catalog also retained two superseded action labels after the documentation wording changed.

## Validation

- `swiftlint lint --strict --quiet`
- `python3 .github/tools/validate_xcstrings.py`
- `python3 -m unittest discover -s .github/tools/tests -p "test_validate_xcstrings.py"`
- focused Breakpoint Phase G, BreakpointManager, and KeyboardShortcut test suites
- full macOS test suite: 3,756 tests passed
- release metadata test suite and validator
- `git diff --check`

Refs #39

Follow-up for #297.