### PR TITLE
fix: capture JetBrains IDE traffic with Java Automatic Setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Improved sidebar grouping cleanup when selected domain/app groups disappear, keeping active filters and sidebar state aligned.
 - Made Clear Session and Follow Live discoverable in a dedicated traffic command bar above protocol filters while keeping filtering and footer tools in their existing workflows.
+- Made Java VM Automatic Setup apply explicit JVM proxy properties while preserving existing `JAVA_TOOL_OPTIONS`, and clarified the fresh-launch, trust-store, and SSL Proxying requirements for JetBrains IDEs.
 
 ### Changed
 

--- a/Rockxy/Localizable.xcstrings
+++ b/Rockxy/Localizable.xcstrings
@@ -4294,6 +4294,16 @@
         }
       }
     },
+    "Automatic Setup only affects the session it launches. An app that is already running keeps its current environment, and some GUI apps ignore shell variables — use macOS System Proxy or this target's Manual Setup for those.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自动设置只影响它启动的会话。已经在运行的应用会保留其当前环境，某些 GUI 应用会忽略 shell 变量——对于这些应用，请使用 macOS 系统代理或该目标的手动设置。"
+          }
+        }
+      }
+    },
     "Automatic Setup can prepare a scoped session for this target; Manual Setup remains available.": {
       "localizations": {
         "zh-Hans": {
@@ -12945,6 +12955,16 @@
         }
       }
     },
+    "For Java, HTTPS interception still needs the Rockxy root CA trusted in the exact JVM or JetBrains trust store and the target host added under SSL Proxying.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "对于 Java，HTTPS 拦截仍需要在对应的 JVM 或 JetBrains 信任库中信任 Rockxy 根 CA，并在 SSL 代理中添加目标主机。"
+          }
+        }
+      }
+    },
     "For example: Checkout API": {
       "localizations": {
         "zh-Hans": {
@@ -16259,12 +16279,12 @@
         }
       }
     },
-    "Java/Kotlin ships a manual keystore + HttpClient workflow when a local JDK is installed.": {
+    "Java VMs support a scoped Automatic Setup session plus a manual keystore workflow.": {
       "localizations": {
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "安装本地 JDK 后，Java/Kotlin 会提供手动密钥库 + HttpClient 工作流。"
+            "value": "Java VMs 支持限定范围的自动设置会话以及手动密钥库工作流。"
           }
         }
       }
@@ -27732,12 +27752,12 @@
         }
       }
     },
-    "Rockxy ships a keytool import command and a Java HttpClient sample for a manual capture check on machines with a local JDK.": {
+    "Automatic Setup prepares a scoped shell that sets JAVA_TOOL_OPTIONS proxy properties for the JVM. HTTPS interception still needs the Rockxy root CA trusted in the exact JVM or JetBrains trust store and the target host added under SSL Proxying.": {
       "localizations": {
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "Rockxy 提供 keytool 导入命令和 Java HttpClient 示例，用于在装有本地 JDK 的机器上手动检查捕获。"
+            "value": "自动设置会准备一个限定范围的 shell，为 JVM 设置 JAVA_TOOL_OPTIONS 代理属性。HTTPS 拦截仍需要在对应的 JVM 或 JetBrains 信任库中信任 Rockxy 根 CA，并在 SSL 代理中添加目标主机。"
           }
         }
       }
@@ -32180,6 +32200,16 @@
           "stringUnit": {
             "state": "translated",
             "value": "启动代理以通过 Rockxy 路由系统流量。"
+          }
+        }
+      }
+    },
+    "Start the Rockxy proxy before opening a prepared terminal.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "打开预配置终端前，请先启动 Rockxy 代理。"
           }
         }
       }

--- a/Rockxy/Models/UI/DeveloperSetupCatalog.swift
+++ b/Rockxy/Models/UI/DeveloperSetupCatalog.swift
@@ -121,9 +121,9 @@ extension SetupTarget {
             category: .runtime,
             iconName: "cup.and.saucer",
             manualSupport: .availableNow,
-            automationSupport: .none,
+            automationSupport: .runtimeTerminal,
             shortSummary: String(
-                localized: "Java/Kotlin ships a manual keystore + HttpClient workflow when a local JDK is installed.",
+                localized: "Java VMs support a scoped Automatic Setup session plus a manual keystore workflow.",
                 bundle: RockxyLocalization.bundle
             ),
             manualSummary: String(
@@ -133,8 +133,11 @@ extension SetupTarget {
                 """, bundle: RockxyLocalization.bundle
             ),
             currentSupportSummary: String(
-                localized: "Rockxy ships a keytool import command and a Java HttpClient sample for a manual capture check on machines with a local JDK.",
-                bundle: RockxyLocalization.bundle
+                localized: """
+                Automatic Setup prepares a scoped shell that sets JAVA_TOOL_OPTIONS proxy properties for the \
+                JVM. HTTPS interception still needs the Rockxy root CA trusted in the exact JVM or JetBrains \
+                trust store and the target host added under SSL Proxying.
+                """, bundle: RockxyLocalization.bundle
             )
         )
     }

--- a/Rockxy/Models/UI/DeveloperSetupSessionSetup.swift
+++ b/Rockxy/Models/UI/DeveloperSetupSessionSetup.swift
@@ -147,11 +147,34 @@ struct DeveloperSetupProcessRunner: DeveloperSetupProcessRunning {
 // MARK: - RockxySetupScriptContext
 
 struct RockxySetupScriptContext: Equatable {
+    // MARK: Lifecycle
+
+    init(
+        proxyHost: String,
+        proxyPort: Int,
+        certificatePath: String?,
+        generatedAt: Date,
+        appName: String,
+        targetID: SetupTarget.ID = .python
+    ) {
+        self.proxyHost = proxyHost
+        self.proxyPort = proxyPort
+        self.certificatePath = certificatePath
+        self.generatedAt = generatedAt
+        self.appName = appName
+        self.targetID = targetID
+    }
+
+    // MARK: Internal
+
     let proxyHost: String
     let proxyPort: Int
     let certificatePath: String?
     let generatedAt: Date
     let appName: String
+    /// The routed target this script was generated for. Only `.javaVMs` receives
+    /// JVM-specific proxy properties; every other target keeps the shared shell.
+    let targetID: SetupTarget.ID
 }
 
 // MARK: - RockxySetupScriptBuilder
@@ -237,6 +260,10 @@ enum RockxySetupScriptBuilder {
             lines.append("# Export or trust the Rockxy root certificate to enable certificate environment hints.")
         }
 
+        if context.targetID == .javaVMs {
+            lines.append(contentsOf: javaProxyLines(proxyHost: context.proxyHost, proxyPort: context.proxyPort))
+        }
+
         lines.append(contentsOf: [
             "",
             "echo \"\(context.appName) setup session is ready: $HTTP_PROXY\"",
@@ -245,6 +272,28 @@ enum RockxySetupScriptBuilder {
         ])
 
         return lines.joined(separator: "\n")
+    }
+
+    /// JVM proxy properties for the Java VMs target. Re-sourcing removes the
+    /// previous Rockxy block before appending the current one, so user options
+    /// added at any point survive and stale proxy properties never accumulate.
+    static func javaProxyLines(proxyHost: String, proxyPort: Int) -> [String] {
+        let proxyOptions = "-Dhttp.proxyHost=\(proxyHost) -Dhttp.proxyPort=\(proxyPort) " +
+            "-Dhttps.proxyHost=\(proxyHost) -Dhttps.proxyPort=\(proxyPort)"
+        return [
+            "",
+            "# Java VMs: route the JVM through Rockxy while preserving existing JAVA_TOOL_OPTIONS.",
+            "# Remove the previous Rockxy block before appending the current one.",
+            "if [ -n \"${ROCKXY_JAVA_PROXY_OPTS:-}\" ] && [ -n \"${JAVA_TOOL_OPTIONS:-}\" ]; then",
+            "  export JAVA_TOOL_OPTIONS=\"${JAVA_TOOL_OPTIONS//$ROCKXY_JAVA_PROXY_OPTS/}\"",
+            "fi",
+            "export ROCKXY_JAVA_PROXY_OPTS=\(shellDoubleQuoted(proxyOptions))",
+            "if [ -n \"${JAVA_TOOL_OPTIONS:-}\" ]; then",
+            "  export JAVA_TOOL_OPTIONS=\"$JAVA_TOOL_OPTIONS $ROCKXY_JAVA_PROXY_OPTS\"",
+            "else",
+            "  export JAVA_TOOL_OPTIONS=\"$ROCKXY_JAVA_PROXY_OPTS\"",
+            "fi",
+        ]
     }
 
     static func shellSingleQuoted(_ value: String) -> String {
@@ -395,7 +444,7 @@ final class DeveloperSetupSessionSetupViewModel {
         self.pasteboard = pasteboard ?? DeveloperSetupSystemPasteboard()
         self.scriptURL = scriptURL
         self.generatedAt = generatedAt
-        context = Self.makeContext(coordinator: coordinator, generatedAt: generatedAt())
+        context = Self.makeContext(coordinator: coordinator, targetID: targetID, generatedAt: generatedAt())
     }
 
     // MARK: Internal
@@ -457,7 +506,13 @@ final class DeveloperSetupSessionSetupViewModel {
         )
     }
 
-    static func makeContext(coordinator: MainContentCoordinator, generatedAt: Date) -> RockxySetupScriptContext {
+    static func makeContext(
+        coordinator: MainContentCoordinator,
+        targetID: SetupTarget.ID,
+        generatedAt: Date
+    )
+        -> RockxySetupScriptContext
+    {
         let settings = AppSettingsManager.shared.settings
         let port = DeveloperSetupViewModel.resolveSnippetPort(
             isProxyRunning: coordinator.isProxyRunning,
@@ -473,7 +528,8 @@ final class DeveloperSetupSessionSetupViewModel {
             proxyPort: port,
             certificatePath: certificatePath,
             generatedAt: generatedAt,
-            appName: RockxyIdentity.current.displayName
+            appName: RockxyIdentity.current.displayName,
+            targetID: targetID
         )
     }
 
@@ -494,7 +550,7 @@ final class DeveloperSetupSessionSetupViewModel {
     }
 
     func refresh() {
-        context = Self.makeContext(coordinator: coordinator, generatedAt: generatedAt())
+        context = Self.makeContext(coordinator: coordinator, targetID: targetID, generatedAt: generatedAt())
     }
 
     func prepareScript() throws {
@@ -540,6 +596,14 @@ final class DeveloperSetupSessionSetupViewModel {
     }
 
     func openPreparedTerminal() async {
+        guard coordinator.isProxyRunning else {
+            statusMessage = String(
+                localized: "Start the Rockxy proxy before opening a prepared terminal.",
+                bundle: RockxyLocalization.bundle
+            )
+            return
+        }
+
         guard prepareScriptForLaunch() else {
             return
         }

--- a/Rockxy/Views/DeveloperSetup/DeveloperSetupAutomaticWindowView.swift
+++ b/Rockxy/Views/DeveloperSetup/DeveloperSetupAutomaticWindowView.swift
@@ -112,6 +112,35 @@ struct DeveloperSetupAutomaticWindowView: View {
                 .font(setupMetrics.font())
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
+
+                Text(
+                    String(
+                        localized: """
+                        Automatic Setup only affects the session it launches. An app that is already running \
+                        keeps its current environment, and some GUI apps ignore shell variables — use macOS \
+                        System Proxy or this target's Manual Setup for those.
+                        """,
+                        bundle: RockxyLocalization.bundle
+                    )
+                )
+                .font(setupMetrics.secondaryFont())
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+                if viewModel.target.id == .javaVMs {
+                    Text(
+                        String(
+                            localized: """
+                            For Java, HTTPS interception still needs the Rockxy root CA trusted in the exact \
+                            JVM or JetBrains trust store and the target host added under SSL Proxying.
+                            """,
+                            bundle: RockxyLocalization.bundle
+                        )
+                    )
+                    .font(setupMetrics.secondaryFont())
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+                }
             }
         }
     }

--- a/RockxyTests/ViewModels/DeveloperSetupCheckpointTests.swift
+++ b/RockxyTests/ViewModels/DeveloperSetupCheckpointTests.swift
@@ -14,6 +14,27 @@ private struct FailingProcessRunner: DeveloperSetupProcessRunning {
     }
 }
 
+// MARK: - CapturingProcessRunner
+
+private final class CapturingProcessRunner: DeveloperSetupProcessRunning, @unchecked Sendable {
+    // MARK: Internal
+
+    var wasInvoked: Bool {
+        lock.withLock { invocationCount > 0 }
+    }
+
+    func run(executableURL _: URL, arguments _: [String]) throws {
+        lock.withLock { invocationCount += 1 }
+    }
+
+    // MARK: Private
+
+    private let lock = NSLock()
+    private var invocationCount = 0
+}
+
+// MARK: - CapturingPasteboard
+
 @MainActor
 private final class CapturingPasteboard: DeveloperSetupPasteboardWriting {
     private(set) var string: String?
@@ -53,6 +74,15 @@ struct DeveloperSetupRouteStoreTests {
         #expect(store.consumeAutomaticRoute()?.targetID == .python)
     }
 
+    @Test("Java VMs is an eligible Automatic Setup route target")
+    func automaticRouteAcceptsJavaVMs() {
+        let store = DeveloperSetupRouteStore()
+
+        #expect(SetupTarget.javaVMs.isRuntimeTerminalTarget)
+        #expect(store.requestAutomatic(targetID: .javaVMs) == true)
+        #expect(store.consumeAutomaticRoute()?.targetID == .javaVMs)
+    }
+
     @Test("A newer route wins over an older one by generation")
     func newerRouteWinsByGeneration() {
         let store = DeveloperSetupRouteStore()
@@ -77,6 +107,8 @@ struct DeveloperSetupRouteStoreTests {
 
 @MainActor
 struct DeveloperSetupSessionTargetTests {
+    // MARK: Internal
+
     @Test("Session setup reflects the routed target instead of a generic default")
     func sessionReflectsRoutedTarget() {
         let viewModel = DeveloperSetupSessionSetupViewModel(
@@ -116,6 +148,27 @@ struct DeveloperSetupSessionTargetTests {
         )
 
         #expect(viewModel.targetID == .ruby)
+    }
+
+    @Test("Routing a Java session regenerates the script with JVM proxy properties")
+    func javaSessionGeneratesJVMProxyProperties() {
+        let viewModel = DeveloperSetupSessionSetupViewModel(
+            coordinator: MainContentCoordinator(),
+            targetID: .python
+        )
+
+        viewModel.applyRoute(
+            DeveloperSetupRoute(targetID: .javaVMs, tab: .setup, destination: .automatic, generation: 1),
+            destination: .automatic
+        )
+
+        #expect(viewModel.targetID == .javaVMs)
+        #expect(viewModel.isRuntimeTerminalTarget)
+        #expect(viewModel.context.targetID == .javaVMs)
+
+        let script = RockxySetupScriptBuilder.script(context: viewModel.context)
+        #expect(script.contains("-Dhttps.proxyHost="))
+        #expect(script.contains("export JAVA_TOOL_OPTIONS="))
     }
 
     @Test("Runtime-terminal targets remain terminal-eligible")
@@ -161,12 +214,14 @@ struct DeveloperSetupSessionTargetTests {
     }
 
     @Test("Custom terminal copies the setup command and reports it")
-    func customTerminalCopiesCommand() async throws {
+    func customTerminalCopiesCommand() async {
         let scriptURL = temporaryScriptURL()
         defer { try? FileManager.default.removeItem(at: scriptURL.deletingLastPathComponent()) }
         let pasteboard = CapturingPasteboard()
+        let coordinator = MainContentCoordinator()
+        coordinator.isProxyRunning = true
         let viewModel = DeveloperSetupSessionSetupViewModel(
-            coordinator: MainContentCoordinator(),
+            coordinator: coordinator,
             targetID: .python,
             pasteboard: pasteboard,
             scriptURL: scriptURL
@@ -179,12 +234,41 @@ struct DeveloperSetupSessionTargetTests {
         #expect(pasteboard.string == viewModel.manualSourceCommand)
     }
 
-    @Test("View model surfaces launcher failure instead of a success message")
-    func viewModelReportsLauncherFailure() async throws {
+    @Test("Automatic terminal launch is blocked while the proxy is stopped")
+    func stoppedProxyBlocksAutomaticTerminalLaunch() async {
         let scriptURL = temporaryScriptURL()
         defer { try? FileManager.default.removeItem(at: scriptURL.deletingLastPathComponent()) }
+        let pasteboard = CapturingPasteboard()
+        let processRunner = CapturingProcessRunner()
+        let coordinator = MainContentCoordinator()
+        coordinator.isProxyRunning = false
         let viewModel = DeveloperSetupSessionSetupViewModel(
-            coordinator: MainContentCoordinator(),
+            coordinator: coordinator,
+            targetID: .javaVMs,
+            processRunner: processRunner,
+            pasteboard: pasteboard,
+            scriptURL: scriptURL
+        )
+
+        await viewModel.openPreparedTerminal()
+
+        #expect(viewModel.statusMessage == String(
+            localized: "Start the Rockxy proxy before opening a prepared terminal.",
+            bundle: RockxyLocalization.bundle
+        ))
+        #expect(FileManager.default.fileExists(atPath: scriptURL.path) == false)
+        #expect(processRunner.wasInvoked == false)
+        #expect(pasteboard.string == nil)
+    }
+
+    @Test("View model surfaces launcher failure instead of a success message")
+    func viewModelReportsLauncherFailure() async {
+        let scriptURL = temporaryScriptURL()
+        defer { try? FileManager.default.removeItem(at: scriptURL.deletingLastPathComponent()) }
+        let coordinator = MainContentCoordinator()
+        coordinator.isProxyRunning = true
+        let viewModel = DeveloperSetupSessionSetupViewModel(
+            coordinator: coordinator,
             targetID: .python,
             processRunner: FailingProcessRunner(),
             scriptURL: scriptURL
@@ -197,6 +281,8 @@ struct DeveloperSetupSessionTargetTests {
         #expect(status.localizedCaseInsensitiveContains("could not"))
         #expect(status.localizedCaseInsensitiveContains("opened") == false)
     }
+
+    // MARK: Private
 
     private func temporaryScriptURL() -> URL {
         FileManager.default.temporaryDirectory

--- a/RockxyTests/ViewModels/DeveloperSetupSessionSetupTests.swift
+++ b/RockxyTests/ViewModels/DeveloperSetupSessionSetupTests.swift
@@ -1,9 +1,11 @@
 import Foundation
-import Testing
 @testable import Rockxy
+import Testing
 
 @Suite("Developer setup session setup")
 struct DeveloperSetupSessionSetupTests {
+    // MARK: Internal
+
     @Test("Generated setup script exports scoped proxy and certificate hints")
     func generatedSetupScriptExportsScopedProxyAndCertificateHints() {
         let context = RockxySetupScriptContext(
@@ -26,13 +28,65 @@ struct DeveloperSetupSessionSetupTests {
         #expect(script.contains("NODE_OPTIONS"))
     }
 
+    @Test("Java VMs script injects JAVA_TOOL_OPTIONS proxy properties once and preserves the base")
+    func javaScriptInjectsProxyPropertiesAndPreservesBase() {
+        let context = RockxySetupScriptContext(
+            proxyHost: "127.0.0.1",
+            proxyPort: 9_090,
+            certificatePath: nil,
+            generatedAt: Date(timeIntervalSince1970: 0),
+            appName: "Rockxy",
+            targetID: .javaVMs
+        )
+
+        let script = RockxySetupScriptBuilder.script(context: context)
+
+        #expect(script.contains("-Dhttp.proxyHost=127.0.0.1"))
+        #expect(script.contains("-Dhttp.proxyPort=9090"))
+        #expect(script.contains("-Dhttps.proxyHost=127.0.0.1"))
+        #expect(script.contains("-Dhttps.proxyPort=9090"))
+        #expect(script.contains("export JAVA_TOOL_OPTIONS="))
+        #expect(script.contains("${JAVA_TOOL_OPTIONS//$ROCKXY_JAVA_PROXY_OPTS/}"))
+        // The proxy option string is emitted exactly once so re-sourcing cannot stack it.
+        #expect(script.components(separatedBy: "-Dhttp.proxyHost=127.0.0.1").count - 1 == 1)
+    }
+
+    @Test("Non-Java runtime script never injects JAVA_TOOL_OPTIONS")
+    func nonJavaScriptOmitsJavaProxyProperties() {
+        let context = RockxySetupScriptContext(
+            proxyHost: "127.0.0.1",
+            proxyPort: 9_090,
+            certificatePath: nil,
+            generatedAt: Date(timeIntervalSince1970: 0),
+            appName: "Rockxy",
+            targetID: .python
+        )
+
+        let script = RockxySetupScriptBuilder.script(context: context)
+
+        #expect(script.contains("JAVA_TOOL_OPTIONS") == false)
+        #expect(script.contains("-Dhttp.proxyHost") == false)
+    }
+
+    @Test("Sourcing the Java script twice keeps existing JAVA_TOOL_OPTIONS and one proxy block")
+    func javaScriptPreservesExistingOptionsAcrossReSourcing() throws {
+        try assertJavaScriptSourcing(shellPath: "/bin/zsh")
+    }
+
+    @Test("Sourcing the Java script twice in bash keeps existing options and one proxy block")
+    func javaScriptPreservesExistingOptionsAcrossReSourcingBash() throws {
+        try assertJavaScriptSourcing(shellPath: "/bin/bash")
+    }
+
     @Test("Manual source command quotes Application Support paths")
     func manualSourceCommandQuotesApplicationSupportPaths() {
-        let scriptURL = URL(fileURLWithPath: "/Users/stephen/Library/Application Support/Rockxy/setup/rockxy_env_setup.sh")
+        let scriptURL =
+            URL(fileURLWithPath: "/Users/stephen/Library/Application Support/Rockxy/setup/rockxy_env_setup.sh")
 
         let command = RockxySetupScriptBuilder.sourceCommand(scriptURL: scriptURL)
 
-        #expect(command == "set -a 2>/dev/null || true; source \"/Users/stephen/Library/Application Support/Rockxy/setup/rockxy_env_setup.sh\"; set +a 2>/dev/null || true")
+        #expect(command ==
+            "set -a 2>/dev/null || true; source \"/Users/stephen/Library/Application Support/Rockxy/setup/rockxy_env_setup.sh\"; set +a 2>/dev/null || true")
         #expect(!command.contains("__rockxy_setup"))
     }
 
@@ -97,6 +151,13 @@ struct DeveloperSetupSessionSetupTests {
         #expect(userJS.contains("user_pref(\"network.proxy.no_proxies_on\", \"localhost, 127.0.0.1, ::1\");"))
     }
 
+    // MARK: Private
+
+    private struct ShellResult {
+        let exitCode: Int32
+        let output: String
+    }
+
     private func assertGeneratedSetupCommandRuns(shellPath: String) throws {
         try #require(FileManager.default.fileExists(atPath: shellPath))
 
@@ -110,6 +171,47 @@ struct DeveloperSetupSessionSetupTests {
         #expect(result.output.contains("HTTP_PROXY=http://127.0.0.1:9092"))
         #expect(result.output.contains("ROCKXY_SETUP_SESSION=1"))
         #expect(result.output.contains("Rockxy setup session is ready: http://127.0.0.1:9092"))
+    }
+
+    private func assertJavaScriptSourcing(shellPath: String) throws {
+        try #require(FileManager.default.fileExists(atPath: shellPath))
+
+        let scriptURL = try writeTemporaryJavaSetupScript()
+        let sourceCommand = RockxySetupScriptBuilder.sourceCommand(scriptURL: scriptURL)
+        // A harmless value added before the first source and another added between
+        // sources prove both survive while the Rockxy proxy block remains singular.
+        let command = "export JAVA_TOOL_OPTIONS=\"-Dfile.encoding=UTF-8\"; " +
+            "\(sourceCommand); " +
+            "export JAVA_TOOL_OPTIONS=\"$JAVA_TOOL_OPTIONS -Duser.country=VN\"; " +
+            "\(sourceCommand); " +
+            "printf 'JAVA_TOOL_OPTIONS=%s\\n' \"$JAVA_TOOL_OPTIONS\""
+
+        let result = try runShell(shellPath: shellPath, command: command)
+
+        #expect(result.exitCode == 0)
+        #expect(result.output.contains("-Dfile.encoding=UTF-8"))
+        #expect(result.output.contains("-Duser.country=VN"))
+        #expect(result.output.contains("-Dhttp.proxyHost=127.0.0.1"))
+        let proxyBlockCount = result.output.components(separatedBy: "-Dhttp.proxyHost=127.0.0.1").count - 1
+        #expect(proxyBlockCount == 1)
+    }
+
+    private func writeTemporaryJavaSetupScript() throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("rockxy java setup \(UUID().uuidString)", isDirectory: true)
+            .appendingPathComponent("Application Support/Rockxy/setup", isDirectory: true)
+        let scriptURL = directory.appendingPathComponent("rockxy_env_setup.sh")
+        let context = RockxySetupScriptContext(
+            proxyHost: "127.0.0.1",
+            proxyPort: 9_093,
+            certificatePath: nil,
+            generatedAt: Date(timeIntervalSince1970: 0),
+            appName: "Rockxy",
+            targetID: .javaVMs
+        )
+
+        try RockxySetupScriptBuilder.writeScript(context: context, scriptURL: scriptURL)
+        return scriptURL
     }
 
     private func assertGeneratedSetupCommandReportsMissingScript(shellPath: String) throws {
@@ -160,10 +262,5 @@ struct DeveloperSetupSessionSetupTests {
         let standardError = String(data: errorData, encoding: .utf8) ?? ""
         let output = standardOutput + standardError
         return ShellResult(exitCode: process.terminationStatus, output: output)
-    }
-
-    private struct ShellResult {
-        let exitCode: Int32
-        let output: String
     }
 }

--- a/RockxyTests/ViewModels/DeveloperSetupViewModelTests.swift
+++ b/RockxyTests/ViewModels/DeveloperSetupViewModelTests.swift
@@ -76,6 +76,8 @@ struct DeveloperSetupViewModelTests {
         #expect(SetupTarget.python.automationSupport == .runtimeTerminal)
         #expect(SetupTarget.nodeJS.manualSupport == .availableNow)
         #expect(SetupTarget.nodeJS.automationSupport == .runtimeTerminal)
+        #expect(SetupTarget.javaVMs.manualSupport == .availableNow)
+        #expect(SetupTarget.javaVMs.automationSupport == .runtimeTerminal)
         #expect(SetupTarget.postman.automationSupport == .none)
     }
 
@@ -138,7 +140,7 @@ struct DeveloperSetupViewModelTests {
         #expect(matchingIDs.contains(.python))
         #expect(matchingIDs.contains(.nodeJS))
         #expect(matchingIDs.contains(.curl))
-        #expect(matchingIDs.contains(.javaVMs) == false)
+        #expect(matchingIDs.contains(.javaVMs))
     }
 
     @Test("Source list filter keeps pinned results in sync with the user's pinned set")

--- a/docs/automatic-setup/automatic-setup.mdx
+++ b/docs/automatic-setup/automatic-setup.mdx
@@ -1,13 +1,13 @@
 ---
 title: Automatic Setup
-description: Open a prepared Rockxy terminal or browser session for runtimes and tools that do not automatically follow the macOS system proxy.
+description: Open a prepared Rockxy terminal session for runtimes and tools that do not automatically follow the macOS system proxy.
 ---
 
 # Automatic Setup
 
-Automatic Setup prepares a scoped session so supported terminals, runtimes, and browsers can send traffic through Rockxy without changing your whole macOS network configuration.
+Automatic Setup prepares a scoped terminal session so supported runtimes and command-line tools can send traffic through Rockxy without changing your whole macOS network configuration.
 
-Use it when the app or script you are debugging runs from a terminal, runtime, browser profile, or local development tool that may ignore the system proxy.
+Use it when the app or script you are debugging runs from a terminal or local runtime that may ignore the system proxy.
 
 ## What it solves
 
@@ -17,7 +17,6 @@ Some developer tools do not automatically use the macOS system proxy. That commo
 - Python scripts and workers
 - Ruby scripts and Rails-style local services
 - Go, Rust, Java, and cURL workflows
-- browser profiles launched outside your normal profile
 - Electron and framework-adjacent local development flows
 
 When those processes do not inherit proxy and certificate settings, Rockxy may be running correctly but still show no traffic from that target.
@@ -28,23 +27,31 @@ Automatic Setup prepares a new session with Rockxy proxy and certificate hints a
 
 For terminal-oriented flows, Rockxy generates a local setup script and launches the selected terminal with that script sourced. The script exports proxy environment variables such as `HTTP_PROXY`, `HTTPS_PROXY`, and related certificate hints for the current session.
 
-For browser-oriented flows, Rockxy opens a prepared browser profile or browser launch mode that points at the active Rockxy proxy.
-
 <Note>
 Automatic Setup is scoped to the launched session. It does not edit your shell profile, permanently change your OS proxy, or make every app on your Mac use Rockxy.
 </Note>
+
+<Warning>
+Automatic Setup only affects the session it launches. An app that is already running keeps its current environment, so a prepared session cannot retrofit proxy settings onto it. Some GUI apps also ignore shell environment variables entirely. For an already-running or GUI client, launch it fresh from the prepared session where that is possible, or fall back to macOS System Proxy or the target's [Manual Setup](/automatic-setup/manual-setup).
+</Warning>
+
+## Java VMs
+
+Java VMs is an Automatic Setup target. In addition to the shared proxy exports, the generated script sets `JAVA_TOOL_OPTIONS` with explicit `-Dhttp.proxyHost`, `-Dhttp.proxyPort`, `-Dhttps.proxyHost`, and `-Dhttps.proxyPort` properties so a JVM started from that session routes through Rockxy. Existing `JAVA_TOOL_OPTIONS` content is preserved, and re-sourcing does not stack the proxy block.
+
+HTTPS interception still requires importing and trusting the Rockxy root CA in the exact JVM or JetBrains trust store and adding the target host under SSL Proxying — the proxy properties handle routing only. See [Java VMs](/setup-guides/java-vms) for the trust-store steps.
 
 ## How to use it
 
 1. Open Rockxy.
 2. Open the Setup menu or Developer Setup Hub.
 3. Choose **Automatic Setup**.
-4. Pick the terminal or browser you want to launch.
-5. Click **Open Prepared Terminal** or **Open Browser**.
+4. Pick the terminal you want to launch.
+5. Click **Open Prepared Terminal**.
 6. Start your server, script, test runner, or client from that prepared session.
 7. Trigger a request and confirm the traffic appears in Rockxy.
 
-<img src="/images/AutomaticSetupRockxy.png" alt="Rockxy Automatic Setup window for prepared terminal and browser sessions" />
+<img src="/images/AutomaticSetupRockxy.png" alt="Rockxy Automatic Setup window for a prepared terminal session" />
 
 ## Supported launch targets
 
@@ -54,13 +61,6 @@ The Automatic Setup window currently models these terminal choices:
 - iTerm2
 - Ghostty
 - My own Terminal
-
-For browsers, Rockxy models:
-
-- Google Chrome with a new prepared profile
-- Google Chrome with the current profile
-- Firefox
-- Brave as a future option
 
 If you choose **My own Terminal**, Rockxy copies the setup command for you so you can paste it into any shell that supports `source`.
 

--- a/docs/automatic-setup/manual-setup.mdx
+++ b/docs/automatic-setup/manual-setup.mdx
@@ -96,7 +96,7 @@ If you open a new terminal tab or window, run the Manual Setup command again in 
 
 <CardGroup cols={2}>
   <Card title="Automatic Setup" icon="bolt" href="/automatic-setup/automatic-setup">
-    Let Rockxy open a prepared terminal or browser session for you.
+    Let Rockxy open a prepared terminal session for you.
   </Card>
   <Card title="Automatic Setup Troubleshooting" icon="triangle-exclamation" href="/automatic-setup/troubleshooting">
     Diagnose missing traffic, HTTPS errors, and stale setup sessions.

--- a/docs/automatic-setup/troubleshooting.mdx
+++ b/docs/automatic-setup/troubleshooting.mdx
@@ -1,6 +1,6 @@
 ---
 title: Automatic Setup Troubleshooting
-description: Fix common Automatic Setup and Manual Setup problems, including missing traffic, HTTPS trust errors, stale sessions, browser profile issues, and localhost routing.
+description: Fix common Automatic Setup and Manual Setup problems, including missing traffic, HTTPS trust errors, stale sessions, GUI-app routing, and localhost routing.
 ---
 
 # Automatic Setup Troubleshooting
@@ -65,6 +65,29 @@ This may not work:
 
 Run the setup command again in each terminal session that starts traffic you want Rockxy to capture.
 
+## An already-running or GUI app shows no traffic
+
+Automatic Setup and Manual Setup only affect the session they prepare. Child processes launched from that session inherit its environment, but each runtime or HTTP library must still honor those proxy variables; anything already running does not.
+
+That means:
+
+- An app or IDE that was already open keeps its previous environment. Quit it and launch it fresh from the prepared session, or point it at Rockxy another way.
+- Some GUI apps ignore shell environment variables completely, so a prepared shell never reaches them.
+
+For those clients, use macOS System Proxy, or the target-specific Manual Setup, instead of relying on inherited shell variables.
+
+## Java or a JetBrains IDE (PyCharm/IntelliJ) shows no traffic
+
+The Java VMs Automatic Setup target sets `JAVA_TOOL_OPTIONS` proxy properties for JVMs launched from the prepared session.
+
+For a JetBrains IDE, those properties route the IDE's JVM traffic. A Python, Node.js, or other non-JVM Run/Debug child must separately honor the inherited `HTTP_PROXY` / `HTTPS_PROXY` variables or use its own proxy configuration. An IDE startup `CONNECT` row alone does not prove that the application being debugged is routed.
+
+If Java traffic still does not appear:
+
+- Launch the JVM or IDE fresh from the prepared session. A JetBrains IDE that was already open keeps its old environment and will not pick up `JAVA_TOOL_OPTIONS` retroactively.
+- For HTTPS, routing alone is not enough: import and trust the Rockxy root CA in the exact JVM or JetBrains trust store, and add the host under SSL Proxying. See [Java VMs](/setup-guides/java-vms).
+- If the IDE has its own proxy setting that ignores the environment, set macOS System Proxy or configure the IDE's proxy manually.
+
 ## AppleScript permission is blocked
 
 Rockxy may need macOS permission to launch or control supported terminal apps for Automatic Setup.
@@ -76,15 +99,6 @@ If macOS blocks that launch:
 - then try Automatic Setup again.
 
 Manual Setup is the reliable fallback because it only asks you to copy and paste the command yourself.
-
-## Browser opens but HTTPS still fails
-
-Browser setup has two parts:
-
-- the browser profile must use Rockxy's proxy,
-- and the browser must trust Rockxy's root certificate for HTTPS inspection.
-
-If the prepared browser opens but HTTPS requests fail, finish certificate trust first. Firefox can use a separate certificate store, so it may need browser-specific certificate trust even when macOS Keychain is already configured.
 
 ## Localhost requests do not appear
 
@@ -107,7 +121,7 @@ If one library fails while another runtime request works:
 
 <CardGroup cols={2}>
   <Card title="Automatic Setup" icon="bolt" href="/automatic-setup/automatic-setup">
-    Review what Rockxy prepares when it launches a terminal or browser session.
+    Review what Rockxy prepares when it launches a terminal session.
   </Card>
   <Card title="Manual Setup" icon="clipboard" href="/automatic-setup/manual-setup">
     Copy the setup command into your own terminal as a fallback.

--- a/docs/setup-guides/firefox.mdx
+++ b/docs/setup-guides/firefox.mdx
@@ -10,31 +10,17 @@ Firefox is a common case where browser traffic needs app-specific setup instead 
 ## Support in Rockxy
 
 - Manual setup available
-- Prepared Firefox profile available from Developer Setup
 - Validation-backed setup
 
 ## What Rockxy currently provides
 
 - Firefox proxy settings guidance
-- a prepared Firefox profile with Rockxy proxy preferences scoped to that profile
 - browser authority-store certificate guidance
 - a cURL preflight path before you touch the browser setup
 
 ## Recommended workflow
 
-For normal debugging, start with the prepared Firefox profile from Rockxy:
-
-1. Start Rockxy capture.
-2. Open **Tools → Debug My App…**.
-3. Select **Firefox**.
-4. Open **Automatic Setup**.
-5. In **Web Browsers**, choose **Firefox…**.
-6. Click **Open Browser…**.
-7. Open one simple HTTPS page, such as `https://example.com/`.
-
-The prepared profile is launched with Rockxy proxy preferences scoped to that profile. Your normal Firefox profile does not need to be changed back and forth.
-
-Firefox may still require the Rockxy root certificate in its own certificate store. If HTTPS pages fail or Rockxy only shows CONNECT tunnels, complete the certificate steps below.
+Use the Firefox Manual Setup flow in Developer Setup Hub. Configure the browser's proxy, import the Rockxy root CA into Firefox's authority store, add the target hostname under SSL Proxying, and then load one simple HTTPS page such as `https://example.com/`.
 
 ## Manual Firefox setup
 
@@ -103,7 +89,7 @@ If you manually set `HTTP Proxy: 127.0.0.1` in your normal Firefox profile, Fire
 
 When you finish a manual Firefox debugging session, change Firefox back to **No proxy** if you want that profile to browse normally without Rockxy running.
 
-For a scoped workflow, use Rockxy's Developer Setup Firefox profile instead. That profile is launched with Rockxy proxy preferences already written for the debugging session, so your normal Firefox profile does not need to be changed back and forth.
+For a scoped workflow, create a separate Firefox profile and configure Rockxy's proxy only in that profile. The current Developer Setup flow provides the manual settings but does not create or launch a Firefox profile for you.
 
 ## Troubleshooting checklist
 

--- a/docs/setup-guides/java-vms.mdx
+++ b/docs/setup-guides/java-vms.mdx
@@ -5,24 +5,41 @@ description: Configure Java and Kotlin HTTP clients to use Rockxy by importing t
 
 # Java VMs
 
-Java and Kotlin use a manual trust-store workflow rather than the simpler proxy-only path many macOS clients use.
+Java and Kotlin need the Rockxy root certificate in the JVM trust store on top of proxy routing, so they use a trust-store workflow rather than the simpler proxy-only path many macOS clients use.
 
 ## Support in Rockxy
 
-- Manual setup available
-- No runtime automation entry point today
+- Automatic Setup available for Java VMs
+- Manual setup available for trust-store work
 - Validation-backed setup
+
+## What Automatic Setup does for Java
+
+Automatic Setup prepares a scoped shell for the Java VMs target. Alongside the shared `HTTP_PROXY` / `HTTPS_PROXY` exports, it sets `JAVA_TOOL_OPTIONS` with explicit JVM proxy properties so a JVM launched from that session routes through Rockxy:
+
+```sh
+-Dhttp.proxyHost=127.0.0.1 -Dhttp.proxyPort=<port> -Dhttps.proxyHost=127.0.0.1 -Dhttps.proxyPort=<port>
+```
+
+Rockxy preserves any `JAVA_TOOL_OPTIONS` you already set and does not stack the proxy block if you re-source the script.
+
+<Note>
+Automatic Setup only affects the session it launches. A JVM or IDE that is already running keeps its current environment, and GUI apps launched outside that session may ignore shell variables. Launch the JVM (or a JetBrains IDE such as PyCharm/IntelliJ) fresh from the prepared session, or use macOS System Proxy / Manual Setup instead.
+</Note>
+
+For JetBrains IDEs, the JVM properties route the IDE's own JVM traffic. A Python, Node.js, or other non-JVM Run/Debug child only inherits the shared proxy environment; its HTTP client must also honor `HTTP_PROXY` / `HTTPS_PROXY` (or be configured explicitly). Seeing the IDE's startup `CONNECT` request therefore confirms JVM routing, not necessarily the application being debugged.
 
 ## What Rockxy currently provides
 
+- Automatic Setup with `JAVA_TOOL_OPTIONS` JVM proxy properties
 - a `keytool` import path for the Rockxy root certificate
 - a Java `HttpClient` sample
 - Dev Hub guidance for confirming capture on a locally installed JDK
 
 ## What you still need to do
 
-- import the Rockxy root certificate into the active JVM trust store
-- route the Java client through Rockxy's proxy
+- import and trust the Rockxy root certificate in the exact JVM or JetBrains trust store (proxy properties alone do not make HTTPS interception work)
+- add the target host under SSL Proxying so Rockxy decrypts its HTTPS traffic
 - validate with one known request before broader debugging
 
 ## Related pages


### PR DESCRIPTION
## Summary

- enable Automatic Setup for the Java VMs target
- add explicit JVM HTTP and HTTPS proxy properties while preserving existing `JAVA_TOOL_OPTIONS`
- prevent prepared-terminal launch while the Rockxy proxy is stopped
- clarify fresh-launch, child-process, trust-store, and SSL Proxying behavior
- remove stale documentation claims about browser-profile automation that is not exposed by the current UI

## Why

Java VMs was incorrectly marked as manual-only, so the prepared terminal exported generic shell proxy variables without providing the proxy properties used by the JVM. A JetBrains IDE launched from that session could therefore bypass Rockxy even though tools such as cURL worked from the same terminal.

This is a Rockxy Automatic Setup logic bug, not a user configuration error.

## Impact

Java and JetBrains IDE processes launched fresh from the prepared Java VMs session now receive explicit `http.proxyHost`, `http.proxyPort`, `https.proxyHost`, and `https.proxyPort` JVM properties. Existing `JAVA_TOOL_OPTIONS` values are preserved, and sourcing the setup script repeatedly does not stack Rockxy proxy options.

The change remains session-scoped. It does not modify the macOS system proxy, shell profiles, or JVM trust stores. HTTPS inspection still requires the Rockxy root CA to be trusted by the exact JVM or JetBrains trust store and the destination hostname to be included under SSL Proxying. Non-JVM child processes must honor the inherited `HTTP_PROXY` and `HTTPS_PROXY` variables or use their own proxy configuration.

## Related issues

Fixes #302
Refs #74

## Validation

- SwiftFormat lint: passed for all modified Swift files
- `swiftlint lint --strict`: passed with 0 violations
- string catalog validation: passed
- focused Developer Setup and runtime-localization regression suites: passed
- Debug build: passed
- manual proxy-stopped guard: passed
- manual PyCharm 2026.2.1 cold-launch from the prepared Java VMs terminal: captured JetBrains traffic through Rockxy with successful CONNECT responses
- manual PyCharm terminal child-process check: inherited proxy variables and JVM options
- manual Python HTTPS request from the PyCharm terminal: captured successfully and decrypted after enabling SSL Proxying for the hostname