### PR TITLE
fix(localization): correct Simplified Chinese translations and unify terminology

### DIFF
--- a/Rockxy/Localizable.xcstrings
+++ b/Rockxy/Localizable.xcstrings
@@ -9,7 +9,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "  •  已逐出 %lld 项"
+            "value": "  •  已淘汰 %lld 项"
           }
         }
       }
@@ -60,7 +60,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "无法读取\"%1$@\"。\n\n%2$@"
+            "value": "无法读取“%1$@”。\n\n%2$@"
           }
         }
       }
@@ -166,7 +166,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "%@\n\nRockxy 已从当前 App 包中重新注册辅助工具。您仍需在系统设置 > 登录项中批准它。"
+            "value": "%@\n\nRockxy 已从当前 App 包中重新注册辅助工具。你仍需在系统设置 > 登录项中批准它。"
           }
         }
       }
@@ -186,7 +186,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "%@\n\nRockxy 已重新安装 Helper，但其协议版本与此 App 构建不兼容。"
+            "value": "%@\n\nRockxy 已重新安装辅助工具，但其协议版本与此 App 构建不兼容。"
           }
         }
       }
@@ -216,7 +216,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "%@\n\nRockxy 已重新安装 Helper，但安装的 Helper 看起来仍旧早于此 App 构建。"
+            "value": "%@\n\nRockxy 已重新安装辅助工具，但安装的辅助工具看起来仍旧早于此 App 构建。"
           }
         }
       }
@@ -463,7 +463,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "%@ 在此 Mac 上不可用。"
+            "value": "%@ 在这台 Mac 上不可用。"
           }
         }
       }
@@ -688,7 +688,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "%1$@，%2$lld 条活动规则"
+            "value": "%1$@，%2$lld 条活跃规则"
           }
         }
       }
@@ -836,7 +836,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "%lld 条活动 Map Local 规则。打开 Map Local。"
+            "value": "%lld 条活跃 Map Local 规则。打开 Map Local。"
           }
         }
       }
@@ -846,7 +846,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "有 %lld 条活动的 Map Remote 规则。打开 Map Remote。"
+            "value": "有 %lld 条活跃的 Map Remote 规则。打开 Map Remote。"
           }
         }
       }
@@ -866,7 +866,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "%lld 条活动规则"
+            "value": "%lld 条活跃规则"
           }
         }
       }
@@ -896,7 +896,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "缺少 %lld 个基准请求标头"
+            "value": "缺少 %lld 个基线请求标头"
           }
         }
       }
@@ -1054,7 +1054,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "已包括 %1$lld 个 · 已跳过 %2$lld 个"
+            "value": "已包含 %1$lld 个 · 已跳过 %2$lld 个"
           }
         }
       }
@@ -1346,7 +1346,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "%lld 处重叠；Tunnel Without Decryption 优先"
+            "value": "%lld 处重叠；“不解密隧道”优先"
           }
         }
       }
@@ -1666,7 +1666,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "^[%lld 台主机](inflect: true)"
+            "value": "^[%lld 个主机](inflect: true)"
           }
         }
       }
@@ -1852,7 +1852,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "有 1 条活动断点规则。打开“断点规则”。"
+            "value": "有 1 条活跃断点规则。打开断点规则。"
           }
         }
       }
@@ -1862,7 +1862,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "有 1 条活动的 Map Local 规则。打开 Map Local。"
+            "value": "有 1 条活跃的 Map Local 规则。打开 Map Local。"
           }
         }
       }
@@ -2102,7 +2102,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "可见 5 字节的 gRPC 前缀"
+            "value": "检测到 5 字节的 gRPC 前缀"
           }
         }
       }
@@ -2205,7 +2205,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "此 App 捆绑了更新版本的 Helper。"
+            "value": "此 App 捆绑了更新版本的辅助工具。"
           }
         }
       }
@@ -2245,7 +2245,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "请求必须匹配您设置的每个条件。空字段可匹配任意值。"
+            "value": "请求必须匹配你设置的每个条件。空字段可匹配任意值。"
           }
         }
       }
@@ -2491,7 +2491,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "活动项目"
+            "value": "活跃项目"
           }
         }
       }
@@ -2501,7 +2501,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "活动项目：%@"
+            "value": "活跃项目：%@"
           }
         }
       }
@@ -2601,7 +2601,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "添加包括或排除条件以预览匹配项"
+            "value": "添加包含或排除条件以预览匹配项"
           }
         }
       }
@@ -2947,7 +2947,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "添加这个已启用的配置将禁用当前启用的配置。"
+            "value": "添加这个已启用的配置将停用当前启用的配置。"
           }
         }
       }
@@ -2957,7 +2957,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "仅将被 Focus 或 Noise 隐藏的 %lld 个请求添加到本次审查。你的 Focus 和 Noise 设置不会更改。"
+            "value": "仅将被焦点或噪声隐藏的 %lld 个请求添加到本次审查。你的焦点和噪声设置不会更改。"
           }
         }
       }
@@ -3280,7 +3280,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "允许列表已开启，但没有可匹配的有效已启用规则。在启用规则前，Rockxy 不会记录流量。"
+            "value": "允许列表已启用，但没有可匹配的有效已启用规则。在启用规则前，Rockxy 不会记录流量。"
           }
         }
       }
@@ -3833,7 +3833,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "请在“系统设置 > 登录项”中批准 Helper 工具以完成安装。"
+            "value": "请在“系统设置 > 登录项”中批准辅助工具以完成安装。"
           }
         }
       }
@@ -3923,7 +3923,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "向 Rockxy Assistant 询问所选内容…"
+            "value": "向 Rockxy AI 助手询问所选内容…"
           }
         }
       }
@@ -4149,7 +4149,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "启动时自动开始录制流量"
+            "value": "启动时自动开始记录流量"
           }
         }
       }
@@ -4269,7 +4269,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "自动对敏感标头进行脱敏"
+            "value": "自动脱敏敏感标头"
           }
         }
       }
@@ -4379,7 +4379,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "发送到 MCP 客户端前自动对敏感信息进行脱敏。"
+            "value": "发送到 MCP 客户端前自动脱敏敏感信息。"
           }
         }
       }
@@ -4482,7 +4482,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "适用于调试和面向工具提示的均衡本地模型"
+            "value": "适用于调试和工具调用类提示词的均衡本地模型"
           }
         }
       }
@@ -4632,7 +4632,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "二进制负载"
+            "value": "二进制有效载荷"
           }
         }
       }
@@ -4642,7 +4642,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "已省略二进制载荷"
+            "value": "已省略二进制有效载荷"
           }
         }
       }
@@ -4752,7 +4752,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "阻止列表是一种网络干预。已启用的规则会参与 Rockxy 的全局首次匹配运行时顺序。"
+            "value": "阻止列表是一种网络干预。已启用的规则会参与 Rockxy 的全局首个匹配运行时顺序。"
           }
         }
       }
@@ -4832,7 +4832,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "正文编辑不可用。应用元数据更改或继续原始流量都会保留正文的每个字节。"
+            "value": "正文编辑不可用。应用元数据更改或继续发送原始流量都会保留正文的每个字节。"
           }
         }
       }
@@ -5298,7 +5298,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "取消活动请求"
+            "value": "取消活跃请求"
           }
         }
       }
@@ -5698,7 +5698,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "证书已安装并在您的钥匙串中受信任。"
+            "value": "证书已安装并在你的钥匙串中受信任。"
           }
         }
       }
@@ -5708,7 +5708,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "证书已安装并受信任。请再次发出请求以检查 HTTPS 内容。"
+            "value": "证书已安装并受信任。请再次发送请求以检查 HTTPS 内容。"
           }
         }
       }
@@ -5728,7 +5728,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "证书已安装但不受信任。请返回并再次尝试 \"安装并信任\"。"
+            "value": "证书已安装但不受信任。请返回并再次尝试 “安装并信任”。"
           }
         }
       }
@@ -6018,7 +6018,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "检查提供商的错误正文、请求 id、身份验证、速率限制标头和重试时间。"
+            "value": "检查提供商的错误正文、请求 ID、身份验证、速率限制标头和重试时机。"
           }
         }
       }
@@ -6028,7 +6028,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "检查提供方的错误代码/消息、请求 ID、身份验证标头以及重试时机。"
+            "value": "检查提供商的错误代码/消息、请求 ID、身份验证标头以及重试时机。"
           }
         }
       }
@@ -6038,7 +6038,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "检查原始交易/签名、钱包签名者状态、nonce、gas 以及提供方拒绝详情。"
+            "value": "检查原始交易/签名、钱包签名者状态、nonce、gas 以及提供商拒绝详情。"
           }
         }
       }
@@ -6438,7 +6438,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "选择与您的运行时匹配的 Go HTTP 客户端，然后复制代码片段。"
+            "value": "选择与你的运行时匹配的 Go HTTP 客户端，然后复制代码片段。"
           }
         }
       }
@@ -6518,7 +6518,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "选择要保存到此 HAR 归档中的已捕获事务。"
+            "value": "选择要保存到此 HAR 文件中的已捕获事务。"
           }
         }
       }
@@ -6794,7 +6794,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "点按 \"+\" 或按下 ⌘N 以添加新条目"
+            "value": "点击 “+” 或按下 ⌘N 以添加新条目"
           }
         }
       }
@@ -6804,7 +6804,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "点按 \"+\" 或按下 ⌘N 以添加定义。"
+            "value": "点击 “+” 或按 ⌘N 以添加定义。"
           }
         }
       }
@@ -6814,7 +6814,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "点按 \"+\" 或按下 ⌘N 以创建配置。"
+            "value": "点击 “+” 或按 ⌘N 以创建配置。"
           }
         }
       }
@@ -6824,7 +6824,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "点击 \"+\" 或按 ⌘N 创建规则。"
+            "value": "点击 “+” 或按 ⌘N 创建规则。"
           }
         }
       }
@@ -6834,7 +6834,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "点按 \"+\" 或按下 ⌘N 以导入 .proto 文件。"
+            "value": "点击 “+” 或按 ⌘N 以导入 .proto 文件。"
           }
         }
       }
@@ -6854,7 +6854,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "点按 + 或按下 ⌘N 以创建脚本。"
+            "value": "点击 + 或按 ⌘N 以创建脚本。"
           }
         }
       }
@@ -6864,7 +6864,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "点按或拖移以滚动正文文本"
+            "value": "点击或拖移以滚动正文文本"
           }
         }
       }
@@ -6884,7 +6884,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "点按候选项上的 R 列以完成此基础比较。"
+            "value": "点击候选项上的 R 列以完成此基础比较。"
           }
         }
       }
@@ -7301,7 +7301,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "正在关闭活动连接并恢复系统路由。"
+            "value": "正在关闭活跃连接并恢复系统路由。"
           }
         }
       }
@@ -7481,7 +7481,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "Rockxy 正在关闭活动连接并恢复系统路由。"
+            "value": "Rockxy 正在关闭活跃连接并恢复系统路由。"
           }
         }
       }
@@ -8009,7 +8009,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "将 Rockxy 配置为本地代理，并在 Go 客户端中载入导出的根证书。"
+            "value": "将 Rockxy 配置为本地代理，并在 Go 客户端中加载导出的根证书。"
           }
         }
       }
@@ -8059,7 +8059,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "开始本地推断前，请确认已脱敏的流量和对话。"
+            "value": "开始本地推理前，请确认已脱敏的流量和对话。"
           }
         }
       }
@@ -8145,7 +8145,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "将此 Mac 连接到 Wi-Fi 或以太网，以公开可访问的 LAN IP。"
+            "value": "将这台 Mac 连接到 Wi-Fi 或以太网，以获取可访问的局域网 IP。"
           }
         }
       }
@@ -8845,7 +8845,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "无法导入 \"%1$@\"。\n\n%2$@"
+            "value": "无法导入 “%1$@”。\n\n%2$@"
           }
         }
       }
@@ -8861,7 +8861,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "无法导入 \"%1$@\"。\n\n该文件可能不是有效的 HAR 归档。%2$@"
+            "value": "无法导入 “%1$@”。\n\n该文件可能不是有效的 HAR 文件。%2$@"
           }
         }
       }
@@ -8887,7 +8887,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "无法读取 \"%1$@\"。\n\n%2$@"
+            "value": "无法读取 “%1$@”。\n\n%2$@"
           }
         }
       }
@@ -9027,7 +9027,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "创建 Focus 集"
+            "value": "创建焦点集"
           }
         }
       }
@@ -9037,7 +9037,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "创建 Rockxy 的本地证书颁发机构以进行 HTTPS 检查。"
+            "value": "创建 Rockxy 的本地证书颁发机构，用于检查 HTTPS。"
           }
         }
       }
@@ -10207,7 +10207,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "此 Mac 之外的设备无法访问仅本地主机模式。请关闭“仅监听本地主机”，然后重启代理。"
+            "value": "这台 Mac 之外的设备无法访问“仅监听本地主机”模式。请关闭“仅监听本地主机”，然后重启代理。"
           }
         }
       }
@@ -10300,7 +10300,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "禁用"
+            "value": "停用"
           }
         }
       }
@@ -10330,7 +10330,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "禁用缓存（No-Cache 标头）"
+            "value": "停用缓存（No-Cache 标头）"
           }
         }
       }
@@ -10350,7 +10350,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "禁用规则"
+            "value": "停用规则"
           }
         }
       }
@@ -10360,7 +10360,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "禁用脚本"
+            "value": "停用脚本"
           }
         }
       }
@@ -10390,7 +10390,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "已禁用"
+            "value": "已停用"
           }
         }
       }
@@ -10420,7 +10420,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "在支持的情况下禁用"
+            "value": "在支持的情况下停用"
           }
         }
       }
@@ -10553,7 +10553,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "您在此处看到了认证问题吗？"
+            "value": "你在此处看到了认证问题吗？"
           }
         }
       }
@@ -10957,7 +10957,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "编辑 Focus 集"
+            "value": "编辑焦点集"
           }
         }
       }
@@ -11487,7 +11487,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "已为 %@ 启用 SSL 代理。请再次发出请求以进行检查。"
+            "value": "已为 %@ 启用 SSL 代理。请再次发送请求以检查它。"
           }
         }
       }
@@ -13609,7 +13609,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "帧捕获已在安全限制处停止；实时连接仍保持活动。"
+            "value": "帧捕获已在安全限制处停止；实时连接仍保持活跃。"
           }
         }
       }
@@ -14522,7 +14522,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "隐藏的筛选器处于活动状态"
+            "value": "当前有隐藏的筛选器生效"
           }
         }
       }
@@ -14642,7 +14642,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "从 Focus 集中隐藏此域名及其子域名。"
+            "value": "从焦点集中隐藏此域名及其子域名。"
           }
         }
       }
@@ -14692,7 +14692,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "历史记录保留在此 Mac 上。身份验证和 cookie 标头值会被脱敏；URL 和正文仍在本地存储。"
+            "value": "历史记录保留在这台 Mac 上。身份验证和 cookie 标头值会被脱敏；URL 和正文仍在本地存储。"
           }
         }
       }
@@ -14782,7 +14782,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "此处的主机会跳过解密，但仍通过 Rockxy 传输。这绝不会禁用 Rockxy 代理。"
+            "value": "此处的主机会跳过解密，但仍通过 Rockxy 传输。这绝不会停用 Rockxy 代理。"
           }
         }
       }
@@ -14828,7 +14828,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "来自提供方的 HTTP %lld"
+            "value": "来自提供商的 HTTP %lld"
           }
         }
       }
@@ -14858,7 +14858,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "HTTP 429 和附近的重复请求支持此推断；应用程序策略仍未知。"
+            "value": "HTTP 429 和附近的重复请求支持此假设；应用程序策略仍未知。"
           }
         }
       }
@@ -15264,7 +15264,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "如果您更喜欢使用“终端”，请导出公共 PEM，然后为已准备的模拟器运行 xcrun simctl keychain <udid> add-root-cert <path-to-pem>。"
+            "value": "如果你更喜欢使用“终端”，请导出公开 PEM，然后为已准备的模拟器运行 xcrun simctl keychain <udid> add-root-cert <path-to-pem>。"
           }
         }
       }
@@ -15762,7 +15762,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "推断使用已配置的本地端点"
+            "value": "推理使用已配置的本地端点"
           }
         }
       }
@@ -15872,7 +15872,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "检查响应负载以及向该主机发出的邻近请求。"
+            "value": "检查响应有效载荷以及向该主机发出的邻近请求。"
           }
         }
       }
@@ -16062,7 +16062,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "在此 Mac 上安装证书…"
+            "value": "在这台 Mac 上安装证书…"
           }
         }
       }
@@ -16152,7 +16152,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "验证此手动流程前，请先在此 Mac 上安装所选的运行时、工具链或客户端。"
+            "value": "验证此手动流程前，请先在这台 Mac 上安装所选的运行时、工具链或客户端。"
           }
         }
       }
@@ -16242,7 +16242,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "已安装的 Helper 版本已过时，应进行更新。"
+            "value": "已安装的辅助工具版本已过时，应进行更新。"
           }
         }
       }
@@ -16558,7 +16558,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "匹配规则 '%1$@' 无效：%2$@"
+            "value": "匹配规则 ‘%1$@’ 无效：%2$@"
           }
         }
       }
@@ -16890,7 +16890,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "将 Android 信任保持为仅调试"
+            "value": "将 Android 的证书信任限制为仅调试构建"
           }
         }
       }
@@ -17166,7 +17166,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "启动您的 App 或访问域名，即可在列表中看到它"
+            "value": "启动你的 App 或访问域名，即可在列表中看到它"
           }
         }
       }
@@ -17376,7 +17376,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "在 Safari 中加载一个 HTTPS 页面，或运行一次目标应用的登录流程，并确认 Rockxy 捕获到该请求。VPN 可能会绕过 Wi-Fi 代理，因此请在验证时将其禁用。"
+            "value": "在 Safari 中加载一个 HTTPS 页面，或运行一次目标应用的登录流程，并确认 Rockxy 捕获到该请求。VPN 可能会绕过 Wi-Fi 代理，因此请在验证时将其停用。"
           }
         }
       }
@@ -17426,7 +17426,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "正在载入发布说明…"
+            "value": "正在加载发布说明…"
           }
         }
       }
@@ -17516,7 +17516,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "本地调查始终可用。向已配置的模型发送提示需要明确确认“审查数据”。"
+            "value": "本地调查始终可用。向已配置的模型发送提示词需要明确确认“审查数据”。"
           }
         }
       }
@@ -17636,7 +17636,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "仅限此 Mac 的本地连接"
+            "value": "仅限这台 Mac 的本地连接"
           }
         }
       }
@@ -17726,7 +17726,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "macOS 系统代理已禁用"
+            "value": "macOS 系统代理已停用"
           }
         }
       }
@@ -17876,7 +17876,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "常见 HTTP 技术栈支持手动配置 Golang。"
+            "value": "支持为常见 HTTP 技术栈手动配置 Golang。"
           }
         }
       }
@@ -17916,7 +17916,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "常见 HTTP 客户端示例支持手动配置 Ruby。"
+            "value": "支持手动配置 Ruby，并提供常见 HTTP 客户端示例。"
           }
         }
       }
@@ -18049,7 +18049,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "Map Local 遵循 Rockxy 的全局首个匹配规则顺序。可从“更多”菜单重新排序规则；不可用的本地目标会安全回退到源站。"
+            "value": "Map Local 遵循 Rockxy 的全局首个匹配规则顺序。可从“更多”菜单重新排序规则；不可用的本地目标会安全回退到源服务器。"
           }
         }
       }
@@ -18059,7 +18059,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "Map Local 从本地文件提供匹配请求的响应，你可以设置状态码、标头和正文，从而模拟端点。"
+            "value": "Map Local 会为匹配的请求从本地文件提供响应，你可以设置状态码、标头和正文，从而模拟端点。"
           }
         }
       }
@@ -18358,7 +18358,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "匹配规则 '%1$@' 超过 %2$lld 个字符。"
+            "value": "匹配规则 ‘%1$@’ 超过 %2$lld 个字符。"
           }
         }
       }
@@ -18687,7 +18687,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "通过此本地端点，模型和已审查流量都会保留在此 Mac 上。"
+            "value": "通过此本地端点，模型和已审查流量都会保留在这台 Mac 上。"
           }
         }
       }
@@ -19121,7 +19121,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "网络条件会限制带宽并增加延迟，帮助您重现 App 在慢速连接下的表现。"
+            "value": "网络条件会限制带宽并增加延迟，帮助你重现 App 在慢速连接下的表现。"
           }
         }
       }
@@ -19597,7 +19597,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "没有活动筛选条件"
+            "value": "当前没有生效的筛选器"
           }
         }
       }
@@ -19607,7 +19607,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "无活动脚本"
+            "value": "无活跃脚本"
           }
         }
       }
@@ -20067,7 +20067,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "此交换未证实任何故障。仅当你想检查标头、时序或有效载荷时才打开“详细信息”。"
+            "value": "此次交互未证实任何故障。仅当你想检查标头、时序或有效载荷时才打开“详细信息”。"
           }
         }
       }
@@ -20147,7 +20147,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "没有活动的隐藏筛选器"
+            "value": "当前没有生效的隐藏筛选器"
           }
         }
       }
@@ -20517,7 +20517,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "活动筛选器中没有符合 OpenAPI 条件的请求"
+            "value": "当前筛选器中没有符合 OpenAPI 条件的请求"
           }
         }
       }
@@ -20617,7 +20617,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "无固定的请求"
+            "value": "无置顶请求"
           }
         }
       }
@@ -20697,7 +20697,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "未找到可访问的 Wi-Fi 或以太网 IPv4 地址。请将此 Mac 连接到与设备相同的网络，然后重试。"
+            "value": "未找到可访问的 Wi-Fi 或以太网 IPv4 地址。请将这台 Mac 连接到与设备相同的网络，然后重试。"
           }
         }
       }
@@ -21730,7 +21730,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "只能启用一个配置。它遵循 Rockxy 的全局首次匹配规则顺序，并应用于拦截的 HTTP 和 HTTPS 流量。"
+            "value": "只能启用一个配置。它遵循 Rockxy 的全局首个匹配规则顺序，并应用于拦截的 HTTP 和 HTTPS 流量。"
           }
         }
       }
@@ -22633,7 +22633,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "原始载荷已受保护"
+            "value": "原始有效载荷已受保护"
           }
         }
       }
@@ -22683,7 +22683,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "覆盖 %@。其他组件保留自请求。"
+            "value": "覆盖 %@。其他组件取自原请求。"
           }
         }
       }
@@ -22735,7 +22735,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "通过本地网络将 Babylon 调试客户端与此 Mac 配对。"
+            "value": "通过本地网络将 Babylon 调试客户端与这台 Mac 配对。"
           }
         }
       }
@@ -22866,7 +22866,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "将 Rockxy 的主机和端口粘贴到 Firefox 网络设置中，将根证书导入浏览器的证书颁发机构存储，然后载入页面进行确认。"
+            "value": "将 Rockxy 的主机和端口粘贴到 Firefox 网络设置中，将根证书导入浏览器的证书颁发机构存储，然后加载页面进行确认。"
           }
         }
       }
@@ -23116,7 +23116,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "有效负载编码"
+            "value": "有效载荷编码"
           }
         }
       }
@@ -23126,7 +23126,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "负载传输占请求时长的大部分。"
+            "value": "有效载荷传输占请求时长的大部分。"
           }
         }
       }
@@ -23136,7 +23136,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "负载视图"
+            "value": "有效载荷视图"
           }
         }
       }
@@ -23146,7 +23146,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "载荷已截断"
+            "value": "有效载荷已截断"
           }
         }
       }
@@ -23256,7 +23256,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "固定"
+            "value": "置顶"
           }
         }
       }
@@ -23276,7 +23276,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "固定证据"
+            "value": "置顶证据"
           }
         }
       }
@@ -23296,7 +23296,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "已固定"
+            "value": "已置顶"
           }
         }
       }
@@ -23982,7 +23982,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "项目尚未就绪。请先重试载入目录。"
+            "value": "项目尚未就绪。请先重试加载项目目录。"
           }
         }
       }
@@ -23992,7 +23992,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "项目存储在此 Mac 本地。"
+            "value": "项目存储在这台 Mac 本地。"
           }
         }
       }
@@ -24052,7 +24052,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "无法载入项目。在项目修复之前，流量标签页和过滤器的更改不会被保存。"
+            "value": "无法加载项目。在项目修复之前，流量标签页和过滤器的更改不会被保存。"
           }
         }
       }
@@ -24072,7 +24072,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "项目会保存标签页名称、筛选器和布局。每个项目分别保留独立的内存中流量。"
+            "value": "项目会保存标签页名称、筛选器和布局。每个项目在内存中分别保留独立的流量。"
           }
         }
       }
@@ -24168,7 +24168,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "提供方 API 基础 URL"
+            "value": "提供商 API 基础 URL"
           }
         }
       }
@@ -24178,7 +24178,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "提供方数据和 API 文档"
+            "value": "提供商数据和 API 文档"
           }
         }
       }
@@ -24238,7 +24238,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "提供方、链或节点基准"
+            "value": "提供商、链或节点基线"
           }
         }
       }
@@ -24736,7 +24736,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "Raw 包含请求行或状态行以及标头。其他格式侧重于正文内容，当选定的有效负载不匹配时可能显示为不可用状态。"
+            "value": "Raw 包含请求行或状态行以及标头。其他格式侧重于正文内容，当选定的有效载荷不匹配时可能显示为不可用状态。"
           }
         }
       }
@@ -25002,7 +25002,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "已准备好进行 HTTPS 拦截"
+            "value": "HTTPS 拦截已就绪"
           }
         }
       }
@@ -25132,7 +25132,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "正在录制"
+            "value": "正在记录"
           }
         }
       }
@@ -25152,7 +25152,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "录制已暂停"
+            "value": "记录已暂停"
           }
         }
       }
@@ -25182,7 +25182,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "对识别到的敏感数据进行脱敏"
+            "value": "脱敏识别到的敏感数据"
           }
         }
       }
@@ -25192,7 +25192,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "发送到 AI 前对敏感数据进行脱敏"
+            "value": "发送到 AI 前脱敏敏感数据"
           }
         }
       }
@@ -25202,7 +25202,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "正在对敏感字段进行脱敏"
+            "value": "正在脱敏敏感字段"
           }
         }
       }
@@ -25242,7 +25242,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "上传前会对识别出的敏感标头、URL 和正文值（Authorization、Cookie、API 密钥）进行脱敏。此操作会尽力而为，但不作保证。"
+            "value": "上传前会脱敏识别出的敏感标头、URL 和正文值（Authorization、Cookie、API 密钥）。此操作会尽力而为，但不作保证。"
           }
         }
       }
@@ -25455,7 +25455,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "仅在你选择加入时才会包括相关请求。"
+            "value": "仅在你选择加入时才会包含相关请求。"
           }
         }
       }
@@ -25555,7 +25555,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "远程模型端点必须使用 HTTPS。仅允许在此 Mac 上使用纯 HTTP。"
+            "value": "远程模型端点必须使用 HTTPS。仅允许在这台 Mac 上使用纯 HTTP。"
           }
         }
       }
@@ -26499,7 +26499,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "重置后台项目"
+            "value": "重置后台项"
           }
         }
       }
@@ -26979,7 +26979,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "恢复录制"
+            "value": "恢复记录"
           }
         }
       }
@@ -27239,7 +27239,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "审阅并共享…"
+            "value": "审查并共享…"
           }
         }
       }
@@ -27409,7 +27409,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "将匹配的请求改写到其他主机、端口、路径或查询。"
+            "value": "将匹配的请求重写到其他主机、端口、路径或查询。"
           }
         }
       }
@@ -27505,7 +27505,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "Rockxy 可通过临时本地链接共享此 Mac 的公开根 CA，而 Android 仍需手动配置代理、用户 CA 和调试信任；发布构建通常不会信任用户 CA。"
+            "value": "Rockxy 可通过临时本地链接共享这台 Mac 的公开根 CA，而 Android 仍需手动配置代理、用户 CA 和调试信任；发布构建通常不会信任用户 CA。"
           }
         }
       }
@@ -27635,7 +27635,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "Rockxy 无法包括已排除的流量。审查的数据未发生变化。"
+            "value": "Rockxy 无法包含已排除的流量。审查的数据未发生变化。"
           }
         }
       }
@@ -27645,7 +27645,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "Rockxy 无法载入默认根证书的详细信息。"
+            "value": "Rockxy 无法加载默认根证书的详细信息。"
           }
         }
       }
@@ -27795,7 +27795,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "Rockxy 不收集分析或崩溃报告。捕获的流量会留在你的设备上，除非你明确导出、共享或发布。"
+            "value": "Rockxy 不收集分析或崩溃报告。捕获的流量会留在你这台 Mac 上，除非你明确导出、共享或发布。"
           }
         }
       }
@@ -27855,7 +27855,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "Rockxy 会生成本地根证书颁发机构 (CA)，以便为每个主机创建证书并拦截 HTTPS 流量。必须在 macOS 钥匙串中安装并信任根 CA。任何证书数据都不会离开你的设备。"
+            "value": "Rockxy 会生成本地根证书颁发机构 (CA)，以便为每个主机创建证书并拦截 HTTPS 流量。必须在 macOS 钥匙串中安装并信任根 CA。任何证书数据都不会离开这台 Mac。"
           }
         }
       }
@@ -27898,7 +27898,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "Rockxy 正在此 Mac 上捕获流量。"
+            "value": "Rockxy 正在这台 Mac 上捕获流量。"
           }
         }
       }
@@ -28014,7 +28014,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "由于 %@，Rockxy 正在直接更改 macOS 代理。如果 Rockxy 或 Xcode 意外停止，你的 Mac 可能会一直使用失效的代理，直到 Rockxy 将其恢复。请安装或修复 Helper 工具，以便更安全地自动清理。"
+            "value": "由于 %@，Rockxy 正在直接更改 macOS 代理。如果 Rockxy 或 Xcode 意外停止，你的 Mac 可能会一直使用失效的代理，直到 Rockxy 将其恢复。请安装或修复辅助工具，以便更安全地自动清理。"
           }
         }
       }
@@ -28054,7 +28054,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "Rockxy 通过将此主机返回到受保护的加密隧道，使应用保持连接。"
+            "value": "Rockxy 通过将此主机重新置于受保护的加密隧道，使应用保持连接。"
           }
         }
       }
@@ -28084,7 +28084,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "Rockxy 需要根 CA 证书才能检查 HTTPS 流量。此向导将生成本地证书，将其安装到您的 macOS 钥匙串，并验证设置。任何证书数据都不会离开您的设备。"
+            "value": "Rockxy 需要根 CA 证书才能检查 HTTPS 流量。此向导将生成本地证书，将其安装到你的 macOS 钥匙串，并验证设置。任何证书数据都不会离开这台 Mac。"
           }
         }
       }
@@ -28164,7 +28164,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "Rockxy 已移除过时的 Helper 文件，并请求 macOS 重置登录项和后台项目数据。"
+            "value": "Rockxy 已移除过时的辅助工具文件，并请求 macOS 重置登录项和后台项数据。"
           }
         }
       }
@@ -28214,7 +28214,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "Rockxy 提供动态路由处理程序以及下一个开发环境块，其中包括 NODE_USE_ENV_PROXY，以便服务器端 fetch 随后可通过 Rockxy 路由。"
+            "value": "Rockxy 提供动态路由处理程序以及 next dev 环境配置块，其中包含 NODE_USE_ENV_PROXY，以便服务器端 fetch 随后可通过 Rockxy 路由。"
           }
         }
       }
@@ -28224,7 +28224,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "Rockxy 提供 Firefox 设置片段和 cURL 预检步骤，以便您在更改浏览器前确认代理路径。"
+            "value": "Rockxy 提供 Firefox 设置片段和 cURL 预检步骤，以便你在更改浏览器前确认代理路径。"
           }
         }
       }
@@ -28314,7 +28314,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "Rockxy 提供手动 Flutter 代码片段和本地捕获检查。该检查确认探针已到达 Rockxy，但不确认是哪个设备、仿真器、模拟器或 Dart 运行时发出的。通过本地 VPN 伴侣应用对 Android Emulator 进行无代码路由不属于此手动流程。"
+            "value": "Rockxy 提供手动 Flutter 代码片段和本地捕获检查。该检查确认探针已到达 Rockxy，但不确认是哪个设备、模拟器、仿真器或 Dart 运行时发出的。通过本地 VPN 伴侣应用对 Android Emulator 进行无代码路由不属于此手动流程。"
           }
         }
       }
@@ -28364,7 +28364,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "Rockxy 提供一个 shell 启动命令和一个主进程 session.setProxy 片段，两者都指向活动端口上的 127.0.0.1。"
+            "value": "Rockxy 提供一个 shell 启动命令和一个主进程 session.setProxy 片段，两者都指向当前端口上的 127.0.0.1。"
           }
         }
       }
@@ -28560,7 +28560,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "Rockxy 将停止捕获、请求管理员批准、移除过时的 Helper 文件和注册状态，然后从此应用重新安装 Helper。\n\n当“安装”、“重试”、“更新”或“重新安装”都无法恢复 Helper 时，请使用此功能。"
+            "value": "Rockxy 将停止捕获、请求管理员批准、移除过时的辅助工具文件和注册状态，然后从此应用重新安装辅助工具。\n\n当“安装”、“重试”、“更新”或“重新安装”都无法恢复辅助工具时，请使用此功能。"
           }
         }
       }
@@ -28580,7 +28580,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "Rockxy 将使用 networksetup，并可能要求您输入密码。"
+            "value": "Rockxy 将使用 networksetup，并可能要求你输入密码。"
           }
         }
       }
@@ -28600,7 +28600,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "Rockxy 所有的响应文件可用"
+            "value": "有由 Rockxy 生成的响应文件可用"
           }
         }
       }
@@ -29219,7 +29219,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "运行所选的 %1$@ 本地验证探针，并等待 Rockxy 捕获 GET %2$@。这确认探针已通过代理到达 Rockxy，但不会将该请求归因于特定的应用、进程、设备、模拟器、仿真器或运行时。"
+            "value": "运行所选的 %1$@ 本地验证探针，并等待 Rockxy 捕获 GET %2$@。这确认探针已通过代理到达 Rockxy，但不会将该请求归因于特定的应用、进程、设备、仿真器、模拟器或运行时。"
           }
         }
       }
@@ -29415,7 +29415,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "请保存完整的提供方配置以启用模型访问。"
+            "value": "请保存完整的提供商配置以启用模型访问。"
           }
         }
       }
@@ -29585,7 +29585,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "将公共 Rockxy 根 CA 保存为 PEM 文件"
+            "value": "将公开 Rockxy 根 CA 保存为 PEM 文件"
           }
         }
       }
@@ -29695,7 +29695,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "代理重新启动后，保存的监听器设置才会生效。在此之前，上方的实时端点将保持活动。"
+            "value": "代理重新启动后，保存的监听器设置才会生效。在此之前，上方的实时端点将保持活跃。"
           }
         }
       }
@@ -29755,7 +29755,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "已保存，但脚本载入失败"
+            "value": "已保存，但脚本加载失败"
           }
         }
       }
@@ -29765,7 +29765,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "已保存，但已达到启用 10 个脚本的配额。请禁用其他脚本以激活此脚本。"
+            "value": "已保存，但已达到启用 10 个脚本的配额。请停用其他脚本以激活此脚本。"
           }
         }
       }
@@ -29945,7 +29945,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "脚本功能已关闭。已启用的脚本会保留，但在您开启脚本功能前不会运行。"
+            "value": "脚本功能已关闭。已启用的脚本会保留，但在你开启脚本功能前不会运行。"
           }
         }
       }
@@ -30355,7 +30355,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "选择一个帧以检查其载荷。"
+            "value": "选择一个帧以检查其有效载荷。"
           }
         }
       }
@@ -30385,7 +30385,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "选择要为匹配请求提供的本地文件"
+            "value": "选择用于服务匹配请求的本地文件"
           }
         }
       }
@@ -30485,7 +30485,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "选择一个运行时事件以检查其标识符、时间和元数据。"
+            "value": "选择一个运行时事件以检查其标识符、时序和元数据。"
           }
         }
       }
@@ -30565,7 +30565,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "选择一个请求以检查有效载荷和计时详细信息。"
+            "value": "选择一个请求以检查有效载荷和时序详细信息。"
           }
         }
       }
@@ -30575,7 +30575,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "选择一个请求以检查原始载荷，或恰好选择两个请求进行比较。"
+            "value": "选择一个请求以检查原始有效载荷，或恰好选择两个请求进行比较。"
           }
         }
       }
@@ -30675,7 +30675,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "选择两个请求并选取 \"比较所选项\"，即可开始基本本地比较。"
+            "value": "选择两个请求并选取 “比较所选项”，即可开始基本本地比较。"
           }
         }
       }
@@ -31025,7 +31025,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "敏感标头、查询值和正文字段会在“审阅数据”之前被脱敏。"
+            "value": "敏感标头、查询值和正文字段会在“审查数据”之前被脱敏。"
           }
         }
       }
@@ -31518,7 +31518,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "从此 Mac 以临时本地 QR 码和链接的形式共享公开的 Rockxy 根 CA，然后在设备或模拟器上完成平台信任步骤。"
+            "value": "从这台 Mac 以临时本地 QR 码和链接的形式共享公开的 Rockxy 根 CA，然后在设备或模拟器上完成平台信任步骤。"
           }
         }
       }
@@ -32443,7 +32443,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "SSE 节奏根据已捕获的事件显示。除非提供方公开 token 边界，否则 token 边界不可用。"
+            "value": "SSE 节奏根据已捕获的事件显示。除非提供商公开 token 边界，否则 token 边界不可用。"
           }
         }
       }
@@ -32476,7 +32476,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "已为 %@ 启用 SSL 代理。请再次发出请求以进行检查。"
+            "value": "已为 %@ 启用 SSL 代理。请再次发送请求以检查它。"
           }
         }
       }
@@ -32586,7 +32586,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "在此 Mac 上启动 Ollama，然后再次检查。（%@）"
+            "value": "在这台 Mac 上启动 Ollama，然后再次检查。（%@）"
           }
         }
       }
@@ -32656,7 +32656,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "更改录制状态前，请先启动代理。⌥⌘R"
+            "value": "更改记录状态前，请先启动代理。⌥⌘R"
           }
         }
       }
@@ -32866,7 +32866,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "状态、时间、负载和规则检查看起来正常。"
+            "value": "状态、时序、有效载荷和规则检查看起来正常。"
           }
         }
       }
@@ -32996,7 +32996,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "将 .proto 源文件存储在此 Mac 上。"
+            "value": "将 .proto 源文件存储在这台 Mac 上。"
           }
         }
       }
@@ -33615,7 +33615,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "已达到活动阻止列表规则的上限。请禁用另一条规则后重试。"
+            "value": "已达到活跃阻止列表规则的上限。请停用另一条规则后重试。"
           }
         }
       }
@@ -33625,7 +33625,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "已达到活动断点规则上限。请禁用另一条规则后重试。"
+            "value": "已达到活跃断点规则上限。请停用另一条规则后重试。"
           }
         }
       }
@@ -33635,7 +33635,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "活动筛选器没有匹配任何请求"
+            "value": "当前筛选器没有匹配任何请求"
           }
         }
       }
@@ -33655,7 +33655,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "已达到活动 Map Remote 规则的上限。请禁用另一条规则后重试。"
+            "value": "已达到活跃 Map Remote 规则的上限。请停用另一条规则后重试。"
           }
         }
       }
@@ -33745,7 +33745,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "阻止列表会对匹配请求返回 403 或断开连接，让您可以模拟端点不可用的情况。"
+            "value": "阻止列表会对匹配请求返回 403 或断开连接，让你可以模拟端点不可用的情况。"
           }
         }
       }
@@ -33775,7 +33775,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "捕获的请求已不再可供审阅。"
+            "value": "捕获的请求已不再可供审查。"
           }
         }
       }
@@ -33875,7 +33875,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "已配置的提供商正在处理已审阅的请求上下文。"
+            "value": "已配置的提供商正在处理已审查的请求上下文。"
           }
         }
       }
@@ -33885,7 +33885,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "CONNECT 交换会建立隧道；应用程序 HTTPS 有效载荷属于该隧道内的流量。"
+            "value": "CONNECT 交互会建立隧道；应用程序 HTTPS 有效载荷属于该隧道内的流量。"
           }
         }
       }
@@ -34071,7 +34071,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "Gist 负载为 %@，超过了 25 MB 的限制。"
+            "value": "Gist 有效载荷为 %@，超过了 25 MB 的限制。"
           }
         }
       }
@@ -34091,7 +34091,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "Helper 已注册，但 Rockxy 无法与其连接。"
+            "value": "辅助工具已注册，但 Rockxy 无法与其连接。"
           }
         }
       }
@@ -34101,7 +34101,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "无法使用 Helper 工具"
+            "value": "无法使用辅助工具"
           }
         }
       }
@@ -34141,7 +34141,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "需要更新 Helper 工具"
+            "value": "需要更新辅助工具"
           }
         }
       }
@@ -34171,7 +34171,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "辅助工具将被移除。Rockxy 将使用 networksetup，并可能要求您输入密码。"
+            "value": "辅助工具将被移除。Rockxy 将使用 networksetup，并可能要求你输入密码。"
           }
         }
       }
@@ -34191,7 +34191,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "Host 标头会保持原始请求发送时的值。目标主机、DNS 查询和 TLS 服务器名称仍使用上方改写后的主机。"
+            "value": "Host 标头会保持原始请求发送时的值。目标主机、DNS 查询和 TLS 服务器名称仍使用上方重写后的主机。"
           }
         }
       }
@@ -34231,7 +34231,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "已安装的 Helper 与此 Rockxy 副本不匹配，请重新安装后再继续"
+            "value": "已安装的辅助工具与此 Rockxy 副本不匹配，请重新安装后再继续"
           }
         }
       }
@@ -34251,7 +34251,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "安装的 Helper 与此版本的 Rockxy 不兼容。"
+            "value": "安装的辅助工具与此版本的 Rockxy 不兼容。"
           }
         }
       }
@@ -34281,7 +34281,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "监听器正在此 Mac 上接受本地网络连接。"
+            "value": "监听器正在这台 Mac 上接受本地网络连接。"
           }
         }
       }
@@ -34441,7 +34441,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "该提供方凭据无法访问此模型或端点。"
+            "value": "该提供商凭据无法访问此模型或端点。"
           }
         }
       }
@@ -34451,7 +34451,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "缺少提供方凭据。请在设置中替换它。"
+            "value": "缺少提供商凭据。请在设置中替换它。"
           }
         }
       }
@@ -34461,7 +34461,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "已达到提供方速率限制。请在 %lld 秒后重试。"
+            "value": "已达到提供商速率限制。请在 %lld 秒后重试。"
           }
         }
       }
@@ -34491,7 +34491,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "提供方拒绝了已保存的凭据。"
+            "value": "提供商拒绝了已保存的凭据。"
           }
         }
       }
@@ -34537,7 +34537,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "提供方返回了 HTTP %1$lld：%2$@"
+            "value": "提供商返回了 HTTP %1$lld：%2$@"
           }
         }
       }
@@ -34547,7 +34547,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "代理 Helper 工具将被移除。更改代理设置时，系统可能会提示你输入密码。"
+            "value": "代理辅助工具将被移除。更改代理设置时，系统可能会提示你输入密码。"
           }
         }
       }
@@ -34577,7 +34577,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "协调后的项目结构无效，未被应用。"
+            "value": "合并整理后的项目结构无效，未被应用。"
           }
         }
       }
@@ -35103,7 +35103,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "这些映射定义存储在此 Mac 本地。此版本仅使用启发式方法解码 Protobuf — 已保存的映射和架构不会应用于已捕获的流量。"
+            "value": "这些映射定义存储在这台 Mac 本地。此版本仅使用启发式方法解码 Protobuf — 已保存的映射和架构不会应用于已捕获的流量。"
           }
         }
       }
@@ -35335,7 +35335,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "此 gRPC 消息已压缩。Rockxy 会保留帧边界，但尚未解码压缩的消息负载。"
+            "value": "此 gRPC 消息已压缩。Rockxy 会保留帧边界，但尚未解码压缩的消息有效载荷。"
           }
         }
       }
@@ -35395,7 +35395,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "此链接仅从这台 Mac 提供您的公共 Rockxy 根 CA。它会自动过期。请勿安装来源不明的证书。"
+            "value": "此链接仅从这台 Mac 提供你的公开 Rockxy 根 CA。它会自动过期。请勿安装来源不明的证书。"
           }
         }
       }
@@ -35405,7 +35405,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "此 Mac 和本地网络"
+            "value": "这台 Mac 和本地网络"
           }
         }
       }
@@ -35445,7 +35445,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "此提供方需要使用其原生适配器。请选择 OpenAI、Anthropic、Gemini、OpenAI 兼容端点或 Ollama。"
+            "value": "此提供商需要使用其原生适配器。请选择 OpenAI、Anthropic、Gemini、OpenAI 兼容端点或 Ollama。"
           }
         }
       }
@@ -35515,7 +35515,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "这会从此 Mac 移除存储的 %@ 文件。"
+            "value": "这会从这台 Mac 移除存储的 %@ 文件。"
           }
         }
       }
@@ -35615,7 +35615,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "此审阅仅限于所选请求。其他流量将不会被包含。"
+            "value": "此审查仅限于所选请求。其他流量将不会被包含。"
           }
         }
       }
@@ -35625,7 +35625,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "此 Rockxy App 包不完整，因此无法安装辅助工具。请重新安装最新的 Rockxy 版本。如果您通过 Homebrew 安装了 Rockxy，请在修复版本发布后重新安装。"
+            "value": "此 Rockxy App 包不完整，因此无法安装辅助工具。请重新安装最新的 Rockxy 版本。如果你通过 Homebrew 安装了 Rockxy，请在修复版本发布后重新安装。"
           }
         }
       }
@@ -35635,7 +35635,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "此行旨在提供如实指引；目前不要期待耳机会支持一键配对或自动安装证书。"
+            "value": "此行旨在提供如实指引；目前不要期待头显会支持一键配对或自动安装证书。"
           }
         }
       }
@@ -35645,7 +35645,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "无法保存此规则。请禁用另一条断点规则后重试。"
+            "value": "无法保存此规则。请停用另一条断点规则后重试。"
           }
         }
       }
@@ -35665,7 +35665,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "这会在移除 Rockxy 辅助工具文件后运行 sfltool resetbtm。它可能会重置其他 App 的后台项目状态，因此仅应在正常强制重置无法恢复 Rockxy 时使用。"
+            "value": "这会在移除 Rockxy 辅助工具文件后运行 sfltool resetbtm。它可能会重置其他 App 的后台项状态，因此仅应在正常强制重置无法恢复 Rockxy 时使用。"
           }
         }
       }
@@ -35765,7 +35765,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "这会将根证书安装到您的 macOS 钥匙串并标记为受信任。macOS 会提示您输入密码以授权此更改。"
+            "value": "这会将根证书安装到你的 macOS 钥匙串并标记为受信任。macOS 会提示你输入密码以授权此更改。"
           }
         }
       }
@@ -35825,7 +35825,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "计时"
+            "value": "时序"
           }
         }
       }
@@ -36118,7 +36118,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "捕获的载荷总字节数"
+            "value": "捕获的有效载荷总字节数"
           }
         }
       }
@@ -36178,7 +36178,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "追踪状态、响应标头、时间和附近的故障。"
+            "value": "追踪状态、响应标头、时序和附近的故障。"
           }
         }
       }
@@ -36703,7 +36703,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "尝试重置后台项目"
+            "value": "尝试重置后台项"
           }
         }
       }
@@ -36733,7 +36733,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "为连接到 %@ 的新连接开启 HTTPS 解密"
+            "value": "为连接到 %@ 的新连接启用 HTTPS 解密"
           }
         }
       }
@@ -36866,7 +36866,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "意外的 '='。"
+            "value": "意外的 ‘=’。"
           }
         }
       }
@@ -36876,7 +36876,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "意外字符 '%@'。"
+            "value": "意外字符 ‘%@’。"
           }
         }
       }
@@ -37106,7 +37106,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "取消固定证据"
+            "value": "取消置顶证据"
           }
         }
       }
@@ -37126,7 +37126,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "从当前会话中取消固定所选请求。"
+            "value": "从当前会话中取消置顶所选请求。"
           }
         }
       }
@@ -37909,7 +37909,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "在比较应用调用之前，将其用作提供方/链的基准。"
+            "value": "在比较应用调用之前，将其用作提供商/链的基线。"
           }
         }
       }
@@ -38365,7 +38365,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "检测到 VPN 或 iCloud 专用代理（%@）。可能无法捕获流量。请停用 VPN/专用代理以使用 Rockxy。"
+            "value": "检测到 VPN 或 iCloud 私密转送（%@）。可能无法捕获流量。请停用 VPN/私密转送以使用 Rockxy。"
           }
         }
       }
@@ -38681,7 +38681,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "关闭后将跳过阻止列表规则。其他干预规则仍保持活动。"
+            "value": "关闭后将跳过阻止列表规则。其他干预规则仍保持活跃。"
           }
         }
       }
@@ -38870,7 +38870,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "您可以随时取消此检查。"
+            "value": "你可以随时取消此检查。"
           }
         }
       }
@@ -38900,7 +38900,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "您：%@"
+            "value": "你：%@"
           }
         }
       }
@@ -38930,7 +38930,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "当前录制的请求/响应数据将丢失。Rockxy 将停止捕获，并在退出前恢复 macOS 代理设置。"
+            "value": "当前记录的请求/响应数据将丢失。Rockxy 将停止捕获，并在退出前恢复 macOS 代理设置。"
           }
         }
       }

--- a/Rockxy/Localizable.xcstrings
+++ b/Rockxy/Localizable.xcstrings
@@ -688,7 +688,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "%1$@，%2$lld 条活跃规则"
+            "value": "%1$@，%2$lld 条生效中的规则"
           }
         }
       }
@@ -698,7 +698,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "%@，活跃项目"
+            "value": "%@，当前项目"
           }
         }
       }
@@ -826,7 +826,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "有 %lld 条活跃的断点规则。打开断点规则。"
+            "value": "有 %lld 条生效中的断点规则。打开断点规则。"
           }
         }
       }
@@ -836,7 +836,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "%lld 条活跃 Map Local 规则。打开 Map Local。"
+            "value": "%lld 条生效中的 Map Local 规则。打开 Map Local。"
           }
         }
       }
@@ -846,7 +846,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "有 %lld 条活跃的 Map Remote 规则。打开 Map Remote。"
+            "value": "有 %lld 条生效中的 Map Remote 规则。打开 Map Remote。"
           }
         }
       }
@@ -856,7 +856,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "%lld 条活跃的修改标头规则"
+            "value": "%lld 条生效中的修改标头规则"
           }
         }
       }
@@ -866,7 +866,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "%lld 条活跃规则"
+            "value": "%lld 条生效中的规则"
           }
         }
       }
@@ -1852,7 +1852,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "有 1 条活跃断点规则。打开断点规则。"
+            "value": "有 1 条生效中的断点规则。打开断点规则。"
           }
         }
       }
@@ -1862,7 +1862,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "有 1 条活跃的 Map Local 规则。打开 Map Local。"
+            "value": "有 1 条生效中的 Map Local 规则。打开 Map Local。"
           }
         }
       }
@@ -1872,7 +1872,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "有 1 条活跃的 Map Remote 规则。打开 Map Remote。"
+            "value": "有 1 条生效中的 Map Remote 规则。打开 Map Remote。"
           }
         }
       }
@@ -2491,7 +2491,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "活跃项目"
+            "value": "当前项目"
           }
         }
       }
@@ -2501,7 +2501,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "活跃项目：%@"
+            "value": "当前项目：%@"
           }
         }
       }
@@ -4269,7 +4269,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "自动脱敏敏感标头"
+            "value": "自动对敏感标头脱敏"
           }
         }
       }
@@ -4379,7 +4379,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "发送到 MCP 客户端前自动脱敏敏感信息。"
+            "value": "发送到 MCP 客户端前自动对敏感信息脱敏。"
           }
         }
       }
@@ -5298,7 +5298,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "取消活跃请求"
+            "value": "取消当前请求"
           }
         }
       }
@@ -7301,7 +7301,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "正在关闭活跃连接并恢复系统路由。"
+            "value": "正在关闭活动连接并恢复系统路由。"
           }
         }
       }
@@ -7481,7 +7481,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "Rockxy 正在关闭活跃连接并恢复系统路由。"
+            "value": "Rockxy 正在关闭活动连接并恢复系统路由。"
           }
         }
       }
@@ -13609,7 +13609,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "帧捕获已在安全限制处停止；实时连接仍保持活跃。"
+            "value": "帧捕获已在安全限制处停止；实时连接仍保持活动。"
           }
         }
       }
@@ -19607,7 +19607,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "无活跃脚本"
+            "value": "无生效中的脚本"
           }
         }
       }
@@ -25182,7 +25182,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "脱敏识别到的敏感数据"
+            "value": "对识别到的敏感数据脱敏"
           }
         }
       }
@@ -25192,7 +25192,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "发送到 AI 前脱敏敏感数据"
+            "value": "发送到 AI 前对敏感数据脱敏"
           }
         }
       }
@@ -25202,7 +25202,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "正在脱敏敏感字段"
+            "value": "正在对敏感字段脱敏"
           }
         }
       }
@@ -25242,7 +25242,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "上传前会脱敏识别出的敏感标头、URL 和正文值（Authorization、Cookie、API 密钥）。此操作会尽力而为，但不作保证。"
+            "value": "上传前会对识别出的敏感标头、URL 和正文值（Authorization、Cookie、API 密钥）脱敏。此操作会尽力而为，但不作保证。"
           }
         }
       }
@@ -28314,7 +28314,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "Rockxy 提供手动 Flutter 代码片段和本地捕获检查。该检查确认探针已到达 Rockxy，但不确认是哪个设备、模拟器、仿真器或 Dart 运行时发出的。通过本地 VPN 伴侣应用对 Android Emulator 进行无代码路由不属于此手动流程。"
+            "value": "Rockxy 提供手动 Flutter 代码片段和本地捕获检查。该检查确认探针已到达 Rockxy，但不确认是哪个设备、仿真器、模拟器或 Dart 运行时发出的。通过本地 VPN 伴侣应用对 Android Emulator 进行无代码路由不属于此手动流程。"
           }
         }
       }
@@ -29219,7 +29219,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "运行所选的 %1$@ 本地验证探针，并等待 Rockxy 捕获 GET %2$@。这确认探针已通过代理到达 Rockxy，但不会将该请求归因于特定的应用、进程、设备、仿真器、模拟器或运行时。"
+            "value": "运行所选的 %1$@ 本地验证探针，并等待 Rockxy 捕获 GET %2$@。这确认探针已通过代理到达 Rockxy，但不会将该请求归因于特定的应用、进程、设备、模拟器、仿真器或运行时。"
           }
         }
       }
@@ -29239,7 +29239,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "从 Flutter 客户端运行“验证”标签页生成的请求，并在调试更广泛的流程前确认 Rockxy 已捕获该请求。这会验证代理路径，而非发出请求的确切设备、模拟器、仿真器或 Dart 运行时。"
+            "value": "从 Flutter 客户端运行“验证”标签页生成的请求，并在调试更广泛的流程前确认 Rockxy 已捕获该请求。这会验证代理路径，而非发出请求的确切设备、仿真器、模拟器或 Dart 运行时。"
           }
         }
       }
@@ -29695,7 +29695,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "代理重新启动后，保存的监听器设置才会生效。在此之前，上方的实时端点将保持活跃。"
+            "value": "代理重新启动后，保存的监听器设置才会生效。在此之前，上方的实时端点仍保持可用。"
           }
         }
       }
@@ -30385,7 +30385,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "选择用于服务匹配请求的本地文件"
+            "value": "选择用于响应匹配请求的本地文件"
           }
         }
       }
@@ -33615,7 +33615,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "已达到活跃阻止列表规则的上限。请停用另一条规则后重试。"
+            "value": "已达到生效中的阻止列表规则的上限。请停用另一条规则后重试。"
           }
         }
       }
@@ -33625,7 +33625,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "已达到活跃断点规则上限。请停用另一条规则后重试。"
+            "value": "已达到生效中的断点规则上限。请停用另一条规则后重试。"
           }
         }
       }
@@ -33645,7 +33645,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "已达到活跃 Map Local 规则的上限。请停用另一条规则，然后重试。"
+            "value": "已达到生效中的 Map Local 规则的上限。请停用另一条规则，然后重试。"
           }
         }
       }
@@ -33655,7 +33655,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "已达到活跃 Map Remote 规则的上限。请停用另一条规则后重试。"
+            "value": "已达到生效中的 Map Remote 规则的上限。请停用另一条规则后重试。"
           }
         }
       }
@@ -38365,7 +38365,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "检测到 VPN 或 iCloud 私密转送（%@）。可能无法捕获流量。请停用 VPN/私密转送以使用 Rockxy。"
+            "value": "检测到 VPN 或 iCloud 专用代理（%@）。可能无法捕获流量。请停用 VPN/专用代理以使用 Rockxy。"
           }
         }
       }
@@ -38681,7 +38681,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "关闭后将跳过阻止列表规则。其他干预规则仍保持活跃。"
+            "value": "关闭后将跳过阻止列表规则。其他干预规则仍保持生效。"
           }
         }
       }

--- a/Rockxy/Localizable.xcstrings
+++ b/Rockxy/Localizable.xcstrings
@@ -2102,7 +2102,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "检测到 5 字节的 gRPC 前缀"
+            "value": "可见 5 字节的 gRPC 前缀"
           }
         }
       }

--- a/Rockxy/Localizable.xcstrings
+++ b/Rockxy/Localizable.xcstrings
@@ -688,7 +688,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "%1$@，%2$lld 条生效中的规则"
+            "value": "%1$@，%2$lld 条生效规则"
           }
         }
       }
@@ -826,7 +826,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "有 %lld 条生效中的断点规则。打开断点规则。"
+            "value": "有 %lld 条生效的断点规则。打开断点规则。"
           }
         }
       }
@@ -836,7 +836,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "%lld 条生效中的 Map Local 规则。打开 Map Local。"
+            "value": "%lld 条生效的 Map Local 规则。打开 Map Local。"
           }
         }
       }
@@ -846,7 +846,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "有 %lld 条生效中的 Map Remote 规则。打开 Map Remote。"
+            "value": "有 %lld 条生效的 Map Remote 规则。打开 Map Remote。"
           }
         }
       }
@@ -856,7 +856,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "%lld 条生效中的修改标头规则"
+            "value": "%lld 条生效的修改标头规则"
           }
         }
       }
@@ -866,7 +866,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "%lld 条生效中的规则"
+            "value": "%lld 条生效规则"
           }
         }
       }
@@ -1852,7 +1852,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "有 1 条生效中的断点规则。打开断点规则。"
+            "value": "有 1 条生效的断点规则。打开断点规则。"
           }
         }
       }
@@ -1862,7 +1862,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "有 1 条生效中的 Map Local 规则。打开 Map Local。"
+            "value": "有 1 条生效的 Map Local 规则。打开 Map Local。"
           }
         }
       }
@@ -1872,7 +1872,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "有 1 条生效中的 Map Remote 规则。打开 Map Remote。"
+            "value": "有 1 条生效的 Map Remote 规则。打开 Map Remote。"
           }
         }
       }
@@ -6794,7 +6794,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "点击 “+” 或按下 ⌘N 以添加新条目"
+            "value": "点按“+”或按 ⌘N 以添加新条目"
           }
         }
       }
@@ -6804,7 +6804,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "点击 “+” 或按 ⌘N 以添加定义。"
+            "value": "点按“+”或按 ⌘N 以添加定义。"
           }
         }
       }
@@ -6814,7 +6814,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "点击 “+” 或按 ⌘N 以创建配置。"
+            "value": "点按“+”或按 ⌘N 以创建配置。"
           }
         }
       }
@@ -6824,7 +6824,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "点击 “+” 或按 ⌘N 创建规则。"
+            "value": "点按“+”或按 ⌘N 创建规则。"
           }
         }
       }
@@ -6834,7 +6834,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "点击 “+” 或按 ⌘N 以导入 .proto 文件。"
+            "value": "点按“+”或按 ⌘N 以导入 .proto 文件。"
           }
         }
       }
@@ -6854,7 +6854,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "点击 + 或按 ⌘N 以创建脚本。"
+            "value": "点按 + 或按 ⌘N 以创建脚本。"
           }
         }
       }
@@ -6864,7 +6864,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "点击或拖移以滚动正文文本"
+            "value": "点按或拖移以滚动正文文本"
           }
         }
       }
@@ -6884,7 +6884,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "点击候选项上的 R 列以完成此基础比较。"
+            "value": "点按候选项上的 R 列以完成此基础比较。"
           }
         }
       }
@@ -19607,7 +19607,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "无生效中的脚本"
+            "value": "无生效脚本"
           }
         }
       }
@@ -33615,7 +33615,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "已达到生效中的阻止列表规则的上限。请停用另一条规则后重试。"
+            "value": "已达到阻止列表规则的启用上限。请停用另一条规则后重试。"
           }
         }
       }
@@ -33625,7 +33625,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "已达到生效中的断点规则上限。请停用另一条规则后重试。"
+            "value": "已达到断点规则的启用上限。请停用另一条规则后重试。"
           }
         }
       }
@@ -33645,7 +33645,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "已达到生效中的 Map Local 规则的上限。请停用另一条规则，然后重试。"
+            "value": "已达到 Map Local 规则的启用上限。请停用另一条规则，然后重试。"
           }
         }
       }
@@ -33655,7 +33655,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "已达到生效中的 Map Remote 规则的上限。请停用另一条规则后重试。"
+            "value": "已达到 Map Remote 规则的启用上限。请停用另一条规则后重试。"
           }
         }
       }


### PR DESCRIPTION
## Description
This pull request repairs the **Simplified Chinese (zh-Hans)** localization shipped in `Rockxy/Localizable.xcstrings`. A pass over all 3,905 catalog keys (1,365 sentences read in full) found mistranslations that can mislead users, terminology used inconsistently across the same feature, and word-for-word machine-translation phrasing. Only `zh-Hans` string values are touched: English source strings, format placeholders, `state` fields, protocol names, URLs, shortcuts, and product names are unchanged.

## Changes
- Fix mistranslations that change the meaning (e.g. `next dev`, Vision Pro headset, `Rockxy-owned`, `your machine`).
- Unify terminology so one English word maps to one Chinese term per context; sources and rationale per term are listed in the glossary below. Context-dependent words (`active`) now use the natural term for each context (当前/活动/生效) instead of one global mapping; in-effect rules use 生效规则/启用上限 per the maintainer review.
- Polish machine-translation phrasing (filler 对…进行…, word order, missing verbs) and small details (pronouns, full-width quotes, click/load wording, counters).
- 226 zh-Hans values changed (Localizable.xcstrings); Apple’s official zh-CN naming (iCloud 专用代理) and Apple’s simulator/emulator terminology (Xcode Simulator = 模拟器) are kept per the maintainer review. No Swift code, no English strings, no behavior change.

## Localization (if applicable)
- **Language / locale:** Simplified Chinese (`zh-Hans`).
- **Affected catalog:** `Rockxy/Localizable.xcstrings` (226 values). `InfoPlist.xcstrings` was reviewed but needed no changes.
- **Verification:** `python3 .github/tools/validate_xcstrings.py` passes; placeholder/format-token parity is 100% intact; no non-translatable details were altered.
- **Review tooling (disclosed per CONTRIBUTING.md):** this diff was reviewed with the **DeepSeek V4 Flash** model (`deepseek-v4-flash-vision-exp`). The review compares every English source string against its current and proposed Chinese value, applies a fixed terminology policy (Apple Simplified Chinese style, official Apple product names, and majority usage within the catalog), and was machine-checked for placeholder parity. In line with the contribution guide, bulk-generated/machine-reviewed translations still benefit from a native-speaker pass before the PR is marked ready for merge. Maintainer feedback in the review was then applied contextually (see the glossary row for `active`).

### Terminology unification glossary

| English term | Unified Simplified Chinese | Strings | Source of the unified term | Reason |
|---|---|---|---|---|
| active (context-dependent) | `当前 / 活动 / 生效（按语境）` | 26 | Context-specific Chinese UI terminology. | One Chinese term cannot cover all contexts: 当前 for the active project/request/filter, 活动 for established network connections (standard networking term), 生效 for rules/scripts that are in effect (生效规则 / 启用上限 wording per maintainer review), 可用 for a still-running endpoint. |
| disable | `停用` | 12 | Apple Simplified Chinese UI wording (启用/停用 pair). | disable was rendered 禁用/停用, sometimes in adjacent sentences; 停用 pairs with 启用. |
| provider | `提供商` | 17 | Majority usage in this catalog (28 vs. 15 occurrences). | 提供商/提供方 mixed, including two variants of the same sentence; 提供商 is the AI-industry convention. |
| payload | `有效载荷` | 16 | Industry/Apple standard term for payload. | The same feature used 有效载荷/负载/有效负载; 负载 also means “load / load balancing”. |
| review | `审查` | 7 | Existing shipped feature name Review Data → 审查数据; majority usage (37 vs. 5). | 审阅/审查 mixed for the same action; the feature name already ships as 审查数据. |
| filter (active filter) | `当前筛选器 / 当前没有生效的筛选器` | 6 | Catalog majority (14 × 筛选器 vs. 6 × 过滤器); Apple uses 筛选器. | “active filter” means the currently applied filter; 活动筛选器 read as “live filter”. |
| first-match | `首个匹配` | 3 | Majority usage (3 vs. 2). | 首次匹配/首个匹配 mixed for Rockxy’s global first-match rule order. |
| baseline | `基线` | 1 | Developer-tool convention (baseline = 基线). | 基准 collides with “benchmark”; the same word was translated both ways. |
| timing | `时序` | 3 | Network/performance tooling convention (phase timing). | 计时/时间/时序 all translated “timing”; 时序 expresses phased timing unambiguously. |
| rewrite | `重写` | 2 | Dominant usage in the catalog. | The Rewrite feature was rendered 改写 and 重写 inconsistently. |
| origin | `源服务器` | 1 | Chinese CDN/backend convention. | fall back to the origin was 源站 elsewhere 源服务器; unified to 源服务器. |
| public (key/cert) | `公开` | 5 | Common Simplified Chinese crypto usage (公开证书/公开密钥). | 公共/公开 mixed for “public” in certificate/CA strings. |
| helper (tool) | `辅助工具` | 18 | Catalog majority (40 vs. 19) and Apple wording for helper tools. | The same component was called Helper and 辅助工具; unified to 辅助工具. |
| pin / pinned (UI) | `置顶` | 6 | Apple Simplified Chinese UI convention for pinning items; existing app usage. | 置顶/固定/已固定 coexisted for UI pinning; 固定 is reserved for certificate pinning (证书固定). |
| inference (model) | `推理` | 2 | AI-industry standard (模型推理). | 推断 covered both “inference” and “hypothesis”; separated as 推理 (inference) and 假设 (hypothesis). |
| Focus Set | `焦点集` | 3 | Existing feature concept (sibling strings already use 焦点集). | Focus 集/焦点集 mixed for the same feature. |
| HAR archive | `HAR 文件` | 2 | Developer-tool convention. | HAR 归档 and HAR 文件 both used for HAR exports. |
| Background Items | `后台项` | 2 | macOS Simplified Chinese System Settings wording (“登录项与后台项”). | 后台项/后台项目 mixed; matches macOS. |
| simulator / emulator (in paired strings) | `模拟器 / 仿真器` | 1 | Apple Simplified Chinese developer documentation: Xcode Simulator = 模拟器. | In the combined device/simulator/emulator lists, simulator → 模拟器 and emulator → 仿真器, preserving the source order (per the maintainer’s guidance; the earlier mapping was inverted). |
| Tunnel Without Decryption | `不解密隧道` | 1 | Existing shipped UI label (rule type). | One summary line kept the English name while every other string uses the shipped Chinese label. |
| Assistant (product) | `Rockxy AI 助手` | 1 | Existing app naming (AI 助手). | Ask Rockxy Assistant About Selection… used the English name while the sibling menu uses AI 助手. |
| recording | `记录` | 6 | Catalog majority. | 录制 (implying audio/video) mixed with 记录 for traffic recording. |
| this Mac | `这台 Mac` | 20 | Catalog majority (already used in 11+ strings) and Apple wording. | 此 Mac is stiff; also fixes “your machine” → 这台 Mac (machine was previously rendered 设备/device). |
| you (pronoun) | `你` | 19 | Apple Simplified Chinese UI style; developer-tool tone. | 您 (19×) and 你 (41×) were mixed across the UI; one style must win. |
| on/off wording | `启用（开启→启用）` | 2 | Consistent with the 启用/停用 pair. | Turn on was rendered 开启/启用; “Allow List is on” was 已开启/已启用. |
| include/exclude | `包含` | 2 | Catalog majority. | 包括/包含 both used for include; 其中包括 → 其中包含, include condition → 包含条件. |

### Per-string change table (English · previous Chinese · new Chinese · reason)

<details>
<summary>All 226 changed strings (click to expand)</summary>

_Some rows carry more than one kind of change (e.g. a terminology unification plus a pronoun or quote fix); the Reason column lists the primary one._

| English | Previous (zh-Hans) | Change to (zh-Hans) | Reason |
|---|---|---|---|
|   •  %lld evicted |   •  已逐出 %lld 项 |   •  已淘汰 %lld 项 | Literal translation: evicted → 逐出 (archaic); buffer/cache eviction is 淘汰. Context: oldest runtime events dropped from the in-memory buffer. |
| "%1$@" could not be read.  %2$@ | 无法读取"%1$@"。  %2$@ | 无法读取“%1$@”。  %2$@ | Consistency: ASCII straight quotes replaced with full-width “ ” / ‘ ’ in Chinese text. |
| %@  Rockxy re-registered the helper from the current app bundle. macOS still needs you to approve it in System Settings > Login Items. | %@  Rockxy 已从当前 App 包中重新注册辅助工具。您仍需在系统设置 > 登录项中批准它。 | %@  Rockxy 已从当前 App 包中重新注册辅助工具。你仍需在系统设置 > 登录项中批准它。 | Pronoun 您→你 unified to 你 (Apple Simplified Chinese UI style); Terminology: helper (tool) → 辅助工具 (contextual rationale in glossary below). |
| %@  Rockxy reinstalled the helper, but its protocol version is not compatible with this app build. | %@  Rockxy 已重新安装 Helper，但其协议版本与此 App 构建不兼容。 | %@  Rockxy 已重新安装辅助工具，但其协议版本与此 App 构建不兼容。 | Terminology: helper (tool) → 辅助工具 (contextual rationale in glossary below). |
| %@  Rockxy reinstalled the helper, but the installed helper still appears older than this app build. | %@  Rockxy 已重新安装 Helper，但安装的 Helper 看起来仍旧早于此 App 构建。 | %@  Rockxy 已重新安装辅助工具，但安装的辅助工具看起来仍旧早于此 App 构建。 | Terminology: helper (tool) → 辅助工具 (contextual rationale in glossary below). |
| %@ is not available on this Mac. | %@ 在此 Mac 上不可用。 | %@ 在这台 Mac 上不可用。 | Consistency: this Mac → 这台 Mac (Apple wording; “your machine” is a computer, not a 设备). |
| %1$@, %2$lld active rules | %1$@，%2$lld 条活动规则 | %1$@，%2$lld 条生效规则 | Terminology: active (context-dependent) → 生效中 (contextual rationale in glossary below). |
| %@, Active Project | %@，活跃项目 | %@，当前项目 | Terminology: active (context-dependent) → 当前 (contextual rationale in glossary below). |
| %lld active Breakpoint rules. Open Breakpoint Rules. | 有 %lld 条活跃的断点规则。打开断点规则。 | 有 %lld 条生效的断点规则。打开断点规则。 | Terminology: active (context-dependent) → 生效中 (contextual rationale in glossary below). |
| %lld active Map Local rules. Open Map Local. | %lld 条活动 Map Local 规则。打开 Map Local。 | %lld 条生效的 Map Local 规则。打开 Map Local。 | Terminology: active (context-dependent) → 生效中 (contextual rationale in glossary below). |
| %lld active Map Remote rules. Open Map Remote. | 有 %lld 条活动的 Map Remote 规则。打开 Map Remote。 | 有 %lld 条生效的 Map Remote 规则。打开 Map Remote。 | Terminology: active (context-dependent) → 生效中 (contextual rationale in glossary below). |
| %lld active Modify Header rules | %lld 条活跃的修改标头规则 | %lld 条生效的修改标头规则 | Terminology: active (context-dependent) → 生效中 (contextual rationale in glossary below). |
| %lld active rules | %lld 条活动规则 | %lld 条生效规则 | Terminology: active (context-dependent) → 生效中 (contextual rationale in glossary below). |
| %lld baseline request headers are absent | 缺少 %lld 个基准请求标头 | 缺少 %lld 个基线请求标头 | Terminology: baseline → 基线 (contextual rationale in glossary below). |
| %1$lld included · %2$lld skipped | 已包括 %1$lld 个 · 已跳过 %2$lld 个 | 已包含 %1$lld 个 · 已跳过 %2$lld 个 | Consistency: include → 包含 (包括/包含 mixed). |
| %lld overlaps; Tunnel Without Decryption takes priority | %lld 处重叠；Tunnel Without Decryption 优先 | %lld 处重叠；“不解密隧道”优先 | Terminology: Tunnel Without Decryption → 不解密隧道 (contextual rationale in glossary below). |
| ^[%lld host](inflect: true) | ^[%lld 台主机](inflect: true) | ^[%lld 个主机](inflect: true) | Consistency: counter for host → 个主机 (台 reads as “machine/device”). |
| 1 active Breakpoint rule. Open Breakpoint Rules. | 有 1 条活动断点规则。打开“断点规则”。 | 有 1 条生效的断点规则。打开断点规则。 | Terminology: active (context-dependent) → 生效中 (contextual rationale in glossary below). |
| 1 active Map Local rule. Open Map Local. | 有 1 条活动的 Map Local 规则。打开 Map Local。 | 有 1 条生效的 Map Local 规则。打开 Map Local。 | Terminology: active (context-dependent) → 生效中 (contextual rationale in glossary below). |
| 1 active Map Remote rule. Open Map Remote. | 有 1 条活跃的 Map Remote 规则。打开 Map Remote。 | 有 1 条生效的 Map Remote 规则。打开 Map Remote。 | Terminology: active (context-dependent) → 生效中 (contextual rationale in glossary below). |
| A newer helper version is bundled with this app. | 此 App 捆绑了更新版本的 Helper。 | 此 App 捆绑了更新版本的辅助工具。 | Terminology: helper (tool) → 辅助工具 (contextual rationale in glossary below). |
| A request must match every condition you set. Empty fields match any value. | 请求必须匹配您设置的每个条件。空字段可匹配任意值。 | 请求必须匹配你设置的每个条件。空字段可匹配任意值。 | Pronoun 您→你 unified to 你 (Apple Simplified Chinese UI style); Consistency: second-person pronoun unified to 你 (Apple Simplified Chinese UI style; was 您/你 mixed). |
| Active Project | 活动项目 | 当前项目 | Terminology: active (context-dependent) → 当前 (contextual rationale in glossary below). |
| Active Project: %@ | 活动项目：%@ | 当前项目：%@ | Terminology: active (context-dependent) → 当前 (contextual rationale in glossary below). |
| Add an include or exclude condition to preview matches | 添加包括或排除条件以预览匹配项 | 添加包含或排除条件以预览匹配项 | Consistency: include → 包含 (包括/包含 mixed). |
| Adding this enabled profile will disable the profile that is currently enabled. | 添加这个已启用的配置将禁用当前启用的配置。 | 添加这个已启用的配置将停用当前启用的配置。 | Terminology: disable → 停用 (contextual rationale in glossary below). |
| Adds the %lld request(s) hidden by Focus or Noise to this review only. Your Focus and Noise settings will not change. | 仅将被 Focus 或 Noise 隐藏的 %lld 个请求添加到本次审查。你的 Focus 和 Noise 设置不会更改。 | 仅将被焦点或噪声隐藏的 %lld 个请求添加到本次审查。你的焦点和噪声设置不会更改。 | Terminology: review → 审查 (contextual rationale in glossary below). |
| Allow List is on, but no valid enabled rule can match. Rockxy will not record traffic until a rule is enabled. | 允许列表已开启，但没有可匹配的有效已启用规则。在启用规则前，Rockxy 不会记录流量。 | 允许列表已启用，但没有可匹配的有效已启用规则。在启用规则前，Rockxy 不会记录流量。 | Consistency: on/off wording uses 启用 (开启→启用; Allow List 已开启→已启用), pairing with 停用. |
| Approve the helper tool in System Settings > Login Items to finish installation. | 请在“系统设置 > 登录项”中批准 Helper 工具以完成安装。 | 请在“系统设置 > 登录项”中批准辅助工具以完成安装。 | Terminology: helper (tool) → 辅助工具 (contextual rationale in glossary below). |
| Ask Rockxy Assistant About Selection… | 向 Rockxy Assistant 询问所选内容… | 向 Rockxy AI 助手询问所选内容… | Terminology: Assistant (product) → Rockxy AI 助手 (contextual rationale in glossary below). |
| Auto Start Recording Traffic at Launch | 启动时自动开始录制流量 | 启动时自动开始记录流量 | Consistency: recording → 记录 (traffic recording; 录制 implies audio/video). |
| Automatic redact sensitive headers | 自动对敏感标头进行脱敏 | 自动对敏感标头脱敏 | Machine-translation filler removed while keeping the natural 对…脱敏 structure (进行脱敏 → 对…脱敏; 已准备好进行 HTTPS 拦截 → HTTPS 拦截已就绪). |
| Automatically redact sensitive information before sending to MCP clients. | 发送到 MCP 客户端前自动对敏感信息进行脱敏。 | 发送到 MCP 客户端前自动对敏感信息脱敏。 | Machine-translation filler removed while keeping the natural 对…脱敏 structure (进行脱敏 → 对…脱敏; 已准备好进行 HTTPS 拦截 → HTTPS 拦截已就绪). |
| Balanced local model for debugging and tool-oriented prompts | 适用于调试和面向工具提示的均衡本地模型 | 适用于调试和工具调用类提示词的均衡本地模型 | tool-oriented prompts → 工具调用类提示词 (clarity; also fixes prompt → 提示词). |
| Binary Payload | 二进制负载 | 二进制有效载荷 | Terminology: payload → 有效载荷 (contextual rationale in glossary below). |
| Binary payloads omitted | 已省略二进制载荷 | 已省略二进制有效载荷 | Terminology: payload → 有效载荷 (contextual rationale in glossary below). |
| Block List is a network intervention. Enabled rules participate in Rockxy's global first-match runtime order. | 阻止列表是一种网络干预。已启用的规则会参与 Rockxy 的全局首次匹配运行时顺序。 | 阻止列表是一种网络干预。已启用的规则会参与 Rockxy 的全局首个匹配运行时顺序。 | Terminology: first-match → 首个匹配 (contextual rationale in glossary below). |
| Body editing is unavailable. Applying metadata changes or continuing original preserves every body byte. | 正文编辑不可用。应用元数据更改或继续原始流量都会保留正文的每个字节。 | 正文编辑不可用。应用元数据更改或继续发送原始流量都会保留正文的每个字节。 | Missing verb added: continuing original → 继续发送原始流量. |
| Cancel the active request | 取消活动请求 | 取消当前请求 | Terminology: active (context-dependent) → 当前 (contextual rationale in glossary below). |
| Certificate installed and trusted in your Keychain. | 证书已安装并在您的钥匙串中受信任。 | 证书已安装并在你的钥匙串中受信任。 | Pronoun 您→你 unified to 你 (Apple Simplified Chinese UI style); Consistency: second-person pronoun unified to 你 (Apple Simplified Chinese UI style; was 您/你 mixed). |
| Certificate installed and trusted. Make the request again to inspect HTTPS content. | 证书已安装并受信任。请再次发出请求以检查 HTTPS 内容。 | 证书已安装并受信任。请再次发送请求以检查 HTTPS 内容。 | Inconsistent rendering of the same phrase: 发出请求 vs 发送请求; 以进行检查 vs 以检查它 (matching the sibling string). |
| Certificate is installed but not trusted. Go back and try "Install & Trust" again. | 证书已安装但不受信任。请返回并再次尝试 "安装并信任"。 | 证书已安装但不受信任。请返回并再次尝试 “安装并信任”。 | Consistency: ASCII straight quotes replaced with full-width “ ” / ‘ ’ in Chinese text. |
| Check provider error body, request id, auth, rate-limit headers, and retry timing. | 检查提供商的错误正文、请求 id、身份验证、速率限制标头和重试时间。 | 检查提供商的错误正文、请求 ID、身份验证、速率限制标头和重试时机。 | Terminology: provider → 提供商 (contextual rationale in glossary below). |
| Check provider error code/message, request id, auth headers, and retry timing. | 检查提供方的错误代码/消息、请求 ID、身份验证标头以及重试时机。 | 检查提供商的错误代码/消息、请求 ID、身份验证标头以及重试时机。 | Terminology: provider → 提供商 (contextual rationale in glossary below). |
| Check raw transaction/signature, wallet signer state, nonce, gas, and provider rejection details. | 检查原始交易/签名、钱包签名者状态、nonce、gas 以及提供方拒绝详情。 | 检查原始交易/签名、钱包签名者状态、nonce、gas 以及提供商拒绝详情。 | Terminology: provider → 提供商 (contextual rationale in glossary below). |
| Choose the Go HTTP client that matches your runtime and copy the snippet. | 选择与您的运行时匹配的 Go HTTP 客户端，然后复制代码片段。 | 选择与你的运行时匹配的 Go HTTP 客户端，然后复制代码片段。 | Pronoun 您→你 unified to 你 (Apple Simplified Chinese UI style); Consistency: second-person pronoun unified to 你 (Apple Simplified Chinese UI style; was 您/你 mixed). |
| Choose which captured transactions to save in this HAR archive. | 选择要保存到此 HAR 归档中的已捕获事务。 | 选择要保存到此 HAR 文件中的已捕获事务。 | Terminology: HAR archive → HAR 文件 (contextual rationale in glossary below). |
| Click "+" or ⌘N to add new entry | 点按 "+" 或按下 ⌘N 以添加新条目 | 点按“+”或按 ⌘N 以添加新条目 | Consistency: 点按 restored per Apple macOS Simplified Chinese terminology (Apple uses 点按 for mouse/trackpad clicks); full-width quotes and 按 ⌘N kept (maintainer review). |
| Click "+" or press ⌘N to add a definition. | 点按 "+" 或按下 ⌘N 以添加定义。 | 点按“+”或按 ⌘N 以添加定义。 | Consistency: 点按 restored per Apple macOS Simplified Chinese terminology (Apple uses 点按 for mouse/trackpad clicks); full-width quotes and 按 ⌘N kept (maintainer review). |
| Click "+" or press ⌘N to create a profile. | 点按 "+" 或按下 ⌘N 以创建配置。 | 点按“+”或按 ⌘N 以创建配置。 | Consistency: 点按 restored per Apple macOS Simplified Chinese terminology (Apple uses 点按 for mouse/trackpad clicks); full-width quotes and 按 ⌘N kept (maintainer review). |
| Click "+" or press ⌘N to create a rule. | 点击 "+" 或按 ⌘N 创建规则。 | 点按“+”或按 ⌘N 创建规则。 | Consistency: 点按 restored per Apple macOS Simplified Chinese terminology (Apple uses 点按 for mouse/trackpad clicks); full-width quotes and 按 ⌘N kept (maintainer review). |
| Click "+" or press ⌘N to import a .proto file. | 点按 "+" 或按下 ⌘N 以导入 .proto 文件。 | 点按“+”或按 ⌘N 以导入 .proto 文件。 | Consistency: 点按 restored per Apple macOS Simplified Chinese terminology (Apple uses 点按 for mouse/trackpad clicks); full-width quotes and 按 ⌘N kept (maintainer review). |
| Click + or press ⌘N to create a script. | 点按 + 或按下 ⌘N 以创建脚本。 | 点按 + 或按 ⌘N 以创建脚本。 | Consistency: 点按 restored per Apple macOS Simplified Chinese terminology (Apple uses 点按 for mouse/trackpad clicks); full-width quotes and 按 ⌘N kept (maintainer review). |
| Configure Rockxy as the local proxy and load the exported root certificate in your Go client. | 将 Rockxy 配置为本地代理，并在 Go 客户端中载入导出的根证书。 | 将 Rockxy 配置为本地代理，并在 Go 客户端中加载导出的根证书。 | Consistency: load → 加载 (was 载入/加载 mixed). |
| Confirm the redacted traffic and conversation before local inference begins. | 开始本地推断前，请确认已脱敏的流量和对话。 | 开始本地推理前，请确认已脱敏的流量和对话。 | Terminology: inference (model) → 推理 (contextual rationale in glossary below). |
| Connect this Mac to Wi-Fi or Ethernet to expose a reachable LAN IP. | 将此 Mac 连接到 Wi-Fi 或以太网，以公开可访问的 LAN IP。 | 将这台 Mac 连接到 Wi-Fi 或以太网，以获取可访问的局域网 IP。 | expose a reachable LAN IP → 以获取可访问的局域网 IP. |
| Could not import "%1$@".  %2$@ | 无法导入 "%1$@"。  %2$@ | 无法导入 “%1$@”。  %2$@ | Consistency: ASCII straight quotes replaced with full-width “ ” / ‘ ’ in Chinese text. |
| Could not import "%1$@".  The file may not be a valid HAR archive. %2$@ | 无法导入 "%1$@"。  该文件可能不是有效的 HAR 归档。%2$@ | 无法导入 “%1$@”。  该文件可能不是有效的 HAR 文件。%2$@ | Terminology: HAR archive → HAR 文件 (contextual rationale in glossary below). |
| Could not read "%1$@".  %2$@ | 无法读取 "%1$@"。  %2$@ | 无法读取 “%1$@”。  %2$@ | Consistency: ASCII straight quotes replaced with full-width “ ” / ‘ ’ in Chinese text. |
| Create Focus Set | 创建 Focus 集 | 创建焦点集 | Terminology: Focus Set → 焦点集 (contextual rationale in glossary below). |
| Create Rockxy's local certificate authority for HTTPS inspection. | 创建 Rockxy 的本地证书颁发机构以进行 HTTPS 检查。 | 创建 Rockxy 的本地证书颁发机构，用于检查 HTTPS。 | Machine-translation filler removed while keeping the natural 对…脱敏 structure (进行脱敏 → 对…脱敏; 已准备好进行 HTTPS 拦截 → HTTPS 拦截已就绪). |
| Devices outside this Mac cannot reach localhost-only mode. Turn off Only Listen on localhost, then restart the proxy. | 此 Mac 之外的设备无法访问仅本地主机模式。请关闭“仅监听本地主机”，然后重启代理。 | 这台 Mac 之外的设备无法访问“仅监听本地主机”模式。请关闭“仅监听本地主机”，然后重启代理。 | Consistency: this Mac → 这台 Mac (Apple wording; “your machine” is a computer, not a 设备). |
| Disable | 禁用 | 停用 | Terminology: disable → 停用 (contextual rationale in glossary below). |
| Disable caching (No-Cache headers) | 禁用缓存（No-Cache 标头） | 停用缓存（No-Cache 标头） | Terminology: disable → 停用 (contextual rationale in glossary below). |
| Disable Rule | 禁用规则 | 停用规则 | Terminology: disable → 停用 (contextual rationale in glossary below). |
| Disable Script | 禁用脚本 | 停用脚本 | Terminology: disable → 停用 (contextual rationale in glossary below). |
| Disabled | 已禁用 | 已停用 | Terminology: disable → 停用 (contextual rationale in glossary below). |
| Disabled where supported | 在支持的情况下禁用 | 在支持的情况下停用 | Terminology: disable → 停用 (contextual rationale in glossary below). |
| Do you see an authentication problem here? | 您在此处看到了认证问题吗？ | 你在此处看到了认证问题吗？ | Pronoun 您→你 unified to 你 (Apple Simplified Chinese UI style); Consistency: second-person pronoun unified to 你 (Apple Simplified Chinese UI style; was 您/你 mixed). |
| Edit Focus Set | 编辑 Focus 集 | 编辑焦点集 | Terminology: Focus Set → 焦点集 (contextual rationale in glossary below). |
| Enabled SSL Proxying for %@. Make the request again to inspect it. | 已为 %@ 启用 SSL 代理。请再次发出请求以进行检查。 | 已为 %@ 启用 SSL 代理。请再次发送请求以检查它。 | Inconsistent rendering of the same phrase: 发出请求 vs 发送请求; 以进行检查 vs 以检查它 (matching the sibling string). |
| Hidden filters active | 隐藏的筛选器处于活动状态 | 当前有隐藏的筛选器生效 | Terminology: filter (active filter) → 当前筛选器 (contextual rationale in glossary below). |
| Hides this domain and its subdomains from the Focus Set. | 从 Focus 集中隐藏此域名及其子域名。 | 从焦点集中隐藏此域名及其子域名。 | Terminology: Focus Set → 焦点集 (contextual rationale in glossary below). |
| History stays on this Mac. Authentication and cookie header values are redacted; URLs and bodies remain stored locally. | 历史记录保留在此 Mac 上。身份验证和 cookie 标头值会被脱敏；URL 和正文仍在本地存储。 | 历史记录保留在这台 Mac 上。身份验证和 cookie 标头值会被脱敏；URL 和正文仍在本地存储。 | Consistency: this Mac → 这台 Mac (Apple wording; “your machine” is a computer, not a 设备). |
| Hosts here skip decryption but still flow through Rockxy. It never disables Rockxy proxying. | 此处的主机会跳过解密，但仍通过 Rockxy 传输。这绝不会禁用 Rockxy 代理。 | 此处的主机会跳过解密，但仍通过 Rockxy 传输。这绝不会停用 Rockxy 代理。 | Terminology: disable → 停用 (contextual rationale in glossary below). |
| HTTP %lld from provider | 来自提供方的 HTTP %lld | 来自提供商的 HTTP %lld | Terminology: provider → 提供商 (contextual rationale in glossary below). |
| HTTP 429 and nearby repeated requests support this hypothesis; application policy remains unknown. | HTTP 429 和附近的重复请求支持此推断；应用程序策略仍未知。 | HTTP 429 和附近的重复请求支持此假设；应用程序策略仍未知。 | hypothesis was rendered as 推断 (“inference”); now 假设, keeping 推断/推理 for model inference. |
| If you prefer Terminal, export the public PEM and run xcrun simctl keychain <udid> add-root-cert <path-to-pem> for a prepared simulator. | 如果您更喜欢使用“终端”，请导出公共 PEM，然后为已准备的模拟器运行 xcrun simctl keychain <udid> add-root-cert <path-to-pem>。 | 如果你更喜欢使用“终端”，请导出公开 PEM，然后为已准备的模拟器运行 xcrun simctl keychain <udid> add-root-cert <path-to-pem>。 | Pronoun 您→你 unified to 你 (Apple Simplified Chinese UI style); Terminology: public (key/cert) → 公开 (contextual rationale in glossary below). |
| Inference uses the configured local endpoint | 推断使用已配置的本地端点 | 推理使用已配置的本地端点 | Terminology: inference (model) → 推理 (contextual rationale in glossary below). |
| Inspect the response payload and nearby requests to this host. | 检查响应负载以及向该主机发出的邻近请求。 | 检查响应有效载荷以及向该主机发出的邻近请求。 | Terminology: payload → 有效载荷 (contextual rationale in glossary below). |
| Install Certificate on This Mac… | 在此 Mac 上安装证书… | 在这台 Mac 上安装证书… | Consistency: this Mac → 这台 Mac (Apple wording; “your machine” is a computer, not a 设备). |
| Install the selected runtime, toolchain, or client on this Mac before validating this manual flow. | 验证此手动流程前，请先在此 Mac 上安装所选的运行时、工具链或客户端。 | 验证此手动流程前，请先在这台 Mac 上安装所选的运行时、工具链或客户端。 | Consistency: this Mac → 这台 Mac (Apple wording; “your machine” is a computer, not a 设备). |
| Installed helper version is outdated and should be updated. | 已安装的 Helper 版本已过时，应进行更新。 | 已安装的辅助工具版本已过时，应进行更新。 | Terminology: helper (tool) → 辅助工具 (contextual rationale in glossary below). |
| Invalid matching rule '%1$@': %2$@ | 匹配规则 '%1$@' 无效：%2$@ | 匹配规则 ‘%1$@’ 无效：%2$@ | Consistency: ASCII straight quotes replaced with full-width “ ” / ‘ ’ in Chinese text. |
| Keep Android trust debug-only | 将 Android 信任保持为仅调试 | 将 Android 的证书信任限制为仅调试构建 | Unreadable sentence: 将 Android 信任保持为仅调试 → 将 Android 的证书信任限制为仅调试构建. |
| Launch your app/domain to see it in the list | 启动您的 App 或访问域名，即可在列表中看到它 | 启动你的 App 或访问域名，即可在列表中看到它 | Pronoun 您→你 unified to 你 (Apple Simplified Chinese UI style); Consistency: second-person pronoun unified to 你 (Apple Simplified Chinese UI style; was 您/你 mixed). |
| Load an HTTPS page in Safari or run the target app's login flow once and confirm Rockxy captures the request. A VPN may bypass the Wi-Fi proxy, so disable it while validating. | 在 Safari 中加载一个 HTTPS 页面，或运行一次目标应用的登录流程，并确认 Rockxy 捕获到该请求。VPN 可能会绕过 Wi-Fi 代理，因此请在验证时将其禁用。 | 在 Safari 中加载一个 HTTPS 页面，或运行一次目标应用的登录流程，并确认 Rockxy 捕获到该请求。VPN 可能会绕过 Wi-Fi 代理，因此请在验证时将其停用。 | Terminology: disable → 停用 (contextual rationale in glossary below). |
| Loading release notes… | 正在载入发布说明… | 正在加载发布说明… | Consistency: load → 加载 (was 载入/加载 mixed). |
| Local investigation is always available. Sending a prompt to a configured model requires an explicit Review Data confirmation. | 本地调查始终可用。向已配置的模型发送提示需要明确确认“审查数据”。 | 本地调查始终可用。向已配置的模型发送提示词需要明确确认“审查数据”。 | AI context: prompt → 提示词. |
| Local-only connection on this Mac | 仅限此 Mac 的本地连接 | 仅限这台 Mac 的本地连接 | Consistency: this Mac → 这台 Mac (Apple wording; “your machine” is a computer, not a 设备). |
| macOS System Proxy Disabled | macOS 系统代理已禁用 | macOS 系统代理已停用 | Terminology: disable → 停用 (contextual rationale in glossary below). |
| Manual Golang setup is supported for common HTTP stacks. | 常见 HTTP 技术栈支持手动配置 Golang。 | 支持为常见 HTTP 技术栈手动配置 Golang。 | Passive-subject inversion (Golang): the old text read “common HTTP stacks support configuring Golang”. |
| Manual Ruby setup is supported with common HTTP client examples. | 常见 HTTP 客户端示例支持手动配置 Ruby。 | 支持手动配置 Ruby，并提供常见 HTTP 客户端示例。 | Passive-subject inversion (Ruby) — same fix as M9. |
| Map Local participates in Rockxy's global first-match rule order. Reorder rules from the More menu; unavailable local targets safely fall back to the origin. | Map Local 遵循 Rockxy 的全局首个匹配规则顺序。可从“更多”菜单重新排序规则；不可用的本地目标会安全回退到源站。 | Map Local 遵循 Rockxy 的全局首个匹配规则顺序。可从“更多”菜单重新排序规则；不可用的本地目标会安全回退到源服务器。 | Terminology: first-match → 首个匹配 (contextual rationale in glossary below). |
| Map Local serves a matching request from a local file — you set the status code, headers, and body — so you can mock an endpoint. | Map Local 从本地文件提供匹配请求的响应，你可以设置状态码、标头和正文，从而模拟端点。 | Map Local 会为匹配的请求从本地文件提供响应，你可以设置状态码、标头和正文，从而模拟端点。 | Word order: Map Local serves a matching request from a local file → 为匹配的请求从本地文件提供响应. |
| Matching rule '%1$@' exceeds %2$lld characters. | 匹配规则 '%1$@' 超过 %2$lld 个字符。 | 匹配规则 ‘%1$@’ 超过 %2$lld 个字符。 | Consistency: ASCII straight quotes replaced with full-width “ ” / ‘ ’ in Chinese text. |
| Models and reviewed traffic stay on this Mac through this local endpoint. | 通过此本地端点，模型和已审查流量都会保留在此 Mac 上。 | 通过此本地端点，模型和已审查流量都会保留在这台 Mac 上。 | Terminology: review → 审查 (contextual rationale in glossary below). |
| Network Conditions throttles bandwidth and adds latency so you can reproduce how your app behaves on a slow connection. | 网络条件会限制带宽并增加延迟，帮助您重现 App 在慢速连接下的表现。 | 网络条件会限制带宽并增加延迟，帮助你重现 App 在慢速连接下的表现。 | Pronoun 您→你 unified to 你 (Apple Simplified Chinese UI style); Consistency: second-person pronoun unified to 你 (Apple Simplified Chinese UI style; was 您/你 mixed). |
| No active filter | 没有活动筛选条件 | 当前没有生效的筛选器 | Terminology: filter (active filter) → 当前筛选器 (contextual rationale in glossary below). |
| NO ACTIVE SCRIPTS | 无活动脚本 | 无生效脚本 | Terminology: active (context-dependent) → 生效中 (contextual rationale in glossary below). |
| No failure is proven by this exchange. Open Details only if you want to inspect headers, timing, or payloads. | 此交换未证实任何故障。仅当你想检查标头、时序或有效载荷时才打开“详细信息”。 | 此次交互未证实任何故障。仅当你想检查标头、时序或有效载荷时才打开“详细信息”。 | exchange → 交互 (not 交换) in “CONNECT exchange” / “proven by this exchange”. |
| No hidden filters active | 没有活动的隐藏筛选器 | 当前没有生效的隐藏筛选器 | Terminology: filter (active filter) → 当前筛选器 (contextual rationale in glossary below). |
| No OpenAPI-eligible requests in the active filter | 活动筛选器中没有符合 OpenAPI 条件的请求 | 当前筛选器中没有符合 OpenAPI 条件的请求 | Terminology: filter (active filter) → 当前筛选器 (contextual rationale in glossary below). |
| No Pinned Requests | 无固定的请求 | 无置顶请求 | Terminology: pin / pinned (UI) → 置顶 (contextual rationale in glossary below). |
| No reachable Wi-Fi or Ethernet IPv4 address was found. Connect this Mac to the same network as the device, then try again. | 未找到可访问的 Wi-Fi 或以太网 IPv4 地址。请将此 Mac 连接到与设备相同的网络，然后重试。 | 未找到可访问的 Wi-Fi 或以太网 IPv4 地址。请将这台 Mac 连接到与设备相同的网络，然后重试。 | Consistency: this Mac → 这台 Mac (Apple wording; “your machine” is a computer, not a 设备). |
| Only one profile can be enabled. It follows Rockxy's global first-match rule order and applies to intercepted HTTP and HTTPS traffic. | 只能启用一个配置。它遵循 Rockxy 的全局首次匹配规则顺序，并应用于拦截的 HTTP 和 HTTPS 流量。 | 只能启用一个配置。它遵循 Rockxy 的全局首个匹配规则顺序，并应用于拦截的 HTTP 和 HTTPS 流量。 | Terminology: first-match → 首个匹配 (contextual rationale in glossary below). |
| Original payload protected | 原始载荷已受保护 | 原始有效载荷已受保护 | Terminology: payload → 有效载荷 (contextual rationale in glossary below). |
| Overrides %@. Other components are kept from the request. | 覆盖 %@。其他组件保留自请求。 | 覆盖 %@。其他组件取自原请求。 | Word order: Other components are kept from the request → 其他组件取自原请求. |
| Pair the Babylon debug client with this Mac over the local network. | 通过本地网络将 Babylon 调试客户端与此 Mac 配对。 | 通过本地网络将 Babylon 调试客户端与这台 Mac 配对。 | Consistency: this Mac → 这台 Mac (Apple wording; “your machine” is a computer, not a 设备). |
| Paste Rockxy's host and port into Firefox Network Settings, import the root certificate into the browser authority store, then load a page to confirm. | 将 Rockxy 的主机和端口粘贴到 Firefox 网络设置中，将根证书导入浏览器的证书颁发机构存储，然后载入页面进行确认。 | 将 Rockxy 的主机和端口粘贴到 Firefox 网络设置中，将根证书导入浏览器的证书颁发机构存储，然后加载页面进行确认。 | Consistency: load → 加载 (was 载入/加载 mixed). |
| Payload encoding | 有效负载编码 | 有效载荷编码 | Terminology: payload → 有效载荷 (contextual rationale in glossary below). |
| Payload transfer accounts for most of the request duration. | 负载传输占请求时长的大部分。 | 有效载荷传输占请求时长的大部分。 | Terminology: payload → 有效载荷 (contextual rationale in glossary below). |
| Payload View | 负载视图 | 有效载荷视图 | Terminology: payload → 有效载荷 (contextual rationale in glossary below). |
| Payloads truncated | 载荷已截断 | 有效载荷已截断 | Terminology: payload → 有效载荷 (contextual rationale in glossary below). |
| Pin | 固定 | 置顶 | Terminology: pin / pinned (UI) → 置顶 (contextual rationale in glossary below). |
| Pin Evidence | 固定证据 | 置顶证据 | Terminology: pin / pinned (UI) → 置顶 (contextual rationale in glossary below). |
| Pinned | 已固定 | 已置顶 | Terminology: pin / pinned (UI) → 置顶 (contextual rationale in glossary below). |
| Projects are not ready. Retry loading the catalog first. | 项目尚未就绪。请先重试载入目录。 | 项目尚未就绪。请先重试加载项目目录。 | catalog = project catalog (项目目录), not a filesystem directory; 载入 → 加载. |
| Projects are stored locally on this Mac. | 项目存储在此 Mac 本地。 | 项目存储在这台 Mac 本地。 | Consistency: this Mac → 这台 Mac (Apple wording; “your machine” is a computer, not a 设备). |
| Projects could not be loaded. Traffic Tab and filter changes will not be saved until Projects are repaired. | 无法载入项目。在项目修复之前，流量标签页和过滤器的更改不会被保存。 | 无法加载项目。在项目修复之前，流量标签页和过滤器的更改不会被保存。 | Consistency: load → 加载 (was 载入/加载 mixed). |
| Projects save tab names, filters, and layout. Each Project keeps separate in-memory traffic. | 项目会保存标签页名称、筛选器和布局。每个项目分别保留独立的内存中流量。 | 项目会保存标签页名称、筛选器和布局。每个项目在内存中分别保留独立的流量。 | Word order: separate in-memory traffic → 在内存中分别保留独立的流量. |
| Provider API base URL | 提供方 API 基础 URL | 提供商 API 基础 URL | Terminology: provider → 提供商 (contextual rationale in glossary below). |
| Provider data and API documentation | 提供方数据和 API 文档 | 提供商数据和 API 文档 | Terminology: provider → 提供商 (contextual rationale in glossary below). |
| Provider, chain, or node baseline | 提供方、链或节点基准 | 提供商、链或节点基线 | Terminology: provider → 提供商 (contextual rationale in glossary below). |
| Raw includes the request or status line and headers. Other formats focus on body content and may show an unavailable state when the selected payload does not match. | Raw 包含请求行或状态行以及标头。其他格式侧重于正文内容，当选定的有效负载不匹配时可能显示为不可用状态。 | Raw 包含请求行或状态行以及标头。其他格式侧重于正文内容，当选定的有效载荷不匹配时可能显示为不可用状态。 | Terminology: payload → 有效载荷 (contextual rationale in glossary below). |
| Ready for HTTPS interception | 已准备好进行 HTTPS 拦截 | HTTPS 拦截已就绪 | Machine-translation filler removed while keeping the natural 对…脱敏 structure (进行脱敏 → 对…脱敏; 已准备好进行 HTTPS 拦截 → HTTPS 拦截已就绪). |
| Recording | 正在录制 | 正在记录 | Consistency: recording → 记录 (traffic recording; 录制 implies audio/video). |
| Recording Paused | 录制已暂停 | 记录已暂停 | Consistency: recording → 记录 (traffic recording; 录制 implies audio/video). |
| Redact recognized sensitive data | 对识别到的敏感数据进行脱敏 | 对识别到的敏感数据脱敏 | Machine-translation filler removed while keeping the natural 对…脱敏 structure (进行脱敏 → 对…脱敏; 已准备好进行 HTTPS 拦截 → HTTPS 拦截已就绪). |
| Redact Sensitive Data Before Sending to AI | 发送到 AI 前对敏感数据进行脱敏 | 发送到 AI 前对敏感数据脱敏 | Machine-translation filler removed while keeping the natural 对…脱敏 structure (进行脱敏 → 对…脱敏; 已准备好进行 HTTPS 拦截 → HTTPS 拦截已就绪). |
| Redacting sensitive fields | 正在对敏感字段进行脱敏 | 正在对敏感字段脱敏 | Machine-translation filler removed while keeping the natural 对…脱敏 structure (进行脱敏 → 对…脱敏; 已准备好进行 HTTPS 拦截 → HTTPS 拦截已就绪). |
| Redacts recognized sensitive headers, URLs, and body values (Authorization, Cookie, API keys) before upload. Best-effort, not a guarantee. | 上传前会对识别出的敏感标头、URL 和正文值（Authorization、Cookie、API 密钥）进行脱敏。此操作会尽力而为，但不作保证。 | 上传前会对识别出的敏感标头、URL 和正文值（Authorization、Cookie、API 密钥）脱敏。此操作会尽力而为，但不作保证。 | Machine-translation filler removed while keeping the natural 对…脱敏 structure (进行脱敏 → 对…脱敏; 已准备好进行 HTTPS 拦截 → HTTPS 拦截已就绪). |
| Related requests are included only when you opt in. | 仅在你选择加入时才会包括相关请求。 | 仅在你选择加入时才会包含相关请求。 | Consistency: second-person pronoun unified to 你 (Apple Simplified Chinese UI style; was 您/你 mixed). |
| Remote model endpoints must use HTTPS. Plain HTTP is allowed only on this Mac. | 远程模型端点必须使用 HTTPS。仅允许在此 Mac 上使用纯 HTTP。 | 远程模型端点必须使用 HTTPS。仅允许在这台 Mac 上使用纯 HTTP。 | Consistency: this Mac → 这台 Mac (Apple wording; “your machine” is a computer, not a 设备). |
| Reset Background Items | 重置后台项目 | 重置后台项 | Terminology: Background Items → 后台项 (contextual rationale in glossary below). |
| Resume Recording | 恢复录制 | 恢复记录 | Consistency: recording → 记录 (traffic recording; 录制 implies audio/video). |
| Review & Share… | 审阅并共享… | 审查并共享… | Terminology: review → 审查 (contextual rationale in glossary below). |
| Rewrite matching requests to a different host, port, path, or query. | 将匹配的请求改写到其他主机、端口、路径或查询。 | 将匹配的请求重写到其他主机、端口、路径或查询。 | Terminology: rewrite → 重写 (contextual rationale in glossary below). |
| Rockxy can share this Mac's public Root CA over a temporary local link, while Android still requires manual proxy, user CA, and debug trust configuration; release builds generally will not trust user CAs. | Rockxy 可通过临时本地链接共享此 Mac 的公开根 CA，而 Android 仍需手动配置代理、用户 CA 和调试信任；发布构建通常不会信任用户 CA。 | Rockxy 可通过临时本地链接共享这台 Mac 的公开根 CA，而 Android 仍需手动配置代理、用户 CA 和调试信任；发布构建通常不会信任用户 CA。 | Terminology: public (key/cert) → 公开 (contextual rationale in glossary below). |
| Rockxy could not include the excluded traffic. The reviewed data is unchanged. | Rockxy 无法包括已排除的流量。审查的数据未发生变化。 | Rockxy 无法包含已排除的流量。审查的数据未发生变化。 | Terminology: review → 审查 (contextual rationale in glossary below). |
| Rockxy could not load the default root certificate details. | Rockxy 无法载入默认根证书的详细信息。 | Rockxy 无法加载默认根证书的详细信息。 | Consistency: load → 加载 (was 载入/加载 mixed). |
| Rockxy does not collect analytics or crash reports. Captured traffic stays on your machine unless you explicitly export, share, or publish it. | Rockxy 不收集分析或崩溃报告。捕获的流量会留在你的设备上，除非你明确导出、共享或发布。 | Rockxy 不收集分析或崩溃报告。捕获的流量会留在你这台 Mac 上，除非你明确导出、共享或发布。 | Consistency: this Mac → 这台 Mac (Apple wording; “your machine” is a computer, not a 设备). |
| Rockxy generates a local root Certificate Authority (CA) to create per-host certificates for HTTPS traffic interception. The root CA must be installed and trusted in your macOS Keychain. No certificate data leaves your machine. | Rockxy 会生成本地根证书颁发机构 (CA)，以便为每个主机创建证书并拦截 HTTPS 流量。必须在 macOS 钥匙串中安装并信任根 CA。任何证书数据都不会离开你的设备。 | Rockxy 会生成本地根证书颁发机构 (CA)，以便为每个主机创建证书并拦截 HTTPS 流量。必须在 macOS 钥匙串中安装并信任根 CA。任何证书数据都不会离开这台 Mac。 | Consistency: this Mac → 这台 Mac (Apple wording; “your machine” is a computer, not a 设备). |
| Rockxy is capturing traffic on this Mac. | Rockxy 正在此 Mac 上捕获流量。 | Rockxy 正在这台 Mac 上捕获流量。 | Consistency: this Mac → 这台 Mac (Apple wording; “your machine” is a computer, not a 设备). |
| Rockxy is using direct macOS proxy changes because %@. If Rockxy or Xcode stops unexpectedly, your Mac may stay behind a dead proxy until Rockxy restores it. Install or repair the helper tool for safer automatic cleanup. | 由于 %@，Rockxy 正在直接更改 macOS 代理。如果 Rockxy 或 Xcode 意外停止，你的 Mac 可能会一直使用失效的代理，直到 Rockxy 将其恢复。请安装或修复 Helper 工具，以便更安全地自动清理。 | 由于 %@，Rockxy 正在直接更改 macOS 代理。如果 Rockxy 或 Xcode 意外停止，你的 Mac 可能会一直使用失效的代理，直到 Rockxy 将其恢复。请安装或修复辅助工具，以便更安全地自动清理。 | Terminology: helper (tool) → 辅助工具 (contextual rationale in glossary below). |
| Rockxy kept the app connected by returning this host to a protected encrypted tunnel. | Rockxy 通过将此主机返回到受保护的加密隧道，使应用保持连接。 | Rockxy 通过将此主机重新置于受保护的加密隧道，使应用保持连接。 | returning this host to a protected encrypted tunnel → 重新置于受保护的加密隧道. |
| Rockxy needs a Root CA certificate to inspect HTTPS traffic. This wizard will generate a local certificate, install it in your macOS Keychain, and verify the setup. No certificate data leaves your machine. | Rockxy 需要根 CA 证书才能检查 HTTPS 流量。此向导将生成本地证书，将其安装到您的 macOS 钥匙串，并验证设置。任何证书数据都不会离开您的设备。 | Rockxy 需要根 CA 证书才能检查 HTTPS 流量。此向导将生成本地证书，将其安装到你的 macOS 钥匙串，并验证设置。任何证书数据都不会离开这台 Mac。 | Pronoun 您→你 unified to 你 (Apple Simplified Chinese UI style); Consistency: this Mac → 这台 Mac (Apple wording; “your machine” is a computer, not a 设备). |
| Rockxy removed stale helper files and asked macOS to reset Login and Background Items data. | Rockxy 已移除过时的 Helper 文件，并请求 macOS 重置登录项和后台项目数据。 | Rockxy 已移除过时的辅助工具文件，并请求 macOS 重置登录项和后台项数据。 | Terminology: helper (tool) → 辅助工具 (contextual rationale in glossary below). |
| Rockxy ships a dynamic route handler plus the next dev env block, including NODE_USE_ENV_PROXY, so server-side fetch can then route through Rockxy. | Rockxy 提供动态路由处理程序以及下一个开发环境块，其中包括 NODE_USE_ENV_PROXY，以便服务器端 fetch 随后可通过 Rockxy 路由。 | Rockxy 提供动态路由处理程序以及 next dev 环境配置块，其中包含 NODE_USE_ENV_PROXY，以便服务器端 fetch 随后可通过 Rockxy 路由。 | Mistranslation: `next dev` (the Next.js dev-server command) was rendered as 下一个开发环境块 (“the next development environment block”); the command name must stay `next dev`. |
| Rockxy ships a Firefox settings snippet plus a cURL preflight step so you can confirm the proxy path before touching the browser. | Rockxy 提供 Firefox 设置片段和 cURL 预检步骤，以便您在更改浏览器前确认代理路径。 | Rockxy 提供 Firefox 设置片段和 cURL 预检步骤，以便你在更改浏览器前确认代理路径。 | Pronoun 您→你 unified to 你 (Apple Simplified Chinese UI style); Consistency: second-person pronoun unified to 你 (Apple Simplified Chinese UI style; was 您/你 mixed). |
| Rockxy ships one shell-launch command and one main-process session.setProxy snippet, both pointed at 127.0.0.1 on the active port. | Rockxy 提供一个 shell 启动命令和一个主进程 session.setProxy 片段，两者都指向活动端口上的 127.0.0.1。 | Rockxy 提供一个 shell 启动命令和一个主进程 session.setProxy 片段，两者都指向当前端口上的 127.0.0.1。 | Terminology: active port → 当前端口 (the port currently in use). |
| Rockxy will stop capture, request administrator approval, remove stale helper files and registration state, then reinstall the helper from this app.  Use this when Install, Retry, Update, or Reinstall cannot recover the helper. | Rockxy 将停止捕获、请求管理员批准、移除过时的 Helper 文件和注册状态，然后从此应用重新安装 Helper。  当“安装”、“重试”、“更新”或“重新安装”都无法恢复 Helper 时，请使用此功能。 | Rockxy 将停止捕获、请求管理员批准、移除过时的辅助工具文件和注册状态，然后从此应用重新安装辅助工具。  当“安装”、“重试”、“更新”或“重新安装”都无法恢复辅助工具时，请使用此功能。 | Terminology: helper (tool) → 辅助工具 (contextual rationale in glossary below). |
| Rockxy will use networksetup and may ask for your password. | Rockxy 将使用 networksetup，并可能要求您输入密码。 | Rockxy 将使用 networksetup，并可能要求你输入密码。 | Pronoun 您→你 unified to 你 (Apple Simplified Chinese UI style); Consistency: second-person pronoun unified to 你 (Apple Simplified Chinese UI style; was 您/你 mixed). |
| Rockxy-owned response file available | Rockxy 所有的响应文件可用 | 有由 Rockxy 生成的响应文件可用 | Ambiguity: “Rockxy-owned response file” read as 所有的响应文件 (“all response files”); now clearly 由 Rockxy 生成的响应文件. |
| Run the Validate tab's generated request from your Flutter client and confirm Rockxy captures it before you debug broader flows. This validates the proxy path, not the exact device, emulator, simulator, or Dart runtime that emitted the request. | 从 Flutter 客户端运行“验证”标签页生成的请求，并在调试更广泛的流程前确认 Rockxy 已捕获该请求。这会验证代理路径，而非发出请求的确切设备、模拟器、仿真器或 Dart 运行时。 | 从 Flutter 客户端运行“验证”标签页生成的请求，并在调试更广泛的流程前确认 Rockxy 已捕获该请求。这会验证代理路径，而非发出请求的确切设备、仿真器、模拟器或 Dart 运行时。 | Terminology: simulator / emulator (in paired strings) → 模拟器 / 仿真器 (contextual rationale in glossary below). |
| Save a complete provider configuration to enable model access. | 请保存完整的提供方配置以启用模型访问。 | 请保存完整的提供商配置以启用模型访问。 | Terminology: provider → 提供商 (contextual rationale in glossary below). |
| Save the public Rockxy root CA as a PEM file | 将公共 Rockxy 根 CA 保存为 PEM 文件 | 将公开 Rockxy 根 CA 保存为 PEM 文件 | Terminology: public (key/cert) → 公开 (contextual rationale in glossary below). |
| Saved listener settings apply after the proxy restarts. The live endpoint above stays active until then. | 代理重新启动后，保存的监听器设置才会生效。在此之前，上方的实时端点将保持活动。 | 代理重新启动后，保存的监听器设置才会生效。在此之前，上方的实时端点仍保持可用。 | Terminology: active (context-dependent) → 可用 (contextual rationale in glossary below). |
| Saved, but script failed to load | 已保存，但脚本载入失败 | 已保存，但脚本加载失败 | Consistency: load → 加载 (was 载入/加载 mixed). |
| Saved, but the 10-enabled-script quota is reached. Disable another script to activate this one. | 已保存，但已达到启用 10 个脚本的配额。请禁用其他脚本以激活此脚本。 | 已保存，但已达到启用 10 个脚本的配额。请停用其他脚本以激活此脚本。 | Terminology: disable → 停用 (contextual rationale in glossary below). |
| Scripting is off. Enabled scripts are kept, but none run until you turn Scripting on. | 脚本功能已关闭。已启用的脚本会保留，但在您开启脚本功能前不会运行。 | 脚本功能已关闭。已启用的脚本会保留，但在你开启脚本功能前不会运行。 | Pronoun 您→你 unified to 你 (Apple Simplified Chinese UI style); Consistency: second-person pronoun unified to 你 (Apple Simplified Chinese UI style; was 您/你 mixed). |
| Select a frame to inspect its payload. | 选择一个帧以检查其载荷。 | 选择一个帧以检查其有效载荷。 | Terminology: payload → 有效载荷 (contextual rationale in glossary below). |
| Select a local file to serve for matched requests | 选择要为匹配请求提供的本地文件 | 选择用于响应匹配请求的本地文件 | Phrasing: serve for matched requests → 用于响应匹配请求的本地文件. |
| Select a runtime event to inspect its identifiers, timing, and metadata. | 选择一个运行时事件以检查其标识符、时间和元数据。 | 选择一个运行时事件以检查其标识符、时序和元数据。 | Terminology: timing → 时序 (contextual rationale in glossary below). |
| Select one request to inspect payload and timing details. | 选择一个请求以检查有效载荷和计时详细信息。 | 选择一个请求以检查有效载荷和时序详细信息。 | Terminology: payload → 有效载荷 (contextual rationale in glossary below). |
| Select one request to inspect raw payload, or exactly two requests to compare. | 选择一个请求以检查原始载荷，或恰好选择两个请求进行比较。 | 选择一个请求以检查原始有效载荷，或恰好选择两个请求进行比较。 | Terminology: payload → 有效载荷 (contextual rationale in glossary below). |
| Select two requests and choose "Compare Selected" to start a basic local compare. | 选择两个请求并选取 "比较所选项"，即可开始基本本地比较。 | 选择两个请求并选取 “比较所选项”，即可开始基本本地比较。 | Consistency: ASCII straight quotes replaced with full-width “ ” / ‘ ’ in Chinese text. |
| Sensitive headers, query values, and body fields are redacted before Review Data. | 敏感标头、查询值和正文字段会在“审阅数据”之前被脱敏。 | 敏感标头、查询值和正文字段会在“审查数据”之前被脱敏。 | Terminology: review → 审查 (contextual rationale in glossary below). |
| Share the public Rockxy Root CA from this Mac as a temporary local QR code and link, then finish the platform trust steps on the device or simulator. | 从此 Mac 以临时本地 QR 码和链接的形式共享公开的 Rockxy 根 CA，然后在设备或模拟器上完成平台信任步骤。 | 从这台 Mac 以临时本地 QR 码和链接的形式共享公开的 Rockxy 根 CA，然后在设备或模拟器上完成平台信任步骤。 | Terminology: public (key/cert) → 公开 (contextual rationale in glossary below). |
| SSE cadence is shown from captured events. Token boundaries stay unavailable unless the provider exposes them. | SSE 节奏根据已捕获的事件显示。除非提供方公开 token 边界，否则 token 边界不可用。 | SSE 节奏根据已捕获的事件显示。除非提供商公开 token 边界，否则 token 边界不可用。 | Terminology: provider → 提供商 (contextual rationale in glossary below). |
| SSL Proxying is already enabled for %@. Make the request again to inspect it. | 已为 %@ 启用 SSL 代理。请再次发出请求以进行检查。 | 已为 %@ 启用 SSL 代理。请再次发送请求以检查它。 | Inconsistent rendering of the same phrase: 发出请求 vs 发送请求; 以进行检查 vs 以检查它 (matching the sibling string). |
| Start Ollama on this Mac, then check again. (%@) | 在此 Mac 上启动 Ollama，然后再次检查。（%@） | 在这台 Mac 上启动 Ollama，然后再次检查。（%@） | Consistency: this Mac → 这台 Mac (Apple wording; “your machine” is a computer, not a 设备). |
| Start the proxy before changing recording. ⌥⌘R | 更改录制状态前，请先启动代理。⌥⌘R | 更改记录状态前，请先启动代理。⌥⌘R | Consistency: recording → 记录 (traffic recording; 录制 implies audio/video). |
| Status, timing, payload, and rule checks look normal. | 状态、时间、负载和规则检查看起来正常。 | 状态、时序、有效载荷和规则检查看起来正常。 | Terminology: payload → 有效载荷 (contextual rationale in glossary below). |
| Store .proto source files on this Mac. | 将 .proto 源文件存储在此 Mac 上。 | 将 .proto 源文件存储在这台 Mac 上。 | Consistency: this Mac → 这台 Mac (Apple wording; “your machine” is a computer, not a 设备). |
| The active Block List rule limit was reached. Disable another rule and try again. | 已达到活动阻止列表规则的上限。请禁用另一条规则后重试。 | 已达到阻止列表规则的启用上限。请停用另一条规则后重试。 | Terminology: active (context-dependent) → 生效中 (contextual rationale in glossary below). |
| The active Breakpoint rule limit was reached. Disable another rule and try again. | 已达到活动断点规则上限。请禁用另一条规则后重试。 | 已达到断点规则的启用上限。请停用另一条规则后重试。 | Terminology: active (context-dependent) → 生效中 (contextual rationale in glossary below). |
| The active filter matches no requests | 活动筛选器没有匹配任何请求 | 当前筛选器没有匹配任何请求 | Terminology: filter (active filter) → 当前筛选器 (contextual rationale in glossary below). |
| The active Map Local rule limit was reached. Disable another rule and try again. | 已达到活跃 Map Local 规则的上限。请停用另一条规则，然后重试。 | 已达到 Map Local 规则的启用上限。请停用另一条规则，然后重试。 | Terminology: active (context-dependent) → 生效中 (contextual rationale in glossary below). |
| The active Map Remote rule limit was reached. Disable another rule and try again. | 已达到活动 Map Remote 规则的上限。请禁用另一条规则后重试。 | 已达到 Map Remote 规则的启用上限。请停用另一条规则后重试。 | Terminology: active (context-dependent) → 生效中 (contextual rationale in glossary below). |
| The Block List returns 403 or drops the connection for matching requests, so you can simulate an endpoint being unavailable. | 阻止列表会对匹配请求返回 403 或断开连接，让您可以模拟端点不可用的情况。 | 阻止列表会对匹配请求返回 403 或断开连接，让你可以模拟端点不可用的情况。 | Pronoun 您→你 unified to 你 (Apple Simplified Chinese UI style); Consistency: second-person pronoun unified to 你 (Apple Simplified Chinese UI style; was 您/你 mixed). |
| The captured requests are no longer available for review. | 捕获的请求已不再可供审阅。 | 捕获的请求已不再可供审查。 | Terminology: review → 审查 (contextual rationale in glossary below). |
| The configured provider is processing the reviewed request context. | 已配置的提供商正在处理已审阅的请求上下文。 | 已配置的提供商正在处理已审查的请求上下文。 | Terminology: provider → 提供商 (contextual rationale in glossary below). |
| The CONNECT exchange establishes a tunnel; application HTTPS payloads belong to traffic inside that tunnel. | CONNECT 交换会建立隧道；应用程序 HTTPS 有效载荷属于该隧道内的流量。 | CONNECT 交互会建立隧道；应用程序 HTTPS 有效载荷属于该隧道内的流量。 | exchange → 交互 (not 交换) in “CONNECT exchange” / “proven by this exchange”. |
| The Gist payload is %@, which is larger than the 25 MB limit. | Gist 负载为 %@，超过了 25 MB 的限制。 | Gist 有效载荷为 %@，超过了 25 MB 的限制。 | Terminology: payload → 有效载荷 (contextual rationale in glossary below). |
| The helper is registered, but Rockxy cannot reach it. | Helper 已注册，但 Rockxy 无法与其连接。 | 辅助工具已注册，但 Rockxy 无法与其连接。 | Terminology: helper (tool) → 辅助工具 (contextual rationale in glossary below). |
| the helper tool could not be used | 无法使用 Helper 工具 | 无法使用辅助工具 | Terminology: helper (tool) → 辅助工具 (contextual rationale in glossary below). |
| the helper tool needs to be updated | 需要更新 Helper 工具 | 需要更新辅助工具 | Terminology: helper (tool) → 辅助工具 (contextual rationale in glossary below). |
| The helper tool will be removed. Rockxy will use networksetup and may ask for your password. | 辅助工具将被移除。Rockxy 将使用 networksetup，并可能要求您输入密码。 | 辅助工具将被移除。Rockxy 将使用 networksetup，并可能要求你输入密码。 | Pronoun 您→你 unified to 你 (Apple Simplified Chinese UI style); Terminology: helper (tool) → 辅助工具 (contextual rationale in glossary below). |
| The Host header stays as the original request sent it. The destination host, DNS lookup, and TLS server name still use the rewritten host above. | Host 标头会保持原始请求发送时的值。目标主机、DNS 查询和 TLS 服务器名称仍使用上方改写后的主机。 | Host 标头会保持原始请求发送时的值。目标主机、DNS 查询和 TLS 服务器名称仍使用上方重写后的主机。 | Terminology: rewrite → 重写 (contextual rationale in glossary below). |
| the installed helper does not match this copy of Rockxy — reinstall it before continuing | 已安装的 Helper 与此 Rockxy 副本不匹配，请重新安装后再继续 | 已安装的辅助工具与此 Rockxy 副本不匹配，请重新安装后再继续 | Terminology: helper (tool) → 辅助工具 (contextual rationale in glossary below). |
| The installed helper is incompatible with this version of Rockxy. | 安装的 Helper 与此版本的 Rockxy 不兼容。 | 安装的辅助工具与此版本的 Rockxy 不兼容。 | Terminology: helper (tool) → 辅助工具 (contextual rationale in glossary below). |
| The listener is accepting local-network connections on this Mac. | 监听器正在此 Mac 上接受本地网络连接。 | 监听器正在这台 Mac 上接受本地网络连接。 | Consistency: this Mac → 这台 Mac (Apple wording; “your machine” is a computer, not a 设备). |
| The provider credential cannot access this model or endpoint. | 该提供方凭据无法访问此模型或端点。 | 该提供商凭据无法访问此模型或端点。 | Terminology: provider → 提供商 (contextual rationale in glossary below). |
| The provider credential is missing. Replace it in Settings. | 缺少提供方凭据。请在设置中替换它。 | 缺少提供商凭据。请在设置中替换它。 | Terminology: provider → 提供商 (contextual rationale in glossary below). |
| The provider rate limit was reached. Try again in %lld seconds. | 已达到提供方速率限制。请在 %lld 秒后重试。 | 已达到提供商速率限制。请在 %lld 秒后重试。 | Terminology: provider → 提供商 (contextual rationale in glossary below). |
| The provider rejected the saved credential. | 提供方拒绝了已保存的凭据。 | 提供商拒绝了已保存的凭据。 | Terminology: provider → 提供商 (contextual rationale in glossary below). |
| The provider returned HTTP %1$lld: %2$@ | 提供方返回了 HTTP %1$lld：%2$@ | 提供商返回了 HTTP %1$lld：%2$@ | Terminology: provider → 提供商 (contextual rationale in glossary below). |
| The proxy helper tool will be removed. You may be prompted for your password when changing proxy settings. | 代理 Helper 工具将被移除。更改代理设置时，系统可能会提示你输入密码。 | 代理辅助工具将被移除。更改代理设置时，系统可能会提示你输入密码。 | Terminology: helper (tool) → 辅助工具 (contextual rationale in glossary below). |
| The reconciled Projects were structurally invalid and were not applied. | 协调后的项目结构无效，未被应用。 | 合并整理后的项目结构无效，未被应用。 | reconciled Projects → 合并整理后的项目 (协调 was too literal). |
| These mapping definitions are stored locally on this Mac. This build decodes Protobuf with heuristics only — saved mappings and schemas are not applied to captured traffic. | 这些映射定义存储在此 Mac 本地。此版本仅使用启发式方法解码 Protobuf — 已保存的映射和架构不会应用于已捕获的流量。 | 这些映射定义存储在这台 Mac 本地。此版本仅使用启发式方法解码 Protobuf — 已保存的映射和架构不会应用于已捕获的流量。 | Consistency: this Mac → 这台 Mac (Apple wording; “your machine” is a computer, not a 设备). |
| This gRPC message is compressed. Rockxy preserves the frame boundary but does not decode compressed message payloads yet. | 此 gRPC 消息已压缩。Rockxy 会保留帧边界，但尚未解码压缩的消息负载。 | 此 gRPC 消息已压缩。Rockxy 会保留帧边界，但尚未解码压缩的消息有效载荷。 | Terminology: payload → 有效载荷 (contextual rationale in glossary below). |
| This link serves only your public Rockxy Root CA from this Mac. It expires automatically. Do not install certificates from unknown sources. | 此链接仅从这台 Mac 提供您的公共 Rockxy 根 CA。它会自动过期。请勿安装来源不明的证书。 | 此链接仅从这台 Mac 提供你的公开 Rockxy 根 CA。它会自动过期。请勿安装来源不明的证书。 | Pronoun 您→你 unified to 你 (Apple Simplified Chinese UI style); Terminology: public (key/cert) → 公开 (contextual rationale in glossary below). |
| This Mac and local network | 此 Mac 和本地网络 | 这台 Mac 和本地网络 | Consistency: this Mac → 这台 Mac (Apple wording; “your machine” is a computer, not a 设备). |
| This provider needs its native adapter. Select OpenAI, Anthropic, Gemini, an OpenAI-compatible endpoint, or Ollama. | 此提供方需要使用其原生适配器。请选择 OpenAI、Anthropic、Gemini、OpenAI 兼容端点或 Ollama。 | 此提供商需要使用其原生适配器。请选择 OpenAI、Anthropic、Gemini、OpenAI 兼容端点或 Ollama。 | Terminology: provider → 提供商 (contextual rationale in glossary below). |
| This removes the stored %@ file from this Mac. | 这会从此 Mac 移除存储的 %@ 文件。 | 这会从这台 Mac 移除存储的 %@ 文件。 | Consistency: this Mac → 这台 Mac (Apple wording; “your machine” is a computer, not a 设备). |
| This review is limited to the selected requests. Other traffic will not be included. | 此审阅仅限于所选请求。其他流量将不会被包含。 | 此审查仅限于所选请求。其他流量将不会被包含。 | Terminology: review → 审查 (contextual rationale in glossary below). |
| This Rockxy app package is incomplete, so the helper tool cannot be installed. Reinstall the latest Rockxy release. If you installed Rockxy from Homebrew, reinstall it after the fixed release is published. | 此 Rockxy App 包不完整，因此无法安装辅助工具。请重新安装最新的 Rockxy 版本。如果您通过 Homebrew 安装了 Rockxy，请在修复版本发布后重新安装。 | 此 Rockxy App 包不完整，因此无法安装辅助工具。请重新安装最新的 Rockxy 版本。如果你通过 Homebrew 安装了 Rockxy，请在修复版本发布后重新安装。 | Pronoun 您→你 unified to 你 (Apple Simplified Chinese UI style); Terminology: helper (tool) → 辅助工具 (contextual rationale in glossary below). |
| This row exists for honest guidance; do not expect one-click pairing or automated certificate installation for the headset today. | 此行旨在提供如实指引；目前不要期待耳机会支持一键配对或自动安装证书。 | 此行旨在提供如实指引；目前不要期待头显会支持一键配对或自动安装证书。 | Mistranslation: “headset” here means Vision Pro (Apple 头显); 耳机 (“earphones”) is wrong. The sibling string already uses 头显. |
| This rule could not be saved. Disable another Breakpoint rule and try again. | 无法保存此规则。请禁用另一条断点规则后重试。 | 无法保存此规则。请停用另一条断点规则后重试。 | Terminology: disable → 停用 (contextual rationale in glossary below). |
| This runs sfltool resetbtm after removing Rockxy helper files. It can reset Background Items state for other apps, so use it only when the normal force reset cannot recover Rockxy. | 这会在移除 Rockxy 辅助工具文件后运行 sfltool resetbtm。它可能会重置其他 App 的后台项目状态，因此仅应在正常强制重置无法恢复 Rockxy 时使用。 | 这会在移除 Rockxy 辅助工具文件后运行 sfltool resetbtm。它可能会重置其他 App 的后台项状态，因此仅应在正常强制重置无法恢复 Rockxy 时使用。 | Terminology: helper (tool) → 辅助工具 (contextual rationale in glossary below). |
| This will install the root certificate in your macOS Keychain and mark it as trusted. macOS will prompt you for your password to authorize this change. | 这会将根证书安装到您的 macOS 钥匙串并标记为受信任。macOS 会提示您输入密码以授权此更改。 | 这会将根证书安装到你的 macOS 钥匙串并标记为受信任。macOS 会提示你输入密码以授权此更改。 | Pronoun 您→你 unified to 你 (Apple Simplified Chinese UI style); Consistency: second-person pronoun unified to 你 (Apple Simplified Chinese UI style; was 您/你 mixed). |
| Timing | 计时 | 时序 | Terminology: timing → 时序 (contextual rationale in glossary below). |
| Total captured payload bytes | 捕获的载荷总字节数 | 捕获的有效载荷总字节数 | Terminology: payload → 有效载荷 (contextual rationale in glossary below). |
| Trace the status, response headers, timing, and nearby failures. | 追踪状态、响应标头、时间和附近的故障。 | 追踪状态、响应标头、时序和附近的故障。 | Terminology: timing → 时序 (contextual rationale in glossary below). |
| Try Background Items Reset | 尝试重置后台项目 | 尝试重置后台项 | Terminology: Background Items → 后台项 (contextual rationale in glossary below). |
| Turn on HTTPS decryption for new connections to %@ | 为连接到 %@ 的新连接开启 HTTPS 解密 | 为连接到 %@ 的新连接启用 HTTPS 解密 | Consistency: on/off wording uses 启用 (开启→启用; Allow List 已开启→已启用), pairing with 停用. |
| Unexpected '='. | 意外的 '='。 | 意外的 ‘=’。 | Consistency: ASCII straight quotes replaced with full-width “ ” / ‘ ’ in Chinese text. |
| Unexpected character '%@'. | 意外字符 '%@'。 | 意外字符 ‘%@’。 | Consistency: ASCII straight quotes replaced with full-width “ ” / ‘ ’ in Chinese text. |
| Unpin Evidence | 取消固定证据 | 取消置顶证据 | Terminology: pin / pinned (UI) → 置顶 (contextual rationale in glossary below). |
| Unpin the selected request from the current session. | 从当前会话中取消固定所选请求。 | 从当前会话中取消置顶所选请求。 | Terminology: pin / pinned (UI) → 置顶 (contextual rationale in glossary below). |
| Use this as provider/chain baseline before comparing app calls. | 在比较应用调用之前，将其用作提供方/链的基准。 | 在比较应用调用之前，将其用作提供商/链的基线。 | Terminology: provider → 提供商 (contextual rationale in glossary below). |
| When off, Block List rules are skipped. Other intervention rules remain active. | 关闭后将跳过阻止列表规则。其他干预规则仍保持活动。 | 关闭后将跳过阻止列表规则。其他干预规则仍保持生效。 | Terminology: active (context-dependent) → 生效中 (contextual rationale in glossary below). |
| You can cancel this check at any time. | 您可以随时取消此检查。 | 你可以随时取消此检查。 | Pronoun 您→你 unified to 你 (Apple Simplified Chinese UI style); Consistency: second-person pronoun unified to 你 (Apple Simplified Chinese UI style; was 您/你 mixed). |
| You: %@ | 您：%@ | 你：%@ | Pronoun 您→你 unified to 你 (Apple Simplified Chinese UI style); Consistency: second-person pronoun unified to 你 (Apple Simplified Chinese UI style; was 您/你 mixed). |
| Your current recording Request/Response data will be lost. Rockxy will stop capturing and restore macOS proxy settings before quitting. | 当前录制的请求/响应数据将丢失。Rockxy 将停止捕获，并在退出前恢复 macOS 代理设置。 | 当前记录的请求/响应数据将丢失。Rockxy 将停止捕获，并在退出前恢复 macOS 代理设置。 | Consistency: recording → 记录 (traffic recording; 录制 implies audio/video). |

</details>

## Checklist
- [ ] Tests added or updated — N/A (String Catalog only, no Swift changes)
- [ ] `CHANGELOG.md` updated under `[Unreleased]` — N/A (translation-only PR; English strings and behavior unchanged)
- [ ] Docs updated in `docs/` — N/A (no docs change; the internal audit report is intentionally not part of this PR)
- [ ] User-facing strings localized with `String(localized:)` — N/A (no new strings)
- [x] If string catalogs changed: placeholders and non-translatable technical details are unchanged
- [x] If string catalogs changed: `python3 .github/tools/validate_xcstrings.py` passes
- [ ] No SwiftLint / SwiftFormat violations — N/A (no Swift changes; translation-only PR per CONTRIBUTING.md)
- [ ] Helper packaging / release scripts / platform-compatibility claims — N/A

## CLA
This is a community contribution; the Rockxy CLA check will comment with the acceptance statement and I will accept the ICLA v2.0 before merge.


