### PR TITLE
fix(proxy): harden promotion review paths

### DIFF
--- a/Rockxy/Core/ProxyEngine/BreakpointResponseBuilder.swift
+++ b/Rockxy/Core/ProxyEngine/BreakpointResponseBuilder.swift
@@ -78,6 +78,7 @@ enum BreakpointResponseBuilder {
         method.caseInsensitiveCompare("HEAD") == .orderedSame
             || (100 ..< 200).contains(statusCode)
             || statusCode == 204
+            || statusCode == 205
             || statusCode == 304
     }
 }

--- a/Rockxy/Core/ProxyEngine/ProxyServer.swift
+++ b/Rockxy/Core/ProxyEngine/ProxyServer.swift
@@ -40,11 +40,21 @@ extension Channel {
 /// Tracks accepted client channels so proxy shutdown can close and await every live
 /// connection before its event-loop group is torn down.
 final class ProxyChildChannelRegistry: @unchecked Sendable {
-    func prepareForStart() {
-        lock.lock()
-        precondition(channels.isEmpty, "Cannot restart a proxy while client channels are still registered")
-        isShuttingDown = false
-        lock.unlock()
+    func prepareForStart() async {
+        var staleChannelCount = 0
+        while true {
+            let staleChannels = beginShutdown()
+            staleChannelCount += staleChannels.count
+            await close(staleChannels)
+            await waitUntilEmpty()
+            guard finishPreparingForStartIfEmpty() else {
+                continue
+            }
+            break
+        }
+        if staleChannelCount > 0 {
+            proxyServerLogger.warning("Closed \(staleChannelCount) stale client channels before proxy restart")
+        }
     }
 
     func register(_ channel: Channel) {
@@ -64,14 +74,7 @@ final class ProxyChildChannelRegistry: @unchecked Sendable {
 
     func closeAllAndWait() async {
         let snapshot = beginShutdown()
-
-        await withTaskGroup(of: Void.self) { group in
-            for channel in snapshot {
-                group.addTask {
-                    try? await channel.close().get()
-                }
-            }
-        }
+        await close(snapshot)
         await waitUntilEmpty()
     }
 
@@ -86,6 +89,26 @@ final class ProxyChildChannelRegistry: @unchecked Sendable {
         let snapshot = Array(channels.values)
         lock.unlock()
         return snapshot
+    }
+
+    private func close(_ channels: [Channel]) async {
+        await withTaskGroup(of: Void.self) { group in
+            for channel in channels {
+                group.addTask {
+                    try? await channel.close().get()
+                }
+            }
+        }
+    }
+
+    private func finishPreparingForStartIfEmpty() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        guard channels.isEmpty else {
+            return false
+        }
+        isShuttingDown = false
+        return true
     }
 
     private func remove(_ identifier: ObjectIdentifier) {
@@ -288,7 +311,7 @@ actor ProxyServer {
             return
         }
 
-        childChannelRegistry.prepareForStart()
+        await childChannelRegistry.prepareForStart()
         let group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
         self.eventLoopGroup = group
 

--- a/RockxyTests/Breakpoint/BreakpointLifecycleTests.swift
+++ b/RockxyTests/Breakpoint/BreakpointLifecycleTests.swift
@@ -65,11 +65,36 @@ struct BreakpointLifecycleTests {
         let client = try BreakpointRawHTTPClient.connect(proxyPort: proxyPort, requestURL: originURL)
 
         _ = try await harness.awaitNextPause(timeout: 8)
-        await harness.stop()
+        await harness.stopProxyOnly()
 
         #expect(harness.manager.pausedItems.isEmpty)
         #expect(await origin.requestCount() == 0)
+        await harness.stop()
         client.close()
+    }
+
+    @Test("proxy restart closes stale registered client channels")
+    func proxyRestartClosesStaleChannels() async throws {
+        let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        do {
+            let registry = ProxyChildChannelRegistry()
+            let staleChannel = try await makeActiveChannel(on: eventLoopGroup)
+            registry.register(staleChannel)
+            #expect(staleChannel.isActive)
+
+            await registry.prepareForStart()
+            #expect(!staleChannel.isActive)
+
+            let freshChannel = try await makeActiveChannel(on: eventLoopGroup)
+            registry.register(freshChannel)
+            #expect(freshChannel.isActive)
+            await registry.closeAllAndWait()
+            #expect(!freshChannel.isActive)
+            try await eventLoopGroup.shutdownGracefully()
+        } catch {
+            try? await eventLoopGroup.shutdownGracefully()
+            throw error
+        }
     }
 
     // MARK: Private
@@ -90,6 +115,16 @@ struct BreakpointLifecycleTests {
         Issue.record(
             "Breakpoint queue did not drain after client disconnect (\(harness.manager.pausedItems.count) still paused)."
         )
+    }
+
+    private func makeActiveChannel(on group: EventLoopGroup) async throws -> Channel {
+        try await ServerBootstrap(group: group)
+            .serverChannelOption(.socketOption(.so_reuseaddr), value: 1)
+            .childChannelInitializer { channel in
+                channel.eventLoop.makeSucceededVoidFuture()
+            }
+            .bind(host: "127.0.0.1", port: 0)
+            .get()
     }
 }
 

--- a/RockxyTests/Breakpoint/BreakpointPhaseETests.swift
+++ b/RockxyTests/Breakpoint/BreakpointPhaseETests.swift
@@ -290,9 +290,10 @@ struct BreakpointPhaseETests {
 
         let paused = try await harness.awaitNextPause(timeout: 8)
         #expect(paused.phase == .response)
-        await harness.stop()
+        await harness.stopProxyOnly()
 
         #expect(harness.manager.pausedItems.isEmpty)
+        await harness.stop()
         client.close()
     }
 

--- a/RockxyTests/Breakpoint/BreakpointPhaseGTests.swift
+++ b/RockxyTests/Breakpoint/BreakpointPhaseGTests.swift
@@ -144,7 +144,7 @@ struct BreakpointPhaseGTests {
     private func waitForQueueCount(
         _ count: Int,
         manager: BreakpointManager,
-        timeout seconds: TimeInterval = 5
+        timeout seconds: TimeInterval = 30
     ) async throws {
         let deadline = Date().addingTimeInterval(seconds)
         while Date() < deadline {

--- a/RockxyTests/Breakpoint/BreakpointTestHarness.swift
+++ b/RockxyTests/Breakpoint/BreakpointTestHarness.swift
@@ -70,12 +70,16 @@ actor BreakpointTestHarness {
     }
 
     func stop() async {
-        await proxyServer?.stop()
-        proxyServer = nil
-        proxyPort = nil
+        await stopProxyOnly()
         await MainActor.run {
             manager.resolveAll(decision: .cancel)
         }
+    }
+
+    func stopProxyOnly() async {
+        await proxyServer?.stop()
+        proxyServer = nil
+        proxyPort = nil
     }
 
     func client() async throws -> URLSession {

--- a/RockxyTests/Core/ProxyEngine/BreakpointResponseBuilderTests.swift
+++ b/RockxyTests/Core/ProxyEngine/BreakpointResponseBuilderTests.swift
@@ -78,7 +78,7 @@ struct BreakpointResponseBuilderTests {
         #expect(result.body == nil)
     }
 
-    @Test(arguments: [101, 199, 204, 304])
+    @Test(arguments: [101, 199, 204, 205, 304])
     func bodyForbiddenStatusRemovesBodyAndFraming(statusCode: Int) {
         var originalHead = HTTPResponseHead(version: .http1_1, status: .ok)
         originalHead.headers.add(name: "Content-Length", value: "8")

--- a/RockxyTests/Localization/StringCatalogCoverageTests.swift
+++ b/RockxyTests/Localization/StringCatalogCoverageTests.swift
@@ -23,6 +23,24 @@ struct StringCatalogCoverageTests {
         try validateCatalog(named: "InfoPlist.xcstrings")
     }
 
+    @Test("Locale discovery ignores empty and source localization keys")
+    func localeDiscoveryIgnoresInvalidKeys() {
+        let catalog: [String: Any] = [
+            "sourceLanguage": "en",
+            "strings": [
+                "Start Proxy": [
+                    "localizations": [
+                        "": [String: Any](),
+                        "en": [String: Any](),
+                        "de": [String: Any](),
+                    ],
+                ],
+            ],
+        ]
+
+        #expect(Self.catalogLanguages(in: catalog) == ["de"])
+    }
+
     // MARK: Private
 
     private static func catalogURL(_ fileName: String) -> URL {
@@ -41,20 +59,27 @@ struct StringCatalogCoverageTests {
             let data = try Data(contentsOf: catalogURL(fileName))
             let root = try JSONSerialization.jsonObject(with: data) as? [String: Any]
             let catalog = try #require(root, "\(fileName): not a JSON object")
-            let sourceLanguage = catalog["sourceLanguage"] as? String
-            let strings = try #require(catalog["strings"] as? [String: Any], "\(fileName): missing strings object")
-
-            for rawEntry in strings.values {
-                guard let entry = rawEntry as? [String: Any],
-                      entry["shouldTranslate"] as? Bool != false,
-                      let localizations = entry["localizations"] as? [String: Any] else
-                {
-                    continue
-                }
-                languages.formUnion(localizations.keys.filter { $0 != sourceLanguage })
-            }
+            languages.formUnion(catalogLanguages(in: catalog))
         }
         return languages.sorted()
+    }
+
+    private static func catalogLanguages(in catalog: [String: Any]) -> Set<String> {
+        guard let strings = catalog["strings"] as? [String: Any] else {
+            return []
+        }
+        let sourceLanguage = catalog["sourceLanguage"] as? String
+        var languages: Set<String> = []
+        for rawEntry in strings.values {
+            guard let entry = rawEntry as? [String: Any],
+                  entry["shouldTranslate"] as? Bool != false,
+                  let localizations = entry["localizations"] as? [String: Any] else
+            {
+                continue
+            }
+            languages.formUnion(localizations.keys.filter { !$0.isEmpty && $0 != sourceLanguage })
+        }
+        return languages
     }
 
     private static func sourceUnits(key: String, entry: [String: Any]) -> [String: String] {


### PR DESCRIPTION
## Summary

- suppress response bodies and framing headers for HTTP 205 breakpoint responses
- close stale registered channels before proxy restart and verify shutdown drains paused breakpoint queues through the server lifecycle
- keep Swift locale discovery aligned with the localization validator by ignoring empty and source-language keys
- make the concurrent breakpoint queue timing bound resilient under full-suite MainActor contention

## Validation

- `swiftlint lint --strict --quiet`
- focused proxy, breakpoint lifecycle, response builder, and localization tests
- concurrent breakpoint queue test repeated 10 times
- full `Rockxy` macOS test scheme
- localization validator unit tests and catalog validation
- release metadata unit tests and validation

Refs #39
Follow-up to #297