### PR TITLE
fix(localization): improve Simplified Chinese accuracy

### DIFF
--- a/.github/tools/tests/test_validate_xcstrings.py
+++ b/.github/tools/tests/test_validate_xcstrings.py
@@ -83,5 +83,108 @@ class LanguageDiscoveryTests(unittest.TestCase):
             self.assertTrue(any("'fr' is missing from the catalogs" in error for error in errors))
 
 
+class ZhHansGlossaryTests(unittest.TestCase):
+    def errors(self, key: str, source: str, value: str) -> list[str]:
+        return VALIDATOR.zh_hans_glossary_errors(Path("Localizable.xcstrings"), key, source, value, ())
+
+    def test_redaction_forbids_zhezai_and_yinqu(self) -> None:
+        self.assertTrue(self.errors("Redaction", "Redaction", "遮盖"))
+        self.assertTrue(self.errors("Redact recognized sensitive data", "Redact recognized sensitive data", "隐去识别到的敏感数据"))
+        self.assertEqual(self.errors("Redaction", "Redaction", "脱敏"), [])
+
+    def test_certificate_pinning_forbids_suoding(self) -> None:
+        source = "Certificate pinning still blocks interception"
+        self.assertTrue(self.errors(source, source, "证书锁定仍在阻止拦截"))
+        self.assertEqual(self.errors(source, source, "证书固定仍在阻止拦截"), [])
+
+    def test_pin_ui_action_is_not_a_pinning_rule(self) -> None:
+        # UI "pin"/"pinned" (not "pinning") legitimately uses 固定 and must not trip the rule.
+        self.assertEqual(self.errors("No pinned requests", "No pinned requests", "无固定的请求"), [])
+        source = "Unpin another Assistant conversation before pinning this one."
+        self.assertEqual(self.errors(source, source, "置顶此助手对话前，请先取消置顶另一个对话。"), [])
+
+    def test_named_compose_feature_forbids_bianxie(self) -> None:
+        self.assertTrue(self.errors("Compose", "Compose", "编写"))
+        self.assertEqual(self.errors("Compose", "Compose", "Compose"), [])
+        # "user-authored filter text" has no "Compose" trigger, so 编写 is allowed.
+        source = "%1$@ contains user-authored filter text."
+        self.assertEqual(self.errors(source, source, "%1$@ 包含用户编写的过滤文本。"), [])
+
+    def test_protobuf_wire_format_forbids_xianlu_geshi(self) -> None:
+        source = "This frame does not look like a valid Protobuf wire-format payload."
+        self.assertTrue(self.errors(source, source, "此帧看起来不是有效的 Protobuf 线路格式有效载荷。"))
+        self.assertEqual(self.errors(source, source, "此帧看起来不是有效的 Protobuf 线格式有效载荷。"), [])
+
+    def test_ai_model_token_forbids_lingpai(self) -> None:
+        self.assertTrue(self.errors("Maximum output tokens", "Maximum output tokens", "最大输出令牌数"))
+        self.assertEqual(self.errors("Maximum output tokens", "Maximum output tokens", "最大输出 token 数"), [])
+
+    def test_status_code_requires_zhuangtaima(self) -> None:
+        self.assertTrue(self.errors("Status code", "Status code", "代码"))
+        self.assertEqual(self.errors("Status code", "Status code", "状态码"), [])
+
+    def test_glossary_requires_the_preferred_term(self) -> None:
+        self.assertTrue(self.errors("Redaction", "Redaction", "敏感信息处理"))
+        self.assertTrue(self.errors("Compose", "Compose", "请求编辑器"))
+
+    def test_auth_token_keeps_lingpai(self) -> None:
+        # A pairing/auth token key is not in the AI set, so 令牌 stays valid.
+        self.assertEqual(self.errors("Pairing token", "Pairing token", "配对令牌"), [])
+
+    def test_validate_catalog_flags_mistranslated_zh_hans(self) -> None:
+        catalog = {
+            "sourceLanguage": "en",
+            "strings": {
+                "Redaction": {
+                    "localizations": {
+                        "zh-Hans": {"stringUnit": {"state": "translated", "value": "遮盖"}}
+                    }
+                }
+            },
+            "version": "1.0",
+        }
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            path = Path(temporary_directory) / "Localizable.xcstrings"
+            path.write_text(json.dumps(catalog), encoding="utf-8")
+            errors = VALIDATOR.validate_catalog(path, ["zh-Hans"])
+            self.assertTrue(any("redaction must use" in error for error in errors))
+
+    def test_swift_literal_coverage_reports_missing_catalog_key(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            source_root = root / "Rockxy"
+            source_root.mkdir()
+            (source_root / "Example.swift").write_text(
+                'let value = String(localized: "Missing key", bundle: .main)\n',
+                encoding="utf-8",
+            )
+            catalog = root / "Localizable.xcstrings"
+            catalog.write_text(
+                json.dumps({"sourceLanguage": "en", "strings": {}, "version": "1.0"}),
+                encoding="utf-8",
+            )
+
+            errors = VALIDATOR.validate_swift_literal_coverage(source_root, catalog)
+
+            self.assertTrue(any("Missing key" in error for error in errors))
+
+    def test_swift_literal_coverage_accepts_catalogued_key(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            source_root = root / "Rockxy"
+            source_root.mkdir()
+            (source_root / "Example.swift").write_text(
+                'let value = String(localized: "Known key", bundle: .main)\n',
+                encoding="utf-8",
+            )
+            catalog = root / "Localizable.xcstrings"
+            catalog.write_text(
+                json.dumps({"sourceLanguage": "en", "strings": {"Known key": {}}, "version": "1.0"}),
+                encoding="utf-8",
+            )
+
+            self.assertEqual(VALIDATOR.validate_swift_literal_coverage(source_root, catalog), [])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/.github/tools/validate_xcstrings.py
+++ b/.github/tools/validate_xcstrings.py
@@ -11,6 +11,8 @@ canonical catalogs):
   * no translation value is empty or whitespace-only;
   * printf-style placeholders and positional arguments match between the
     source string and each translation (placeholder parity);
+  * direct, non-interpolated Swift String(localized:) keys exist in the app catalog;
+  * high-confidence zh-Hans terminology rules remain contextually correct;
   * locales in the canonical catalogs match the Xcode project's knownRegions;
   * when `xcrun xcstringstool` is available, each catalog compiles cleanly.
 
@@ -43,6 +45,110 @@ DEFAULT_CATALOGS = [
 ]
 BASELINE_LANGUAGES = {"zh-Hans"}
 DEFAULT_PROJECT_FILE = Path("Rockxy.xcodeproj/project.pbxproj")
+DEFAULT_SWIFT_SOURCE_ROOT = Path("Rockxy")
+DIRECT_LOCALIZED_LITERAL_RE = re.compile(r'String\s*\(\s*localized:\s*"([^"\\]*)"', re.MULTILINE)
+
+# Simplified-Chinese glossary gate. Each rule is narrow and deterministic: it
+# fires only when the *English source* proves the meaning, then forbids a term
+# whose use in that context is a known mistranslation. "Code" is intentionally
+# excluded because it is context-dependent (HTTP status vs. the VS Code app);
+# call-site routing handles it, not a value-wide rule.
+#
+# Exact English keys whose "token" is an AI model token (never an auth/pairing
+# token), so the Simplified-Chinese value must keep the English word "token"
+# rather than the auth-only 令牌.
+ZH_HANS_AI_TOKEN_KEYS = frozenset(
+    {
+        "%@ tokens",
+        "%lld input · %lld output tokens",
+        "Context window tokens",
+        "Maximum output tokens",
+        "tokens",
+        "tokens per response",
+        "Compare model, tokens, finish reason, and latency against adjacent retries.",
+        "Check event count, final event, interruption signs, and first-token/overall duration.",
+        "Rockxy can identify this AI app session, but model, tokens, and tools need decrypted API evidence.",
+        "SSE cadence is shown from captured events. Token boundaries stay unavailable unless the provider exposes them.",
+        "Rockxy uses 8,192 tokens by default and limits local inference to 32,768 tokens to avoid excessive memory pressure.",
+    }
+)
+
+
+def zh_hans_glossary_errors(path: Path, key: str, source: str, value: str, unit_path: tuple[str, ...]) -> list[str]:
+    """Deterministic Simplified-Chinese terminology checks proven by the English source.
+
+    Only forbid-rules are applied so unrelated future strings are never coerced;
+    each rule is gated on an unambiguous English trigger.
+    """
+    lowered = source.lower()
+    semantic_context = f"{key} {source}".lower()
+    is_certificate_pinning = "certificate pinning" in lowered or "pins certificate" in lowered
+    checks: list[tuple[bool, tuple[str, ...], str]] = [
+        # redaction/redacted/redact -> 脱敏/已脱敏 (never 遮盖/隐去).
+        ("redact" in lowered, ("遮盖", "隐去"), "redaction must use 脱敏/已脱敏"),
+        # certificate pinning -> 证书固定 (never 锁定).
+        (is_certificate_pinning, ("锁定",), "certificate pinning must use 固定"),
+        # The named Compose feature stays "Compose" (never 编写).
+        ("Compose" in source, ("编写",), "named Compose feature must stay Compose"),
+        # Protobuf wire format -> 线格式 (never 线路格式).
+        ("wire format" in lowered or "wire-format" in lowered, ("线路格式",), "Protobuf wire format must use 线格式"),
+        # AI model token(s) -> token (never the auth-only 令牌).
+        (key in ZH_HANS_AI_TOKEN_KEYS, ("令牌",), "AI model token must use token, not 令牌"),
+    ]
+    errors: list[str] = []
+    for applies, banned, label in checks:
+        if not applies:
+            continue
+        for term in banned:
+            if term in value:
+                errors.append(
+                    f"{path}: {key!r} zh-Hans glossary at {unit_path}: {label} "
+                    f"(found {term!r} in {value!r})"
+                )
+    requirements: list[tuple[bool, str, str]] = [
+        ("status code" in semantic_context, "状态码", "HTTP status code must use 状态码"),
+        ("redact" in lowered, "脱敏", "redaction must use 脱敏/已脱敏"),
+        (is_certificate_pinning, "固定", "certificate pinning must use 固定"),
+        ("Compose" in source, "Compose", "named Compose feature must stay Compose"),
+        (
+            "wire format" in lowered or "wire-format" in lowered,
+            "线格式",
+            "Protobuf wire format must use 线格式",
+        ),
+        (key in ZH_HANS_AI_TOKEN_KEYS, "token", "AI model token must use token"),
+    ]
+    for applies, required, label in requirements:
+        if applies and required not in value:
+            errors.append(
+                f"{path}: {key!r} zh-Hans glossary at {unit_path}: {label} "
+                f"(missing {required!r} in {value!r})"
+            )
+    return errors
+
+
+def validate_swift_literal_coverage(source_root: Path, catalog_path: Path) -> list[str]:
+    """Require direct, non-interpolated String(localized:) keys to exist in the catalog."""
+    try:
+        catalog = json.loads(catalog_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        return [f"{catalog_path}: cannot check Swift literal coverage ({exc})"]
+    strings = catalog.get("strings")
+    if not isinstance(strings, dict):
+        return [f"{catalog_path}: cannot check Swift literal coverage (missing strings object)"]
+
+    errors: list[str] = []
+    for source_path in sorted(source_root.rglob("*.swift")):
+        try:
+            source = source_path.read_text(encoding="utf-8")
+        except OSError as exc:
+            errors.append(f"{source_path}: cannot read Swift source ({exc})")
+            continue
+        for match in DIRECT_LOCALIZED_LITERAL_RE.finditer(source):
+            key = match.group(1)
+            if key not in strings:
+                line = source.count("\n", 0, match.start()) + 1
+                errors.append(f"{source_path}:{line}: localized key {key!r} is missing from {catalog_path}")
+    return errors
 
 
 def placeholder_multiset(text: str) -> list[str]:
@@ -237,6 +343,10 @@ def validate_catalog(path: Path, required: list[str]) -> list[str]:
                         f"{path}: {key!r} placeholder mismatch for {lang} at {unit_path} "
                         f"(source={src_tokens}, {lang}={translated_tokens})"
                     )
+                if lang == "zh-Hans":
+                    errors.extend(
+                        zh_hans_glossary_errors(path, key, expected_units[unit_path], value, unit_path)
+                    )
     return errors
 
 
@@ -298,6 +408,7 @@ def main() -> int:
     all_errors: list[str] = []
     if catalogs == DEFAULT_CATALOGS:
         all_errors.extend(validate_project_languages(catalog_paths, DEFAULT_PROJECT_FILE))
+        all_errors.extend(validate_swift_literal_coverage(DEFAULT_SWIFT_SOURCE_ROOT, catalog_paths[0]))
     for path in catalog_paths:
         if not path.exists():
             all_errors.append(f"{path}: catalog not found")

--- a/Rockxy/Localizable.xcstrings
+++ b/Rockxy/Localizable.xcstrings
@@ -625,7 +625,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "%@ 个令牌"
+            "value": "%@ 个 token"
           }
         }
       }
@@ -1086,7 +1086,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "%1$lld 个输入令牌 · %2$lld 个输出令牌"
+            "value": "%1$lld 个输入 token · %2$lld 个输出 token"
           }
         }
       }
@@ -1812,7 +1812,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "<保存前已遮盖>"
+            "value": "<保存前已脱敏>"
           }
         }
       }
@@ -3773,7 +3773,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "在断点队列的 Raw 标签页中应用模板。有效的请求模板会替换方法、目标、标头和正文；有效的响应模板会替换状态、标头和正文。"
+            "value": "在断点队列的 Raw 标签页中应用模板。有效的请求模板会替换方法、目标、标头和正文；有效的响应模板会替换状态码、标头和正文。"
           }
         }
       }
@@ -4069,7 +4069,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "发布到 Gist 前，Authorization、Cookies、Set-Cookies 等内容会被遮盖。"
+            "value": "发布到 Gist 前，Authorization、Cookies、Set-Cookies 等内容会被脱敏。"
           }
         }
       }
@@ -4269,7 +4269,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "自动遮盖敏感标头"
+            "value": "自动对敏感标头进行脱敏"
           }
         }
       }
@@ -4369,7 +4369,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "发送到 MCP 客户端前自动遮盖敏感信息。"
+            "value": "发送到 MCP 客户端前自动对敏感信息进行脱敏。"
           }
         }
       }
@@ -5028,7 +5028,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "断点规则会在传输过程中暂停匹配的请求或响应，让你可以先编辑 URL、标头、正文或状态。"
+            "value": "断点规则会在传输过程中暂停匹配的请求或响应，让你可以先编辑 URL、标头、正文或状态码。"
           }
         }
       }
@@ -5768,7 +5768,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "证书锁定仍在阻止拦截"
+            "value": "证书固定仍在阻止拦截"
           }
         }
       }
@@ -5968,7 +5968,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "检查事件数量、最终事件、中断迹象，以及首个令牌/总时长。"
+            "value": "检查事件数量、最终事件、中断迹象，以及首个 token/总时长。"
           }
         }
       }
@@ -6999,12 +6999,489 @@
         }
       }
     },
-    "Code": {
+    "Auth": {
       "localizations": {
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "代码"
+            "value": "认证"
+          }
+        }
+      }
+    },
+    "Certs": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "证书"
+          }
+        }
+      }
+    },
+    "Client/App": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "客户端/App"
+          }
+        }
+      }
+    },
+    "Compact HTTP status code": {
+      "comment": "Compact HTTP response status-code label used in narrow table columns and fields.",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Code"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "状态码"
+          }
+        }
+      }
+    },
+    "Color": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "颜色"
+          }
+        }
+      }
+    },
+    "Content Type": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "内容类型"
+          }
+        }
+      }
+    },
+    "Cookies": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cookie"
+          }
+        }
+      }
+    },
+    "Custom": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自定义"
+          }
+        }
+      }
+    },
+    "Custom HTTP response status code": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自定义 HTTP 响应状态码"
+          }
+        }
+      }
+    },
+    "Debug": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "调试"
+          }
+        }
+      }
+    },
+    "Document": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "文档"
+          }
+        }
+      }
+    },
+    "Fault": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "故障"
+          }
+        }
+      }
+    },
+    "Font": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "字体"
+          }
+        }
+      }
+    },
+    "Form": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "表单"
+          }
+        }
+      }
+    },
+    "Media": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "媒体"
+          }
+        }
+      }
+    },
+    "Note": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "备注"
+          }
+        }
+      }
+    },
+    "Notice": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "通知"
+          }
+        }
+      }
+    },
+    "Other": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "其他"
+          }
+        }
+      }
+    },
+    "Query String": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "查询字符串"
+          }
+        }
+      }
+    },
+    "Request Header": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "请求标头"
+          }
+        }
+      }
+    },
+    "Response Header": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "响应标头"
+          }
+        }
+      }
+    },
+    "Status Code": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "状态码"
+          }
+        }
+      }
+    },
+    "Synopsis": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "摘要"
+          }
+        }
+      }
+    },
+    "Timeline": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "时间线"
+          }
+        }
+      }
+    },
+    "Traffic": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "流量"
+          }
+        }
+      }
+    },
+    "Very Bad Network": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "极差网络"
+          }
+        }
+      }
+    },
+    "Warning": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "警告"
+          }
+        }
+      }
+    },
+    "Breakpoint edit error": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "断点编辑错误"
+          }
+        }
+      }
+    },
+    "Closing active connections and restoring system routing.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在关闭活动连接并恢复系统路由。"
+          }
+        }
+      }
+    },
+    "Common HTTP response status": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "常用 HTTP 响应状态码"
+          }
+        }
+      }
+    },
+    "Enter a valid HTTP URL with a host.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "请输入包含主机的有效 HTTP URL。"
+          }
+        }
+      }
+    },
+    "Enter a valid HTTP method.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "请输入有效的 HTTP 方法。"
+          }
+        }
+      }
+    },
+    "Enter a valid HTTP status code.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "请输入有效的 HTTP 状态码。"
+          }
+        }
+      }
+    },
+    "Enter a valid request path.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "请输入有效的请求路径。"
+          }
+        }
+      }
+    },
+    "Header names must use valid HTTP token characters.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "标头名称只能使用有效的 HTTP token 字符。"
+          }
+        }
+      }
+    },
+    "Header values cannot contain line breaks.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "标头值不能包含换行符。"
+          }
+        }
+      }
+    },
+    "Host, path, and query": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "主机、路径和查询"
+          }
+        }
+      }
+    },
+    "Message editor section": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "消息编辑器部分"
+          }
+        }
+      }
+    },
+    "Proxy shutdown is in progress": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在关闭代理"
+          }
+        }
+      }
+    },
+    "Remove header": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "移除标头"
+          }
+        }
+      }
+    },
+    "Remove query parameter": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "移除查询参数"
+          }
+        }
+      }
+    },
+    "Restoring routing": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在恢复路由"
+          }
+        }
+      }
+    },
+    "Stopping": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在停止"
+          }
+        }
+      }
+    },
+    "Stopping Capture": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在停止捕获"
+          }
+        }
+      }
+    },
+    "Stopping Proxy": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在停止代理"
+          }
+        }
+      }
+    },
+    "Stopping…": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在停止…"
+          }
+        }
+      }
+    },
+    "Rockxy is closing active connections and restoring system routing.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rockxy 正在关闭活动连接并恢复系统路由。"
+          }
+        }
+      }
+    },
+    "The scheme is fixed for this cleartext connection": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此明文连接的协议已固定"
           }
         }
       }
@@ -7180,7 +7657,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "请将模型、令牌、结束原因和延迟与相邻的重试进行比较。"
+            "value": "请将模型、token、结束原因和延迟与相邻的重试进行比较。"
           }
         }
       }
@@ -7422,7 +7899,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "编写"
+            "value": "Compose"
           }
         }
       }
@@ -7442,7 +7919,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "编写…"
+            "value": "Compose…"
           }
         }
       }
@@ -7562,7 +8039,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "在数据离开这台 Mac 前确认经过遮盖的确切流量。"
+            "value": "请在数据离开这台 Mac 前确认已脱敏流量的具体内容。"
           }
         }
       }
@@ -7572,7 +8049,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "开始本地推断前，请确认已遮盖的流量和对话。"
+            "value": "开始本地推断前，请确认已脱敏的流量和对话。"
           }
         }
       }
@@ -7582,7 +8059,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "模型运行前，请确认已隐去敏感信息的流量和对话。"
+            "value": "模型运行前，请确认已脱敏的流量和对话。"
           }
         }
       }
@@ -7846,7 +8323,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "上下文窗口令牌数"
+            "value": "上下文窗口 token 数"
           }
         }
       }
@@ -10096,7 +10573,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "域"
+            "value": "域名"
           }
         }
       }
@@ -14195,7 +14672,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "历史记录保留在此 Mac 上。身份验证和 cookie 标头值会被隐去；URL 和正文仍在本地存储。"
+            "value": "历史记录保留在此 Mac 上。身份验证和 cookie 标头值会被脱敏；URL 和正文仍在本地存储。"
           }
         }
       }
@@ -14737,7 +15214,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "如果应用固定了证书，Rockxy 将无法解密其 HTTPS 流量，除非调试版本放宽固定。"
+            "value": "如果应用启用了证书固定，除非调试版本放宽该策略，否则 Rockxy 无法解密其 HTTPS 流量。"
           }
         }
       }
@@ -14747,7 +15224,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "如果应用锁定了证书，则在调试版本放宽锁定之前，Rockxy 无法解密该 HTTPS 流量。"
+            "value": "如果应用启用了证书固定，则在调试版本放宽该策略之前，Rockxy 无法解密该 HTTPS 流量。"
           }
         }
       }
@@ -14757,7 +15234,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "如果应用固定了自己的证书，则在应用以放宽固定的方式构建之前，Rockxy 无法解密其流量。"
+            "value": "如果应用对自己的证书启用了固定，则在构建应用时放宽该策略之前，Rockxy 无法解密其流量。"
           }
         }
       }
@@ -14837,7 +15314,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "导入证书和私钥，以便为匹配的主机提供已锁定的服务器身份。"
+            "value": "导入证书和私钥，以便为匹配的主机提供固定的服务器身份。"
           }
         }
       }
@@ -17891,7 +18368,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "最大输出令牌数"
+            "value": "最大输出 token 数"
           }
         }
       }
@@ -21586,7 +22063,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "在“编写”中打开"
+            "value": "在 Compose 中打开"
           }
         }
       }
@@ -23079,7 +23556,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "正在准备已隐去敏感信息的预览…"
+            "value": "正在准备脱敏后的预览…"
           }
         }
       }
@@ -24685,7 +25162,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "遮盖识别到的敏感数据"
+            "value": "对识别到的敏感数据进行脱敏"
           }
         }
       }
@@ -24695,7 +25172,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "发送到 AI 前隐去敏感数据"
+            "value": "发送到 AI 前对敏感数据进行脱敏"
           }
         }
       }
@@ -24705,7 +25182,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "正在遮盖敏感字段"
+            "value": "正在对敏感字段进行脱敏"
           }
         }
       }
@@ -24715,7 +25192,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "隐去敏感信息"
+            "value": "脱敏"
           }
         }
       }
@@ -24725,7 +25202,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "遮盖功能已关闭。捕获的标头、URL 和正文将完全按记录内容上传。"
+            "value": "脱敏功能已关闭。捕获的标头、URL 和正文将完全按记录内容上传。"
           }
         }
       }
@@ -24735,7 +25212,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "遮盖清单"
+            "value": "脱敏清单"
           }
         }
       }
@@ -24745,7 +25222,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "上传前隐去识别出的敏感标头、URL 和正文值（Authorization、Cookie、API 密钥）。此操作会尽力而为，但不作保证。"
+            "value": "上传前会对识别出的敏感标头、URL 和正文值（Authorization、Cookie、API 密钥）进行脱敏。此操作会尽力而为，但不作保证。"
           }
         }
       }
@@ -26352,7 +26829,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "响应状态和标头"
+            "value": "响应状态码和标头"
           }
         }
       }
@@ -26362,7 +26839,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "响应状态必须是三位数代码。"
+            "value": "响应状态码必须是三位数。"
           }
         }
       }
@@ -26832,7 +27309,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "复制或共享任何证据前，请审查经过遮盖的确切有效载荷。"
+            "value": "复制或共享任何证据前，请审查经过脱敏的确切有效载荷。"
           }
         }
       }
@@ -26998,7 +27475,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "Rockxy 可以识别此 AI App 会话，但模型、令牌和工具需要解密后的 API 证据。"
+            "value": "Rockxy 可以识别此 AI App 会话，但模型、token 和工具需要解密后的 API 证据。"
           }
         }
       }
@@ -27967,7 +28444,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "Rockxy 将创建可编辑的草稿。只有在“编写”中按下“发送”后才会发送内容。"
+            "value": "Rockxy 将创建可编辑的草稿。只有在 Compose 中按下“发送”后才会发送内容。"
           }
         }
       }
@@ -30498,7 +30975,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "发送已隐去敏感信息的数据"
+            "value": "发送已脱敏数据"
           }
         }
       }
@@ -30518,7 +30995,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "敏感字段已隐去"
+            "value": "敏感字段已脱敏"
           }
         }
       }
@@ -31946,7 +32423,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "SSE 节奏根据已捕获的事件显示。除非提供方公开令牌边界，否则令牌边界不可用。"
+            "value": "SSE 节奏根据已捕获的事件显示。除非提供方公开 token 边界，否则 token 边界不可用。"
           }
         }
       }
@@ -33188,7 +33665,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "应用拒绝了 Rockxy 针对此主机的 TLS 握手。可能存在证书锁定，但自定义信任策略也可能产生相同信号。"
+            "value": "应用拒绝了 Rockxy 针对此主机的 TLS 握手。应用可能启用了证书固定，但自定义信任策略也可能产生相同信号。"
           }
         }
       }
@@ -34090,7 +34567,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "响应正文超过了 %@ MB 的编写限制。"
+            "value": "响应正文超过了 %@ MB 的 Compose 限制。"
           }
         }
       }
@@ -34818,7 +35295,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "此帧看起来不是有效的 Protobuf 线路格式有效载荷。"
+            "value": "此帧看起来不是有效的 Protobuf 线格式有效载荷。"
           }
         }
       }
@@ -35521,7 +35998,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "令牌"
+            "value": "token"
           }
         }
       }
@@ -35531,7 +36008,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "每次响应的令牌数"
+            "value": "每次响应的 token 数"
           }
         }
       }
@@ -38284,7 +38761,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "线路格式启发式检测"
+            "value": "线格式启发式检测"
           }
         }
       }
@@ -38383,7 +38860,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "处理前，你会看到经过遮盖的确切快照。"
+            "value": "处理前，你会看到经过脱敏的确切快照。"
           }
         }
       }

--- a/Rockxy/Models/Log/LogLevel.swift
+++ b/Rockxy/Models/Log/LogLevel.swift
@@ -14,12 +14,12 @@ enum LogLevel: Int, Comparable, CaseIterable {
 
     var displayName: String {
         switch self {
-        case .debug: "Debug"
-        case .info: "Info"
-        case .notice: "Notice"
-        case .warning: "Warning"
-        case .error: "Error"
-        case .fault: "Fault"
+        case .debug: String(localized: "Debug", bundle: RockxyLocalization.bundle)
+        case .info: String(localized: "Info", bundle: RockxyLocalization.bundle)
+        case .notice: String(localized: "Notice", bundle: RockxyLocalization.bundle)
+        case .warning: String(localized: "Warning", bundle: RockxyLocalization.bundle)
+        case .error: String(localized: "Error", bundle: RockxyLocalization.bundle)
+        case .fault: String(localized: "Fault", bundle: RockxyLocalization.bundle)
         }
     }
 

--- a/Rockxy/Models/Rules/NetworkConditionPreset.swift
+++ b/Rockxy/Models/Rules/NetworkConditionPreset.swift
@@ -14,12 +14,13 @@ enum NetworkConditionPreset: String, CaseIterable, Codable {
 
     var displayName: String {
         switch self {
+        // Cellular/network standard names render verbatim regardless of language.
         case .threeG: "3G"
         case .edge: "EDGE"
         case .lte: "LTE"
-        case .veryBadNetwork: "Very Bad Network"
         case .wifi: "WiFi"
-        case .custom: "Custom"
+        case .veryBadNetwork: String(localized: "Very Bad Network", bundle: RockxyLocalization.bundle)
+        case .custom: String(localized: "Custom", bundle: RockxyLocalization.bundle)
         }
     }
 

--- a/Rockxy/Models/UI/FilterField.swift
+++ b/Rockxy/Models/UI/FilterField.swift
@@ -25,22 +25,22 @@ enum FilterField: String, CaseIterable, Codable, Hashable {
     var displayName: String {
         switch self {
         case .url: "URL"
-        case .contains: "Contains"
-        case .host: "Host"
-        case .domain: "Domain"
-        case .path: "Path"
-        case .method: "Method"
-        case .statusCode: "Status Code"
-        case .requestHeader: "Request Header"
-        case .responseHeader: "Response Header"
-        case .requestBody: "Request Body"
-        case .responseBody: "Response Body"
-        case .queryString: "Query String"
-        case .cookies: "Cookies"
-        case .clientApp: "Client/App"
-        case .contentType: "Content Type"
-        case .comment: "Note"
-        case .color: "Color"
+        case .contains: String(localized: "Contains", bundle: RockxyLocalization.bundle)
+        case .host: String(localized: "Host", bundle: RockxyLocalization.bundle)
+        case .domain: String(localized: "Domain", bundle: RockxyLocalization.bundle)
+        case .path: String(localized: "Path", bundle: RockxyLocalization.bundle)
+        case .method: String(localized: "Method", bundle: RockxyLocalization.bundle)
+        case .statusCode: String(localized: "Status Code", bundle: RockxyLocalization.bundle)
+        case .requestHeader: String(localized: "Request Header", bundle: RockxyLocalization.bundle)
+        case .responseHeader: String(localized: "Response Header", bundle: RockxyLocalization.bundle)
+        case .requestBody: String(localized: "Request Body", bundle: RockxyLocalization.bundle)
+        case .responseBody: String(localized: "Response Body", bundle: RockxyLocalization.bundle)
+        case .queryString: String(localized: "Query String", bundle: RockxyLocalization.bundle)
+        case .cookies: String(localized: "Cookies", bundle: RockxyLocalization.bundle)
+        case .clientApp: String(localized: "Client/App", bundle: RockxyLocalization.bundle)
+        case .contentType: String(localized: "Content Type", bundle: RockxyLocalization.bundle)
+        case .comment: String(localized: "Note", bundle: RockxyLocalization.bundle)
+        case .color: String(localized: "Color", bundle: RockxyLocalization.bundle)
         }
     }
 }

--- a/Rockxy/Models/UI/InspectorTab.swift
+++ b/Rockxy/Models/UI/InspectorTab.swift
@@ -17,12 +17,13 @@ enum InspectorTab: String, CaseIterable {
 
     var displayName: String {
         switch self {
-        case .headers: "Headers"
-        case .body: "Body"
-        case .cookies: "Cookies"
-        case .timing: "Timing"
-        case .raw: "Raw"
-        case .certificates: "Certs"
+        case .headers: String(localized: "Headers", bundle: RockxyLocalization.bundle)
+        case .body: String(localized: "Body", bundle: RockxyLocalization.bundle)
+        case .cookies: String(localized: "Cookies", bundle: RockxyLocalization.bundle)
+        case .timing: String(localized: "Timing", bundle: RockxyLocalization.bundle)
+        case .raw: String(localized: "Raw", bundle: RockxyLocalization.bundle)
+        case .certificates: String(localized: "Certs", bundle: RockxyLocalization.bundle)
+        // Protocol names render verbatim regardless of language.
         case .websocket: "WebSocket"
         case .graphql: "GraphQL"
         }

--- a/Rockxy/Models/UI/MainTab.swift
+++ b/Rockxy/Models/UI/MainTab.swift
@@ -12,9 +12,9 @@ enum MainTab: String, CaseIterable {
 
     var displayName: String {
         switch self {
-        case .traffic: "Traffic"
-        case .logs: "Logs"
-        case .timeline: "Timeline"
+        case .traffic: String(localized: "Traffic", bundle: RockxyLocalization.bundle)
+        case .logs: String(localized: "Logs", bundle: RockxyLocalization.bundle)
+        case .timeline: String(localized: "Timeline", bundle: RockxyLocalization.bundle)
         }
     }
 

--- a/Rockxy/Models/UI/ProtocolFilter.swift
+++ b/Rockxy/Models/UI/ProtocolFilter.swift
@@ -32,7 +32,27 @@ enum ProtocolFilter: String, CaseIterable, Hashable {
     // MARK: Internal
 
     static var contentFilters: [ProtocolFilter] {
-        [.all, .http, .https, .websocket, .ai, .aiSession, .web3RPC, .rpcError, .json, .xml, .js, .css, .graphql, .grpc, .document, .media, .form, .font, .other]
+        [
+            .all,
+            .http,
+            .https,
+            .websocket,
+            .ai,
+            .aiSession,
+            .web3RPC,
+            .rpcError,
+            .json,
+            .xml,
+            .js,
+            .css,
+            .graphql,
+            .grpc,
+            .document,
+            .media,
+            .form,
+            .font,
+            .other
+        ]
     }
 
     static var statusFilters: [ProtocolFilter] {
@@ -41,25 +61,26 @@ enum ProtocolFilter: String, CaseIterable, Hashable {
 
     var displayName: String {
         switch self {
-        case .all: "All"
+        case .all: String(localized: "All", bundle: RockxyLocalization.bundle)
+        case .ai: String(localized: "AI API", bundle: RockxyLocalization.bundle)
+        case .aiSession: String(localized: "AI Session", bundle: RockxyLocalization.bundle)
+        case .rpcError: String(localized: "RPC Error", bundle: RockxyLocalization.bundle)
+        case .document: String(localized: "Document", bundle: RockxyLocalization.bundle)
+        case .media: String(localized: "Media", bundle: RockxyLocalization.bundle)
+        case .form: String(localized: "Form", bundle: RockxyLocalization.bundle)
+        case .font: String(localized: "Font", bundle: RockxyLocalization.bundle)
+        case .other: String(localized: "Other", bundle: RockxyLocalization.bundle)
+        // Protocol names, content-type acronyms, and HTTP status ranges render verbatim.
         case .http: "HTTP"
         case .https: "HTTPS"
         case .websocket: "WebSocket"
-        case .ai: "AI API"
-        case .aiSession: "AI Session"
         case .web3RPC: "Web3"
-        case .rpcError: "RPC Error"
         case .json: "JSON"
         case .xml: "XML"
         case .js: "JS"
         case .css: "CSS"
         case .graphql: "GraphQL"
         case .grpc: "gRPC"
-        case .document: "Document"
-        case .media: "Media"
-        case .form: "Form"
-        case .font: "Font"
-        case .other: "Other"
         case .status1xx: "1xx"
         case .status2xx: "2xx"
         case .status3xx: "3xx"

--- a/Rockxy/Models/UI/RequestInspectorTab.swift
+++ b/Rockxy/Models/UI/RequestInspectorTab.swift
@@ -14,13 +14,13 @@ enum RequestInspectorTab: String, CaseIterable {
 
     var displayName: String {
         switch self {
-        case .headers: "Headers"
-        case .query: "Query"
-        case .body: "Body"
-        case .cookies: "Cookies"
-        case .raw: "Raw"
-        case .synopsis: "Synopsis"
-        case .comments: "Notes"
+        case .headers: String(localized: "Headers", bundle: RockxyLocalization.bundle)
+        case .query: String(localized: "Query", bundle: RockxyLocalization.bundle)
+        case .body: String(localized: "Body", bundle: RockxyLocalization.bundle)
+        case .cookies: String(localized: "Cookies", bundle: RockxyLocalization.bundle)
+        case .raw: String(localized: "Raw", bundle: RockxyLocalization.bundle)
+        case .synopsis: String(localized: "Synopsis", bundle: RockxyLocalization.bundle)
+        case .comments: String(localized: "Notes", bundle: RockxyLocalization.bundle)
         }
     }
 }

--- a/Rockxy/Models/UI/ResponseInspectorTab.swift
+++ b/Rockxy/Models/UI/ResponseInspectorTab.swift
@@ -19,12 +19,13 @@ enum ResponseInspectorTab: String, CaseIterable {
 
     var displayName: String {
         switch self {
+        // "AI" is a product/acronym token; "Set-Cookie" is an HTTP header name — both verbatim.
         case .ai: "AI"
-        case .headers: "Headers"
-        case .body: "Body"
+        case .headers: String(localized: "Headers", bundle: RockxyLocalization.bundle)
+        case .body: String(localized: "Body", bundle: RockxyLocalization.bundle)
         case .setCookie: "Set-Cookie"
-        case .auth: "Auth"
-        case .timeline: "Timeline"
+        case .auth: String(localized: "Auth", bundle: RockxyLocalization.bundle)
+        case .timeline: String(localized: "Timeline", bundle: RockxyLocalization.bundle)
         }
     }
 }

--- a/Rockxy/Views/Breakpoint/BreakpointEditorView.swift
+++ b/Rockxy/Views/Breakpoint/BreakpointEditorView.swift
@@ -331,7 +331,7 @@ struct BreakpointEditorView: View {
             .accessibilityLabel(String(localized: "Common HTTP response status", bundle: RockxyLocalization.bundle))
 
             TextField(
-                String(localized: "Code", bundle: RockxyLocalization.bundle),
+                String(localized: "Compact HTTP status code", bundle: RockxyLocalization.bundle),
                 text: Binding(
                     get: { String(draftFor(itemId)?.statusCode ?? 200) },
                     set: { value in

--- a/Rockxy/Views/Diff/DiffCandidateTableView.swift
+++ b/Rockxy/Views/Diff/DiffCandidateTableView.swift
@@ -105,7 +105,7 @@ struct DiffCandidateTableView: View {
             }
             .width(clientColumnWidth)
 
-            TableColumn(String(localized: "Code", bundle: RockxyLocalization.bundle)) { transaction in
+            TableColumn(String(localized: "Compact HTTP status code", bundle: RockxyLocalization.bundle)) { transaction in
                 if let statusCode = transaction.response?.statusCode {
                     DiffStatusCodeBadge(statusCode: statusCode)
                 } else {

--- a/Rockxy/Views/Inspector/ResponseInspectorView.swift
+++ b/Rockxy/Views/Inspector/ResponseInspectorView.swift
@@ -260,7 +260,11 @@ struct ResponseInspectorView: View {
                 Button {
                     openResponseBody(bundleIdentifier: "com.microsoft.VSCode")
                 } label: {
-                    Label("Code", systemImage: "chevron.left.forwardslash.chevron.right")
+                    Label {
+                        Text(verbatim: "Code")
+                    } icon: {
+                        Image(systemName: "chevron.left.forwardslash.chevron.right")
+                    }
                 }
 
                 Button {

--- a/Rockxy/Views/RequestList/RequestTableView.swift
+++ b/Rockxy/Views/RequestList/RequestTableView.swift
@@ -122,7 +122,7 @@ struct RequestTableView: NSViewRepresentable {
             ),
             ColumnSpec(
                 id: "code",
-                title: String(localized: "Code", bundle: RockxyLocalization.bundle),
+                title: String(localized: "Compact HTTP status code", bundle: RockxyLocalization.bundle),
                 width: 52,
                 minWidth: 44
             ),
@@ -2038,7 +2038,7 @@ extension RequestTableView {
                 ("client", String(localized: "Client", bundle: RockxyLocalization.bundle)),
                 ("method", String(localized: "Method", bundle: RockxyLocalization.bundle)),
                 ("state", String(localized: "Status", bundle: RockxyLocalization.bundle)),
-                ("code", String(localized: "Code", bundle: RockxyLocalization.bundle)),
+                ("code", String(localized: "Compact HTTP status code", bundle: RockxyLocalization.bundle)),
                 ("time", String(localized: "Time", bundle: RockxyLocalization.bundle)),
                 ("duration", String(localized: "Duration", bundle: RockxyLocalization.bundle)),
                 ("requestSize", String(localized: "Request", bundle: RockxyLocalization.bundle)),

--- a/RockxyTests/Localization/RuntimeLocalizationRegressionTests.swift
+++ b/RockxyTests/Localization/RuntimeLocalizationRegressionTests.swift
@@ -136,6 +136,75 @@ struct RuntimeLocalizationRegressionTests {
         #expect(viewModel.selectedTarget.id == .docker)
     }
 
+    @Test("HTTP status-code table and breakpoint call sites use a contextual compact key, not Code")
+    func statusCodeCallSitesUseStatusCodeKey() throws {
+        let sites = [
+            "Rockxy/Views/RequestList/RequestTableView.swift",
+            "Rockxy/Views/Diff/DiffCandidateTableView.swift",
+            "Rockxy/Views/Breakpoint/BreakpointEditorView.swift",
+        ]
+        for file in sites {
+            let source = try readProjectFile(file)
+            #expect(
+                !source.contains("localized: \"Code\""),
+                "\(file): must not localize the ambiguous \"Code\" key for HTTP status codes"
+            )
+            #expect(
+                source.contains("localized: \"Compact HTTP status code\""),
+                "\(file): compact HTTP status-code UI must use its contextual localization key"
+            )
+        }
+    }
+
+    @Test("VS Code Open-with menu renders the app name verbatim, not through localization")
+    func vsCodeLabelIsVerbatim() throws {
+        let source = try readProjectFile("Rockxy/Views/Inspector/ResponseInspectorView.swift")
+        #expect(source.contains("Text(verbatim: \"Code\")"))
+        #expect(!source.contains("Label(\"Code\""))
+        #expect(!source.contains("localized: \"Code\""))
+    }
+
+    @Test("Visible enum displayName owners resolve user-facing labels through the runtime bundle")
+    func enumDisplayNamesResolveThroughRuntimeBundle() throws {
+        let files = [
+            "Rockxy/Models/UI/MainTab.swift",
+            "Rockxy/Models/UI/InspectorTab.swift",
+            "Rockxy/Models/UI/RequestInspectorTab.swift",
+            "Rockxy/Models/UI/ResponseInspectorTab.swift",
+            "Rockxy/Models/UI/ProtocolFilter.swift",
+            "Rockxy/Models/UI/FilterField.swift",
+            "Rockxy/Models/Log/LogLevel.swift",
+            "Rockxy/Models/Rules/NetworkConditionPreset.swift",
+        ]
+        for file in files {
+            let source = try readProjectFile(file)
+            #expect(
+                source.contains("String(localized:") && source.contains("bundle: RockxyLocalization.bundle"),
+                "\(file): displayName must resolve visible labels through RockxyLocalization.bundle"
+            )
+        }
+    }
+
+    @Test("Protocol, header, and app-name tokens stay verbatim in enum displayName")
+    func enumTokensStayVerbatim() {
+        // Verbatim tokens never change with the selected language.
+        #expect(InspectorTab.websocket.displayName == "WebSocket")
+        #expect(InspectorTab.graphql.displayName == "GraphQL")
+        #expect(ResponseInspectorTab.ai.displayName == "AI")
+        #expect(ResponseInspectorTab.setCookie.displayName == "Set-Cookie")
+        #expect(FilterField.url.displayName == "URL")
+        #expect(ProtocolFilter.http.displayName == "HTTP")
+        #expect(ProtocolFilter.grpc.displayName == "gRPC")
+        #expect(NetworkConditionPreset.threeG.displayName == "3G")
+        #expect(NetworkConditionPreset.wifi.displayName == "WiFi")
+        // Localized labels resolve to a non-empty string in any runtime language.
+        #expect(!MainTab.traffic.displayName.isEmpty)
+        #expect(!LogLevel.warning.displayName.isEmpty)
+        #expect(!FilterField.statusCode.displayName.isEmpty)
+        #expect(!NetworkConditionPreset.veryBadNetwork.displayName.isEmpty)
+        #expect(!RequestInspectorTab.synopsis.displayName.isEmpty)
+    }
+
     // MARK: Private
 
     private enum ResolveError: Error {

--- a/RockxyTests/Localization/StringCatalogCoverageTests.swift
+++ b/RockxyTests/Localization/StringCatalogCoverageTests.swift
@@ -23,6 +23,42 @@ struct StringCatalogCoverageTests {
         try validateCatalog(named: "InfoPlist.xcstrings")
     }
 
+    @Test("The ambiguous standalone Code key is retired from Localizable.xcstrings")
+    func codeKeyIsRemoved() throws {
+        let data = try Data(contentsOf: Self.catalogURL("Localizable.xcstrings"))
+        let root = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        let catalog = try #require(root)
+        let strings = try #require(catalog["strings"] as? [String: Any])
+        #expect(strings["Code"] == nil, "The context-free \"Code\" key must not return; use a contextual key")
+        #expect(strings["Status code"] != nil, "The HTTP status-code label key must remain")
+        #expect(strings["Compact HTTP status code"] != nil, "Compact status labels need a contextual key")
+    }
+
+    @Test("Localizable.xcstrings honors the Simplified-Chinese terminology glossary")
+    func zhHansGlossary() throws {
+        let data = try Data(contentsOf: Self.catalogURL("Localizable.xcstrings"))
+        let root = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        let catalog = try #require(root)
+        let strings = try #require(catalog["strings"] as? [String: Any])
+
+        for (key, rawEntry) in strings {
+            guard let entry = rawEntry as? [String: Any],
+                  entry["shouldTranslate"] as? Bool != false,
+                  let localizations = entry["localizations"] as? [String: Any],
+                  let node = localizations["zh-Hans"] as? [String: Any] else
+            {
+                continue
+            }
+            let expectedUnits = Self.sourceUnits(key: key, entry: entry)
+            for (unitPath, value) in Self.collectUnits(node) {
+                let source = expectedUnits[unitPath] ?? key
+                for issue in Self.zhHansGlossaryIssues(key: key, source: source, value: value) {
+                    Issue.record(Comment(rawValue: "Localizable.xcstrings: \(key) zh-Hans glossary — \(issue)"))
+                }
+            }
+        }
+    }
+
     @Test("Locale discovery ignores empty and source localization keys")
     func localeDiscoveryIgnoresInvalidKeys() {
         let catalog: [String: Any] = [
@@ -42,6 +78,22 @@ struct StringCatalogCoverageTests {
     }
 
     // MARK: Private
+
+    /// Exact English keys whose "token" is an AI model token (never an auth/pairing
+    /// token), mirroring `ZH_HANS_AI_TOKEN_KEYS` in `validate_xcstrings.py`.
+    private static let zhHansAITokenKeys: Set<String> = [
+        "%@ tokens",
+        "%lld input · %lld output tokens",
+        "Context window tokens",
+        "Maximum output tokens",
+        "tokens",
+        "tokens per response",
+        "Compare model, tokens, finish reason, and latency against adjacent retries.",
+        "Check event count, final event, interruption signs, and first-token/overall duration.",
+        "Rockxy can identify this AI app session, but model, tokens, and tools need decrypted API evidence.",
+        "SSE cadence is shown from captured events. Token boundaries stay unavailable unless the provider exposes them.",
+        "Rockxy uses 8,192 tokens by default and limits local inference to 32,768 tokens to avoid excessive memory pressure.",
+    ]
 
     private static func catalogURL(_ fileName: String) -> URL {
         // <repo>/RockxyTests/Localization/StringCatalogCoverageTests.swift → <repo>/Rockxy/<fileName>
@@ -112,6 +164,54 @@ struct StringCatalogCoverageTests {
             }
         }
         return units
+    }
+
+    /// Deterministic Simplified-Chinese forbid-rules, gated on the English source.
+    /// Mirrors `zh_hans_glossary_errors` in `.github/tools/validate_xcstrings.py`.
+    private static func zhHansGlossaryIssues(key: String, source: String, value: String) -> [String] {
+        let lowered = source.lowercased()
+        let semanticContext = "\(key) \(source)".lowercased()
+        let isCertificatePinning = lowered.contains("certificate pinning")
+            || lowered.contains("pins certificate")
+        var issues: [String] = []
+
+        func forbid(_ applies: Bool, _ banned: [String], _ label: String) {
+            guard applies else {
+                return
+            }
+            for term in banned where value.contains(term) {
+                issues.append("\(label) (found \(term))")
+            }
+        }
+
+        forbid(lowered.contains("redact"), ["遮盖", "隐去"], "redaction must use 脱敏/已脱敏")
+        forbid(isCertificatePinning, ["锁定"], "certificate pinning must use 固定")
+        forbid(source.contains("Compose"), ["编写"], "named Compose feature must stay Compose")
+        forbid(
+            lowered.contains("wire format") || lowered.contains("wire-format"),
+            ["线路格式"],
+            "Protobuf wire format must use 线格式"
+        )
+        forbid(zhHansAITokenKeys.contains(key), ["令牌"], "AI model token must use token, not 令牌")
+
+        func require(_ applies: Bool, _ term: String, _ label: String) {
+            guard applies, !value.contains(term) else {
+                return
+            }
+            issues.append("\(label) (missing \(term))")
+        }
+
+        require(semanticContext.contains("status code"), "状态码", "HTTP status code must use 状态码")
+        require(lowered.contains("redact"), "脱敏", "redaction must use 脱敏/已脱敏")
+        require(isCertificatePinning, "固定", "certificate pinning must use 固定")
+        require(source.contains("Compose"), "Compose", "named Compose feature must stay Compose")
+        require(
+            lowered.contains("wire format") || lowered.contains("wire-format"),
+            "线格式",
+            "Protobuf wire format must use 线格式"
+        )
+        require(zhHansAITokenKeys.contains(key), "token", "AI model token must use token")
+        return issues
     }
 
     private static func placeholderTokens(in text: String) -> [String] {

--- a/docs/development/localization.mdx
+++ b/docs/development/localization.mdx
@@ -172,6 +172,35 @@ If a technical token must move to make the sentence natural, use positional
 placeholders so its semantic argument order remains unambiguous; do not change the
 placeholder's conversion type.
 
+## Simplified Chinese terminology
+
+Several English words carry more than one meaning in Rockxy, so the correct
+Simplified Chinese depends on the **English source context**, not the word alone.
+Never blanket-replace a Chinese term across the catalog — decide per entry, guided
+by the English key. The validator enforces the high-confidence rules below as
+deterministic forbid-checks (see `zh_hans_glossary_errors` in
+`.github/tools/validate_xcstrings.py`, mirrored in `StringCatalogCoverageTests`).
+
+| English context | Use | Not | Notes |
+|---|---|---|---|
+| HTTP status code | `状态码` | `代码` | Compact table/breakpoint labels use **`Compact HTTP status code`**, whose English value stays `Code`. The bare **`Code`** key is retired because it collided with the VS Code app name. |
+| VS Code app name (Open with menu) | `Code` (verbatim) | `代码` | An app/product name. Rendered with `Text(verbatim:)`, never localized. |
+| AI model token(s) — usage, context window, streaming | `token` (verbatim) | `令牌` | Model tokens are counted, not credentials. |
+| Auth / pairing / access / sharing token | `令牌` | `token` | Credentials — keep `令牌`. |
+| The named **Compose** feature | `Compose` (verbatim) | `编写` | A product surface name. “user-authored / user-written” text still translates to `编写`. |
+| redact / redaction / redacted | `脱敏` / `已脱敏` | `遮盖` / `隐去` | One term everywhere for the privacy action. |
+| certificate pinning | `证书固定` | `证书锁定` | The UI action to **pin** a request/favorite still uses `固定`. |
+| Protobuf wire format | `线格式` | `线路格式` | The Protobuf binary encoding. |
+
+The `Code` example is the reason context matters: the same four letters are an HTTP
+status-code column, a text-editor app name, and a source-code noun. Read the English
+source and, when the meaning is genuinely ambiguous, add a translator `comment` to the
+catalog entry rather than guessing.
+
+The validator also checks direct, non-interpolated `String(localized:)` literals in
+`Rockxy/` against `Localizable.xcstrings`. Adding a runtime lookup without its catalog
+entry is therefore a validation error instead of an English fallback in a shipped locale.
+
 ## Runtime review
 
 Catalog validation proves structure and placeholder safety, but it cannot judge


### PR DESCRIPTION
## Summary

- replace the ambiguous `Code` localization key with a contextual compact HTTP status-code label while keeping the Visual Studio Code app name verbatim
- route visible enum labels through the runtime localization bundle and add missing catalog entries
- standardize high-confidence Simplified Chinese terminology for status codes, model tokens, redaction, certificate pinning, Compose, and Protobuf wire format
- enforce Swift literal coverage and terminology rules in localization validation, tests, and contributor documentation

## Why

Community review identified terminology that was grammatically valid but technically incorrect in context, including translating an HTTP status code as source code. The existing catalog checks also could not detect direct runtime localization keys that were absent from the catalog.

## Impact

Simplified Chinese labels are more accurate across workspace tables, inspectors, settings, filters, and breakpoint surfaces. Compact English UI remains unchanged, product names and protocol tokens stay verbatim, and future regressions are caught during validation.

## Related issues

Refs #289

## Validation

- `python3 .github/tools/validate_xcstrings.py`
- `python3 -m unittest discover -s .github/tools/tests` (50 tests)
- `swiftlint lint --strict --quiet`
- focused `StringCatalogCoverageTests` and `RuntimeLocalizationRegressionTests`
- `xcodebuild -project Rockxy.xcodeproj -scheme Rockxy -configuration Debug build`
