### PR TITLE
fix(https): reset live tunnels when decryption policy changes

### DIFF
--- a/Rockxy/Core/ProxyEngine/HTTPProxyHandler.swift
+++ b/Rockxy/Core/ProxyEngine/HTTPProxyHandler.swift
@@ -32,10 +32,14 @@ final class HTTPProxyHandler: ChannelInboundHandler, RemovableChannelHandler, @u
         ruleEngine: RuleEngine,
         scriptPluginManager: ScriptPluginManager? = nil,
         connectionLimiter: ConnectionLimiter,
+        sslProxyingManager: SSLProxyingManager,
+        bypassProxyManager: BypassProxyManager,
         customCertificateManager: CustomCertificateManager = .shared,
         upstreamProxySnapshotProvider: @escaping @Sendable () -> UpstreamProxyResolvedConfiguration? = { nil },
         captureContextProvider: @escaping @Sendable () -> TrafficCaptureContext? = { nil },
         clientIdentityHandle: ClientIdentityHandle? = nil,
+        clientConnectionDescriptor: ProxyConnectionDescriptor? = nil,
+        liveTunnelRegistry: LiveTunnelRegistry? = nil,
         onTransactionComplete: @escaping @Sendable (HTTPTransaction) -> Void,
         onBreakpointHit: (@Sendable (BreakpointRequestData) async -> (BreakpointDecision, BreakpointRequestData))? =
             nil,
@@ -45,10 +49,14 @@ final class HTTPProxyHandler: ChannelInboundHandler, RemovableChannelHandler, @u
         self.ruleEngine = ruleEngine
         self.scriptPluginManager = scriptPluginManager
         self.connectionLimiter = connectionLimiter
+        self.sslProxyingManager = sslProxyingManager
+        self.bypassProxyManager = bypassProxyManager
         self.customCertificateManager = customCertificateManager
         self.upstreamProxySnapshotProvider = upstreamProxySnapshotProvider
         self.captureContextProvider = captureContextProvider
         self.clientIdentityHandle = clientIdentityHandle
+        self.clientConnectionDescriptor = clientConnectionDescriptor
+        self.liveTunnelRegistry = liveTunnelRegistry
         self.onTransactionComplete = onTransactionComplete
         self.onBreakpointHit = onBreakpointHit
         self.breakpointBridgeTracker = breakpointBridgeTracker
@@ -124,10 +132,14 @@ final class HTTPProxyHandler: ChannelInboundHandler, RemovableChannelHandler, @u
     private let ruleEngine: RuleEngine
     private let scriptPluginManager: ScriptPluginManager?
     private let connectionLimiter: ConnectionLimiter
+    private let sslProxyingManager: SSLProxyingManager
+    private let bypassProxyManager: BypassProxyManager
     private let customCertificateManager: CustomCertificateManager
     private let upstreamProxySnapshotProvider: @Sendable () -> UpstreamProxyResolvedConfiguration?
     private let captureContextProvider: @Sendable () -> TrafficCaptureContext?
     private let clientIdentityHandle: ClientIdentityHandle?
+    private let clientConnectionDescriptor: ProxyConnectionDescriptor?
+    private let liveTunnelRegistry: LiveTunnelRegistry?
     private let onTransactionComplete: @Sendable (HTTPTransaction) -> Void
     private let onBreakpointHit: (@Sendable (BreakpointRequestData) async -> (
         BreakpointDecision,
@@ -714,13 +726,16 @@ extension HTTPProxyHandler {
                 ruleEngine: self.ruleEngine,
                 scriptPluginManager: self.scriptPluginManager,
                 connectionLimiter: self.connectionLimiter,
-                bypassProxyManager: .shared,
+                sslProxyingManager: self.sslProxyingManager,
+                bypassProxyManager: self.bypassProxyManager,
                 customCertificateManager: self.customCertificateManager,
                 upstreamProxySnapshotProvider: self.upstreamProxySnapshotProvider,
                 captureContextProvider: self.captureContextProvider,
                 tunnelCaptureContext: requestData.captureContext,
                 clientSourcePort: self.clientSourcePort,
                 clientApplicationIdentity: clientApplicationIdentity,
+                clientConnectionDescriptor: self.clientConnectionDescriptor,
+                liveTunnelRegistry: self.liveTunnelRegistry,
                 onTransactionComplete: self.onTransactionComplete,
                 onBreakpointHit: self.onBreakpointHit,
                 breakpointBridgeTracker: self.breakpointBridgeTracker

--- a/Rockxy/Core/ProxyEngine/HTTPSProxyRelayHandler.swift
+++ b/Rockxy/Core/ProxyEngine/HTTPSProxyRelayHandler.swift
@@ -44,7 +44,17 @@ final class HTTPSProxyRelayHandler: ChannelInboundHandler, @unchecked Sendable {
         self.upstreamProxySnapshotProvider = upstreamProxySnapshotProvider
         self.captureContextProvider = captureContextProvider
         self.clientSourcePort = clientSourcePort
-        self.onTransactionComplete = onTransactionComplete
+        // Every transaction this handler emits was decrypted inside an intercepted tunnel, so
+        // stamp capture truth once at the single delivery seam. The request list then reports
+        // it as intercepted regardless of how the host policy later changes. The stamp runs on
+        // the event loop before the downstream callback hands the transaction off, preserving
+        // the existing happens-before ordering used for other pre-delivery fields.
+        self.onTransactionComplete = { transaction in
+            if transaction.sslCapture == nil {
+                transaction.sslCapture = .intercepted
+            }
+            onTransactionComplete(transaction)
+        }
         self.onBreakpointHit = onBreakpointHit
         self.breakpointBridgeTracker = breakpointBridgeTracker
     }

--- a/Rockxy/Core/ProxyEngine/LiveTunnelRegistry.swift
+++ b/Rockxy/Core/ProxyEngine/LiveTunnelRegistry.swift
@@ -1,0 +1,249 @@
+import Foundation
+import NIOCore
+import os
+
+private let liveTunnelLogger = Logger(
+    subsystem: RockxyIdentity.current.logSubsystem,
+    category: "LiveTunnelRegistry"
+)
+
+// MARK: - LiveTunnelRegistry
+
+/// Typed lifecycle seam that tracks live *raw* CONNECT tunnels (host + client application +
+/// tunnel reason) so an SSL-proxying policy change can close exactly the tunnels the *current*
+/// effective policy would now intercept. Closing a matched tunnel forces the client's next request to open a
+/// fresh CONNECT that enters TLS interception, without restarting the proxy or disturbing
+/// bypassed / auto-passthrough hosts or connections that are already being intercepted
+/// (those are never registered here).
+///
+/// Race handling. A tunnel's raw classification is computed from SSL policy that may mutate
+/// concurrently. Each handler captures `currentGeneration()` *before* it reads policy; the
+/// registry bumps the generation on every policy change. At registration time the registry
+/// re-checks: if a mutation landed after the captured generation and the current effective
+/// policy now requires interception, the raw classification is stale and the channel is
+/// closed immediately instead of tracked. Combined with the sweep in
+/// `invalidateTunnelsNowRequiringInterception()`, no raw tunnel whose decision overlapped a
+/// mutation can escape invalidation:
+///   • registered before the sweep's snapshot → closed by the sweep, or
+///   • registered after the mutation bumped the generation → closed by the register re-check.
+final class LiveTunnelRegistry: @unchecked Sendable {
+    // MARK: Lifecycle
+
+    /// - Parameter shouldInterceptNow: predicate returning `true` when the current effective
+    ///   policy would intercept `host` for the tunnel's resolved client application (typically
+    ///   `initialTunnelMode(...) == .intercept`).
+    ///   Injected so the registry stays testable and free of a hard dependency on the shared
+    ///   managers.
+    init(
+        shouldInterceptNow: @escaping @Sendable (String, ClientApplicationIdentity?) -> Bool,
+        shouldResolveApplicationNow: @escaping @Sendable () -> Bool = { false },
+        resolveApplication: (@Sendable (ProxyConnectionDescriptor) async -> ClientApplicationIdentity?)? = nil
+    ) {
+        self.shouldInterceptNow = shouldInterceptNow
+        self.shouldResolveApplicationNow = shouldResolveApplicationNow
+        self.resolveApplication = resolveApplication
+    }
+
+    // MARK: Internal
+
+    /// Snapshot of the policy generation, captured by a handler *before* it classifies a
+    /// tunnel from SSL policy. Passed back into `registerRawTunnel` so a mutation racing that
+    /// classification is detectable at registration time.
+    func currentGeneration() -> UInt64 {
+        lock.lock()
+        defer { lock.unlock() }
+        return generation
+    }
+
+    /// Registers a live raw tunnel keyed by its client channel. If a policy mutation occurred
+    /// after `decisionGeneration` was captured, the current effective policy is re-evaluated.
+    /// An unresolved application is resolved first when application rules could override the
+    /// host decision; otherwise a newly-interceptable channel is closed immediately.
+    func registerRawTunnel(
+        channel: Channel,
+        host: String,
+        application: ClientApplicationIdentity? = nil,
+        connectionDescriptor: ProxyConnectionDescriptor? = nil,
+        reason: TLSInterceptHandler.RawTunnelReason,
+        decisionGeneration: UInt64
+    ) {
+        let identifier = ObjectIdentifier(channel)
+        lock.lock()
+        let raced = decisionGeneration != generation
+        tunnels[identifier] = Entry(
+            channel: channel,
+            host: host,
+            application: application,
+            connectionDescriptor: connectionDescriptor,
+            reason: reason
+        )
+        lock.unlock()
+
+        channel.closeFuture.whenComplete { [weak self] _ in
+            self?.remove(identifier)
+        }
+
+        // Entries whose application identity is still unknown but resolvable must not be closed on
+        // a host-only decision while application rules are active: the tunnel could belong to an
+        // application with a Tunnel rule that outranks a host Decrypt. Defer to resolution, which
+        // re-evaluates the latest policy with the resolved identity (including a nil result).
+        if application == nil,
+           connectionDescriptor != nil,
+           resolveApplicationIfNeeded(for: identifier)
+        {
+            return
+        }
+
+        if raced, shouldInterceptNow(host, application) {
+            liveTunnelLogger.info(
+                "Closing raced raw tunnel for \(host, privacy: .public) — policy now requires interception"
+            )
+            channel.close(promise: nil)
+        }
+    }
+
+    /// Invoked when SSL-proxying policy changes. Bumps the generation and closes every tracked
+    /// raw tunnel whose host the current effective policy would now intercept. Unrelated hosts,
+    /// bypassed hosts, and still-auto-passthrough hosts are left untouched.
+    func invalidateTunnelsNowRequiringInterception() {
+        lock.lock()
+        generation &+= 1
+        let snapshot = Array(tunnels)
+        lock.unlock()
+
+        // Partition tracked tunnels into those whose close decision must wait for identity
+        // resolution and those safe to evaluate immediately. A tunnel with no resolved identity
+        // but a resolvable descriptor may belong to an application whose Tunnel rule outranks a
+        // host Decrypt, so a host-only decision must not close it until resolution completes.
+        var toClose: [Entry] = []
+
+        for (identifier, entry) in snapshot {
+            if entry.application == nil,
+               entry.connectionDescriptor != nil,
+               resolveApplicationIfNeeded(for: identifier)
+            {
+                continue
+            }
+            // Resolution may have completed between the snapshot and the attempt above. Read the
+            // current entry so an application Tunnel identity cannot be lost to a stale nil.
+            guard let currentEntry = currentEntry(for: identifier) else {
+                continue
+            }
+            if shouldInterceptNow(currentEntry.host, currentEntry.application) {
+                toClose.append(currentEntry)
+            }
+        }
+
+        if !toClose.isEmpty {
+            liveTunnelLogger.info("Resetting \(toClose.count) live raw tunnel(s) after SSL policy change")
+            for entry in toClose {
+                entry.channel.close(promise: nil)
+            }
+        }
+    }
+
+    /// Number of currently tracked tunnels. Test/diagnostics hook.
+    func trackedTunnelCount() -> Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return tunnels.count
+    }
+
+    // MARK: Private
+
+    private struct Entry {
+        let channel: Channel
+        let host: String
+        var application: ClientApplicationIdentity?
+        let connectionDescriptor: ProxyConnectionDescriptor?
+        let reason: TLSInterceptHandler.RawTunnelReason
+    }
+
+    private let lock = NSLock()
+    private let shouldInterceptNow: @Sendable (String, ClientApplicationIdentity?) -> Bool
+    private let shouldResolveApplicationNow: @Sendable () -> Bool
+    private let resolveApplication: (@Sendable (ProxyConnectionDescriptor) async -> ClientApplicationIdentity?)?
+    private var tunnels: [ObjectIdentifier: Entry] = [:]
+    private var resolvingApplications: Set<ObjectIdentifier> = []
+    private var generation: UInt64 = 0
+
+    private func remove(_ identifier: ObjectIdentifier) {
+        lock.lock()
+        tunnels.removeValue(forKey: identifier)
+        resolvingApplications.remove(identifier)
+        lock.unlock()
+    }
+
+    private func currentEntry(for identifier: ObjectIdentifier) -> Entry? {
+        lock.lock()
+        defer { lock.unlock() }
+        return tunnels[identifier]
+    }
+
+    /// Resolves identity only after an SSL-policy mutation needs it. Host-only capture therefore
+    /// keeps its fast path, while adding the first application rule can still distinguish and
+    /// reset a pre-existing Chrome tunnel without touching Safari's tunnel to the same host.
+    /// Returns `true` only when resolution was started or is already in flight. Callers use a
+    /// `false` result to fall back to an immediate policy decision, so a missing resolver or an
+    /// application-rule mutation racing this method can never strand an interceptable tunnel.
+    private func resolveApplicationIfNeeded(for identifier: ObjectIdentifier) -> Bool {
+        guard shouldResolveApplicationNow(), let resolver = resolveApplication else {
+            return false
+        }
+
+        lock.lock()
+        guard let entry = tunnels[identifier], entry.application == nil,
+              let descriptor = entry.connectionDescriptor else {
+            lock.unlock()
+            return false
+        }
+        if resolvingApplications.contains(identifier) {
+            lock.unlock()
+            return true
+        }
+        resolvingApplications.insert(identifier)
+        lock.unlock()
+
+        Task { [weak self] in
+            let application = await resolver(descriptor)
+            guard let self else {
+                return
+            }
+            guard let currentEntry = self.finishApplicationResolution(
+                identifier: identifier,
+                application: application
+            ) else {
+                return
+            }
+
+            // Re-evaluate the latest effective policy with the resolved identity. A resolved
+            // application Tunnel rule preserves the channel; another application or a nil identity
+            // still closes it when the current host policy requires interception.
+            guard self.shouldInterceptNow(currentEntry.host, application) else {
+                return
+            }
+            liveTunnelLogger.info(
+                "Resetting resolved application tunnel for \(currentEntry.host, privacy: .public) after SSL policy change"
+            )
+            currentEntry.channel.close(promise: nil)
+        }
+        return true
+    }
+
+    /// Synchronous lock boundary kept outside the async task so the code remains valid under
+    /// Swift 6's prohibition on directly locking from an asynchronous context.
+    private func finishApplicationResolution(
+        identifier: ObjectIdentifier,
+        application: ClientApplicationIdentity?
+    ) -> Entry? {
+        lock.lock()
+        defer { lock.unlock() }
+        resolvingApplications.remove(identifier)
+        guard var entry = tunnels[identifier] else {
+            return nil
+        }
+        entry.application = application
+        tunnels[identifier] = entry
+        return entry
+    }
+}

--- a/Rockxy/Core/ProxyEngine/ProxyServer.swift
+++ b/Rockxy/Core/ProxyEngine/ProxyServer.swift
@@ -300,10 +300,15 @@ actor ProxyServer {
         certificateManager: CertificateManager = .shared,
         ruleEngine: RuleEngine = RuleEngine(),
         scriptPluginManager: ScriptPluginManager? = nil,
+        sslProxyingManager: SSLProxyingManager? = nil,
+        bypassProxyManager: BypassProxyManager? = nil,
         upstreamProxySnapshotProvider: @escaping @Sendable () -> UpstreamProxyResolvedConfiguration? = { nil },
         captureContextProvider: @escaping @Sendable () -> TrafficCaptureContext? = { nil },
         clientIdentityHandleProvider: @escaping @Sendable (ProxyConnectionDescriptor) -> ClientIdentityHandle? =
             ProxyServer.defaultClientIdentityHandleProvider,
+        clientIdentityResolver: @escaping @Sendable (ProxyConnectionDescriptor) async -> ClientApplicationIdentity? = {
+            await ProcessResolver.shared.identityResolver.resolveIdentity(descriptor: $0)
+        },
         onTransactionComplete: @escaping @Sendable (HTTPTransaction) -> Void = { _ in },
         onBreakpointHit: (@Sendable (BreakpointRequestData) async -> (BreakpointDecision, BreakpointRequestData))? = nil
     ) {
@@ -311,9 +316,12 @@ actor ProxyServer {
         self.certificateManager = certificateManager
         self.ruleEngine = ruleEngine
         self.scriptPluginManager = scriptPluginManager
+        self.sslProxyingManagerOverride = sslProxyingManager
+        self.bypassProxyManagerOverride = bypassProxyManager
         self.upstreamProxySnapshotProvider = upstreamProxySnapshotProvider
         self.captureContextProvider = captureContextProvider
         self.clientIdentityHandleProvider = clientIdentityHandleProvider
+        self.clientIdentityResolver = clientIdentityResolver
         self.onTransactionComplete = onTransactionComplete
         self.onBreakpointHit = onBreakpointHit
     }
@@ -393,7 +401,34 @@ actor ProxyServer {
         let childRegistry = childChannelRegistry
         let bridgeTracker = breakpointBridgeTracker
         let identityProvider = clientIdentityHandleProvider
+        let identityResolver = clientIdentityResolver
         let proxyPort = configuration.port
+        let sslManagerOverride = sslProxyingManagerOverride
+        let bypassManagerOverride = bypassProxyManagerOverride
+        // Resolve the UI-owned policy managers on their actor, then capture the stable references
+        // in a registry whose reads use only their explicitly thread-safe, nonisolated methods.
+        // A fresh registry per start also prevents closed-channel state leaking across restarts.
+        let policyState = await MainActor.run {
+            let sslProxyingManager = sslManagerOverride ?? SSLProxyingManager.shared
+            let bypassProxyManager = bypassManagerOverride ?? BypassProxyManager.shared
+            let registry = LiveTunnelRegistry(
+                shouldInterceptNow: { host, application in
+                    TLSInterceptHandler.initialTunnelMode(
+                        host: host,
+                        sslProxyingManager: sslProxyingManager,
+                        bypassProxyManager: bypassProxyManager,
+                        application: application
+                    ) == .intercept
+                },
+                shouldResolveApplicationNow: {
+                    sslProxyingManager.hasEnabledApplicationRules()
+                },
+                resolveApplication: identityResolver
+            )
+            return (registry, sslProxyingManager, bypassProxyManager)
+        }
+        let (tunnelRegistry, sslProxyingManager, bypassProxyManager) = policyState
+        liveTunnelRegistry = tunnelRegistry
         refreshUpstreamProxySnapshot()
         let upstreamProxyProvider: @Sendable () -> UpstreamProxyResolvedConfiguration? = {
             self.currentUpstreamProxyConfiguration()
@@ -410,6 +445,29 @@ actor ProxyServer {
             Task {
                 await self.refreshUpstreamProxySnapshot()
             }
+        }
+
+        // Any SSL-proxying mutation (inspector, settings, import, global enable) routes through
+        // save()/forceGlobalPassthrough and posts this notification. Reset live raw tunnels the
+        // new policy would now intercept so the client's next request is decrypted. The registry
+        // itself is Sendable and thread-safe; the closure captures only it, not self.
+        sslPolicyObserver = NotificationCenter.default.addObserver(
+            forName: .sslProxyingStateDidChange,
+            object: nil,
+            queue: nil
+        ) { _ in
+            tunnelRegistry.invalidateTunnelsNowRequiringInterception()
+        }
+
+        // Bypass-list mutations also feed `initialTunnelMode`: removing a bypass entry can turn a
+        // tracked `.bypassProxyList` raw tunnel into intercept mode while the client is still
+        // connected through Rockxy. Route it through the same invalidation seam.
+        bypassPolicyObserver = NotificationCenter.default.addObserver(
+            forName: .bypassProxyListDidChange,
+            object: nil,
+            queue: nil
+        ) { _ in
+            tunnelRegistry.invalidateTunnelsNowRequiringInterception()
         }
 
         let bootstrap = ServerBootstrap(group: group)
@@ -445,9 +503,13 @@ actor ProxyServer {
                         ruleEngine: ruleEng,
                         scriptPluginManager: scriptMgr,
                         connectionLimiter: limiter,
+                        sslProxyingManager: sslProxyingManager,
+                        bypassProxyManager: bypassProxyManager,
                         upstreamProxySnapshotProvider: upstreamProxyProvider,
                         captureContextProvider: captureProvider,
                         clientIdentityHandle: identityHandle,
+                        clientConnectionDescriptor: descriptor,
+                        liveTunnelRegistry: tunnelRegistry,
                         onTransactionComplete: decoratedCallback,
                         onBreakpointHit: breakpointHit,
                         breakpointBridgeTracker: bridgeTracker
@@ -468,6 +530,11 @@ actor ProxyServer {
         } catch {
             try? await group.shutdownGracefully()
             eventLoopGroup = nil
+            // The observers were installed before `bind`. `stop()` guards on `serverChannel`,
+            // which never got set on a failed start, so it can't clean them — remove them here or
+            // a retry would overwrite the tokens and leak the originals.
+            removePolicyObservers()
+            liveTunnelRegistry = nil
             if let ioError = error as? IOError, ioError.errnoCode == EADDRINUSE {
                 throw ProxyServerError.portInUse(configuration.port)
             }
@@ -486,10 +553,7 @@ actor ProxyServer {
         isStopping = true
         defer { isStopping = false }
         serverChannel = nil
-        if let upstreamProxyObserver {
-            NotificationCenter.default.removeObserver(upstreamProxyObserver)
-            self.upstreamProxyObserver = nil
-        }
+        removePolicyObservers()
 
         do {
             try await channel.close().get()
@@ -499,6 +563,7 @@ actor ProxyServer {
 
         await childChannelRegistry.closeAllAndWait()
         await breakpointBridgeTracker.waitUntilIdle()
+        liveTunnelRegistry = nil
 
         if let group = eventLoopGroup {
             do {
@@ -520,12 +585,19 @@ actor ProxyServer {
     private let certificateManager: CertificateManager
     private let ruleEngine: RuleEngine
     private let scriptPluginManager: ScriptPluginManager?
+    private let sslProxyingManagerOverride: SSLProxyingManager?
+    private let bypassProxyManagerOverride: BypassProxyManager?
     private let upstreamProxySnapshotProvider: @Sendable () -> UpstreamProxyResolvedConfiguration?
     private let captureContextProvider: @Sendable () -> TrafficCaptureContext?
     private let clientIdentityHandleProvider: @Sendable (ProxyConnectionDescriptor) -> ClientIdentityHandle?
+    private let clientIdentityResolver: @Sendable (ProxyConnectionDescriptor) async -> ClientApplicationIdentity?
     private let connectionLimiter = ConnectionLimiter()
     private let childChannelRegistry = ProxyChildChannelRegistry()
     private let breakpointBridgeTracker = BreakpointBridgeTracker()
+    /// Tracks live raw CONNECT tunnels so an SSL-policy change can reset exactly the tunnels the
+    /// current effective policy would now intercept. The predicate mirrors the raw/intercept
+    /// selection in `TLSInterceptHandler.initialTunnelMode`, including application-scoped rules.
+    private var liveTunnelRegistry: LiveTunnelRegistry?
     private let onTransactionComplete: @Sendable (HTTPTransaction) -> Void
     private let onBreakpointHit: (@Sendable (BreakpointRequestData) async -> (
         BreakpointDecision,
@@ -536,8 +608,28 @@ actor ProxyServer {
     private var serverChannel: Channel?
     private var isStopping = false
     private var upstreamProxyObserver: NSObjectProtocol?
+    private var sslPolicyObserver: NSObjectProtocol?
+    private var bypassPolicyObserver: NSObjectProtocol?
     private let upstreamProxySnapshotLock = NSLock()
     nonisolated(unsafe) private var upstreamProxyConfiguration: UpstreamProxyResolvedConfiguration?
+
+    /// Removes every notification observer installed by `start()`. Safe to call on both the clean
+    /// stop path and the failed-start path; each token is niled so a later start reinstalls fresh
+    /// observers without leaking the originals.
+    private func removePolicyObservers() {
+        if let upstreamProxyObserver {
+            NotificationCenter.default.removeObserver(upstreamProxyObserver)
+            self.upstreamProxyObserver = nil
+        }
+        if let sslPolicyObserver {
+            NotificationCenter.default.removeObserver(sslPolicyObserver)
+            self.sslPolicyObserver = nil
+        }
+        if let bypassPolicyObserver {
+            NotificationCenter.default.removeObserver(bypassPolicyObserver)
+            self.bypassPolicyObserver = nil
+        }
+    }
 
     private func refreshUpstreamProxySnapshot() {
         let snapshot = upstreamProxySnapshotProvider()

--- a/Rockxy/Core/ProxyEngine/SSLProxyingManager.swift
+++ b/Rockxy/Core/ProxyEngine/SSLProxyingManager.swift
@@ -237,6 +237,16 @@ final class SSLProxyingManager {
         shouldIntercept(host: host, application: nil)
     }
 
+    /// Whether the host is covered by the TLS-only bypass patterns configured in HTTPS
+    /// Decryption. Exposed separately from `shouldIntercept` so quick actions can explain why a
+    /// Decrypt request cannot take effect instead of silently adding an overridden rule.
+    nonisolated func isHostInTLSBypassList(_ host: String) -> Bool {
+        passthroughLock.lock()
+        let patterns = cachedBypassPatterns
+        passthroughLock.unlock()
+        return matchesBypassPattern(host, patterns: patterns)
+    }
+
     /// Combined host + application interception decision, table-order independent.
     ///
     /// Deterministic order: global disabled/passthrough/bypass ⇒ tunnel; any matching enabled
@@ -245,6 +255,28 @@ final class SSLProxyingManager {
     /// participate only for a non-nil resolved identity — a nil (remote/unresolved) identity
     /// can never enable application decryption.
     nonisolated func shouldIntercept(host: String, application: ClientApplicationIdentity?) -> Bool {
+        guard isDecryptionConfigured(host: host, application: application) else {
+            return false
+        }
+
+        passthroughLock.lock()
+        let globalPassthrough = _forceGlobalPassthrough
+        passthroughLock.unlock()
+
+        return !globalPassthrough
+    }
+
+    /// Whether the persisted HTTPS policy selects Decrypt for this host/application pair.
+    ///
+    /// This intentionally excludes the temporary certificate-readiness fallback
+    /// (`forceGlobalPassthrough`) and per-host auto-passthrough state. Settings, sidebar menus,
+    /// and inspectors use it to present the configured rule accurately even while Rockxy is
+    /// temporarily unable to intercept. The proxy pipeline must continue to call
+    /// `shouldIntercept(host:application:)`, which layers runtime readiness on top.
+    nonisolated func isDecryptionConfigured(
+        host: String,
+        application: ClientApplicationIdentity? = nil
+    ) -> Bool {
         lock.lock()
         let enabled = cachedIsEnabled
         let includeSnapshot = cachedEnabledIncludeRules
@@ -258,13 +290,8 @@ final class SSLProxyingManager {
         }
 
         passthroughLock.lock()
-        let globalPassthrough = _forceGlobalPassthrough
         let bypassPatterns = cachedBypassPatterns
         passthroughLock.unlock()
-
-        if globalPassthrough {
-            return false
-        }
 
         if matchesBypassPattern(host, patterns: bypassPatterns) {
             return false
@@ -308,10 +335,21 @@ final class SSLProxyingManager {
 
     nonisolated func clearAutoPassthrough() {
         passthroughLock.lock()
+        let hadEntries = !autoPassthroughHosts.isEmpty
         autoPassthroughHosts.removeAll()
         passthroughLock.unlock()
         persistPassthroughHosts()
         Self.logger.info("Cleared all auto-passthrough hosts")
+
+        guard hadEntries else {
+            return
+        }
+
+        // Certificate readiness clears `forceGlobalPassthrough` before it clears these per-host
+        // fallbacks. The first state notification therefore still sees the hosts as passthrough.
+        // Notify again after the fallback state is actually gone so any live raw tunnel whose
+        // host is now interceptable is reset before the browser reuses it.
+        NotificationCenter.default.post(name: .sslProxyingStateDidChange, object: nil)
     }
 
     /// Clears the protection fallback for one host so its next connection can retry TLS interception.
@@ -337,6 +375,12 @@ final class SSLProxyingManager {
         }
 
         persistPassthroughHosts()
+        // Clearing the auto-passthrough fallback can make this host interceptable again while a
+        // raw `.autoPassthrough` tunnel is still live (the inspector retry path may not touch any
+        // rule, so `save()` never fires). Post the policy-change notification so the live-tunnel
+        // observer resets that tunnel and the next request enters interception. Posted only on a
+        // real state change — the no-match early return above never reaches here.
+        NotificationCenter.default.post(name: .sslProxyingStateDidChange, object: nil)
         return true
     }
 

--- a/Rockxy/Core/ProxyEngine/TLSInterceptHandler.swift
+++ b/Rockxy/Core/ProxyEngine/TLSInterceptHandler.swift
@@ -103,6 +103,8 @@ final class TLSInterceptHandler: ChannelInboundHandler, RemovableChannelHandler,
         tunnelCaptureContext: TrafficCaptureContext? = nil,
         clientSourcePort: UInt16? = nil,
         clientApplicationIdentity: ClientApplicationIdentity? = nil,
+        clientConnectionDescriptor: ProxyConnectionDescriptor? = nil,
+        liveTunnelRegistry: LiveTunnelRegistry? = nil,
         onTransactionComplete: @escaping @Sendable (HTTPTransaction) -> Void,
         onBreakpointHit: (@Sendable (BreakpointRequestData) async -> (BreakpointDecision, BreakpointRequestData))? =
             nil,
@@ -122,6 +124,8 @@ final class TLSInterceptHandler: ChannelInboundHandler, RemovableChannelHandler,
         self.tunnelCaptureContext = tunnelCaptureContext
         self.clientSourcePort = clientSourcePort
         self.clientApplicationIdentity = clientApplicationIdentity
+        self.clientConnectionDescriptor = clientConnectionDescriptor
+        self.liveTunnelRegistry = liveTunnelRegistry
         self.onTransactionComplete = onTransactionComplete
         self.onBreakpointHit = onBreakpointHit
         self.breakpointBridgeTracker = breakpointBridgeTracker
@@ -152,6 +156,7 @@ final class TLSInterceptHandler: ChannelInboundHandler, RemovableChannelHandler,
         sourcePort: UInt16?,
         measuredDuration: TimeInterval? = nil,
         isTLSFailure: Bool = false,
+        sslCapture: HTTPTransaction.SSLCaptureMode? = nil,
         captureContext: TrafficCaptureContext? = nil
     )
         -> HTTPTransaction
@@ -178,6 +183,7 @@ final class TLSInterceptHandler: ChannelInboundHandler, RemovableChannelHandler,
                 sourcePort: sourcePort,
                 measuredDuration: measuredDuration,
                 isTLSFailure: isTLSFailure,
+                sslCapture: sslCapture,
                 captureContext: captureContext
             )
         }
@@ -202,6 +208,7 @@ final class TLSInterceptHandler: ChannelInboundHandler, RemovableChannelHandler,
         transaction.measuredDuration = measuredDuration
         transaction.sourcePort = sourcePort
         transaction.isTLSFailure = isTLSFailure
+        transaction.sslCapture = sslCapture
         return transaction
     }
 
@@ -300,6 +307,8 @@ final class TLSInterceptHandler: ChannelInboundHandler, RemovableChannelHandler,
     private let tunnelCaptureContext: TrafficCaptureContext?
     private let clientSourcePort: UInt16?
     private let clientApplicationIdentity: ClientApplicationIdentity?
+    private let clientConnectionDescriptor: ProxyConnectionDescriptor?
+    private let liveTunnelRegistry: LiveTunnelRegistry?
     private let onTransactionComplete: @Sendable (HTTPTransaction) -> Void
     private let onBreakpointHit: (@Sendable (BreakpointRequestData) async -> (
         BreakpointDecision,
@@ -315,23 +324,32 @@ final class TLSInterceptHandler: ChannelInboundHandler, RemovableChannelHandler,
         let host = self.host
         let port = self.port
 
+        // Capture the policy generation BEFORE reading SSL policy, so a mutation racing this
+        // classification is detectable when the raw tunnel is registered (see LiveTunnelRegistry).
+        let decisionGeneration = liveTunnelRegistry?.currentGeneration() ?? 0
+
         switch Self.initialTunnelMode(
             host: host,
             sslProxyingManager: sslProxyingManager,
             bypassProxyManager: bypassProxyManager,
             application: clientApplicationIdentity
         ) {
-        case .rawTunnel(.bypassProxyList):
-            tlsLogger.info("Bypass proxy list matched \(host), passing through as raw tunnel")
-            setupRawTunnel(context: context, host: host, port: port)
-            return
-        case .rawTunnel(.noSSLProxyingRule):
-            tlsLogger.info("No SSL proxying rule for \(host), passing through as raw tunnel")
-            setupRawTunnel(context: context, host: host, port: port)
-            return
-        case .rawTunnel(.autoPassthrough):
-            tlsLogger.info("Auto-passthrough for \(host) (previous TLS rejection), raw tunnel")
-            setupRawTunnel(context: context, host: host, port: port)
+        case let .rawTunnel(reason):
+            switch reason {
+            case .bypassProxyList:
+                tlsLogger.info("Bypass proxy list matched \(host), passing through as raw tunnel")
+            case .noSSLProxyingRule:
+                tlsLogger.info("No SSL proxying rule for \(host), passing through as raw tunnel")
+            case .autoPassthrough:
+                tlsLogger.info("Auto-passthrough for \(host) (previous TLS rejection), raw tunnel")
+            }
+            setupRawTunnel(
+                context: context,
+                host: host,
+                port: port,
+                trackingReason: reason,
+                decisionGeneration: decisionGeneration
+            )
             return
         case .intercept:
             break
@@ -474,10 +492,19 @@ final class TLSInterceptHandler: ChannelInboundHandler, RemovableChannelHandler,
         }
     }
 
+    /// Sets up a raw byte tunnel to the upstream.
+    ///
+    /// When `trackingReason` is non-nil the resulting live tunnel is registered with the
+    /// `LiveTunnelRegistry` so a later SSL-policy change that makes this host eligible for
+    /// interception can close it (forcing a fresh, intercepted CONNECT). The cert-failure
+    /// fallbacks from the `.intercept` branch pass `nil` — that host was already classified for
+    /// interception, so a policy change gains nothing and re-closing could loop.
     nonisolated private func setupRawTunnel(
         context: ChannelHandlerContext,
         host: String,
-        port: Int
+        port: Int,
+        trackingReason: RawTunnelReason? = nil,
+        decisionGeneration: UInt64 = 0
     ) {
         guard connectionLimiter.acquire(host: host, port: port) else {
             tlsLogger.warning("Connection limit reached for \(host):\(port), closing")
@@ -508,6 +535,19 @@ final class TLSInterceptHandler: ChannelInboundHandler, RemovableChannelHandler,
                     prepareClientChannel: context.pipeline.removeHandler(context: context),
                     enableClientAutoRead: true
                 ) {
+                    // Track the live raw tunnel so a later policy change can reset it. The
+                    // registry closes the channel immediately if the raw decision raced a
+                    // mutation that now requires interception.
+                    if let trackingReason {
+                        self.liveTunnelRegistry?.registerRawTunnel(
+                            channel: clientChannel,
+                            host: host,
+                            application: self.clientApplicationIdentity,
+                            connectionDescriptor: self.clientConnectionDescriptor,
+                            reason: trackingReason,
+                            decisionGeneration: decisionGeneration
+                        )
+                    }
                     self.onTransactionComplete(
                         Self.makeTunnelTransaction(
                             host: host,
@@ -517,6 +557,7 @@ final class TLSInterceptHandler: ChannelInboundHandler, RemovableChannelHandler,
                             state: .completed,
                             sourcePort: self.clientSourcePort,
                             measuredDuration: self.tunnelElapsedDuration(),
+                            sslCapture: .tunneled,
                             captureContext: self.tunnelCaptureContext
                         )
                     )
@@ -681,6 +722,9 @@ final class PostHandshakeHandler: ChannelInboundHandler, RemovableChannelHandler
         tearDownAndPassthrough(context: context)
     }
 
+    /// Builds the CONNECT row for a raw tunnel established after the handshake pipeline was
+    /// torn down (non-TLS data seen inside the tunnel). This is a passthrough, not an
+    /// interception, so it is captured as `.tunneled`.
     nonisolated func makeSuccessfulTunnelTransaction() -> HTTPTransaction {
         TLSInterceptHandler.makeTunnelTransaction(
             host: host,
@@ -690,6 +734,7 @@ final class PostHandshakeHandler: ChannelInboundHandler, RemovableChannelHandler
             state: .completed,
             sourcePort: clientSourcePort,
             measuredDuration: tunnelElapsedDuration(),
+            sslCapture: .tunneled,
             captureContext: tunnelCaptureContext
         )
     }

--- a/Rockxy/Localizable.xcstrings
+++ b/Rockxy/Localizable.xcstrings
@@ -4,6 +4,116 @@
     "": {
       "shouldTranslate": false
     },
+    "Added host Decrypt rules for domains observed from %@. These rules apply to every application.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已为从 %@ 观察到的域名添加主机解密规则。这些规则适用于所有应用程序。"
+          }
+        }
+      }
+    },
+    "Configured %lld of %lld observed hosts. Review Tunnel or bypass rules for the remaining hosts.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已配置 %lld 个观察主机（共 %lld 个）。请检查其余主机的隧道或绕过规则。"
+          }
+        }
+      }
+    },
+    "Creates host rules that apply to these domains in every application.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "创建适用于每个应用程序中这些域名的主机规则。"
+          }
+        }
+      }
+    },
+    "Decrypt This Host": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "解密此主机"
+          }
+        }
+      }
+    },
+    "Review Rules": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "检查规则"
+          }
+        }
+      }
+    },
+    "Set domains observed from %@ to Tunnel. These host rules apply to every application.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已将从 %@ 观察到的域名设为隧道传输。这些主机规则适用于所有应用程序。"
+          }
+        }
+      }
+    },
+    "The host is unavailable.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "主机不可用。"
+          }
+        }
+      }
+    },
+    "This host is in Full Proxy Bypass. Remove that bypass entry before decrypting it.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此主机位于完整代理绕过列表中。请先移除该绕过条目，再进行解密。"
+          }
+        }
+      }
+    },
+    "This host is in the HTTPS TLS Bypass list. Remove that bypass pattern before decrypting it.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此主机位于 HTTPS TLS 绕过列表中。请先移除该绕过模式，再进行解密。"
+          }
+        }
+      }
+    },
+    "Tunnel rule %@ takes priority. Review that broader rule before decrypting this host.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "隧道规则 %@ 优先。解密此主机前，请检查该范围更广的规则。"
+          }
+        }
+      }
+    },
+    "Tunnel This Host": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "隧道传输此主机"
+          }
+        }
+      }
+    },
     "A rule with this application and behavior already exists.": {
       "localizations": {
         "zh-Hans": {
@@ -254,18 +364,44 @@
         }
       }
     },
-    "Set %@ to decrypt HTTPS on new connections. Reconnect the app.": {
+    "Set %@ to decrypt HTTPS. %@ stays tunneled: %@": {
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "new",
-            "value": "Set %1$@ to decrypt HTTPS on new connections. Reconnect the app."
+            "value": "Set %1$@ to decrypt HTTPS. %2$@ stays tunneled: %3$@"
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "已将 %1$@ 的新 HTTPS 连接设为解密。请重新连接应用。"
+            "value": "已将 %1$@ 设为解密 HTTPS。但 %2$@ 仍以隧道传输：%3$@"
+          }
+        }
+      }
+    },
+    "Set %@ to decrypt HTTPS. Matching tunneled connections reset automatically — if one stays tunneled, reconnect the app.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Set %1$@ to decrypt HTTPS. Matching tunneled connections reset automatically — if one stays tunneled, reconnect the app."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已将 %1$@ 设为解密 HTTPS。匹配的实时连接将自动重置——如仍以隧道传输，请重新连接应用。"
+          }
+        }
+      }
+    },
+    "Tunnel rule %@ takes priority. Change that host behavior before decrypting it.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "隧道规则 %@ 优先。请先更改该主机行为，再进行解密。"
           }
         }
       }
@@ -37110,12 +37246,12 @@
         }
       }
     },
-    "Turn on HTTPS decryption for other known hosts used by %@": {
+    "Add host decryption rules for other known hosts used by %@; these rules apply to every application": {
       "localizations": {
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "为 %@ 使用的其他已知主机启用 HTTPS 解密"
+            "value": "为 %@ 使用的其他已知主机添加主机解密规则；这些规则适用于所有应用程序"
           }
         }
       }

--- a/Rockxy/Models/Network/HTTPTransaction.swift
+++ b/Rockxy/Models/Network/HTTPTransaction.swift
@@ -41,6 +41,18 @@ final class HTTPTransaction: Identifiable, @unchecked Sendable {
 
     // MARK: Internal
 
+    /// Capture-time TLS disposition of a transaction: whether it was passed through raw
+    /// (`.tunneled`) or man-in-the-middled (`.intercepted`) at the moment of capture. The
+    /// request list uses this so a historical row reports capture truth instead of recomputing
+    /// its SSL badge from the *current* host policy — a raw CONNECT must stay tunneled even
+    /// after the host's rule is later enabled. Runtime-only: portable/persisted sessions omit
+    /// it; on reload the badge is derived deterministically from the record's own shape
+    /// (CONNECT → tunneled, decrypted non-CONNECT HTTPS/WSS → intercepted), never from policy.
+    enum SSLCaptureMode: Sendable {
+        case tunneled
+        case intercepted
+    }
+
     let id: UUID
     let timestamp: Date
     var request: HTTPRequestData
@@ -64,6 +76,11 @@ final class HTTPTransaction: Identifiable, @unchecked Sendable {
     var isPinned: Bool = false
     var isSaved: Bool = false
     var isTLSFailure: Bool = false
+    /// See `SSLCaptureMode`. Live captures always stamp this: raw tunnels record `.tunneled` and
+    /// `HTTPSProxyRelayHandler` stamps every decrypted transaction `.intercepted`. `nil` therefore
+    /// only occurs on legacy/reloaded/imported transactions whose capture disposition was not
+    /// persisted (and on TLS-failure rows, which are never shown in the request list).
+    var sslCapture: SSLCaptureMode?
     var webSocketFrameVersion: Int = 0
     var matchedRuleID: UUID?
     var matchedRuleName: String?

--- a/Rockxy/Views/Inspector/HTTPSInspectionPromptView.swift
+++ b/Rockxy/Views/Inspector/HTTPSInspectionPromptView.swift
@@ -343,10 +343,23 @@ struct HTTPSInspectionScopePresentation: Equatable {
     static func host(
         value: String,
         isReady: Bool,
-        requiresRetry: Bool = false
+        requiresRetry: Bool = false,
+        decryptBlockedReason: String? = nil
     )
         -> HTTPSInspectionScopePresentation
     {
+        if let decryptBlockedReason {
+            return HTTPSInspectionScopePresentation(
+                kind: .host,
+                value: value,
+                state: .available,
+                control: .button,
+                action: .openSSLProxyingList,
+                controlTitle: String(localized: "Review Rules", bundle: RockxyLocalization.bundle),
+                actionDescription: decryptBlockedReason
+            )
+        }
+
         if requiresRetry {
             return HTTPSInspectionScopePresentation(
                 kind: .host,
@@ -410,9 +423,13 @@ struct HTTPSInspectionScopePresentation: Equatable {
             state: state,
             control: .button,
             action: .enableApp(name, fallbackDomain: fallbackDomain),
-            controlTitle: String(localized: "Decrypt App", bundle: RockxyLocalization.bundle),
+            // A name-only transaction has no stable application identity. This action expands
+            // the app's observed domains into host rules, which apply to every client. Do not
+            // label it "Decrypt App" — that would imply application-scoped isolation and can
+            // unexpectedly decrypt the same hosts in Safari or another application.
+            controlTitle: String(localized: "Decrypt Observed Hosts", bundle: RockxyLocalization.bundle),
             actionDescription: String(
-                localized: "Turn on HTTPS decryption for other known hosts used by \(name)",
+                localized: "Add host decryption rules for other known hosts used by \(name); these rules apply to every application",
                 bundle: RockxyLocalization.bundle
             )
         )

--- a/Rockxy/Views/Inspector/ResponseInspectorView.swift
+++ b/Rockxy/Views/Inspector/ResponseInspectorView.swift
@@ -69,12 +69,19 @@ struct ResponseInspectorView: View {
         }
         let canInterceptHTTPS = coordinator.readiness.canInterceptHTTPS
         let domainRuleEnabled = coordinator.isSSLProxyingEnabled(for: transaction.request.host)
+        let resolvedApplicationIdentity = transaction.clientApplicationIdentity
+            ?? normalizedClientAppName.flatMap(coordinator.observedApplicationIdentity(named:))
+        let hostDecryptBlockedReason = coordinator.sslProxyingHostDecryptBlockedReason(
+            for: transaction.request.host,
+            application: resolvedApplicationIdentity
+        )
         let hasRecentTLSRejection = SSLProxyingManager.shared.isAutoPassthrough(transaction.request.host)
         let promptWithoutAppScope = HTTPSInspectionPromptModel.make(
             transaction: transaction,
             canInterceptHTTPS: canInterceptHTTPS,
             domainRuleEnabled: domainRuleEnabled,
             hasRecentTLSRejection: hasRecentTLSRejection,
+            hostDecryptBlockedReason: hostDecryptBlockedReason,
             appScope: nil
         )
         guard let promptWithoutAppScope,
@@ -94,11 +101,11 @@ struct ResponseInspectorView: View {
                 name: appName,
                 knownHostCount: domains.count,
                 enabledHostCount: domains.count(where: coordinator.isSSLProxyingEnabled(for:)),
-                identity: transaction.clientApplicationIdentity,
-                isApplicationDecryptReady: transaction.clientApplicationIdentity.map {
+                identity: resolvedApplicationIdentity,
+                isApplicationDecryptReady: resolvedApplicationIdentity.map {
                     coordinator.isSSLProxyingEnabled(for: $0)
                 } ?? false,
-                isApplicationTunnelActive: transaction.clientApplicationIdentity.map { identity in
+                isApplicationTunnelActive: resolvedApplicationIdentity.map { identity in
                     SSLProxyingManager.shared.applicationExcludeRules.contains {
                         $0.isEnabled && $0.applicationIdentifier == identity.identifier
                     }
@@ -111,6 +118,7 @@ struct ResponseInspectorView: View {
             canInterceptHTTPS: canInterceptHTTPS,
             domainRuleEnabled: domainRuleEnabled,
             hasRecentTLSRejection: hasRecentTLSRejection,
+            hostDecryptBlockedReason: hostDecryptBlockedReason,
             appScope: appScope
         )
     }
@@ -750,6 +758,7 @@ struct HTTPSInspectionPromptModel: Equatable {
         canInterceptHTTPS: Bool,
         domainRuleEnabled: Bool,
         hasRecentTLSRejection: Bool = false,
+        hostDecryptBlockedReason: String? = nil,
         appScope: HTTPSInspectionAppScope?
     )
         -> HTTPSInspectionPromptModel?
@@ -789,7 +798,8 @@ struct HTTPSInspectionPromptModel: Equatable {
             hostScope: appScope?.isApplicationTunnelActive == true ? nil : .host(
                 value: host,
                 isReady: domainRuleEnabled,
-                requiresRetry: hasTLSRejectionEvidence
+                requiresRetry: hasTLSRejectionEvidence,
+                decryptBlockedReason: hostDecryptBlockedReason
             ),
             appScope: hasTLSRejectionEvidence ? nil : appScope.flatMap { scope in
                 if let identity = scope.identity {

--- a/Rockxy/Views/Main/Extensions/MainContentCoordinator+Filtering.swift
+++ b/Rockxy/Views/Main/Extensions/MainContentCoordinator+Filtering.swift
@@ -85,12 +85,19 @@ extension MainContentCoordinator {
             return .insecure
         }
 
-        let host = transaction.request.host
-        guard !host.isEmpty else {
-            return .secureTunneled
+        // Capture truth wins over current policy: a CONNECT tunnel that was passed through raw
+        // stays tunneled even after the host's rule is later enabled, and genuinely decrypted
+        // traffic stays intercepted.
+        if let capture = transaction.sslCapture {
+            return capture == .intercepted ? .secureIntercepted : .secureTunneled
         }
 
-        return SSLProxyingManager.shared.shouldIntercept(host) ? .secureIntercepted : .secureTunneled
+        // Legacy / reloaded / imported rows carry no recorded disposition. Derive it from the
+        // record's own shape — never from current host policy, which would make a historical row
+        // flip meaning when a rule is toggled. A secure CONNECT row is a tunnel record and stays
+        // tunneled; any captured non-CONNECT HTTPS/WSS transaction is decrypted application
+        // traffic (a raw tunnel never yields per-request records) and is intercepted.
+        return transaction.request.method == "CONNECT" ? .secureTunneled : .secureIntercepted
     }
 
     // MARK: - Filtered Transactions

--- a/Rockxy/Views/Main/Extensions/MainContentCoordinator+SidebarMenu.swift
+++ b/Rockxy/Views/Main/Extensions/MainContentCoordinator+SidebarMenu.swift
@@ -14,10 +14,73 @@ extension MainContentCoordinator {
     // MARK: - SSL Proxying
 
     func isSSLProxyingEnabled(for domain: String) -> Bool {
-        guard SSLProxyingManager.shared.isEnabled else {
+        let normalizedDomain = normalizedSSLHost(domain)
+        guard !normalizedDomain.isEmpty,
+              !BypassProxyManager.shared.isHostBypassed(normalizedDomain) else
+        {
             return false
         }
-        return SSLProxyingManager.shared.includeRules.contains { $0.isEnabled && $0.matches(domain) }
+        return SSLProxyingManager.shared.isDecryptionConfigured(host: normalizedDomain)
+    }
+
+    /// Returns a user-facing reason when a one-host Decrypt shortcut cannot safely override the
+    /// current policy. Exact host Tunnel rules are intentionally omitted: selecting Decrypt for
+    /// that same host replaces the exact opposite behavior. Broader Tunnel and bypass rules must
+    /// be reviewed explicitly because removing them would affect other traffic.
+    func sslProxyingHostDecryptBlockedReason(
+        for domain: String,
+        application: ClientApplicationIdentity? = nil,
+        allowReplacingExactTunnel: Bool = true
+    ) -> String? {
+        let normalizedDomain = normalizedSSLHost(domain)
+        guard !normalizedDomain.isEmpty else {
+            return String(localized: "The host is unavailable.", bundle: RockxyLocalization.bundle)
+        }
+
+        if let application,
+           SSLProxyingManager.shared.applicationExcludeRules.contains(where: {
+               $0.isEnabled && $0.applicationIdentifier == application.identifier
+           })
+        {
+            return String(
+                localized: "The application Tunnel rule takes priority. Change the application behavior first.",
+                bundle: RockxyLocalization.bundle
+            )
+        }
+
+        if BypassProxyManager.shared.isHostBypassed(normalizedDomain) {
+            return String(
+                localized: "This host is in Full Proxy Bypass. Remove that bypass entry before decrypting it.",
+                bundle: RockxyLocalization.bundle
+            )
+        }
+
+        if SSLProxyingManager.shared.isHostInTLSBypassList(normalizedDomain) {
+            return String(
+                localized: "This host is in the HTTPS TLS Bypass list. Remove that bypass pattern before decrypting it.",
+                bundle: RockxyLocalization.bundle
+            )
+        }
+
+        if let rule = SSLProxyingManager.shared.excludeRules.first(where: {
+            guard $0.isEnabled, $0.matches(normalizedDomain) else {
+                return false
+            }
+            return !allowReplacingExactTunnel || !sslHostPatternsAreEqual($0.domain, normalizedDomain)
+        }) {
+            if sslHostPatternsAreEqual(rule.domain, normalizedDomain) {
+                return String(
+                    localized: "Tunnel rule \(rule.domain) takes priority. Change that host behavior before decrypting it.",
+                    bundle: RockxyLocalization.bundle
+                )
+            }
+            return String(
+                localized: "Tunnel rule \(rule.domain) takes priority. Review that broader rule before decrypting this host.",
+                bundle: RockxyLocalization.bundle
+            )
+        }
+
+        return nil
     }
 
     func isSSLProxyingEnabled(for application: ClientApplicationIdentity) -> Bool {
@@ -37,7 +100,10 @@ extension MainContentCoordinator {
 
     @discardableResult
     func enableSSLProxyingForDomain(_ domain: String, refreshPresentation: Bool = true) -> Bool {
-        guard !domain.isEmpty else {
+        let normalizedDomain = normalizedSSLHost(domain)
+        guard !normalizedDomain.isEmpty,
+              sslProxyingHostDecryptBlockedReason(for: normalizedDomain) == nil else
+        {
             return false
         }
 
@@ -48,42 +114,82 @@ extension MainContentCoordinator {
             didChange = true
         }
 
-        if let existing = SSLProxyingManager.shared.includeRules.first(where: { $0.matches(domain) }) {
-            if !existing.isEnabled {
+        // An already-effective wildcard Decrypt rule needs no exact duplicate.
+        if isSSLProxyingEnabled(for: normalizedDomain) {
+            if didChange, refreshPresentation {
+                refreshSSLProxyingPresentation()
+            }
+            return didChange
+        }
+
+        let exactTunnelIDs = Set(SSLProxyingManager.shared.excludeRules.filter {
+            sslHostPatternsAreEqual($0.domain, normalizedDomain)
+        }.map(\.id))
+        if !exactTunnelIDs.isEmpty {
+            SSLProxyingManager.shared.removeRules(ids: exactTunnelIDs)
+            didChange = true
+        }
+
+        let exactDecryptRules = SSLProxyingManager.shared.includeRules.filter {
+            sslHostPatternsAreEqual($0.domain, normalizedDomain)
+        }
+        if exactDecryptRules.isEmpty {
+            let rule = SSLProxyingRule(domain: normalizedDomain, listType: .include)
+            SSLProxyingManager.shared.addRule(rule)
+            didChange = true
+        } else {
+            for existing in exactDecryptRules where !existing.isEnabled {
                 SSLProxyingManager.shared.setRuleEnabled(id: existing.id, enabled: true)
                 didChange = true
             }
-        } else {
-            let rule = SSLProxyingRule(domain: domain, listType: .include)
-            SSLProxyingManager.shared.addRule(rule)
-            didChange = true
         }
 
         if didChange, refreshPresentation {
             refreshSSLProxyingPresentation()
         }
-        Self.logger.info("Enabled SSL proxying for domain: \(domain)")
+        Self.logger.info("Enabled SSL proxying for exact host: \(normalizedDomain)")
         return didChange
     }
 
     @discardableResult
     func disableSSLProxyingForDomain(_ domain: String, refreshPresentation: Bool = true) -> Bool {
-        guard !domain.isEmpty else {
+        let normalizedDomain = normalizedSSLHost(domain)
+        guard !normalizedDomain.isEmpty else {
             return false
         }
-        let matchingIncludeIDs = SSLProxyingManager.shared.includeRules
-            .filter { $0.matches(domain) }
-            .map(\.id)
-        let idSet = Set(matchingIncludeIDs)
-        if !idSet.isEmpty {
-            SSLProxyingManager.shared.removeRules(ids: idSet)
-            if refreshPresentation {
-                refreshSSLProxyingPresentation()
-            }
-            Self.logger.info("Disabled SSL proxying for domain: \(domain)")
-            return true
+
+        var didChange = false
+        // Only replace the exact host behavior. Removing a matching wildcard Decrypt rule would
+        // unexpectedly disable decryption for sibling hosts; an exact Tunnel exception safely
+        // overrides it instead.
+        let exactDecryptIDs = Set(SSLProxyingManager.shared.includeRules.filter {
+            sslHostPatternsAreEqual($0.domain, normalizedDomain)
+        }.map(\.id))
+        if !exactDecryptIDs.isEmpty {
+            SSLProxyingManager.shared.removeRules(ids: exactDecryptIDs)
+            didChange = true
         }
-        return false
+
+        let exactTunnelRules = SSLProxyingManager.shared.excludeRules.filter {
+            sslHostPatternsAreEqual($0.domain, normalizedDomain)
+        }
+        if exactTunnelRules.isEmpty {
+            SSLProxyingManager.shared.addRule(
+                SSLProxyingRule(domain: normalizedDomain, listType: .exclude)
+            )
+            didChange = true
+        } else {
+            for existing in exactTunnelRules where !existing.isEnabled {
+                SSLProxyingManager.shared.setRuleEnabled(id: existing.id, enabled: true)
+                didChange = true
+            }
+        }
+
+        if didChange, refreshPresentation {
+            refreshSSLProxyingPresentation()
+        }
+        Self.logger.info("Set exact host to tunnel without decryption: \(normalizedDomain)")
+        return didChange
     }
 
     @discardableResult
@@ -243,8 +349,30 @@ extension MainContentCoordinator {
         return orderedDomains.sorted { $0.localizedCaseInsensitiveCompare($1) == .orderedAscending }
     }
 
+    /// Returns a stable identity only when every observed identity with this display name agrees.
+    /// Name-only transactions can then inherit a previously observed Chrome/Safari identity for
+    /// the inspector action, while same-name applications remain ambiguous and fail closed.
+    func observedApplicationIdentity(named appName: String) -> ClientApplicationIdentity? {
+        let normalizedName = appName.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !normalizedName.isEmpty else {
+            return nil
+        }
+
+        let candidates = (appNodes + TrafficDomainSnapshot.shared.appEntries).compactMap { app -> ClientApplicationIdentity? in
+            guard app.name.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == normalizedName else {
+                return nil
+            }
+            return app.identity
+        }
+        let identitiesByIdentifier = Dictionary(candidates.map { ($0.identifier, $0) }) { first, _ in first }
+        guard identitiesByIdentifier.count == 1 else {
+            return nil
+        }
+        return identitiesByIdentifier.values.first
+    }
+
     func isSSLProxyingFullyEnabled(forAppNamed appName: String, fallbackDomain: String? = nil) -> Bool {
-        if let identity = appNodes.first(where: { $0.name == appName })?.identity {
+        if let identity = observedApplicationIdentity(named: appName) {
             return isSSLProxyingEnabled(for: identity)
         }
         let domains = observedDomainsForApp(named: appName, fallbackDomain: fallbackDomain)
@@ -259,17 +387,13 @@ extension MainContentCoordinator {
             return
         }
 
-        if !SSLProxyingManager.shared.isEnabled {
-            SSLProxyingManager.shared.setEnabled(true)
+        if let blockedReason = sslProxyingHostDecryptBlockedReason(for: domain) {
+            activeToast = ToastMessage(style: .warning, text: blockedReason)
+            return
         }
 
-        let existing = SSLProxyingManager.shared.includeRules.first { $0.matches(domain) }
-        let alreadyEnabled = existing?.isEnabled == true
-        if let existing, !existing.isEnabled {
-            SSLProxyingManager.shared.setRuleEnabled(id: existing.id, enabled: true)
-        } else if existing == nil {
-            enableSSLProxyingForDomain(domain)
-        }
+        let alreadyEnabled = isSSLProxyingEnabled(for: domain)
+        enableSSLProxyingForDomain(domain)
 
         activeToast = ToastMessage(
             style: .success,
@@ -287,6 +411,11 @@ extension MainContentCoordinator {
 
     func retrySSLProxyingFromInspector(for domain: String) {
         guard !domain.isEmpty else {
+            return
+        }
+
+        if let blockedReason = sslProxyingHostDecryptBlockedReason(for: domain) {
+            activeToast = ToastMessage(style: .warning, text: blockedReason)
             return
         }
 
@@ -341,13 +470,24 @@ extension MainContentCoordinator {
             )
         )
 
-        activeToast = ToastMessage(
-            style: .success,
-            text: String(
-                localized: "Enabled SSL Proxying for domains from \(appName). Make the request again to inspect them.",
-                bundle: RockxyLocalization.bundle
+        let enabledCount = domains.count(where: isSSLProxyingEnabled(for:))
+        if enabledCount == domains.count {
+            activeToast = ToastMessage(
+                style: .success,
+                text: String(
+                    localized: "Added host Decrypt rules for domains observed from \(appName). These rules apply to every application.",
+                    bundle: RockxyLocalization.bundle
+                )
             )
-        )
+        } else {
+            activeToast = ToastMessage(
+                style: .warning,
+                text: String(
+                    localized: "Configured \(enabledCount) of \(domains.count) observed hosts. Review Tunnel or bypass rules for the remaining hosts.",
+                    bundle: RockxyLocalization.bundle
+                )
+            )
+        }
     }
 
     func setSSLProxyingFromInspector(
@@ -355,27 +495,54 @@ extension MainContentCoordinator {
         listType: SSLProxyingListType,
         fallbackDomain: String? = nil
     ) {
+        // Configure the application-wide rule first. It applies to every host the application
+        // uses regardless of whether the currently inspected host can decrypt, so feedback is
+        // derived only after the rule is installed.
         setSSLProxyingBehaviorForApplication(
             application,
             listType: listType,
             fallbackDomain: fallbackDomain
         )
-        let message = switch listType {
+
+        switch listType {
         case .include:
-            String(
-                localized: "Set \(application.displayName) to decrypt HTTPS on new connections. Reconnect the app.",
-                bundle: RockxyLocalization.bundle
-            )
+            // App Decrypt is application-wide, but the supplied current host can still be pinned
+            // to Tunnel by a broader host Tunnel rule, Full Proxy Bypass, or the HTTPS TLS Bypass
+            // list. Warn truthfully in that case instead of claiming the current host will decrypt.
+            if let fallbackDomain,
+               !fallbackDomain.isEmpty,
+               let blockedReason = sslProxyingHostDecryptBlockedReason(
+                   for: fallbackDomain,
+                   allowReplacingExactTunnel: false
+               )
+            {
+                activeToast = ToastMessage(
+                    style: .warning,
+                    text: String(
+                        localized: "Set \(application.displayName) to decrypt HTTPS. \(fallbackDomain) stays tunneled: \(blockedReason)",
+                        bundle: RockxyLocalization.bundle
+                    )
+                )
+            } else {
+                activeToast = ToastMessage(
+                    style: .success,
+                    text: String(
+                        localized: "Set \(application.displayName) to decrypt HTTPS. Matching tunneled connections reset automatically — if one stays tunneled, reconnect the app.",
+                        bundle: RockxyLocalization.bundle
+                    )
+                )
+            }
         case .exclude:
-            String(
-                localized: "Set \(application.displayName) to tunnel HTTPS on new connections. Reconnect the app.",
-                bundle: RockxyLocalization.bundle
+            // Tunnel keeps new-connection semantics: already intercepted connections are not
+            // tracked as live raw tunnels, so they are not reset.
+            activeToast = ToastMessage(
+                style: .success,
+                text: String(
+                    localized: "Set \(application.displayName) to tunnel HTTPS on new connections. Reconnect the app.",
+                    bundle: RockxyLocalization.bundle
+                )
             )
         }
-        activeToast = ToastMessage(
-            style: .success,
-            text: message
-        )
     }
 
     func disableSSLProxyingFromInspector(forAppNamed appName: String, fallbackDomain: String? = nil) {
@@ -399,7 +566,7 @@ extension MainContentCoordinator {
         activeToast = ToastMessage(
             style: .success,
             text: String(
-                localized: "Disabled SSL Proxying for domains from \(appName). Requests from it will stay tunneled.",
+                localized: "Set domains observed from \(appName) to Tunnel. These host rules apply to every application.",
                 bundle: RockxyLocalization.bundle
             )
         )
@@ -516,6 +683,14 @@ extension MainContentCoordinator {
 
     private func normalizedObservedHost(_ value: String) -> String {
         value.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private func normalizedSSLHost(_ value: String) -> String {
+        value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    }
+
+    private func sslHostPatternsAreEqual(_ lhs: String, _ rhs: String) -> Bool {
+        normalizedSSLHost(lhs) == normalizedSSLHost(rhs)
     }
 
     // MARK: - Bypass Proxy List

--- a/Rockxy/Views/RequestList/RequestTableView.swift
+++ b/Rockxy/Views/RequestList/RequestTableView.swift
@@ -1248,7 +1248,9 @@ extension RequestTableView {
         @objc
         func handleSSLProxyingAppDecrypt(_ sender: NSMenuItem) {
             withCoordinator(sender) { coordinator, transaction in
-                guard let identity = transaction.clientApplicationIdentity else {
+                guard let identity = transaction.clientApplicationIdentity
+                    ?? transaction.clientApp.flatMap(coordinator.observedApplicationIdentity(named:)) else
+                {
                     return
                 }
                 coordinator.setSSLProxyingFromInspector(
@@ -1262,7 +1264,9 @@ extension RequestTableView {
         @objc
         func handleSSLProxyingAppTunnel(_ sender: NSMenuItem) {
             withCoordinator(sender) { coordinator, transaction in
-                guard let identity = transaction.clientApplicationIdentity else {
+                guard let identity = transaction.clientApplicationIdentity
+                    ?? transaction.clientApp.flatMap(coordinator.observedApplicationIdentity(named:)) else
+                {
                     return
                 }
                 coordinator.setSSLProxyingFromInspector(
@@ -1961,7 +1965,11 @@ extension RequestTableView {
 
         private func sslProxyingMenuItem(for transaction: HTTPTransaction) -> NSMenuItem {
             let submenu = NSMenu()
-            if transaction.clientApplicationIdentity != nil {
+            let applicationIdentity = MainActor.assumeIsolated {
+                transaction.clientApplicationIdentity
+                    ?? transaction.clientApp.flatMap { mainCoordinator?.observedApplicationIdentity(named: $0) }
+            }
+            if applicationIdentity != nil {
                 submenu.addItem(menuItem(
                     String(localized: "Decrypt All HTTPS from This Application", bundle: RockxyLocalization.bundle),
                     action: #selector(handleSSLProxyingAppDecrypt(_:)),
@@ -1973,23 +1981,18 @@ extension RequestTableView {
                 action: #selector(handleSSLProxying(_:)),
                 transaction: transaction
             )
-            let hasApplicationTunnel = MainActor.assumeIsolated {
-                guard let identity = transaction.clientApplicationIdentity else {
-                    return false
-                }
-                return SSLProxyingManager.shared.applicationExcludeRules.contains {
-                    $0.isEnabled && $0.applicationIdentifier == identity.identifier
-                }
-            }
-            if hasApplicationTunnel {
-                hostItem.isEnabled = false
-                hostItem.toolTip = String(
-                    localized: "The application Tunnel rule takes priority. Change the application behavior first.",
-                    bundle: RockxyLocalization.bundle
+            let hostDecryptBlockedReason = MainActor.assumeIsolated {
+                mainCoordinator?.sslProxyingHostDecryptBlockedReason(
+                    for: transaction.request.host,
+                    application: applicationIdentity
                 )
             }
+            if let hostDecryptBlockedReason {
+                hostItem.isEnabled = false
+                hostItem.toolTip = hostDecryptBlockedReason
+            }
             submenu.addItem(hostItem)
-            if transaction.clientApplicationIdentity != nil {
+            if applicationIdentity != nil {
                 submenu.addItem(menuItem(
                     String(localized: "Tunnel All HTTPS from This Application", bundle: RockxyLocalization.bundle),
                     action: #selector(handleSSLProxyingAppTunnel(_:)),

--- a/Rockxy/Views/Sidebar/FavoriteTransactionHTTPSBehaviorMenu.swift
+++ b/Rockxy/Views/Sidebar/FavoriteTransactionHTTPSBehaviorMenu.swift
@@ -50,7 +50,7 @@ struct FavoriteTransactionHTTPSBehaviorMenu: View {
                     systemImage: "globe"
                 )
             }
-            .disabled(!hostActionState.canDecryptHost)
+            .disabled(!hostActionState.canDecryptHost || policyBlockedReason != nil)
             .help(hostActionHelp)
 
             if let applicationIdentity {
@@ -81,6 +81,7 @@ struct FavoriteTransactionHTTPSBehaviorMenu: View {
 
     private var applicationIdentity: ClientApplicationIdentity? {
         transaction.clientApplicationIdentity
+            ?? transaction.clientApp.flatMap(coordinator.observedApplicationIdentity(named:))
     }
 
     private var hasApplicationTunnel: Bool {
@@ -100,6 +101,9 @@ struct FavoriteTransactionHTTPSBehaviorMenu: View {
     }
 
     private var hostActionHelp: String {
+        if let policyBlockedReason {
+            return policyBlockedReason
+        }
         switch hostActionState.blocker {
         case .applicationTunnel:
             return String(
@@ -111,5 +115,12 @@ struct FavoriteTransactionHTTPSBehaviorMenu: View {
         case nil:
             return ""
         }
+    }
+
+    private var policyBlockedReason: String? {
+        coordinator.sslProxyingHostDecryptBlockedReason(
+            for: transaction.request.host,
+            application: applicationIdentity
+        )
     }
 }

--- a/Rockxy/Views/Sidebar/SidebarView.swift
+++ b/Rockxy/Views/Sidebar/SidebarView.swift
@@ -802,7 +802,7 @@ struct SidebarView: View {
                 coordinator.disableSSLProxyingForDomain(domain)
             } label: {
                 Label(
-                    String(localized: "Disable SSL Proxying", bundle: RockxyLocalization.bundle),
+                    String(localized: "Tunnel This Host", bundle: RockxyLocalization.bundle),
                     systemImage: "lock.shield"
                 )
             }
@@ -811,10 +811,12 @@ struct SidebarView: View {
                 coordinator.enableSSLProxyingForDomain(domain)
             } label: {
                 Label(
-                    String(localized: "Enable SSL Proxying", bundle: RockxyLocalization.bundle),
+                    String(localized: "Decrypt This Host", bundle: RockxyLocalization.bundle),
                     systemImage: "lock.shield"
                 )
             }
+            .disabled(coordinator.sslProxyingHostDecryptBlockedReason(for: domain) != nil)
+            .help(coordinator.sslProxyingHostDecryptBlockedReason(for: domain) ?? "")
         }
 
         SidebarOpenHTTPSDecryptionButton()
@@ -1145,6 +1147,10 @@ struct SidebarView: View {
                     systemImage: "lock.shield"
                 )
             }
+            .help(String(
+                localized: "Creates host rules that apply to these domains in every application.",
+                bundle: RockxyLocalization.bundle
+            ))
         }
 
         Button {

--- a/RockxyTests/Core/ProxyEngine/LiveTunnelRegistryTests.swift
+++ b/RockxyTests/Core/ProxyEngine/LiveTunnelRegistryTests.swift
@@ -1,0 +1,968 @@
+import Foundation
+import NIOCore
+import NIOEmbedded
+import NIOPosix
+@testable import Rockxy
+import Testing
+
+// MARK: - CloseFlag
+
+/// Records whether a channel's `closeFuture` has fired. Proves the *actual* downstream
+/// channel was closed, not merely that a predicate returned true.
+private final class CloseFlag: @unchecked Sendable {
+    private(set) var isClosed = false
+
+    func observe(_ channel: Channel) {
+        channel.closeFuture.whenComplete { [self] _ in
+            lock.lock()
+            isClosed = true
+            lock.unlock()
+        }
+    }
+
+    var closed: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return isClosed
+    }
+
+    private let lock = NSLock()
+}
+
+private enum LiveTunnelIntegrationError: Error {
+    case missingBoundPort
+    case proxyResponse(String)
+    case timeout(String)
+}
+
+private final class ConnectResponseHandler: ChannelInboundHandler, @unchecked Sendable {
+    typealias InboundIn = ByteBuffer
+
+    init(responsePromise: EventLoopPromise<Void>) {
+        self.responsePromise = responsePromise
+    }
+
+    func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+        var buffer = unwrapInboundIn(data)
+        received += buffer.readString(length: buffer.readableBytes) ?? ""
+        guard !completed, received.contains("\r\n\r\n") else {
+            return
+        }
+
+        completed = true
+        if received.contains(" 200 ") {
+            responsePromise.succeed(())
+        } else {
+            responsePromise.fail(LiveTunnelIntegrationError.proxyResponse(received))
+        }
+    }
+
+    func errorCaught(context: ChannelHandlerContext, error: Error) {
+        if !completed {
+            completed = true
+            responsePromise.fail(error)
+        }
+        context.close(promise: nil)
+    }
+
+    private let responsePromise: EventLoopPromise<Void>
+    private var received = ""
+    private var completed = false
+}
+
+/// Records that the injected application resolver ran, so a test can wait for asynchronous
+/// identity resolution to complete before asserting a preserve/close outcome deterministically.
+private final class ResolutionGate: @unchecked Sendable {
+    func markResolved() {
+        lock.lock()
+        resolvedCount += 1
+        lock.unlock()
+    }
+
+    var resolved: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return resolvedCount > 0
+    }
+
+    private let lock = NSLock()
+    private var resolvedCount = 0
+}
+
+private final class FutureCompletionGate: @unchecked Sendable {
+    func complete(_ result: Result<Void, Error>, promise: EventLoopPromise<Void>) {
+        lock.lock()
+        guard !completed else {
+            lock.unlock()
+            return
+        }
+        completed = true
+        lock.unlock()
+        promise.completeWith(result)
+    }
+
+    private let lock = NSLock()
+    private var completed = false
+}
+
+// MARK: - LiveTunnelRegistryTests
+
+/// Exercises the live-tunnel reset seam with the *real* raw/intercept predicate
+/// (`TLSInterceptHandler.initialTunnelMode`) wired to isolated `SSLProxyingManager` /
+/// `BypassProxyManager` instances, and real `EmbeddedChannel`s so each assertion proves the
+/// downstream channel is genuinely closed (or preserved) after a policy change.
+@MainActor
+struct LiveTunnelRegistryTests {
+    @Test("enabling SSL proxying closes a real live CONNECT tunnel through ProxyServer")
+    func proxyServerClosesLiveConnectAfterRuleEnabled() async throws {
+        let sslManager = makeSSLProxyingManager()
+        let bypassManager = makeBypassProxyManager()
+
+        sslManager.clearAutoPassthrough()
+        sslManager.replaceAllRules([])
+        sslManager.setEnabled(false)
+        sslManager.setBypassDomains("")
+        sslManager.forceGlobalPassthrough = false
+        #expect(!sslManager.shouldIntercept("127.0.0.1"))
+
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        let rawTunnelReadyPromise = group.next().makePromise(of: Void.self)
+        var originChannel: Channel?
+        var clientChannel: Channel?
+        var proxyServer: ProxyServer?
+
+        do {
+            let origin = try await ServerBootstrap(group: group)
+                .serverChannelOption(.socketOption(.so_reuseaddr), value: 1)
+                .childChannelInitializer { channel in
+                    channel.eventLoop.makeSucceededVoidFuture()
+                }
+                .bind(host: "127.0.0.1", port: 0)
+                .get()
+            originChannel = origin
+            guard let originPort = origin.localAddress?.port else {
+                throw LiveTunnelIntegrationError.missingBoundPort
+            }
+
+            // Reserve an ephemeral port, then immediately hand it to ProxyServer.
+            let reservation = try await ServerBootstrap(group: group)
+                .serverChannelOption(.socketOption(.so_reuseaddr), value: 1)
+                .bind(host: "127.0.0.1", port: 0)
+                .get()
+            guard let proxyPort = reservation.localAddress?.port else {
+                throw LiveTunnelIntegrationError.missingBoundPort
+            }
+            try await reservation.close().get()
+
+            let proxy = ProxyServer(
+                configuration: ProxyConfiguration(
+                    port: proxyPort,
+                    listenAddress: "127.0.0.1",
+                    listenIPv6: false
+                ),
+                sslProxyingManager: sslManager,
+                bypassProxyManager: bypassManager,
+                onTransactionComplete: { transaction in
+                    if transaction.request.method == "CONNECT", transaction.sslCapture == .tunneled {
+                        rawTunnelReadyPromise.succeed(())
+                    }
+                }
+            )
+            proxyServer = proxy
+            try await proxy.start()
+
+            let responsePromise = group.next().makePromise(of: Void.self)
+            let client = try await ClientBootstrap(group: group)
+                .channelInitializer { channel in
+                    channel.pipeline.addHandler(ConnectResponseHandler(responsePromise: responsePromise))
+                }
+                .connect(host: "127.0.0.1", port: proxyPort)
+                .get()
+            clientChannel = client
+
+            var request = client.allocator.buffer(capacity: 128)
+            request.writeString(
+                "CONNECT 127.0.0.1:\(originPort) HTTP/1.1\r\n" +
+                    "Host: 127.0.0.1:\(originPort)\r\n\r\n"
+            )
+            try await client.writeAndFlush(request).get()
+            try await wait(
+                for: responsePromise.futureResult,
+                timeout: .seconds(3),
+                label: "waiting for CONNECT 200 response"
+            )
+            #expect(client.isActive)
+            try await wait(
+                for: rawTunnelReadyPromise.futureResult,
+                timeout: .seconds(3),
+                label: "waiting for raw CONNECT registration"
+            )
+
+            // This is the issue #310 transition: the browser already owns a live raw CONNECT,
+            // then the user enables SSL Proxying for that host. ProxyServer's real notification
+            // observer must close the existing client connection so the next request creates a
+            // fresh CONNECT that can enter interception.
+            sslManager.addRule(SSLProxyingRule(domain: "127.0.0.1", listType: .include))
+            #expect(!sslManager.shouldIntercept("127.0.0.1"))
+            sslManager.setEnabled(true)
+            #expect(sslManager.shouldIntercept("127.0.0.1"))
+            try await wait(
+                for: client.closeFuture,
+                timeout: .seconds(3),
+                label: "waiting for live raw CONNECT reset"
+            )
+            #expect(!client.isActive)
+
+            await proxy.stop()
+            proxyServer = nil
+            try await origin.close().get()
+            originChannel = nil
+            try await group.shutdownGracefully()
+        } catch {
+            if let clientChannel, clientChannel.isActive {
+                try? await clientChannel.close().get()
+            }
+            if let proxyServer {
+                await proxyServer.stop()
+            }
+            if let originChannel, originChannel.isActive {
+                try? await originChannel.close().get()
+            }
+            try? await group.shutdownGracefully()
+            throw error
+        }
+    }
+
+    @Test("policy change resets the matching raw tunnel but preserves unrelated hosts")
+    func resetsMatchingPreservesUnrelated() throws {
+        let sslManager = makeSSLProxyingManager()
+        let bypassManager = makeBypassProxyManager()
+        sslManager.setEnabled(true)
+        sslManager.setBypassDomains("")
+
+        let registry = makeRegistry(sslManager: sslManager, bypassManager: bypassManager)
+
+        let matchChannel = EmbeddedChannel()
+        let otherChannel = EmbeddedChannel()
+        let matchFlag = CloseFlag()
+        let otherFlag = CloseFlag()
+        matchFlag.observe(matchChannel)
+        otherFlag.observe(otherChannel)
+
+        let generation = registry.currentGeneration()
+        registry.registerRawTunnel(
+            channel: matchChannel,
+            host: "match.example.com",
+            reason: .noSSLProxyingRule,
+            decisionGeneration: generation
+        )
+        registry.registerRawTunnel(
+            channel: otherChannel,
+            host: "other.example.com",
+            reason: .noSSLProxyingRule,
+            decisionGeneration: generation
+        )
+        #expect(registry.trackedTunnelCount() == 2)
+
+        sslManager.addRule(SSLProxyingRule(domain: "match.example.com", listType: .include))
+        registry.invalidateTunnelsNowRequiringInterception()
+        drain(matchChannel)
+        drain(otherChannel)
+
+        #expect(matchFlag.closed)
+        #expect(!otherFlag.closed)
+
+        _ = try? matchChannel.finish()
+        _ = try? otherChannel.finish()
+    }
+
+    @Test("application Decrypt resets only matching application's live tunnel")
+    func applicationDecryptResetsOnlyMatchingApplication() throws {
+        let sslManager = makeSSLProxyingManager()
+        let bypassManager = makeBypassProxyManager()
+        let appA = ClientApplicationIdentity.bundle(identifier: "com.example.AppA", displayName: "App A")
+        let appB = ClientApplicationIdentity.bundle(identifier: "com.example.AppB", displayName: "App B")
+        sslManager.setEnabled(true)
+        sslManager.setBypassDomains("")
+
+        let registry = makeRegistry(sslManager: sslManager, bypassManager: bypassManager)
+        let appAChannel = EmbeddedChannel()
+        let appBChannel = EmbeddedChannel()
+        let unresolvedChannel = EmbeddedChannel()
+        let appAFlag = CloseFlag()
+        let appBFlag = CloseFlag()
+        let unresolvedFlag = CloseFlag()
+        appAFlag.observe(appAChannel)
+        appBFlag.observe(appBChannel)
+        unresolvedFlag.observe(unresolvedChannel)
+
+        let generation = registry.currentGeneration()
+        registry.registerRawTunnel(
+            channel: appAChannel,
+            host: "shared.example.com",
+            application: appA,
+            reason: .noSSLProxyingRule,
+            decisionGeneration: generation
+        )
+        registry.registerRawTunnel(
+            channel: appBChannel,
+            host: "shared.example.com",
+            application: appB,
+            reason: .noSSLProxyingRule,
+            decisionGeneration: generation
+        )
+        registry.registerRawTunnel(
+            channel: unresolvedChannel,
+            host: "shared.example.com",
+            application: nil,
+            reason: .noSSLProxyingRule,
+            decisionGeneration: generation
+        )
+
+        sslManager.addApplicationRule(ApplicationSSLProxyingRule(identity: appA, listType: .include))
+        registry.invalidateTunnelsNowRequiringInterception()
+        drain(appAChannel)
+        drain(appBChannel)
+        drain(unresolvedChannel)
+
+        #expect(appAFlag.closed)
+        #expect(!appBFlag.closed)
+        #expect(!unresolvedFlag.closed)
+        #expect(registry.trackedTunnelCount() == 2)
+
+        _ = try? appAChannel.finish()
+        _ = try? appBChannel.finish()
+        _ = try? unresolvedChannel.finish()
+    }
+
+    @Test("first application rule resolves old unidentified tunnels and resets only the matching app")
+    func applicationDecryptLazilyResolvesExistingTunnels() async throws {
+        let sslManager = makeSSLProxyingManager()
+        let bypassManager = makeBypassProxyManager()
+        let chrome = ClientApplicationIdentity.bundle(
+            identifier: "com.google.Chrome",
+            displayName: "Google Chrome"
+        )
+        let safari = ClientApplicationIdentity.bundle(
+            identifier: "com.apple.Safari",
+            displayName: "Safari"
+        )
+        sslManager.setEnabled(true)
+        sslManager.setBypassDomains("")
+
+        let registry = LiveTunnelRegistry(
+            shouldInterceptNow: { host, application in
+                TLSInterceptHandler.initialTunnelMode(
+                    host: host,
+                    sslProxyingManager: sslManager,
+                    bypassProxyManager: bypassManager,
+                    application: application
+                ) == .intercept
+            },
+            shouldResolveApplicationNow: {
+                sslManager.hasEnabledApplicationRules()
+            },
+            resolveApplication: { descriptor in
+                descriptor.clientPort == 51_001 ? chrome : safari
+            }
+        )
+        let chromeChannel = EmbeddedChannel()
+        let safariChannel = EmbeddedChannel()
+        let chromeFlag = CloseFlag()
+        let safariFlag = CloseFlag()
+        chromeFlag.observe(chromeChannel)
+        safariFlag.observe(safariChannel)
+
+        let generation = registry.currentGeneration()
+        registry.registerRawTunnel(
+            channel: chromeChannel,
+            host: "shared.example.com",
+            connectionDescriptor: makeDescriptor(clientPort: 51_001),
+            reason: .noSSLProxyingRule,
+            decisionGeneration: generation
+        )
+        registry.registerRawTunnel(
+            channel: safariChannel,
+            host: "shared.example.com",
+            connectionDescriptor: makeDescriptor(clientPort: 51_002),
+            reason: .noSSLProxyingRule,
+            decisionGeneration: generation
+        )
+
+        sslManager.addApplicationRule(ApplicationSSLProxyingRule(identity: chrome, listType: .include))
+        registry.invalidateTunnelsNowRequiringInterception()
+
+        for _ in 0 ..< 100 {
+            drain(chromeChannel)
+            drain(safariChannel)
+            if chromeFlag.closed {
+                break
+            }
+            try await Task.sleep(for: .milliseconds(5))
+        }
+
+        #expect(chromeFlag.closed)
+        #expect(!safariFlag.closed)
+        #expect(registry.trackedTunnelCount() == 1)
+
+        _ = try? chromeChannel.finish()
+        _ = try? safariChannel.finish()
+    }
+
+    @Test("host Decrypt preserves an unresolved tunnel whose resolved application has a Tunnel rule")
+    func hostDecryptPreservesResolvedApplicationTunnel() async throws {
+        let sslManager = makeSSLProxyingManager()
+        let bypassManager = makeBypassProxyManager()
+        let tunneledApp = ClientApplicationIdentity.bundle(
+            identifier: "com.example.Tunneled",
+            displayName: "Tunneled App"
+        )
+        sslManager.setEnabled(true)
+        sslManager.setBypassDomains("")
+
+        let gate = ResolutionGate()
+        let registry = makeResolvingRegistry(
+            sslManager: sslManager,
+            bypassManager: bypassManager
+        ) { _ in
+            gate.markResolved()
+            return tunneledApp
+        }
+
+        // The tunnel is registered while no application rules exist, so its identity stays
+        // unresolved (host-only fast path). Only the later mutation makes it resolvable.
+        let channel = EmbeddedChannel()
+        let flag = CloseFlag()
+        flag.observe(channel)
+        registry.registerRawTunnel(
+            channel: channel,
+            host: "shared.example.com",
+            connectionDescriptor: makeDescriptor(clientPort: 51_010),
+            reason: .noSSLProxyingRule,
+            decisionGeneration: registry.currentGeneration()
+        )
+        #expect(registry.trackedTunnelCount() == 1)
+
+        // A host-wide Decrypt plus an application Tunnel rule that must outrank it once resolved.
+        sslManager.addRule(SSLProxyingRule(domain: "*", listType: .include))
+        sslManager.addApplicationRule(ApplicationSSLProxyingRule(identity: tunneledApp, listType: .exclude))
+        registry.invalidateTunnelsNowRequiringInterception()
+        try await settleResolution(gate: gate, channel: channel)
+
+        #expect(!flag.closed)
+        #expect(registry.trackedTunnelCount() == 1)
+
+        _ = try? channel.finish()
+    }
+
+    @Test("host Decrypt closes an unresolved tunnel once resolution returns nil")
+    func hostDecryptClosesAfterNilResolution() async throws {
+        let sslManager = makeSSLProxyingManager()
+        let bypassManager = makeBypassProxyManager()
+        let unrelatedApp = ClientApplicationIdentity.bundle(
+            identifier: "com.example.Unrelated",
+            displayName: "Unrelated App"
+        )
+        sslManager.setEnabled(true)
+        sslManager.setBypassDomains("")
+
+        let gate = ResolutionGate()
+        let registry = makeResolvingRegistry(
+            sslManager: sslManager,
+            bypassManager: bypassManager
+        ) { _ in
+            gate.markResolved()
+            return nil
+        }
+
+        let channel = EmbeddedChannel()
+        let flag = CloseFlag()
+        flag.observe(channel)
+        registry.registerRawTunnel(
+            channel: channel,
+            host: "shared.example.com",
+            connectionDescriptor: makeDescriptor(clientPort: 51_020),
+            reason: .noSSLProxyingRule,
+            decisionGeneration: registry.currentGeneration()
+        )
+
+        // An enabled application rule turns on lazy resolution; the host itself gains a Decrypt
+        // rule. Resolution cannot identify the client, so the host-only decision closes it.
+        sslManager.addApplicationRule(ApplicationSSLProxyingRule(identity: unrelatedApp, listType: .include))
+        sslManager.addRule(SSLProxyingRule(domain: "shared.example.com", listType: .include))
+        registry.invalidateTunnelsNowRequiringInterception()
+
+        for _ in 0 ..< 200 {
+            drain(channel)
+            if flag.closed {
+                break
+            }
+            try await Task.sleep(for: .milliseconds(5))
+        }
+
+        #expect(gate.resolved)
+        #expect(flag.closed)
+
+        _ = try? channel.finish()
+    }
+
+    @Test("raced registration defers to an asynchronously resolved application Tunnel")
+    func racedRegistrationRespectsResolvedApplicationTunnel() async throws {
+        let sslManager = makeSSLProxyingManager()
+        let bypassManager = makeBypassProxyManager()
+        let tunneledApp = ClientApplicationIdentity.bundle(
+            identifier: "com.example.RacedTunnel",
+            displayName: "Raced Tunnel App"
+        )
+        sslManager.setEnabled(true)
+        sslManager.setBypassDomains("")
+
+        let gate = ResolutionGate()
+        let registry = makeResolvingRegistry(
+            sslManager: sslManager,
+            bypassManager: bypassManager
+        ) { _ in
+            gate.markResolved()
+            return tunneledApp
+        }
+
+        // The raw classification was taken under the old (no-rule) policy.
+        let decisionGeneration = registry.currentGeneration()
+
+        // Policy mutates before the tunnel registers: host-wide Decrypt plus the application
+        // Tunnel rule that must outrank it once the identity resolves.
+        sslManager.addRule(SSLProxyingRule(domain: "*", listType: .include))
+        sslManager.addApplicationRule(ApplicationSSLProxyingRule(identity: tunneledApp, listType: .exclude))
+        registry.invalidateTunnelsNowRequiringInterception()
+
+        let channel = EmbeddedChannel()
+        let flag = CloseFlag()
+        flag.observe(channel)
+        registry.registerRawTunnel(
+            channel: channel,
+            host: "shared.example.com",
+            connectionDescriptor: makeDescriptor(clientPort: 51_030),
+            reason: .noSSLProxyingRule,
+            decisionGeneration: decisionGeneration
+        )
+        try await settleResolution(gate: gate, channel: channel)
+
+        #expect(gate.resolved)
+        #expect(!flag.closed)
+        #expect(registry.trackedTunnelCount() == 1)
+
+        _ = try? channel.finish()
+    }
+
+    @Test("raced registration falls back to the host decision when no resolver is available")
+    func racedRegistrationWithoutResolverStillCloses() throws {
+        let sslManager = makeSSLProxyingManager()
+        let bypassManager = makeBypassProxyManager()
+        let application = ClientApplicationIdentity.bundle(
+            identifier: "com.example.Unresolvable",
+            displayName: "Unresolvable App"
+        )
+        sslManager.setEnabled(true)
+        sslManager.setBypassDomains("")
+
+        let registry = LiveTunnelRegistry(
+            shouldInterceptNow: { host, identity in
+                TLSInterceptHandler.initialTunnelMode(
+                    host: host,
+                    sslProxyingManager: sslManager,
+                    bypassProxyManager: bypassManager,
+                    application: identity
+                ) == .intercept
+            },
+            shouldResolveApplicationNow: { sslManager.hasEnabledApplicationRules() }
+        )
+        let decisionGeneration = registry.currentGeneration()
+        sslManager.addApplicationRule(ApplicationSSLProxyingRule(identity: application, listType: .include))
+        sslManager.addRule(SSLProxyingRule(domain: "shared.example.com", listType: .include))
+        registry.invalidateTunnelsNowRequiringInterception()
+
+        let channel = EmbeddedChannel()
+        let flag = CloseFlag()
+        flag.observe(channel)
+        registry.registerRawTunnel(
+            channel: channel,
+            host: "shared.example.com",
+            connectionDescriptor: makeDescriptor(clientPort: 51_040),
+            reason: .noSSLProxyingRule,
+            decisionGeneration: decisionGeneration
+        )
+        drain(channel)
+
+        #expect(flag.closed)
+        #expect(registry.trackedTunnelCount() == 0)
+        _ = try? channel.finish()
+    }
+
+    @Test("application Tunnel preserves its connection when host Decrypt resets others")
+    func applicationTunnelBeatsHostDecryptDuringReset() throws {
+        let sslManager = makeSSLProxyingManager()
+        let bypassManager = makeBypassProxyManager()
+        let appA = ClientApplicationIdentity.bundle(identifier: "com.example.AppA", displayName: "App A")
+        let appB = ClientApplicationIdentity.bundle(identifier: "com.example.AppB", displayName: "App B")
+        sslManager.setEnabled(true)
+        sslManager.setBypassDomains("")
+
+        let registry = makeRegistry(sslManager: sslManager, bypassManager: bypassManager)
+        let excludedChannel = EmbeddedChannel()
+        let includedChannel = EmbeddedChannel()
+        let excludedFlag = CloseFlag()
+        let includedFlag = CloseFlag()
+        excludedFlag.observe(excludedChannel)
+        includedFlag.observe(includedChannel)
+
+        let generation = registry.currentGeneration()
+        registry.registerRawTunnel(
+            channel: excludedChannel,
+            host: "api.example.com",
+            application: appA,
+            reason: .noSSLProxyingRule,
+            decisionGeneration: generation
+        )
+        registry.registerRawTunnel(
+            channel: includedChannel,
+            host: "api.example.com",
+            application: appB,
+            reason: .noSSLProxyingRule,
+            decisionGeneration: generation
+        )
+
+        sslManager.addApplicationRule(ApplicationSSLProxyingRule(identity: appA, listType: .exclude))
+        sslManager.addRule(SSLProxyingRule(domain: "api.example.com", listType: .include))
+        registry.invalidateTunnelsNowRequiringInterception()
+        drain(excludedChannel)
+        drain(includedChannel)
+
+        #expect(!excludedFlag.closed)
+        #expect(includedFlag.closed)
+        #expect(registry.trackedTunnelCount() == 1)
+
+        _ = try? excludedChannel.finish()
+        _ = try? includedChannel.finish()
+    }
+
+    @Test("raw classification that raced a policy mutation is closed at registration")
+    func racedRawClassificationClosedAtRegistration() throws {
+        let sslManager = makeSSLProxyingManager()
+        let bypassManager = makeBypassProxyManager()
+        sslManager.setEnabled(true)
+        sslManager.setBypassDomains("")
+
+        let registry = makeRegistry(sslManager: sslManager, bypassManager: bypassManager)
+
+        // Decision was taken under the old (no-rule → raw) policy.
+        let decisionGeneration = registry.currentGeneration()
+
+        // Policy mutates before this tunnel manages to register.
+        sslManager.addRule(SSLProxyingRule(domain: "match.example.com", listType: .include))
+        registry.invalidateTunnelsNowRequiringInterception()
+
+        let channel = EmbeddedChannel()
+        let flag = CloseFlag()
+        flag.observe(channel)
+        registry.registerRawTunnel(
+            channel: channel,
+            host: "match.example.com",
+            reason: .noSSLProxyingRule,
+            decisionGeneration: decisionGeneration
+        )
+        drain(channel)
+
+        // The stale raw decision must not be tracked — it is closed immediately so the client
+        // reconnects into interception.
+        #expect(flag.closed)
+        #expect(registry.trackedTunnelCount() == 0)
+
+        _ = try? channel.finish()
+    }
+
+    @Test("closing a channel drains it from the registry (shutdown compatibility)")
+    func channelCloseDrainsRegistry() throws {
+        let sslManager = makeSSLProxyingManager()
+        let bypassManager = makeBypassProxyManager()
+        let registry = makeRegistry(sslManager: sslManager, bypassManager: bypassManager)
+
+        let channel = EmbeddedChannel()
+        registry.registerRawTunnel(
+            channel: channel,
+            host: "drain.example.com",
+            reason: .noSSLProxyingRule,
+            decisionGeneration: registry.currentGeneration()
+        )
+        #expect(registry.trackedTunnelCount() == 1)
+
+        // EmbeddedChannel queues closeFuture callbacks on its embedded loop. Drain that loop to
+        // mirror the real proxy stop path waiting for channel teardown to complete.
+        channel.close(promise: nil)
+        drain(channel)
+        #expect(registry.trackedTunnelCount() == 0)
+
+        _ = try? channel.finish()
+    }
+
+    @Test("retryInterception closes a live auto-passthrough tunnel via the manager notification")
+    func retryClearsAutoPassthroughTunnel() throws {
+        let sslManager = makeSSLProxyingManager()
+        let bypassManager = makeBypassProxyManager()
+        sslManager.setEnabled(true)
+        sslManager.setBypassDomains("")
+        let host = "retry.example.com"
+        // The host is in scope for interception, but a recent TLS rejection parks it in
+        // auto-passthrough so its live tunnel is raw.
+        sslManager.addRule(SSLProxyingRule(domain: host, listType: .include))
+        sslManager.markHostForPassthrough(host)
+
+        let registry = makeRegistry(sslManager: sslManager, bypassManager: bypassManager)
+
+        // Mirror ProxyServer's observer: a policy change drives the same invalidation seam.
+        let observer = NotificationCenter.default.addObserver(
+            forName: .sslProxyingStateDidChange,
+            object: nil,
+            queue: nil
+        ) { _ in
+            registry.invalidateTunnelsNowRequiringInterception()
+        }
+        defer { NotificationCenter.default.removeObserver(observer) }
+
+        let channel = EmbeddedChannel()
+        let flag = CloseFlag()
+        flag.observe(channel)
+        registry.registerRawTunnel(
+            channel: channel,
+            host: host,
+            reason: .autoPassthrough,
+            decisionGeneration: registry.currentGeneration()
+        )
+        // Still auto-passthrough, so the tunnel is tracked (not interceptable yet).
+        #expect(registry.trackedTunnelCount() == 1)
+        #expect(!flag.closed)
+
+        // Clearing the fallback posts .sslProxyingStateDidChange; the observer invalidates and the
+        // now-interceptable raw tunnel is closed so the next request enters interception.
+        #expect(sslManager.retryInterception(for: host))
+        drain(channel)
+        #expect(flag.closed)
+
+        _ = try? channel.finish()
+    }
+
+    @Test("clearing all auto-passthrough hosts closes newly interceptable live raw tunnels")
+    func clearAllAutoPassthroughClosesTunnelViaNotification() throws {
+        let sslManager = makeSSLProxyingManager()
+        let bypassManager = makeBypassProxyManager()
+        sslManager.setEnabled(true)
+        sslManager.setBypassDomains("")
+        let host = "certificate-ready.example.com"
+        sslManager.addRule(SSLProxyingRule(domain: host, listType: .include))
+        sslManager.markHostForPassthrough(host)
+
+        let registry = makeRegistry(sslManager: sslManager, bypassManager: bypassManager)
+        let observer = NotificationCenter.default.addObserver(
+            forName: .sslProxyingStateDidChange,
+            object: nil,
+            queue: nil
+        ) { _ in
+            registry.invalidateTunnelsNowRequiringInterception()
+        }
+        defer { NotificationCenter.default.removeObserver(observer) }
+
+        let channel = EmbeddedChannel()
+        let flag = CloseFlag()
+        flag.observe(channel)
+        registry.registerRawTunnel(
+            channel: channel,
+            host: host,
+            reason: .autoPassthrough,
+            decisionGeneration: registry.currentGeneration()
+        )
+
+        sslManager.clearAutoPassthrough()
+        drain(channel)
+
+        #expect(flag.closed)
+        #expect(registry.trackedTunnelCount() == 0)
+
+        _ = try? channel.finish()
+    }
+
+    @Test("removing a bypass entry closes the now-interceptable live raw tunnel")
+    func bypassRemovalClosesTunnelViaNotification() throws {
+        let sslManager = makeSSLProxyingManager()
+        let bypassManager = makeBypassProxyManager()
+        let host = "bypass-removal.example.com"
+        sslManager.setEnabled(true)
+        sslManager.setBypassDomains("")
+        sslManager.addRule(SSLProxyingRule(domain: host, listType: .include))
+        bypassManager.addDomain(host)
+
+        let registry = makeRegistry(sslManager: sslManager, bypassManager: bypassManager)
+        let observer = NotificationCenter.default.addObserver(
+            forName: .bypassProxyListDidChange,
+            object: nil,
+            queue: nil
+        ) { _ in
+            registry.invalidateTunnelsNowRequiringInterception()
+        }
+        defer { NotificationCenter.default.removeObserver(observer) }
+
+        let channel = EmbeddedChannel()
+        let flag = CloseFlag()
+        flag.observe(channel)
+        registry.registerRawTunnel(
+            channel: channel,
+            host: host,
+            reason: .bypassProxyList,
+            decisionGeneration: registry.currentGeneration()
+        )
+
+        let matchingIDs = Set(bypassManager.domains.filter { $0.matches(host) }.map(\.id))
+        bypassManager.removeDomains(ids: matchingIDs)
+        drain(channel)
+
+        #expect(flag.closed)
+        #expect(registry.trackedTunnelCount() == 0)
+        _ = try? channel.finish()
+    }
+
+    @Test("bypassed host tunnel is never reset by a policy change")
+    func bypassedHostPreserved() throws {
+        let sslManager = makeSSLProxyingManager()
+        let bypassManager = makeBypassProxyManager()
+        sslManager.setEnabled(true)
+        sslManager.setBypassDomains("")
+        sslManager.addRule(SSLProxyingRule(domain: "*", listType: .include))
+        bypassManager.addDomain("bypass.example.com")
+
+        let registry = makeRegistry(sslManager: sslManager, bypassManager: bypassManager)
+
+        let channel = EmbeddedChannel()
+        let flag = CloseFlag()
+        flag.observe(channel)
+        registry.registerRawTunnel(
+            channel: channel,
+            host: "bypass.example.com",
+            reason: .bypassProxyList,
+            decisionGeneration: registry.currentGeneration()
+        )
+
+        registry.invalidateTunnelsNowRequiringInterception()
+
+        #expect(!flag.closed)
+        #expect(registry.trackedTunnelCount() == 1)
+
+        _ = try? channel.finish()
+    }
+
+    // MARK: Private
+
+    private func makeRegistry(
+        sslManager: SSLProxyingManager,
+        bypassManager: BypassProxyManager
+    )
+        -> LiveTunnelRegistry
+    {
+        LiveTunnelRegistry(shouldInterceptNow: { host, application in
+            TLSInterceptHandler.initialTunnelMode(
+                host: host,
+                sslProxyingManager: sslManager,
+                bypassProxyManager: bypassManager,
+                application: application
+            ) == .intercept
+        })
+    }
+
+    /// Builds a registry whose lazy application resolution is gated on the manager actually
+    /// having enabled application rules (matching production wiring) and whose resolver is
+    /// injected so a test can decide which identity a descriptor maps to.
+    private func makeResolvingRegistry(
+        sslManager: SSLProxyingManager,
+        bypassManager: BypassProxyManager,
+        resolver: @escaping @Sendable (ProxyConnectionDescriptor) async -> ClientApplicationIdentity?
+    )
+        -> LiveTunnelRegistry
+    {
+        LiveTunnelRegistry(
+            shouldInterceptNow: { host, application in
+                TLSInterceptHandler.initialTunnelMode(
+                    host: host,
+                    sslProxyingManager: sslManager,
+                    bypassProxyManager: bypassManager,
+                    application: application
+                ) == .intercept
+            },
+            shouldResolveApplicationNow: { sslManager.hasEnabledApplicationRules() },
+            resolveApplication: resolver
+        )
+    }
+
+    /// Drains the embedded channel until the injected resolver has run, then a few more cycles so
+    /// any post-resolution close is flushed — leaving a definitive preserve/close state to assert.
+    private func settleResolution(gate: ResolutionGate, channel: EmbeddedChannel) async throws {
+        for _ in 0 ..< 200 {
+            drain(channel)
+            if gate.resolved {
+                break
+            }
+            try await Task.sleep(for: .milliseconds(5))
+        }
+        for _ in 0 ..< 5 {
+            drain(channel)
+            try await Task.sleep(for: .milliseconds(5))
+        }
+        drain(channel)
+    }
+
+    private func makeSSLProxyingManager() -> SSLProxyingManager {
+        SSLProxyingManager(
+            storageURL: makeTempURL(prefix: "rockxy-live-tunnel-ssl"),
+            passthroughStorageURL: makeTempURL(prefix: "rockxy-live-tunnel-passthrough")
+        )
+    }
+
+    private func makeBypassProxyManager() -> BypassProxyManager {
+        BypassProxyManager(storageURL: makeTempURL(prefix: "rockxy-live-tunnel-bypass"))
+    }
+
+    private func makeDescriptor(clientPort: UInt16) -> ProxyConnectionDescriptor {
+        ProxyConnectionDescriptor(
+            acceptedAt: .now(),
+            clientHost: "127.0.0.1",
+            clientPort: clientPort,
+            proxyHost: "127.0.0.1",
+            proxyPort: 9_090
+        )
+    }
+
+    private func wait(
+        for future: EventLoopFuture<Void>,
+        timeout: TimeAmount,
+        label: String
+    ) async throws {
+        let resultPromise = future.eventLoop.makePromise(of: Void.self)
+        let gate = FutureCompletionGate()
+        future.whenComplete { result in
+            gate.complete(result, promise: resultPromise)
+        }
+        let timeoutTask = future.eventLoop.scheduleTask(in: timeout) {
+            gate.complete(
+                .failure(LiveTunnelIntegrationError.timeout(label)),
+                promise: resultPromise
+            )
+        }
+        defer { timeoutTask.cancel() }
+        try await resultPromise.futureResult.get()
+    }
+
+    private func makeTempURL(prefix: String) -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(prefix)-\(UUID().uuidString).json")
+    }
+
+    private func drain(_ channel: EmbeddedChannel) {
+        channel.embeddedEventLoop.run()
+    }
+}

--- a/RockxyTests/Core/ProxyEngine/SSLProxyingManagerTests.swift
+++ b/RockxyTests/Core/ProxyEngine/SSLProxyingManagerTests.swift
@@ -154,9 +154,24 @@ struct SSLProxyingManagerTests {
     @Test("shouldIntercept returns false when forceGlobalPassthrough is set")
     func interceptGlobalPassthrough() {
         let manager = makeManager()
+        manager.addRule(SSLProxyingRule(domain: "anything.com", listType: .include))
         manager.forceGlobalPassthrough = true
         #expect(!manager.shouldIntercept("anything.com"))
+        #expect(manager.isDecryptionConfigured(host: "anything.com"))
         manager.forceGlobalPassthrough = false
+        #expect(manager.shouldIntercept("anything.com"))
+    }
+
+    @Test("TLS bypass query exposes the reason a matching Decrypt rule is ineffective")
+    func tlsBypassQuery() {
+        let manager = makeManager()
+        manager.setBypassDomains("ocsp.example.com,*.private.example")
+        manager.addRule(SSLProxyingRule(domain: "ocsp.example.com", listType: .include))
+
+        #expect(manager.isHostInTLSBypassList("OCSP.EXAMPLE.COM"))
+        #expect(manager.isHostInTLSBypassList("api.private.example"))
+        #expect(!manager.isHostInTLSBypassList("public.example"))
+        #expect(!manager.shouldIntercept("ocsp.example.com"))
     }
 
     @Test("adding include rule clears matching auto passthrough host")

--- a/RockxyTests/Core/ProxyEngine/TLSInterceptHandlerTests.swift
+++ b/RockxyTests/Core/ProxyEngine/TLSInterceptHandlerTests.swift
@@ -166,6 +166,42 @@ struct TLSInterceptHandlerTests {
         #expect(transaction.isTLSFailure == true)
     }
 
+    @Test("raw tunnel capture is tagged tunneled")
+    func rawTunnelCaptureModeTunneled() {
+        let transaction = TLSInterceptHandler.makeTunnelTransaction(
+            host: "example.com",
+            port: 443,
+            statusCode: 200,
+            statusMessage: "Connection Established",
+            state: .completed,
+            sourcePort: 54_321,
+            sslCapture: .tunneled
+        )
+
+        #expect(transaction.sslCapture == .tunneled)
+    }
+
+    @Test("non-TLS raw fallback records a tunneled CONNECT")
+    func protocolDetectorRawFallbackIsTunneled() {
+        let recorded = RecordedTransactionBox()
+        let handler = PostHandshakeHandler(
+            host: "api.example.com",
+            port: 443,
+            ruleEngine: RuleEngine(),
+            scriptPluginManager: nil,
+            connectionLimiter: ConnectionLimiter(),
+            sslProxyingManager: .shared,
+            clientSourcePort: 60_123,
+            onTransactionComplete: { transaction in
+                recorded.record(transaction)
+            }
+        )
+
+        handler.recordSuccessfulTunnel()
+
+        #expect(recorded.transaction?.sslCapture == .tunneled)
+    }
+
     @Test("post-handshake helper builds successful CONNECT transaction")
     func postHandshakeSuccessfulTunnelTransaction() {
         let handler = PostHandshakeHandler(

--- a/RockxyTests/Views/Inspector/InspectorRoutingTests.swift
+++ b/RockxyTests/Views/Inspector/InspectorRoutingTests.swift
@@ -444,8 +444,9 @@ struct InspectorRoutingTests {
         #expect(prompt?.hostScope?.controlTitle == "Decrypt Host")
         #expect(prompt?.hostScope?.action == .enableDomain("api.example.com"))
         #expect(prompt?.appScope?.control == .button)
-        #expect(prompt?.appScope?.controlTitle == "Decrypt App")
+        #expect(prompt?.appScope?.controlTitle == "Decrypt Observed Hosts")
         #expect(prompt?.appScope?.action == .enableApp("Brave Browser Helper", fallbackDomain: "api.example.com"))
+        #expect(prompt?.appScope?.actionDescription.contains("apply to every application") == true)
         #expect(prompt?.requiresCertificateSetup == false)
         #expect(prompt?.insight == .tunnelEstablished(statusCode: 200))
         #expect(prompt?.insight?.title == "Content Not Inspected")
@@ -742,7 +743,7 @@ struct InspectorRoutingTests {
         #expect(prompt?.hostScope?.action == nil)
         #expect(prompt?.appScope?.state == .partial)
         #expect(prompt?.appScope?.control == .button)
-        #expect(prompt?.appScope?.controlTitle == "Decrypt App")
+        #expect(prompt?.appScope?.controlTitle == "Decrypt Observed Hosts")
         #expect(prompt?.appScope?.action == .enableApp("Google Chrome", fallbackDomain: "api.example.com"))
     }
 
@@ -766,7 +767,7 @@ struct InspectorRoutingTests {
         #expect(appHosts?.state == .partial)
         #expect(appHosts?.control == .button)
         #expect(appHosts?.action == .enableApp("Brave Browser Helper", fallbackDomain: "api.example.com"))
-        #expect(appHosts?.controlTitle == "Decrypt App")
+        #expect(appHosts?.controlTitle == "Decrypt Observed Hosts")
 
         let duplicateScope = HTTPSInspectionScopePresentation.appHosts(
             name: "curl",
@@ -785,6 +786,20 @@ struct InspectorRoutingTests {
             fallbackDomain: "client.crisp.chat"
         )
         #expect(equivalentScope == nil)
+    }
+
+    @Test("blocked host Decrypt opens rule review instead of claiming it can enable")
+    func blockedHostDecryptOpensRuleReview() {
+        let blocked = HTTPSInspectionScopePresentation.host(
+            value: "api.example.com",
+            isReady: false,
+            decryptBlockedReason: "Tunnel rule *.example.com takes priority."
+        )
+
+        #expect(blocked.controlTitle == "Review Rules")
+        #expect(blocked.action == .openSSLProxyingList)
+        #expect(blocked.actionDescription == "Tunnel rule *.example.com takes priority.")
+        #expect(blocked.state == .available)
     }
 
     @Test("Plain HTTP response does not show HTTPS prompt")

--- a/RockxyTests/Views/Main/SidebarSSLProxyingTests.swift
+++ b/RockxyTests/Views/Main/SidebarSSLProxyingTests.swift
@@ -78,6 +78,27 @@ struct SidebarSSLProxyingTests {
         #expect(coordinator.isSSLProxyingEnabled(for: "api.example.com"))
     }
 
+    @Test("matching Tunnel rule prevents the sidebar from claiming Decrypt is enabled")
+    func tunnelOverlapIsNotReportedAsDecrypt() {
+        let coordinator = MainContentCoordinator()
+        let manager = SSLProxyingManager.shared
+        let originalRules = manager.rules
+        let originalBypassDomains = manager.bypassDomains
+        defer {
+            manager.replaceAllRules(originalRules)
+            manager.setBypassDomains(originalBypassDomains)
+        }
+
+        manager.setBypassDomains("")
+        manager.replaceAllRules([
+            SSLProxyingRule(domain: "*.example.com", listType: .include),
+            SSLProxyingRule(domain: "api.example.com", listType: .exclude),
+        ])
+
+        #expect(!coordinator.isSSLProxyingEnabled(for: "api.example.com"))
+        #expect(coordinator.isSSLProxyingEnabled(for: "cdn.example.com"))
+    }
+
     @Test("global SSL proxying off reports domain as disabled")
     func globalToggleOffReportsDisabled() {
         let coordinator = MainContentCoordinator()
@@ -119,6 +140,78 @@ struct SidebarSSLProxyingTests {
         #expect(manager.isEnabled)
         #expect(manager.includeRules.count == 1)
         #expect(manager.includeRules.first?.isEnabled == true)
+    }
+
+    @Test("one-host Decrypt replaces only an exact Tunnel rule")
+    func decryptHostReplacesExactTunnel() {
+        let coordinator = MainContentCoordinator()
+        let manager = SSLProxyingManager.shared
+        let originalRules = manager.rules
+        let originalEnabled = manager.isEnabled
+        let originalBypassDomains = manager.bypassDomains
+        defer {
+            manager.replaceAllRules(originalRules)
+            manager.setEnabled(originalEnabled)
+            manager.setBypassDomains(originalBypassDomains)
+        }
+
+        manager.setBypassDomains("")
+        manager.replaceAllRules([
+            SSLProxyingRule(domain: "api.example.com", listType: .exclude)
+        ])
+        manager.setEnabled(true)
+
+        #expect(coordinator.enableSSLProxyingForDomain(" API.EXAMPLE.COM "))
+        #expect(manager.excludeRules.isEmpty)
+        #expect(manager.includeRules.count == 1)
+        #expect(manager.includeRules[0].domain == "api.example.com")
+        #expect(coordinator.isSSLProxyingEnabled(for: "api.example.com"))
+    }
+
+    @Test("one-host Decrypt never removes or overrides a broader Tunnel rule")
+    func decryptHostPreservesBroaderTunnel() {
+        let coordinator = MainContentCoordinator()
+        let manager = SSLProxyingManager.shared
+        let originalRules = manager.rules
+        let originalBypassDomains = manager.bypassDomains
+        defer {
+            manager.replaceAllRules(originalRules)
+            manager.setBypassDomains(originalBypassDomains)
+        }
+
+        manager.setBypassDomains("")
+        let wildcardTunnel = SSLProxyingRule(domain: "*.example.com", listType: .exclude)
+        manager.replaceAllRules([wildcardTunnel])
+
+        #expect(!coordinator.enableSSLProxyingForDomain("api.example.com"))
+        #expect(manager.rules == [wildcardTunnel])
+        #expect(coordinator.sslProxyingHostDecryptBlockedReason(for: "api.example.com")?.contains("*.example.com") == true)
+    }
+
+    @Test("one-host Decrypt does not re-enable a disabled wildcard rule")
+    func decryptHostDoesNotReenableDisabledWildcard() {
+        let coordinator = MainContentCoordinator()
+        let manager = SSLProxyingManager.shared
+        let originalRules = manager.rules
+        let originalBypassDomains = manager.bypassDomains
+        defer {
+            manager.replaceAllRules(originalRules)
+            manager.setBypassDomains(originalBypassDomains)
+        }
+
+        manager.setBypassDomains("")
+        let disabledWildcard = SSLProxyingRule(
+            domain: "*.example.com",
+            isEnabled: false,
+            listType: .include
+        )
+        manager.replaceAllRules([disabledWildcard])
+
+        #expect(coordinator.enableSSLProxyingForDomain("api.example.com"))
+        #expect(manager.rules.first(where: { $0.id == disabledWildcard.id })?.isEnabled == false)
+        #expect(manager.includeRules.contains {
+            $0.domain == "api.example.com" && $0.isEnabled
+        })
     }
 
     @Test("application behavior replaces the opposite behavior and applies to future hosts")
@@ -164,12 +257,90 @@ struct SidebarSSLProxyingTests {
         )
 
         coordinator.setSSLProxyingFromInspector(for: identity, listType: .include)
+        #expect(coordinator.activeToast?.style == .success)
         #expect(coordinator.activeToast?.text ==
-            "Set Toast App to decrypt HTTPS on new connections. Reconnect the app.")
+            "Set Toast App to decrypt HTTPS. Matching tunneled connections reset automatically — if one stays tunneled, reconnect the app.")
 
         coordinator.setSSLProxyingFromInspector(for: identity, listType: .exclude)
         #expect(coordinator.activeToast?.text ==
             "Set Toast App to tunnel HTTPS on new connections. Reconnect the app.")
+    }
+
+    @Test("app Decrypt inspector warns when the current host stays tunneled but keeps the app rule")
+    func appDecryptInspectorWarnsWhenHostBlocked() {
+        let coordinator = MainContentCoordinator()
+        let manager = SSLProxyingManager.shared
+        let originalRules = manager.rules
+        let originalAppRules = manager.applicationRules
+        let originalEnabled = manager.isEnabled
+        let originalBypassDomains = manager.bypassDomains
+        defer {
+            manager.replaceAllRules(originalRules)
+            manager.replaceAllApplicationRules(originalAppRules)
+            manager.setEnabled(originalEnabled)
+            manager.setBypassDomains(originalBypassDomains)
+        }
+        let identity = ClientApplicationIdentity.bundle(
+            identifier: "com.example.BlockedHostApp",
+            displayName: "Blocked Host App"
+        )
+        manager.setBypassDomains("")
+        // A broader host Tunnel rule outranks the application Decrypt for the current host.
+        manager.replaceAllRules([
+            SSLProxyingRule(domain: "*.example.com", listType: .exclude)
+        ])
+        manager.replaceAllApplicationRules([])
+        manager.setEnabled(true)
+
+        coordinator.setSSLProxyingFromInspector(
+            for: identity,
+            listType: .include,
+            fallbackDomain: "api.example.com"
+        )
+
+        #expect(coordinator.activeToast?.style == .warning)
+        #expect(coordinator.activeToast?.text.contains("api.example.com") == true)
+        #expect(coordinator.activeToast?.text.contains("*.example.com") == true)
+        // The application-wide rule is still installed — a blocked current host does not reject it.
+        #expect(coordinator.isSSLProxyingEnabled(for: identity))
+    }
+
+    @Test("app Decrypt inspector also warns when an exact host Tunnel remains in force")
+    func appDecryptInspectorWarnsForExactHostTunnel() {
+        let coordinator = MainContentCoordinator()
+        let manager = SSLProxyingManager.shared
+        let originalRules = manager.rules
+        let originalAppRules = manager.applicationRules
+        let originalEnabled = manager.isEnabled
+        let originalBypassDomains = manager.bypassDomains
+        defer {
+            manager.replaceAllRules(originalRules)
+            manager.replaceAllApplicationRules(originalAppRules)
+            manager.setEnabled(originalEnabled)
+            manager.setBypassDomains(originalBypassDomains)
+        }
+        let identity = ClientApplicationIdentity.bundle(
+            identifier: "com.example.ExactTunnelApp",
+            displayName: "Exact Tunnel App"
+        )
+        manager.setBypassDomains("")
+        manager.replaceAllRules([
+            SSLProxyingRule(domain: "api.example.com", listType: .exclude)
+        ])
+        manager.replaceAllApplicationRules([])
+        manager.setEnabled(true)
+
+        coordinator.setSSLProxyingFromInspector(
+            for: identity,
+            listType: .include,
+            fallbackDomain: "api.example.com"
+        )
+
+        #expect(coordinator.activeToast?.style == .warning)
+        #expect(coordinator.activeToast?.text.contains("api.example.com") == true)
+        #expect(coordinator.activeToast?.text.contains("Change that host behavior") == true)
+        #expect(coordinator.isSSLProxyingEnabled(for: identity))
+        #expect(!manager.isDecryptionConfigured(host: "api.example.com", application: identity))
     }
 
     @Test("application tunnel action wins over a host decrypt rule")
@@ -233,6 +404,27 @@ struct SidebarSSLProxyingTests {
         #expect(manager.rules.contains(where: { $0.id == excludeRule.id }))
     }
 
+    @Test("one-host Tunnel preserves wildcard Decrypt for sibling hosts")
+    func tunnelHostPreservesWildcardDecrypt() {
+        let coordinator = MainContentCoordinator()
+        let manager = SSLProxyingManager.shared
+        let originalRules = manager.rules
+        let originalBypassDomains = manager.bypassDomains
+        defer {
+            manager.replaceAllRules(originalRules)
+            manager.setBypassDomains(originalBypassDomains)
+        }
+
+        manager.setBypassDomains("")
+        let wildcardDecrypt = SSLProxyingRule(domain: "*.example.com", listType: .include)
+        manager.replaceAllRules([wildcardDecrypt])
+
+        #expect(coordinator.disableSSLProxyingForDomain("api.example.com"))
+        #expect(manager.rules.contains(where: { $0.id == wildcardDecrypt.id }))
+        #expect(!manager.isDecryptionConfigured(host: "api.example.com"))
+        #expect(manager.isDecryptionConfigured(host: "cdn.example.com"))
+    }
+
     @Test("observedDomainsForApp falls back to matching transactions and current host")
     func observedDomainsForAppFallsBackToTransactions() {
         let coordinator = MainContentCoordinator()
@@ -259,6 +451,32 @@ struct SidebarSSLProxyingTests {
         )
 
         #expect(domains == ["api.example.com", "cdn.example.com"])
+    }
+
+    @Test("name-only inspector scope reuses one unambiguous observed application identity")
+    func observedApplicationIdentityIsFailClosed() {
+        let coordinator = MainContentCoordinator()
+        let chrome = ClientApplicationIdentity.bundle(
+            identifier: "com.google.Chrome",
+            displayName: "Google Chrome"
+        )
+        let lookalike = ClientApplicationIdentity.bundle(
+            identifier: "com.example.Chrome",
+            displayName: "Google Chrome"
+        )
+        TrafficDomainSnapshot.shared.reset()
+        defer { TrafficDomainSnapshot.shared.reset() }
+
+        coordinator.appNodes = [
+            AppInfo(name: "Google Chrome", domains: ["api.example.com"], requestCount: 1),
+            AppInfo(name: "Google Chrome", domains: ["cdn.example.com"], requestCount: 1, identity: chrome),
+        ]
+        #expect(coordinator.observedApplicationIdentity(named: " google chrome ") == chrome)
+
+        coordinator.appNodes.append(
+            AppInfo(name: "Google Chrome", domains: ["other.example.com"], requestCount: 1, identity: lookalike)
+        )
+        #expect(coordinator.observedApplicationIdentity(named: "Google Chrome") == nil)
     }
 
     @Test("enableSSLProxyingFromInspector for app enables fallback host when cache is empty")
@@ -288,7 +506,7 @@ struct SidebarSSLProxyingTests {
         #expect(coordinator.isSSLProxyingEnabled(for: "api.example.com"))
         #expect(
             coordinator.activeToast?.text ==
-                "Enabled SSL Proxying for domains from Google Chrome. Make the request again to inspect them."
+                "Added host Decrypt rules for domains observed from Google Chrome. These rules apply to every application."
         )
     }
 
@@ -342,7 +560,7 @@ struct SidebarSSLProxyingTests {
         #expect(!coordinator.isSSLProxyingEnabled(for: "api.example.com"))
         #expect(
             coordinator.activeToast?.text ==
-                "Disabled SSL Proxying for domains from Google Chrome. Requests from it will stay tunneled."
+                "Set domains observed from Google Chrome to Tunnel. These host rules apply to every application."
         )
     }
 
@@ -350,9 +568,10 @@ struct SidebarSSLProxyingTests {
     func disableFromInspectorForDomainShowsToast() {
         let coordinator = MainContentCoordinator()
         let manager = SSLProxyingManager.shared
+        let originalRules = manager.rules
         let rule = SSLProxyingRule(domain: "api.example.com", listType: .include)
         manager.addRule(rule)
-        defer { manager.removeRule(id: rule.id) }
+        defer { manager.replaceAllRules(originalRules) }
 
         coordinator.disableSSLProxyingFromInspector(for: "api.example.com")
 
@@ -361,5 +580,28 @@ struct SidebarSSLProxyingTests {
             coordinator.activeToast?.text ==
                 "Disabled SSL Proxying for api.example.com. Requests to it will stay tunneled."
         )
+    }
+
+    @Test("inspector warns instead of claiming success under a broader Tunnel rule")
+    func inspectorWarnsForBroaderTunnel() {
+        let coordinator = MainContentCoordinator()
+        let manager = SSLProxyingManager.shared
+        let originalRules = manager.rules
+        let originalBypassDomains = manager.bypassDomains
+        defer {
+            manager.replaceAllRules(originalRules)
+            manager.setBypassDomains(originalBypassDomains)
+        }
+
+        manager.setBypassDomains("")
+        manager.replaceAllRules([
+            SSLProxyingRule(domain: "*.example.com", listType: .exclude)
+        ])
+
+        coordinator.enableSSLProxyingFromInspector(for: "api.example.com")
+
+        #expect(coordinator.activeToast?.style == .warning)
+        #expect(coordinator.activeToast?.text.contains("*.example.com") == true)
+        #expect(manager.includeRules.isEmpty)
     }
 }

--- a/RockxyTests/Views/RequestList/RequestTableRefreshTests.swift
+++ b/RockxyTests/Views/RequestList/RequestTableRefreshTests.swift
@@ -252,15 +252,15 @@ struct RequestTableRefreshTests {
         #expect(coordinator.filteredRows.first?.host == "aaa.example.com")
     }
 
-    @Test("SSL proxying changes refresh request rows from tunneled to intercepted")
-    func sslProxyingRefreshesRows() async {
+    @Test("nil-metadata CONNECT row stays tunneled regardless of current host policy")
+    func nilMetadataConnectStaysTunneledAcrossPolicyChanges() async {
         let coordinator = MainContentCoordinator()
         let manager = SSLProxyingManager.shared
         let originalRules = manager.rules
         let originalEnabled = manager.isEnabled
         let originalBypassDomains = manager.bypassDomains
         let originalForceGlobalPassthrough = manager.forceGlobalPassthrough
-        let host = "ssl-refresh.test.rockxy.local"
+        let host = "nil-connect.test.rockxy.local"
         defer {
             manager.replaceAllRules(originalRules)
             manager.setEnabled(originalEnabled)
@@ -276,8 +276,95 @@ struct RequestTableRefreshTests {
         manager.forceGlobalPassthrough = false
         coordinator.setupSSLProxyingObserver()
 
-        let transaction = TestFixtures.makeTransaction(url: "https://\(host)/users")
-        coordinator.transactions = [transaction]
+        // A reloaded/imported CONNECT record: a tunnel record with no recorded disposition.
+        let connect = TestFixtures.makeTransaction(method: "CONNECT", url: "https://\(host):443")
+        #expect(connect.sslCapture == nil)
+        coordinator.transactions = [connect]
+        coordinator.recomputeFilteredTransactions()
+
+        #expect(coordinator.filteredRows.first?.sslState == .secureTunneled)
+
+        // Enabling interception for the host must not flip a historical tunnel record.
+        coordinator.enableSSLProxyingFromInspector(for: host)
+        await Task.yield()
+
+        #expect(coordinator.filteredRows.first?.sslState == .secureTunneled)
+        #expect(coordinator.sslState(for: connect) == .secureTunneled)
+    }
+
+    @Test("nil-metadata decrypted HTTPS row stays intercepted regardless of current host policy")
+    func nilMetadataDecryptedHTTPSStaysInterceptedAcrossPolicyChanges() async {
+        let coordinator = MainContentCoordinator()
+        let manager = SSLProxyingManager.shared
+        let originalRules = manager.rules
+        let originalEnabled = manager.isEnabled
+        let originalBypassDomains = manager.bypassDomains
+        let originalForceGlobalPassthrough = manager.forceGlobalPassthrough
+        let host = "nil-decrypted.test.rockxy.local"
+        defer {
+            manager.replaceAllRules(originalRules)
+            manager.setEnabled(originalEnabled)
+            manager.setBypassDomains(originalBypassDomains)
+            manager.forceGlobalPassthrough = originalForceGlobalPassthrough
+            manager.clearAutoPassthrough()
+        }
+
+        manager.clearAutoPassthrough()
+        manager.replaceAllRules([])
+        manager.setEnabled(true)
+        manager.setBypassDomains("")
+        manager.forceGlobalPassthrough = false
+        coordinator.setupSSLProxyingObserver()
+
+        // A reloaded/imported per-request HTTPS record: decrypted application traffic with no
+        // recorded disposition (a raw tunnel never yields non-CONNECT per-request records).
+        let decrypted = TestFixtures.makeTransaction(url: "https://\(host)/users")
+        #expect(decrypted.sslCapture == nil)
+        coordinator.transactions = [decrypted]
+        coordinator.recomputeFilteredTransactions()
+
+        // Current policy does not intercept this host, yet the row reads intercepted from shape.
+        #expect(!manager.shouldIntercept(host))
+        #expect(coordinator.filteredRows.first?.sslState == .secureIntercepted)
+
+        // Enabling then disabling the host rule must never move a historical decrypted record.
+        coordinator.enableSSLProxyingFromInspector(for: host)
+        await Task.yield()
+        #expect(coordinator.filteredRows.first?.sslState == .secureIntercepted)
+
+        manager.replaceAllRules([])
+        manager.setEnabled(false)
+        #expect(coordinator.sslState(for: decrypted) == .secureIntercepted)
+    }
+
+    @Test("raw CONNECT stays tunneled after its host rule is enabled (capture truth)")
+    func rawConnectStaysTunneledAfterRuleEnabled() async {
+        let coordinator = MainContentCoordinator()
+        let manager = SSLProxyingManager.shared
+        let originalRules = manager.rules
+        let originalEnabled = manager.isEnabled
+        let originalBypassDomains = manager.bypassDomains
+        let originalForceGlobalPassthrough = manager.forceGlobalPassthrough
+        let host = "raw-connect.test.rockxy.local"
+        defer {
+            manager.replaceAllRules(originalRules)
+            manager.setEnabled(originalEnabled)
+            manager.setBypassDomains(originalBypassDomains)
+            manager.forceGlobalPassthrough = originalForceGlobalPassthrough
+            manager.clearAutoPassthrough()
+        }
+
+        manager.clearAutoPassthrough()
+        manager.replaceAllRules([])
+        manager.setEnabled(true)
+        manager.setBypassDomains("")
+        manager.forceGlobalPassthrough = false
+        coordinator.setupSSLProxyingObserver()
+
+        // A CONNECT tunnel that was passed through raw at capture time.
+        let connect = TestFixtures.makeTransaction(method: "CONNECT", url: "https://\(host):443")
+        connect.sslCapture = .tunneled
+        coordinator.transactions = [connect]
         coordinator.recomputeFilteredTransactions()
 
         #expect(coordinator.filteredRows.first?.sslState == .secureTunneled)
@@ -285,8 +372,31 @@ struct RequestTableRefreshTests {
         coordinator.enableSSLProxyingFromInspector(for: host)
         await Task.yield()
 
-        #expect(manager.shouldIntercept(host))
-        #expect(coordinator.filteredRows.first?.sslState == .secureIntercepted)
+        // The rule now intercepts the host, but this historical raw CONNECT must not flip.
+        #expect(coordinator.filteredRows.first?.sslState == .secureTunneled)
+    }
+
+    @Test("decrypted traffic stays intercepted even after its host rule is disabled")
+    func decryptedStaysInterceptedAfterRuleDisabled() {
+        let coordinator = MainContentCoordinator()
+        let manager = SSLProxyingManager.shared
+        let originalRules = manager.rules
+        let originalEnabled = manager.isEnabled
+        let host = "decrypted.test.rockxy.local"
+        defer {
+            manager.replaceAllRules(originalRules)
+            manager.setEnabled(originalEnabled)
+        }
+
+        manager.replaceAllRules([])
+        manager.setEnabled(false)
+
+        let decrypted = TestFixtures.makeTransaction(url: "https://\(host)/users")
+        decrypted.sslCapture = .intercepted
+
+        // Current policy would not intercept, but capture truth must win.
+        #expect(!manager.shouldIntercept(host))
+        #expect(coordinator.sslState(for: decrypted) == .secureIntercepted)
     }
 
     @Test("Export preserves capture order unaffected by sort")


### PR DESCRIPTION
## Summary

- Reset live raw CONNECT tunnels when HTTPS Decryption policy changes so matching browser traffic reconnects into interception without restarting capture.
- Resolve application identity only when needed, preserving application Tunnel priority and avoiding resets for unrelated applications, hosts, bypass rules, or auto-passthrough.
- Record whether each transaction was tunneled or intercepted at capture time, then surface accurate states and clearer actions across the inspector, request list, and sidebar.
- Add integration, race-condition, policy-precedence, capture-state, and UX regression coverage.

## Why

Browsers can reuse an existing CONNECT tunnel after a Decrypt rule is enabled. The policy update previously applied only to future tunnels, so the active connection remained encrypted and made decryption appear broken.

## Impact

Matching live tunnels now close once and reconnect under the current policy. An application-specific Decrypt rule does not reset another application using the same host. Application Tunnel remains higher priority, while blocked host actions explain which Tunnel or bypass rule must change.

## Related issues

Refs #310

## Validation

- `swiftlint lint --strict`
- `python3 .github/tools/validate_xcstrings.py`
- Focused macOS test suites: `LiveTunnelRegistryTests`, `SSLProxyingManagerTests`, `TLSInterceptHandlerTests`, `InspectorRoutingTests`, `SidebarSSLProxyingTests`, and `RequestTableRefreshTests`
- Debug build and code-sign verification through `scripts/run-rockxy.sh`