### PR TITLE
fix(rules): persist Map Local rules across relaunches

### DIFF
--- a/Rockxy/ContentView.swift
+++ b/Rockxy/ContentView.swift
@@ -143,6 +143,12 @@ struct ContentView: View {
             guard managesLifecycle, !ProcessInfo.processInfo.isTestHost else {
                 return
             }
+            // Rule loading is app-level and must not wait on project hydration —
+            // start the observer and kick off the (idempotent, non-blocking) load
+            // before hydrating so Map Local and other rule tools have their
+            // persisted rules regardless of how long project hydration takes.
+            coordinator.setupRulesObserver()
+            coordinator.loadInitialRules()
             await coordinator.hydrateProjectsOnLaunch()
             if case .failed = coordinator.projectStore.loadState {
                 coordinator.isProjectRecoveryPresented = true
@@ -150,9 +156,7 @@ struct ContentView: View {
                 RockxyWorkspaceWindowManager.shared.projectDidChange(coordinator: coordinator)
             }
             coordinator.readiness.startObserving()
-            coordinator.setupRulesObserver()
             coordinator.setupSSLProxyingObserver()
-            coordinator.loadInitialRules()
             coordinator.refreshProxyOverrideStatus()
             coordinator.startProxyOnLaunchIfNeeded()
             nearbyTransferReceiver.start(coordinator: coordinator)

--- a/Rockxy/Core/RuleEngine/RuleEngine.swift
+++ b/Rockxy/Core/RuleEngine/RuleEngine.swift
@@ -90,6 +90,19 @@ actor RuleEngine {
         compiledPatterns.removeValue(forKey: id)
     }
 
+    /// Removes only the rules whose IDs are in `ids`, against current engine state.
+    /// Rules absent from `ids` — including concurrent additions from other windows —
+    /// are left untouched, so a stale caller snapshot can never clobber them.
+    func removeRules(ids: Set<UUID>) {
+        guard !ids.isEmpty else {
+            return
+        }
+        rules.removeAll { ids.contains($0.id) }
+        for id in ids {
+            compiledPatterns.removeValue(forKey: id)
+        }
+    }
+
     func toggleRule(id: UUID) {
         guard let index = rules.firstIndex(where: { $0.id == id }) else {
             return
@@ -111,6 +124,36 @@ actor RuleEngine {
 
     func replaceAll(_ newRules: [ProxyRule]) {
         rules = newRules
+        compilePatterns()
+    }
+
+    /// Replaces every Block rule with `importedBlockRules` against current engine
+    /// state, retaining all non-Block rules — including concurrent additions from
+    /// other windows (e.g. Map Local) — in their existing order. The imported set is
+    /// appended after the retained non-Block rules, preserving the import semantic
+    /// that the imported rules become the entire Block category. Enabled imported
+    /// Block rules beyond `maxPerCategory` are disabled so the per-category active
+    /// quota is never exceeded, mirroring the capping applied by a full replace.
+    func replaceBlockRules(_ importedBlockRules: [ProxyRule], maxPerCategory: Int) {
+        let retained = rules.filter { rule in
+            if case .block = rule.action {
+                return false
+            }
+            return true
+        }
+        var capped = importedBlockRules
+        var activeBlockCount = 0
+        for index in capped.indices {
+            guard case .block = capped[index].action, capped[index].isEnabled else {
+                continue
+            }
+            if activeBlockCount < maxPerCategory {
+                activeBlockCount += 1
+            } else {
+                capped[index].isEnabled = false
+            }
+        }
+        rules = retained + capped
         compilePatterns()
     }
 
@@ -302,6 +345,38 @@ actor RuleEngine {
         }
         rules[index].isEnabled = true
         return true
+    }
+
+    /// Bulk enables or disables every Map Local rule against current engine state,
+    /// mutating only Map Local rules and leaving all other categories (and concurrent
+    /// additions) untouched. When enabling, already-enabled rules are preserved first
+    /// and additional rules are enabled in order only while the active Map Local count
+    /// stays below `maxPerCategory`, so the quota is never exceeded.
+    func setMapLocalRulesEnabled(_ enabled: Bool, maxPerCategory: Int) {
+        guard enabled else {
+            for index in rules.indices {
+                if case .mapLocal = rules[index].action {
+                    rules[index].isEnabled = false
+                }
+            }
+            return
+        }
+        var activeCount = rules.filter { rule in
+            guard rule.isEnabled, case .mapLocal = rule.action else {
+                return false
+            }
+            return true
+        }.count
+        for index in rules.indices {
+            guard case .mapLocal = rules[index].action, !rules[index].isEnabled else {
+                continue
+            }
+            guard activeCount < maxPerCategory else {
+                continue
+            }
+            rules[index].isEnabled = true
+            activeCount += 1
+        }
     }
 
     func addNetworkConditionExclusiveIfAllowed(_ rule: ProxyRule, maxPerCategory: Int) -> Bool {

--- a/Rockxy/Core/RuleEngine/RuleStore.swift
+++ b/Rockxy/Core/RuleEngine/RuleStore.swift
@@ -11,6 +11,13 @@ struct RuleStore {
         fileURL = RockxyIdentity.current.appSupportPath("rules.json")
     }
 
+    /// Test/injection seam: persist and load rules at an explicit file URL so the
+    /// real production save/load path can be exercised against a temporary
+    /// directory without touching the app's shared rules file.
+    init(fileURL: URL) {
+        self.fileURL = fileURL
+    }
+
     // MARK: Internal
 
     // MARK: - Errors
@@ -32,7 +39,11 @@ struct RuleStore {
     }
 
     func loadRules() throws -> [ProxyRule] {
-        guard FileManager.default.fileExists(atPath: fileURL.path()) else {
+        // `URL.path()` is percent-encoded (for example, "Application%20Support"),
+        // which `FileManager` treats as a different literal filesystem path. Use
+        // the decoded file path so production rules stored under Application
+        // Support are actually discovered after relaunch.
+        guard FileManager.default.fileExists(atPath: fileURL.path(percentEncoded: false)) else {
             return []
         }
         let data = try Data(contentsOf: fileURL)

--- a/Rockxy/Core/RuleEngine/RuleSyncService.swift
+++ b/Rockxy/Core/RuleEngine/RuleSyncService.swift
@@ -1,6 +1,63 @@
 import Foundation
 import os
 
+// MARK: - RulePersistenceOutcome
+
+/// Result of attempting to durably write the current rule set to disk.
+enum RulePersistenceOutcome: Sendable, Equatable {
+    case saved
+    /// Save failed; `message` is a user-facing localized description.
+    case failed(message: String)
+
+    // MARK: Internal
+
+    var isSaved: Bool {
+        if case .saved = self {
+            return true
+        }
+        return false
+    }
+}
+
+// MARK: - RuleLoadOutcome
+
+/// Result of attempting to load persisted rules from disk.
+enum RuleLoadOutcome: Sendable, Equatable {
+    case loaded
+    /// Load/decode failed; the on-disk file was left untouched. `message` is user-facing.
+    case failed(message: String)
+
+    // MARK: Internal
+
+    var isLoaded: Bool {
+        if case .loaded = self {
+            return true
+        }
+        return false
+    }
+}
+
+// MARK: - RuleMutationResult
+
+/// Combined quota + persistence result for rule-creating surfaces that must not
+/// report success unless the change was durably written.
+enum RuleMutationResult: Sendable, Equatable {
+    case quotaExceeded
+    /// Existing rules could not be loaded, so no mutation was attempted.
+    case loadFailed(message: String)
+    case persisted(RulePersistenceOutcome)
+
+    // MARK: Internal
+
+    /// True only when the mutation was both accepted by the quota gate and saved.
+    var isDurablySaved: Bool {
+        if case .persisted(.saved) = self {
+            return true
+        }
+        return false
+    }
+}
+
 // MARK: - RuleSyncService
 
 /// Coordinates rule mutations between the shared `RuleEngine` actor, disk persistence
@@ -8,6 +65,14 @@ import os
 /// All rule changes should flow through this service.
 enum RuleSyncService {
     // MARK: Internal
+
+    /// Injectable persistence seam. Production uses the identity-scoped rules file;
+    /// serialized tests rebind this to a `RuleStore(fileURL:)` under a temp directory
+    /// to exercise the real save/load path (including failures) safely.
+    ///
+    /// **Mutability contract:** reassigned only from controlled, serialized contexts.
+    /// Do not rebind from parallel tests or arbitrary runtime paths.
+    static var store = RuleStore()
 
     static func addRule(_ rule: ProxyRule) async {
         await RuleEngine.shared.addRule(rule)
@@ -31,6 +96,30 @@ enum RuleSyncService {
 
     static func replaceAllRules(_ rules: [ProxyRule]) async {
         await RuleEngine.shared.replaceAll(rules)
+        await syncAll()
+    }
+
+    /// Removes only the given IDs against current engine state (never a stale
+    /// caller snapshot), then persists once. Concurrent additions and other
+    /// categories are retained.
+    static func removeRules(ids: Set<UUID>) async {
+        await RuleEngine.shared.removeRules(ids: ids)
+        await syncAll()
+    }
+
+    /// Bulk enables/disables every Map Local rule against current engine state
+    /// under the per-category quota, then persists once. Other categories and
+    /// concurrent additions are retained.
+    static func setMapLocalRulesEnabled(_ enabled: Bool, maxPerCategory: Int) async {
+        await RuleEngine.shared.setMapLocalRulesEnabled(enabled, maxPerCategory: maxPerCategory)
+        await syncAll()
+    }
+
+    /// Replaces only Block rules with `importedBlockRules` against current engine
+    /// state under the per-category quota, then persists once. Non-Block rules
+    /// (including concurrent additions from other windows) are retained.
+    static func replaceBlockRules(_ importedBlockRules: [ProxyRule], maxPerCategory: Int) async {
+        await RuleEngine.shared.replaceBlockRules(importedBlockRules, maxPerCategory: maxPerCategory)
         await syncAll()
     }
 
@@ -78,6 +167,35 @@ enum RuleSyncService {
             await syncAll()
         }
         return accepted
+    }
+
+    // MARK: - Persistence-Aware Operations
+
+    /// Adds a rule under the quota gate and reports whether it was durably saved.
+    /// Unlike ``addRuleIfAllowed(_:maxPerCategory:)``, the caller learns if the
+    /// engine mutation was accepted but the disk write failed, so a UI surface can
+    /// avoid reporting success or dismissing prematurely.
+    static func addRuleIfAllowedPersisting(_ rule: ProxyRule, maxPerCategory: Int) async -> RuleMutationResult {
+        // Never overwrite an existing on-disk rule set with a mutation based on
+        // an as-yet-unloaded engine snapshot. This matters when macOS restores an
+        // editor window before the main workspace finishes launching.
+        if case let .failed(message) = await ensureLoaded() {
+            return .loadFailed(message: message)
+        }
+        let accepted = await RuleEngine.shared.addRuleIfAllowed(rule, maxPerCategory: maxPerCategory)
+        guard accepted else {
+            return .quotaExceeded
+        }
+        return await .persisted(syncAll())
+    }
+
+    /// Updates a rule and reports whether the change was durably saved.
+    static func updateRulePersisting(_ rule: ProxyRule) async -> RulePersistenceOutcome {
+        if case let .failed(message) = await ensureLoaded() {
+            return .failed(message: message)
+        }
+        await RuleEngine.shared.updateRule(rule)
+        return await syncAll()
     }
 
     // MARK: - Atomic Quota-Checked Operations
@@ -156,7 +274,18 @@ enum RuleSyncService {
         await RuleEngine.shared.setModifyHeaderToolEnabled(enabled)
     }
 
-    static func loadFromDisk() async {
+    /// Idempotent, app-scoped rule load. The first caller performs the disk load;
+    /// concurrent callers await the same in-flight load, and callers after a
+    /// successful load return immediately. A failed load is NOT cached, so a later
+    /// caller transparently retries. Safe to call from any window's `.task` without
+    /// depending on main-window project hydration.
+    @discardableResult
+    static func ensureLoaded() async -> RuleLoadOutcome {
+        await loadCoordinator.ensureLoaded()
+    }
+
+    @discardableResult
+    static func loadFromDisk() async -> RuleLoadOutcome {
         // Read and apply the breakpoint-tool flag BEFORE loading rules so the
         // rule engine has the correct evaluation gate in place when rules are
         // first compiled and become live.
@@ -175,11 +304,26 @@ enum RuleSyncService {
         let modifyHeaderEnabled = UserDefaults.standard.object(forKey: "modifyHeaderToolEnabled") as? Bool ?? true
         await RuleEngine.shared.setModifyHeaderToolEnabled(modifyHeaderEnabled)
         do {
-            try await RuleEngine.shared.loadRules(from: RuleStore())
-            await syncAll()
+            // A successful load publishes the loaded rules WITHOUT rewriting the
+            // source file — the on-disk copy is already authoritative and the
+            // engine now mirrors it, so re-saving would be redundant churn.
+            try await RuleEngine.shared.loadRules(from: store)
+            await publishAll()
+            return .loaded
         } catch {
+            // Leave the on-disk file untouched: a corrupt/unreadable file must not
+            // be overwritten with an empty/default snapshot, and the load must not
+            // be treated as successful. Publish current engine state so the UI has
+            // a coherent snapshot, surface the failure, and allow a later retry.
             logger.error("Failed to load rules from disk: \(error.localizedDescription)")
             await publishAll()
+            let message = String(
+                localized:
+                "Rockxy could not load your saved rules: \(error.localizedDescription). Your saved rules file was left untouched — try reopening this window to load again.",
+                bundle: RockxyLocalization.bundle
+            )
+            await postFailure(named: .rulesDidFailToLoad, message: message)
+            return .failed(message: message)
         }
     }
 
@@ -187,12 +331,41 @@ enum RuleSyncService {
 
     private static let logger = Logger(subsystem: RockxyIdentity.current.logSubsystem, category: "RuleSyncService")
     private static let persistenceQueue = RulePersistenceQueue()
+    private static let loadCoordinator = RuleLoadCoordinator()
 
-    private static func syncAll() async {
+    @discardableResult
+    private static func syncAll() async -> RulePersistenceOutcome {
+        // Reserve a persistence ticket BEFORE reading engine state. Each triggering
+        // mutation has completed before its own reservation, so a snapshot taken
+        // under a newer ticket necessarily includes the mutations associated with
+        // every earlier ticket. The queue uses that to make
+        // the highest attempted ticket win, so a stale snapshot read under an older
+        // ticket can never overwrite (or falsely claim the durability of) a newer,
+        // encompassing one.
+        let ticket = await persistenceQueue.reserveTicket()
         let allRules = await RuleEngine.shared.allRules
-        await persistenceQueue.save(allRules)
+        let commit = await persistenceQueue.commit(ticket: ticket, allRules, using: store)
+
+        if commit.superseded {
+            // A newer, encompassing snapshot already attempted its write. Do not
+            // publish this stale snapshot or re-emit a failure the newer attempt
+            // already owns. Re-reading and publishing here would introduce another
+            // read/post race and could move observers backwards again.
+            return commit.outcome
+        }
+
+        // This is the newest snapshot attempted so far. Publish the in-engine rules
+        // so observers see a coherent snapshot that matches live evaluation, even
+        // when the durable write failed.
         await publish(allRules)
-        logger.debug("Rules synced: \(allRules.count) rules")
+        switch commit.outcome {
+        case .saved:
+            logger.debug("Rules synced: \(allRules.count) rules")
+        case let .failed(message):
+            logger.error("Failed to persist rules: \(message)")
+            await postFailure(named: .rulePersistenceDidFail, message: message)
+        }
+        return commit.outcome
     }
 
     private static func publishAll() async {
@@ -206,12 +379,128 @@ enum RuleSyncService {
             NotificationCenter.default.post(name: .rulesDidChange, object: allRules)
         }
     }
+
+    private static func postFailure(named name: Notification.Name, message: String) async {
+        await MainActor.run {
+            NotificationCenter.default.post(name: name, object: message)
+        }
+    }
+}
+
+extension RuleSyncService {
+    /// Test seam: clears the idempotent-load cache so a subsequent `ensureLoaded()`
+    /// performs a fresh disk read (used to simulate a process relaunch).
+    static func resetLoadStateForTesting() async {
+        await loadCoordinator.reset()
+    }
+}
+
+// MARK: - RuleLoadCoordinator
+
+/// Serializes and deduplicates rule loading so any window can trigger it safely.
+private actor RuleLoadCoordinator {
+    // MARK: Internal
+
+    func ensureLoaded() async -> RuleLoadOutcome {
+        if loaded {
+            return .loaded
+        }
+        if let inFlight {
+            return await inFlight.value
+        }
+        let task = Task { await RuleSyncService.loadFromDisk() }
+        inFlight = task
+        let outcome = await task.value
+        inFlight = nil
+        // Only cache a successful load; a failure stays uncached so the next
+        // caller retries rather than being stuck with an empty/failed state.
+        if outcome.isLoaded {
+            loaded = true
+        }
+        return outcome
+    }
+
+    func reset() async {
+        // Testing can reset while another app surface still has a load in
+        // flight. Let that read finish before clearing the cache so it cannot
+        // replace the engine after the simulated relaunch has begun.
+        if let inFlight {
+            _ = await inFlight.value
+        }
+        loaded = false
+        inFlight = nil
+    }
+
+    // MARK: Private
+
+    private var loaded = false
+    private var inFlight: Task<RuleLoadOutcome, Never>?
+}
+
+// MARK: - RulePersistenceCommit
+
+/// Result of a ``RulePersistenceQueue/commit(ticket:_:using:)`` attempt.
+struct RulePersistenceCommit: Sendable, Equatable {
+    let outcome: RulePersistenceOutcome
+    /// True when a newer (higher-ticket) snapshot had already been attempted, so
+    /// this stale snapshot was NOT written and `outcome` mirrors that newer attempt.
+    let superseded: Bool
 }
 
 // MARK: - RulePersistenceQueue
 
-private actor RulePersistenceQueue {
-    func save(_ rules: [ProxyRule]) {
-        try? RuleStore().saveRules(rules)
+/// Serializes durable rule writes and defends against the stale-snapshot
+/// write-order race. A ticket is reserved BEFORE the caller reads engine state;
+/// the highest attempted ticket wins, so an older snapshot can never overwrite —
+/// or falsely report the durability of — a newer, encompassing one.
+///
+/// `internal` (not `private`) purely so serialized tests can drive a fresh queue
+/// instance through `@testable import`; production always uses the private static
+/// `RuleSyncService.persistenceQueue`.
+actor RulePersistenceQueue {
+    // MARK: Internal
+
+    /// Reserves a monotonically increasing ticket. Callers MUST reserve before
+    /// reading the engine snapshot they intend to persist. Because each caller's
+    /// mutation completes before reservation, a higher-ticket snapshot includes
+    /// every mutation associated with a lower ticket.
+    func reserveTicket() -> UInt64 {
+        nextTicket += 1
+        return nextTicket
+    }
+
+    /// Durably writes `rules` unless a newer snapshot has already been attempted.
+    /// A superseded (older-ticket) commit never writes and returns the newer
+    /// attempt's outcome, so an older caller cannot report a durability the newer,
+    /// encompassing snapshot did not achieve. Ticket gaps (reserved-but-never-
+    /// committed) are harmless: only magnitude is compared, never contiguity.
+    func commit(ticket: UInt64, _ rules: [ProxyRule], using store: RuleStore) -> RulePersistenceCommit {
+        if ticket < highestAttemptedTicket {
+            return RulePersistenceCommit(outcome: lastOutcome, superseded: true)
+        }
+        highestAttemptedTicket = ticket
+        let outcome = write(rules, using: store)
+        lastOutcome = outcome
+        return RulePersistenceCommit(outcome: outcome, superseded: false)
+    }
+
+    // MARK: Private
+
+    private var nextTicket: UInt64 = 0
+    private var highestAttemptedTicket: UInt64 = 0
+    private var lastOutcome: RulePersistenceOutcome = .saved
+
+    private func write(_ rules: [ProxyRule], using store: RuleStore) -> RulePersistenceOutcome {
+        do {
+            try store.saveRules(rules)
+            return .saved
+        } catch {
+            let message = String(
+                localized:
+                "Rockxy could not save your rules to disk: \(error.localizedDescription). Your latest change is active now but will be lost when Rockxy quits.",
+                bundle: RockxyLocalization.bundle
+            )
+            return .failed(message: message)
+        }
     }
 }

--- a/Rockxy/Core/Services/Infrastructure/AppNotifications.swift
+++ b/Rockxy/Core/Services/Infrastructure/AppNotifications.swift
@@ -26,6 +26,8 @@ extension Notification.Name {
     static let appearanceDidChange = identity.notificationName("appearanceDidChange")
     static let breakpointHit = identity.notificationName("breakpointHit")
     static let rulesDidChange = identity.notificationName("rulesDidChange")
+    static let rulePersistenceDidFail = identity.notificationName("rulePersistenceDidFail")
+    static let rulesDidFailToLoad = identity.notificationName("rulesDidFailToLoad")
     static let scriptsDidChange = identity.notificationName("scriptsDidChange")
     static let scriptConsoleDidAppend = identity.notificationName("scriptConsoleDidAppend")
     static let openDiffWindow = identity.notificationName("openDiffWindow")

--- a/Rockxy/Models/Rules/RulePolicyGate.swift
+++ b/Rockxy/Models/Rules/RulePolicyGate.swift
@@ -137,10 +137,56 @@ final class RulePolicyGate: @unchecked Sendable {
         return accepted
     }
 
+    // MARK: - Persistence-Aware Operations
+
+    /// Adds a rule and reports the combined quota + durable-save result so the
+    /// caller can surface a save failure instead of falsely reporting success.
+    func addRulePersisting(_ rule: ProxyRule) async -> RuleMutationResult {
+        let result = await RuleSyncService.addRuleIfAllowedPersisting(
+            rule,
+            maxPerCategory: policy.maxActiveRulesPerTool
+        )
+        if case .quotaExceeded = result {
+            Self.logger.info("Rule quota reached for \(rule.action.toolCategory)")
+        }
+        return result
+    }
+
+    /// Updates a rule and reports whether the change was durably saved.
+    func updateRulePersisting(_ rule: ProxyRule) async -> RulePersistenceOutcome {
+        await RuleSyncService.updateRulePersisting(rule)
+    }
+
     // MARK: - Pass-Through Operations (no quota impact)
 
     func removeRule(id: UUID) async {
         await RuleSyncService.removeRule(id: id)
+    }
+
+    /// Removes only the given rule IDs against current engine state, retaining
+    /// concurrent additions and other categories. No quota impact.
+    func removeRules(ids: Set<UUID>) async {
+        await RuleSyncService.removeRules(ids: ids)
+    }
+
+    /// Bulk enables/disables every Map Local rule against current engine state,
+    /// enforcing the per-category active-rule quota. Other categories and
+    /// concurrent additions are retained.
+    func setMapLocalRulesEnabled(_ enabled: Bool) async {
+        await RuleSyncService.setMapLocalRulesEnabled(
+            enabled,
+            maxPerCategory: policy.maxActiveRulesPerTool
+        )
+    }
+
+    /// Replaces every Block rule with the imported set against current engine state,
+    /// enforcing the per-category active-rule quota. Non-Block rules and concurrent
+    /// additions from other windows are retained.
+    func replaceBlockRules(_ importedBlockRules: [ProxyRule]) async {
+        await RuleSyncService.replaceBlockRules(
+            importedBlockRules,
+            maxPerCategory: policy.maxActiveRulesPerTool
+        )
     }
 
     func updateRule(_ rule: ProxyRule) async {

--- a/Rockxy/Views/Main/MainContentCoordinator.swift
+++ b/Rockxy/Views/Main/MainContentCoordinator.swift
@@ -599,15 +599,19 @@ final class MainContentCoordinator {
     }
 
     func loadInitialRules() {
-        guard ruleLoadTask == nil else {
+        guard ruleLoadTask == nil, !rulesLoaded else {
             return
         }
         ruleLoadTask = Task { [weak self] in
-            await RuleSyncService.loadFromDisk()
+            // Route through the shared idempotent loader so this and any rule tool
+            // window (e.g. Map Local) share a single disk load and load-state.
+            let outcome = await RuleSyncService.ensureLoaded()
             guard let self else {
                 return
             }
-            self.rulesLoaded = true
+            if outcome.isLoaded {
+                self.rulesLoaded = true
+            }
             self.ruleLoadTask = nil
         }
     }
@@ -621,11 +625,13 @@ final class MainContentCoordinator {
             return
         }
         let task = Task { [weak self] in
-            await RuleSyncService.loadFromDisk()
+            let outcome = await RuleSyncService.ensureLoaded()
             guard let self else {
                 return
             }
-            self.rulesLoaded = true
+            if outcome.isLoaded {
+                self.rulesLoaded = true
+            }
             self.ruleLoadTask = nil
         }
         ruleLoadTask = task

--- a/Rockxy/Views/Rules/BlockListTableView.swift
+++ b/Rockxy/Views/Rules/BlockListTableView.swift
@@ -1,0 +1,203 @@
+import SwiftUI
+
+// Table rendering for the Block List window. Extracted from `BlockListWindowView.swift`
+// to keep that file within the length limit; behavior and type names are unchanged.
+
+// MARK: - BlockListTableView
+
+struct BlockListTableView<ContextMenuContent: View>: View {
+    // MARK: Internal
+
+    let rules: [ProxyRule]
+    @Binding var selectedRuleID: UUID?
+
+    let onToggle: (UUID) -> Void
+    let onEdit: (UUID) -> Void
+    let onDelete: (UUID) -> Void
+    @ViewBuilder let contextMenuItems: (UUID) -> ContextMenuContent
+
+    var body: some View {
+        VStack(spacing: 0) {
+            columnHeader
+            ZStack {
+                zebraRows
+
+                if rules.isEmpty {
+                    Text(String(localized: "Click \"+\" or ⌘N to add new entry", bundle: RockxyLocalization.bundle))
+                        .font(.system(size: toolMetrics.emptyStateFontSize))
+                        .foregroundStyle(.secondary)
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                } else {
+                    ScrollView {
+                        LazyVStack(spacing: 0) {
+                            ForEach(Array(rules.enumerated()), id: \.element.id) { index, rule in
+                                BlockRuleTableRow(
+                                    rule: rule,
+                                    isSelected: selectedRuleID == rule.id,
+                                    rowIndex: index,
+                                    onSelect: { selectedRuleID = rule.id },
+                                    onToggle: { onToggle(rule.id) }
+                                )
+                                .contextMenu {
+                                    contextMenuItems(rule.id)
+                                }
+                                .onTapGesture(count: 2) {
+                                    onEdit(rule.id)
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            .frame(maxHeight: .infinity)
+        }
+        .frame(minHeight: toolMetrics.tableRowHeight * 8, maxHeight: .infinity)
+        .clipped()
+        .background(Color(nsColor: .textBackgroundColor))
+        .clipShape(RoundedRectangle(cornerRadius: 6))
+        .overlay {
+            RoundedRectangle(cornerRadius: 6)
+                .stroke(Color(nsColor: .separatorColor), lineWidth: 1)
+        }
+        .padding(.horizontal, toolMetrics.contentHorizontalPadding)
+    }
+
+    // MARK: Private
+
+    @Environment(\.appUIDisplayMetrics) private var appMetrics
+
+    private var toolMetrics: ToolWindowDisplayMetrics {
+        ToolWindowDisplayMetrics(appMetrics: appMetrics)
+    }
+
+    private var columnHeader: some View {
+        HStack(spacing: 0) {
+            Text(String(localized: "Enabled", bundle: RockxyLocalization.bundle))
+                .frame(width: 66, alignment: .leading)
+            tableDivider
+            Text(String(localized: "Name", bundle: RockxyLocalization.bundle))
+                .frame(width: 300, alignment: .leading)
+            tableDivider
+            Text(String(localized: "Block Action", bundle: RockxyLocalization.bundle))
+                .frame(width: 150, alignment: .leading)
+            tableDivider
+            Text(String(localized: "Method", bundle: RockxyLocalization.bundle))
+                .frame(width: 90, alignment: .leading)
+            tableDivider
+            Text(String(localized: "Matching Rule", bundle: RockxyLocalization.bundle))
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .font(toolMetrics.tableHeaderFont())
+        .lineLimit(1)
+        .padding(.horizontal, toolMetrics.tableCellHorizontalPadding)
+        .frame(height: toolMetrics.tableRowHeight)
+        .background(Color(nsColor: .textBackgroundColor))
+        .overlay(alignment: .bottom) {
+            Divider()
+        }
+    }
+
+    private var tableDivider: some View {
+        Rectangle()
+            .fill(.secondary.opacity(0.22))
+            .frame(width: 1, height: max(16, toolMetrics.tableRowHeight - 10))
+            .padding(.trailing, 10)
+    }
+
+    private var zebraRows: some View {
+        GeometryReader { proxy in
+            let rowCount = max(1, Int(ceil(proxy.size.height / toolMetrics.tableRowHeight)))
+            VStack(spacing: 0) {
+                ForEach(0 ..< rowCount, id: \.self) { index in
+                    Rectangle()
+                        .fill(index.isMultiple(of: 2) ? Color(nsColor: .textBackgroundColor) : Color.secondary
+                            .opacity(0.08))
+                        .frame(height: toolMetrics.tableRowHeight)
+                }
+                Spacer(minLength: 0)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+        }
+        .allowsHitTesting(false)
+    }
+}
+
+// MARK: - BlockRuleTableRow
+
+private struct BlockRuleTableRow: View {
+    // MARK: Internal
+
+    let rule: ProxyRule
+    let isSelected: Bool
+    let rowIndex: Int
+    let onSelect: () -> Void
+    let onToggle: () -> Void
+
+    var body: some View {
+        HStack(spacing: 0) {
+            Toggle("", isOn: Binding(
+                get: { rule.isEnabled },
+                set: { _ in onToggle() }
+            ))
+            .toggleStyle(.checkbox)
+            .labelsHidden()
+            .frame(width: 66)
+
+            Text(rule.name)
+                .lineLimit(1)
+                .truncationMode(.middle)
+                .frame(width: 300, alignment: .leading)
+
+            actionLabel
+                .lineLimit(1)
+                .truncationMode(.tail)
+                .frame(width: 150, alignment: .leading)
+
+            Text(rule.matchCondition.method ?? "ANY")
+                .lineLimit(1)
+                .frame(width: 90, alignment: .leading)
+
+            Text(rule.matchCondition.sourceURLPattern ?? rule.matchCondition.urlPattern ?? "")
+                .font(toolMetrics.font(monospaced: true))
+                .lineLimit(1)
+                .truncationMode(.middle)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .font(toolMetrics.font())
+        .padding(.horizontal, toolMetrics.tableCellHorizontalPadding)
+        .foregroundStyle(rule.isEnabled ? .primary : .secondary)
+        .frame(height: toolMetrics.tableRowHeight)
+        .background(rowBackground)
+        .contentShape(Rectangle())
+        .onTapGesture {
+            onSelect()
+        }
+        .opacity(rule.isEnabled ? 1.0 : 0.5)
+    }
+
+    // MARK: Private
+
+    @Environment(\.appUIDisplayMetrics) private var appMetrics
+
+    private var rowBackground: some ShapeStyle {
+        if isSelected {
+            return AnyShapeStyle(Color.accentColor.opacity(0.22))
+        }
+        return AnyShapeStyle(rowIndex.isMultiple(of: 2) ? Color(nsColor: .textBackgroundColor) : Color.secondary
+            .opacity(0.08))
+    }
+
+    private var toolMetrics: ToolWindowDisplayMetrics {
+        ToolWindowDisplayMetrics(appMetrics: appMetrics)
+    }
+
+    @ViewBuilder private var actionLabel: some View {
+        if case let .block(statusCode) = rule.action {
+            Text(
+                statusCode == 0
+                    ? String(localized: "Drop Connection", bundle: RockxyLocalization.bundle)
+                    : String(localized: "Return 403 Forbidden", bundle: RockxyLocalization.bundle)
+            )
+        }
+    }
+}

--- a/Rockxy/Views/Rules/BlockListWindowView.swift
+++ b/Rockxy/Views/Rules/BlockListWindowView.swift
@@ -124,7 +124,10 @@ final class BlockListViewModel {
             if !accepted {
                 allRules = await RuleEngine.shared.allRules
                 reconcileSelectionAfterRulesChange()
-                mutationError = String(localized: "The active Block List rule limit was reached. Disable another rule and try again.", bundle: RockxyLocalization.bundle)
+                mutationError = String(
+                    localized: "The active Block List rule limit was reached. Disable another rule and try again.",
+                    bundle: RockxyLocalization.bundle
+                )
             }
         }
     }
@@ -207,7 +210,10 @@ final class BlockListViewModel {
             if !accepted {
                 allRules = await RuleEngine.shared.allRules
                 reconcileSelectionAfterRulesChange()
-                mutationError = String(localized: "The active Block List rule limit was reached. Disable another rule and try again.", bundle: RockxyLocalization.bundle)
+                mutationError = String(
+                    localized: "The active Block List rule limit was reached. Disable another rule and try again.",
+                    bundle: RockxyLocalization.bundle
+                )
             }
         }
     }
@@ -217,11 +223,14 @@ final class BlockListViewModel {
     }
 
     func importBlockRules(_ importedRules: [ProxyRule]) {
+        // Replace only the Block category against current engine state so a stale
+        // window snapshot can never clobber concurrent Map Local (or other-category)
+        // additions from another window.
         let nonBlockRules = allRules.filter { !$0.isBlockRule }
         allRules = nonBlockRules + importedRules
         selectedRuleID = importedRules.first?.id
         Task {
-            await RulePolicyGate.shared.replaceAllRules(allRules)
+            await RulePolicyGate.shared.replaceBlockRules(importedRules)
             allRules = await RuleEngine.shared.allRules
             reconcileSelectionAfterRulesChange()
         }
@@ -395,7 +404,10 @@ struct BlockListWindowView: View {
     private var footerHint: String {
         let countText = viewModel.searchText.isEmpty
             ? "\(viewModel.ruleCount) \(String(localized: "rules", bundle: RockxyLocalization.bundle))"
-            : String(localized: "\(viewModel.filteredBlockRules.count) of \(viewModel.ruleCount) rules", bundle: RockxyLocalization.bundle)
+            : String(
+                localized: "\(viewModel.filteredBlockRules.count) of \(viewModel.ruleCount) rules",
+                bundle: RockxyLocalization.bundle
+            )
         return "\(countText) · ⌘N \(String(localized: "New Rule", bundle: RockxyLocalization.bundle)) · ⌘↩ \(String(localized: "Edit", bundle: RockxyLocalization.bundle))"
     }
 
@@ -423,10 +435,16 @@ struct BlockListWindowView: View {
                 .toggleStyle(.checkbox)
                 .font(toolMetrics.font(weight: .medium))
                 .help(
-                    String(localized: "When off, Block List rules are skipped. Other intervention rules remain active.", bundle: RockxyLocalization.bundle)
+                    String(
+                        localized: "When off, Block List rules are skipped. Other intervention rules remain active.",
+                        bundle: RockxyLocalization.bundle
+                    )
                 )
 
-                Text(String(localized: "Return 403 Forbidden or drop matching client connections.", bundle: RockxyLocalization.bundle))
+                Text(String(
+                    localized: "Return 403 Forbidden or drop matching client connections.",
+                    bundle: RockxyLocalization.bundle
+                ))
                 .font(toolMetrics.secondaryFont())
                 .foregroundStyle(.secondary)
             }
@@ -649,7 +667,10 @@ struct BlockListWindowView: View {
         guard let rule = viewModel.blockRules.first(where: { $0.id == id }) else {
             return String(localized: "Enable Rule", bundle: RockxyLocalization.bundle)
         }
-        return rule.isEnabled ? String(localized: "Disable Rule", bundle: RockxyLocalization.bundle) : String(localized: "Enable Rule", bundle: RockxyLocalization.bundle)
+        return rule.isEnabled ? String(localized: "Disable Rule", bundle: RockxyLocalization.bundle) : String(
+            localized: "Enable Rule",
+            bundle: RockxyLocalization.bundle
+        )
     }
 
     private func openEditorForSelection() {
@@ -699,7 +720,10 @@ struct BlockListWindowView: View {
             do {
                 let resourceValues = try url.resourceValues(forKeys: [.fileSizeKey])
                 if let fileSize = resourceValues.fileSize, fileSize > Self.maxImportFileBytes {
-                    importError = String(localized: "File is too large to import (max 1 MB).", bundle: RockxyLocalization.bundle)
+                    importError = String(
+                        localized: "File is too large to import (max 1 MB).",
+                        bundle: RockxyLocalization.bundle
+                    )
                     return
                 }
                 let data = try Data(contentsOf: url)
@@ -716,205 +740,6 @@ struct BlockListWindowView: View {
             }
         case let .failure(error):
             importError = error.localizedDescription
-        }
-    }
-}
-
-// MARK: - BlockListTableView
-
-private struct BlockListTableView<ContextMenuContent: View>: View {
-    // MARK: Internal
-
-    let rules: [ProxyRule]
-    @Binding var selectedRuleID: UUID?
-
-    let onToggle: (UUID) -> Void
-    let onEdit: (UUID) -> Void
-    let onDelete: (UUID) -> Void
-    @ViewBuilder let contextMenuItems: (UUID) -> ContextMenuContent
-
-    var body: some View {
-        VStack(spacing: 0) {
-            columnHeader
-            ZStack {
-                zebraRows
-
-                if rules.isEmpty {
-                    Text(String(localized: "Click \"+\" or ⌘N to add new entry", bundle: RockxyLocalization.bundle))
-                        .font(.system(size: toolMetrics.emptyStateFontSize))
-                        .foregroundStyle(.secondary)
-                        .frame(maxWidth: .infinity, maxHeight: .infinity)
-                } else {
-                    ScrollView {
-                        LazyVStack(spacing: 0) {
-                            ForEach(Array(rules.enumerated()), id: \.element.id) { index, rule in
-                                BlockRuleTableRow(
-                                    rule: rule,
-                                    isSelected: selectedRuleID == rule.id,
-                                    rowIndex: index,
-                                    onSelect: { selectedRuleID = rule.id },
-                                    onToggle: { onToggle(rule.id) }
-                                )
-                                .contextMenu {
-                                    contextMenuItems(rule.id)
-                                }
-                                .onTapGesture(count: 2) {
-                                    onEdit(rule.id)
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-            .frame(maxHeight: .infinity)
-        }
-        .frame(minHeight: toolMetrics.tableRowHeight * 8, maxHeight: .infinity)
-        .clipped()
-        .background(Color(nsColor: .textBackgroundColor))
-        .clipShape(RoundedRectangle(cornerRadius: 6))
-        .overlay {
-            RoundedRectangle(cornerRadius: 6)
-                .stroke(Color(nsColor: .separatorColor), lineWidth: 1)
-        }
-        .padding(.horizontal, toolMetrics.contentHorizontalPadding)
-    }
-
-    // MARK: Private
-
-    @Environment(\.appUIDisplayMetrics) private var appMetrics
-
-    private var toolMetrics: ToolWindowDisplayMetrics {
-        ToolWindowDisplayMetrics(appMetrics: appMetrics)
-    }
-
-    private var columnHeader: some View {
-        HStack(spacing: 0) {
-            Text(String(localized: "Enabled", bundle: RockxyLocalization.bundle))
-                .frame(width: 66, alignment: .leading)
-            tableDivider
-            Text(String(localized: "Name", bundle: RockxyLocalization.bundle))
-                .frame(width: 300, alignment: .leading)
-            tableDivider
-            Text(String(localized: "Block Action", bundle: RockxyLocalization.bundle))
-                .frame(width: 150, alignment: .leading)
-            tableDivider
-            Text(String(localized: "Method", bundle: RockxyLocalization.bundle))
-                .frame(width: 90, alignment: .leading)
-            tableDivider
-            Text(String(localized: "Matching Rule", bundle: RockxyLocalization.bundle))
-                .frame(maxWidth: .infinity, alignment: .leading)
-        }
-        .font(toolMetrics.tableHeaderFont())
-        .lineLimit(1)
-        .padding(.horizontal, toolMetrics.tableCellHorizontalPadding)
-        .frame(height: toolMetrics.tableRowHeight)
-        .background(Color(nsColor: .textBackgroundColor))
-        .overlay(alignment: .bottom) {
-            Divider()
-        }
-    }
-
-    private var tableDivider: some View {
-        Rectangle()
-            .fill(.secondary.opacity(0.22))
-            .frame(width: 1, height: max(16, toolMetrics.tableRowHeight - 10))
-            .padding(.trailing, 10)
-    }
-
-    private var zebraRows: some View {
-        GeometryReader { proxy in
-            let rowCount = max(1, Int(ceil(proxy.size.height / toolMetrics.tableRowHeight)))
-            VStack(spacing: 0) {
-                ForEach(0 ..< rowCount, id: \.self) { index in
-                    Rectangle()
-                        .fill(index.isMultiple(of: 2) ? Color(nsColor: .textBackgroundColor) : Color.secondary
-                            .opacity(0.08))
-                        .frame(height: toolMetrics.tableRowHeight)
-                }
-                Spacer(minLength: 0)
-            }
-            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
-        }
-        .allowsHitTesting(false)
-    }
-}
-
-// MARK: - BlockRuleTableRow
-
-private struct BlockRuleTableRow: View {
-    // MARK: Internal
-
-    let rule: ProxyRule
-    let isSelected: Bool
-    let rowIndex: Int
-    let onSelect: () -> Void
-    let onToggle: () -> Void
-
-    var body: some View {
-        HStack(spacing: 0) {
-            Toggle("", isOn: Binding(
-                get: { rule.isEnabled },
-                set: { _ in onToggle() }
-            ))
-            .toggleStyle(.checkbox)
-            .labelsHidden()
-            .frame(width: 66)
-
-            Text(rule.name)
-                .lineLimit(1)
-                .truncationMode(.middle)
-                .frame(width: 300, alignment: .leading)
-
-            actionLabel
-                .lineLimit(1)
-                .truncationMode(.tail)
-                .frame(width: 150, alignment: .leading)
-
-            Text(rule.matchCondition.method ?? "ANY")
-                .lineLimit(1)
-                .frame(width: 90, alignment: .leading)
-
-            Text(rule.matchCondition.sourceURLPattern ?? rule.matchCondition.urlPattern ?? "")
-                .font(toolMetrics.font(monospaced: true))
-                .lineLimit(1)
-                .truncationMode(.middle)
-                .frame(maxWidth: .infinity, alignment: .leading)
-        }
-        .font(toolMetrics.font())
-        .padding(.horizontal, toolMetrics.tableCellHorizontalPadding)
-        .foregroundStyle(rule.isEnabled ? .primary : .secondary)
-        .frame(height: toolMetrics.tableRowHeight)
-        .background(rowBackground)
-        .contentShape(Rectangle())
-        .onTapGesture {
-            onSelect()
-        }
-        .opacity(rule.isEnabled ? 1.0 : 0.5)
-    }
-
-    // MARK: Private
-
-    @Environment(\.appUIDisplayMetrics) private var appMetrics
-
-    private var rowBackground: some ShapeStyle {
-        if isSelected {
-            return AnyShapeStyle(Color.accentColor.opacity(0.22))
-        }
-        return AnyShapeStyle(rowIndex.isMultiple(of: 2) ? Color(nsColor: .textBackgroundColor) : Color.secondary
-            .opacity(0.08))
-    }
-
-    private var toolMetrics: ToolWindowDisplayMetrics {
-        ToolWindowDisplayMetrics(appMetrics: appMetrics)
-    }
-
-    @ViewBuilder private var actionLabel: some View {
-        if case let .block(statusCode) = rule.action {
-            Text(
-                statusCode == 0
-                    ? String(localized: "Drop Connection", bundle: RockxyLocalization.bundle)
-                    : String(localized: "Return 403 Forbidden", bundle: RockxyLocalization.bundle)
-            )
         }
     }
 }
@@ -971,7 +796,10 @@ private struct AddBlockRuleSheet: View {
     var body: some View {
         VStack(spacing: 0) {
             VStack(alignment: .leading, spacing: toolMetrics.formRowSpacing) {
-                Text(isEditing ? String(localized: "Edit Block Rule", bundle: RockxyLocalization.bundle) : String(localized: "New Block Rule", bundle: RockxyLocalization.bundle))
+                Text(isEditing ? String(localized: "Edit Block Rule", bundle: RockxyLocalization.bundle) : String(
+                    localized: "New Block Rule",
+                    bundle: RockxyLocalization.bundle
+                ))
                 .font(
                     .system(
                         size: max(15, toolMetrics.bodyFontSize + 2),
@@ -1043,7 +871,10 @@ private struct AddBlockRuleSheet: View {
     }
 
     private var primaryButtonTitle: String {
-        isEditing ? String(localized: "Save", bundle: RockxyLocalization.bundle) : String(localized: "Add", bundle: RockxyLocalization.bundle)
+        isEditing ? String(localized: "Save", bundle: RockxyLocalization.bundle) : String(
+            localized: "Add",
+            bundle: RockxyLocalization.bundle
+        )
     }
 
     private var trimmedName: String {
@@ -1059,7 +890,10 @@ private struct AddBlockRuleSheet: View {
         case .returnForbidden:
             String(localized: "Send an HTTP 403 response to the client.", bundle: RockxyLocalization.bundle)
         case .dropConnection:
-            String(localized: "Close the matching client connection without a response.", bundle: RockxyLocalization.bundle)
+            String(
+                localized: "Close the matching client connection without a response.",
+                bundle: RockxyLocalization.bundle
+            )
         }
     }
 
@@ -1077,12 +911,21 @@ private struct AddBlockRuleSheet: View {
                     switch context.origin {
                     case .selectedTransaction:
                         if let method = context.sourceMethod {
-                            Text(String(localized: "Created from: \(method) \(context.sourceHost)\(context.sourcePath ?? "")", bundle: RockxyLocalization.bundle))
+                            Text(String(
+                                localized: "Created from: \(method) \(context.sourceHost)\(context.sourcePath ?? "")",
+                                bundle: RockxyLocalization.bundle
+                            ))
                         } else {
-                            Text(String(localized: "Created from: \(context.sourceHost)\(context.sourcePath ?? "")", bundle: RockxyLocalization.bundle))
+                            Text(String(
+                                localized: "Created from: \(context.sourceHost)\(context.sourcePath ?? "")",
+                                bundle: RockxyLocalization.bundle
+                            ))
                         }
                     case .domainQuickCreate:
-                        Text(String(localized: "Created from domain: \(context.sourceHost)", bundle: RockxyLocalization.bundle))
+                        Text(String(
+                            localized: "Created from domain: \(context.sourceHost)",
+                            bundle: RockxyLocalization.bundle
+                        ))
                     }
                 }
                 .font(toolMetrics.secondaryFont())

--- a/Rockxy/Views/Rules/MapLocalEditorViewModel.swift
+++ b/Rockxy/Views/Rules/MapLocalEditorViewModel.swift
@@ -381,6 +381,17 @@ final class MapLocalEditorViewModel {
         )
     }
 
+    /// After a brand-new rule's save fails to persist, the optimistically-added rule
+    /// already lives in `RuleEngine` under `rule.id`. Adopting that identity flips the
+    /// next Save from add-new to update-existing semantics so a retry updates the same
+    /// rule instead of appending a duplicate under a fresh UUID. The editor stays open
+    /// with the failure visible; no engine rollback is performed, so a concurrent
+    /// mutation cannot be erased.
+    func adoptFailedAddIdentity(_ rule: ProxyRule) {
+        existingID = rule.id
+        originalRule = rule
+    }
+
     func urlPatternForSaving() -> String {
         let trimmed = urlText.trimmingCharacters(in: .whitespacesAndNewlines)
         guard matchType == .wildcard else {

--- a/Rockxy/Views/Rules/MapLocalEditorWindowView.swift
+++ b/Rockxy/Views/Rules/MapLocalEditorWindowView.swift
@@ -1,0 +1,739 @@
+import AppKit
+import os
+import SwiftUI
+
+// Presents the native Map Local rule editor window.
+// Split out of `MapLocalWindowView.swift` to keep each file within the length limit.
+
+// MARK: - MapLocalEditorWindowView
+
+struct MapLocalEditorWindowView: View {
+    // MARK: Internal
+
+    @State var viewModel = MapLocalEditorViewModel()
+
+    var body: some View {
+        VStack(spacing: 0) {
+            ScrollView {
+                VStack(alignment: .leading, spacing: toolMetrics.formRowSpacing + 3) {
+                    Text(editorTitle)
+                        .font(.system(size: max(15, toolMetrics.bodyFontSize + 2), weight: .semibold))
+
+                    if let provenance = quickCreateProvenance {
+                        provenanceBanner(provenance)
+                    }
+
+                    ruleDetailsSection
+                    responseSourceSection
+                }
+                .padding(.horizontal, toolMetrics.formHorizontalPadding)
+                .padding(.vertical, toolMetrics.formVerticalPadding)
+            }
+
+            Divider()
+            footer
+        }
+        .font(toolMetrics.font())
+        .frame(minWidth: max(860, toolMetrics.bodyFontSize * 28 + 496))
+        .frame(height: max(680, toolMetrics.bodyFontSize * 20 + 420))
+        .navigationTitle(viewModel.windowTitle)
+        .onAppear { viewModel.load(context: editorStore.context) }
+        .onChange(of: editorStore.draftVersion) { _, _ in
+            viewModel.load(context: editorStore.context)
+        }
+        .alert(
+            String(localized: "Map Local", bundle: RockxyLocalization.bundle),
+            isPresented: Binding(
+                get: { viewModel.errorMessage != nil },
+                set: {
+                    if !$0 {
+                        viewModel.errorMessage = nil
+                    }
+                }
+            )
+        ) {
+            Button(String(localized: "OK", bundle: RockxyLocalization.bundle)) { viewModel.errorMessage = nil }
+        } message: {
+            if let error = viewModel.errorMessage {
+                Text(error)
+            }
+        }
+    }
+
+    // MARK: Private
+
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.appUIDisplayMetrics) private var appMetrics
+    @State private var editorStore = MapLocalEditorStore.shared
+    @State private var isSaving = false
+
+    private var editorTitle: String {
+        viewModel.existingID == nil
+            ? String(localized: "New Map Local Rule", bundle: RockxyLocalization.bundle)
+            : String(localized: "Edit Map Local Rule", bundle: RockxyLocalization.bundle)
+    }
+
+    private var quickCreateProvenance: String? {
+        guard let draft = viewModel.draft else {
+            return nil
+        }
+        if let sourceURL = draft.sourceURL {
+            return String(
+                localized: "Created from \(draft.sourceMethod ?? "ANY") \(sourceURL.absoluteString)",
+                bundle: RockxyLocalization.bundle
+            )
+        }
+        return String(localized: "Created from domain \(draft.sourceHost)", bundle: RockxyLocalization.bundle)
+    }
+
+    private var fileStatusColor: Color {
+        if viewModel.isCapturedBinary {
+            return .blue
+        }
+        if viewModel.isExternalReference {
+            return viewModel.isSelectedFileAvailable ? .green : .orange
+        }
+        return viewModel.isSelectedFileAvailable ? .green : .secondary
+    }
+
+    private var fileStatusMessage: String {
+        if viewModel.isCapturedBinary {
+            return String(
+                localized: "Captured binary response will be written when the rule is saved.",
+                bundle: RockxyLocalization.bundle
+            )
+        }
+        if viewModel.isExternalReference {
+            if viewModel.isExternalFullHTTPMessage {
+                return String(
+                    localized: "Full HTTP response file detected — previewing file-owned status, headers, and body.",
+                    bundle: RockxyLocalization.bundle
+                )
+            }
+            return viewModel.isSelectedFileAvailable
+                ? String(localized: "External file available", bundle: RockxyLocalization.bundle)
+                : String(localized: "External file is currently unavailable", bundle: RockxyLocalization.bundle)
+        }
+        return viewModel.isSelectedFileAvailable
+            ? String(localized: "Rockxy-owned response file available", bundle: RockxyLocalization.bundle)
+            : String(
+                localized: "Rockxy will create this response file when the rule is saved.",
+                bundle: RockxyLocalization.bundle
+            )
+    }
+
+    private var toolMetrics: ToolWindowDisplayMetrics {
+        ToolWindowDisplayMetrics(appMetrics: appMetrics)
+    }
+
+    private var localFileResponseDescription: String {
+        if viewModel.isInlineResponseEditable {
+            return String(
+                localized: "Edit the status line, response headers, and body. Rockxy always recalculates Content-Length.",
+                bundle: RockxyLocalization.bundle
+            )
+        }
+        if viewModel.isCapturedBinary {
+            return String(
+                localized: "Edit status and headers here. Captured binary body bytes stay preserved and text after the blank line is ignored.",
+                bundle: RockxyLocalization.bundle
+            )
+        }
+        if viewModel.isExternalFullHTTPMessage {
+            if viewModel.externalFullMessageHasBinaryBody {
+                return String(
+                    localized: "Read-only preview. This file controls the status and headers; its binary body is preserved but not shown.",
+                    bundle: RockxyLocalization.bundle
+                )
+            }
+            return String(
+                localized: "Read-only preview. This file controls the status, ordered headers, and body at request time.",
+                bundle: RockxyLocalization.bundle
+            )
+        }
+        return String(
+            localized: "Edit status and headers here. The body comes from the user-owned file and text after the blank line is ignored.",
+            bundle: RockxyLocalization.bundle
+        )
+    }
+
+    private var ruleDetailsSection: some View {
+        VStack(alignment: .leading, spacing: 7) {
+            Text(String(localized: "Rule Details", bundle: RockxyLocalization.bundle))
+                .font(toolMetrics.font(weight: .semibold))
+
+            VStack(alignment: .leading, spacing: toolMetrics.formRowSpacing) {
+                HStack(alignment: .top, spacing: toolMetrics.controlSpacing) {
+                    fieldGroup(String(localized: "Name", bundle: RockxyLocalization.bundle)) {
+                        TextField(
+                            String(localized: "Untitled", bundle: RockxyLocalization.bundle),
+                            text: $viewModel.name
+                        )
+                        .textFieldStyle(.roundedBorder)
+                        .accessibilityLabel(String(localized: "Rule name", bundle: RockxyLocalization.bundle))
+                    }
+                    .frame(width: max(250, toolMetrics.fieldWidth(250)))
+
+                    fieldGroup(String(localized: "URL pattern", bundle: RockxyLocalization.bundle)) {
+                        TextField("https://example.com/api/*", text: $viewModel.urlText)
+                            .textFieldStyle(.roundedBorder)
+                            .font(toolMetrics.font(monospaced: true))
+                            .accessibilityLabel(String(localized: "URL pattern", bundle: RockxyLocalization.bundle))
+                    }
+                    .frame(maxWidth: .infinity)
+                }
+
+                if let validationMessage = viewModel.urlValidationMessage {
+                    Label(validationMessage, systemImage: "exclamationmark.triangle.fill")
+                        .font(toolMetrics.secondaryFont())
+                        .foregroundStyle(.red)
+                }
+
+                MapLocalHTTPSPrerequisiteNotice(
+                    isHTTPSPattern: viewModel.isHTTPSPattern,
+                    targetHost: viewModel.httpsTargetHost,
+                    toolMetrics: toolMetrics
+                )
+
+                HStack(alignment: .center, spacing: toolMetrics.controlSpacing * 2) {
+                    inlineField(String(localized: "Method", bundle: RockxyLocalization.bundle)) {
+                        methodMenu
+                    }
+                    inlineField(String(localized: "Match type", bundle: RockxyLocalization.bundle)) {
+                        matchTypeMenu
+                    }
+
+                    if viewModel.matchType == .wildcard {
+                        Text(String(localized: "Supports * and ?.", bundle: RockxyLocalization.bundle))
+                            .font(toolMetrics.secondaryFont())
+                            .foregroundStyle(.secondary)
+                    }
+                    Spacer()
+                }
+
+                if viewModel.matchType == .wildcard {
+                    Toggle(
+                        String(localized: "Include all subpaths of this URL", bundle: RockxyLocalization.bundle),
+                        isOn: $viewModel.includeSubpaths
+                    )
+                    .toggleStyle(.checkbox)
+                }
+
+                if let validationMessage = viewModel.directoryRegexValidationMessage {
+                    Label(validationMessage, systemImage: "exclamationmark.triangle.fill")
+                        .font(toolMetrics.secondaryFont())
+                        .foregroundStyle(.red)
+                }
+
+                MapLocalRuleTesterSection(viewModel: viewModel, toolMetrics: toolMetrics)
+
+                Divider()
+
+                HStack(alignment: .center, spacing: toolMetrics.controlSpacing) {
+                    Text(String(localized: "Response delay", bundle: RockxyLocalization.bundle))
+                        .foregroundStyle(.secondary)
+                    delayMenu
+                    if viewModel.delayPreset == .custom {
+                        Stepper(
+                            String(
+                                localized: "\(viewModel.customDelaySeconds) seconds",
+                                bundle: RockxyLocalization.bundle
+                            ),
+                            value: $viewModel.customDelaySeconds,
+                            in: 0 ... 300
+                        )
+                        .frame(width: toolMetrics.fieldWidth(160))
+                    }
+                    Spacer()
+                }
+            }
+            .padding(.horizontal, toolMetrics.formHorizontalPadding - 2)
+            .padding(.vertical, toolMetrics.formVerticalPadding - 2)
+            .background(Color(nsColor: .textBackgroundColor))
+            .clipShape(RoundedRectangle(cornerRadius: 6))
+            .overlay {
+                RoundedRectangle(cornerRadius: 6)
+                    .stroke(Color(nsColor: .separatorColor), lineWidth: 1)
+            }
+        }
+    }
+
+    private var responseSourceSection: some View {
+        VStack(alignment: .leading, spacing: 7) {
+            Text(String(localized: "Response Source", bundle: RockxyLocalization.bundle))
+                .font(toolMetrics.font(weight: .semibold))
+
+            VStack(alignment: .leading, spacing: toolMetrics.formRowSpacing) {
+                Picker(
+                    String(localized: "Source type", bundle: RockxyLocalization.bundle),
+                    selection: $viewModel.targetMode
+                ) {
+                    Text(MapLocalTargetMode.localFile.displayName).tag(MapLocalTargetMode.localFile)
+                    Text(MapLocalTargetMode.localDirectory.displayName).tag(MapLocalTargetMode.localDirectory)
+                }
+                .pickerStyle(.segmented)
+                .labelsHidden()
+                .frame(width: toolMetrics.menuWidth(240))
+                .frame(maxWidth: .infinity, alignment: .center)
+
+                Divider()
+
+                responseStatusRow
+
+                if viewModel.targetMode == .localFile {
+                    localFileSection
+                } else {
+                    localDirectorySection
+                }
+            }
+            .padding(.horizontal, toolMetrics.formHorizontalPadding - 2)
+            .padding(.vertical, toolMetrics.formVerticalPadding - 2)
+            .background(Color(nsColor: .textBackgroundColor))
+            .clipShape(RoundedRectangle(cornerRadius: 6))
+            .overlay {
+                RoundedRectangle(cornerRadius: 6)
+                    .stroke(Color(nsColor: .separatorColor), lineWidth: 1)
+            }
+        }
+    }
+
+    private var localFileSection: some View {
+        VStack(alignment: .leading, spacing: toolMetrics.formRowSpacing) {
+            HStack(alignment: .bottom, spacing: toolMetrics.controlSpacing) {
+                fieldGroup(String(localized: "Local file", bundle: RockxyLocalization.bundle)) {
+                    Text(viewModel.filePath)
+                        .font(toolMetrics.font(monospaced: true))
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                        .textSelection(.enabled)
+                        .padding(.horizontal, 7)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .background(Color(nsColor: .controlBackgroundColor))
+                        .clipShape(RoundedRectangle(cornerRadius: 5))
+                        .overlay {
+                            RoundedRectangle(cornerRadius: 5)
+                                .stroke(Color(nsColor: .separatorColor), lineWidth: 1)
+                        }
+                        .help(viewModel.filePath)
+                }
+                .frame(maxWidth: .infinity)
+
+                Button(String(localized: "Choose…", bundle: RockxyLocalization.bundle)) { viewModel.choosePath() }
+                    .frame(height: toolMetrics.formControlHeight)
+
+                fileActionsMenu
+            }
+
+            HStack(spacing: 7) {
+                Circle()
+                    .fill(fileStatusColor)
+                    .frame(width: 8, height: 8)
+                Text(fileStatusMessage)
+                    .font(toolMetrics.secondaryFont())
+                    .foregroundStyle(.secondary)
+                Spacer()
+                Text(viewModel.responseContentType)
+                    .font(toolMetrics.metadataFont(monospaced: true))
+                    .foregroundStyle(.secondary)
+                    .help(String(
+                        localized: "Configured Content-Type, or the file-extension fallback.",
+                        bundle: RockxyLocalization.bundle
+                    ))
+            }
+
+            if let validationMessage = viewModel.externalFileValidationMessage {
+                Label(validationMessage, systemImage: "exclamationmark.triangle.fill")
+                    .font(toolMetrics.secondaryFont())
+                    .foregroundStyle(.orange)
+            }
+
+            MapLocalHTTPResponseSection(
+                text: $viewModel.httpMessageText,
+                bodyIsEditable: viewModel.isInlineResponseEditable,
+                bodyDescription: localFileResponseDescription,
+                toolMetrics: toolMetrics,
+                messageIsEditable: !viewModel.isExternalFullHTTPMessage
+            )
+        }
+    }
+
+    private var responseStatusRow: some View {
+        HStack(alignment: .center, spacing: toolMetrics.controlSpacing) {
+            Text(String(localized: "Status code", bundle: RockxyLocalization.bundle))
+                .foregroundStyle(.secondary)
+            TextField(
+                "",
+                value: Binding(
+                    get: { viewModel.responseStatusCode },
+                    set: { viewModel.setResponseStatusCode($0) }
+                ),
+                format: .number
+            )
+            .textFieldStyle(.roundedBorder)
+            .frame(width: 84, height: toolMetrics.formControlHeight)
+            .accessibilityLabel(String(localized: "HTTP response status code", bundle: RockxyLocalization.bundle))
+            .disabled(viewModel.isExternalFullHTTPMessage)
+            Text(viewModel.isExternalFullHTTPMessage
+                ? String(
+                    localized: "The selected full HTTP response file controls this status code.",
+                    bundle: RockxyLocalization.bundle
+                )
+                : String(
+                    localized: "Applied to every response from this rule. Valid range: 100–599.",
+                    bundle: RockxyLocalization.bundle
+                ))
+                .font(toolMetrics.secondaryFont())
+                .foregroundStyle(.secondary)
+            Spacer()
+        }
+    }
+
+    private var localDirectorySection: some View {
+        VStack(alignment: .leading, spacing: toolMetrics.formRowSpacing) {
+            fieldGroup(String(localized: "Local directory", bundle: RockxyLocalization.bundle)) {
+                HStack(spacing: toolMetrics.controlSpacing) {
+                    TextField(
+                        String(localized: "Choose a directory", bundle: RockxyLocalization.bundle),
+                        text: $viewModel.directoryPath
+                    )
+                    .textFieldStyle(.roundedBorder)
+                    .font(toolMetrics.font(monospaced: true))
+                    Button(String(localized: "Choose…", bundle: RockxyLocalization.bundle)) { viewModel.choosePath() }
+                    Button(String(localized: "Show in Finder", bundle: RockxyLocalization.bundle)) {
+                        viewModel.showSelectedPathInFinder()
+                    }
+                    .disabled(!viewModel.isDirectoryValid)
+                }
+            }
+            HStack(spacing: 8) {
+                Circle()
+                    .fill(viewModel.isDirectoryValid ? Color.green : Color.orange)
+                    .frame(width: 8, height: 8)
+                Text(viewModel.isDirectoryValid
+                    ? String(localized: "Directory available", bundle: RockxyLocalization.bundle)
+                    : String(
+                        localized: "Choose an available directory to continue.",
+                        bundle: RockxyLocalization.bundle
+                    ))
+                    .font(toolMetrics.secondaryFont())
+                    .foregroundStyle(.secondary)
+            }
+
+            HStack(alignment: .top, spacing: 8) {
+                Image(systemName: "folder")
+                    .foregroundStyle(.secondary)
+                Text(
+                    String(
+                        localized: "Request subpaths resolve to files inside this directory. Root requests and missing files continue to the origin.",
+                        bundle: RockxyLocalization.bundle
+                    )
+                        + " "
+                        + String(
+                            localized: "Regex directory rules use the first capture group as the relative file path.",
+                            bundle: RockxyLocalization.bundle
+                        )
+                )
+                .font(toolMetrics.secondaryFont())
+                .foregroundStyle(.secondary)
+                Spacer()
+            }
+            .padding(10)
+            .background(Color(nsColor: .controlBackgroundColor))
+            .clipShape(RoundedRectangle(cornerRadius: 5))
+
+            MapLocalHTTPResponseSection(
+                text: $viewModel.httpMessageText,
+                bodyIsEditable: false,
+                bodyDescription: String(
+                    localized:
+                    "Edit status and headers here. Response bodies come from the matched file in this directory; text after the blank line is ignored.",
+                    bundle: RockxyLocalization.bundle
+                ),
+                toolMetrics: toolMetrics
+            )
+        }
+    }
+
+    private var methodMenu: some View {
+        Menu {
+            ForEach(Array(MapLocalEditorMenuContent.methodSections.enumerated()), id: \.offset) { index, section in
+                ForEach(section) { method in
+                    Button { viewModel.method = method } label: {
+                        menuCheckmarkLabel(method.rawValue, isSelected: viewModel.method == method)
+                    }
+                }
+                if index < MapLocalEditorMenuContent.methodSections.count - 1 {
+                    Divider()
+                }
+            }
+        } label: {
+            dataEntryMenuLabel(viewModel.method.rawValue, width: toolMetrics.menuWidth(90))
+        }
+        .menuIndicator(.hidden)
+        .buttonStyle(.plain)
+        .frame(width: toolMetrics.menuWidth(90))
+    }
+
+    private var matchTypeMenu: some View {
+        Menu {
+            ForEach(Array(MapLocalEditorMenuContent.matchTypeSections.enumerated()), id: \.offset) { index, section in
+                ForEach(section) { matchType in
+                    Button { viewModel.matchType = matchType } label: {
+                        menuCheckmarkLabel(matchType.displayName, isSelected: viewModel.matchType == matchType)
+                    }
+                }
+                if index < MapLocalEditorMenuContent.matchTypeSections.count - 1 {
+                    Divider()
+                }
+            }
+        } label: {
+            dataEntryMenuLabel(viewModel.matchType.displayName, width: toolMetrics.menuWidth(150))
+        }
+        .menuIndicator(.hidden)
+        .buttonStyle(.plain)
+        .frame(width: toolMetrics.menuWidth(150))
+    }
+
+    private var delayMenu: some View {
+        Menu {
+            ForEach(Array(MapLocalEditorMenuContent.delaySections.enumerated()), id: \.offset) { index, section in
+                ForEach(section) { preset in
+                    Button { viewModel.delayPreset = preset } label: {
+                        menuCheckmarkLabel(preset.displayName, isSelected: viewModel.delayPreset == preset)
+                    }
+                }
+                if index < MapLocalEditorMenuContent.delaySections.count - 1 {
+                    Divider()
+                }
+            }
+        } label: {
+            dataEntryMenuLabel(viewModel.delayPreset.displayName, width: toolMetrics.menuWidth(160))
+        }
+        .menuIndicator(.hidden)
+        .buttonStyle(.plain)
+        .frame(width: toolMetrics.menuWidth(160))
+    }
+
+    private var fileActionsMenu: some View {
+        Menu {
+            Button(String(localized: "Show in Finder", bundle: RockxyLocalization.bundle)) {
+                viewModel.showSelectedPathInFinder()
+            }
+            .disabled(!viewModel.isSelectedFileAvailable)
+            Divider()
+            ForEach(MapLocalExternalEditor.allCases) { editor in
+                Button(String(localized: "Open with \(editor.displayName)", bundle: RockxyLocalization.bundle)) {
+                    viewModel.openSelectedPath(with: editor)
+                }
+                .disabled(!viewModel.isSelectedFileAvailable)
+            }
+        } label: {
+            Image(systemName: "ellipsis.circle")
+                .frame(width: toolMetrics.footerControlHeight, height: toolMetrics.formControlHeight)
+        }
+        .menuIndicator(.hidden)
+        .buttonStyle(.plain)
+        .help(String(localized: "File Actions", bundle: RockxyLocalization.bundle))
+    }
+
+    private var footer: some View {
+        HStack {
+            Spacer()
+            Button {
+                dismiss()
+            } label: {
+                footerButtonLabel(String(localized: "Cancel", bundle: RockxyLocalization.bundle))
+            }
+            .keyboardShortcut(.cancelAction)
+
+            Button {
+                saveAndClose()
+            } label: {
+                footerButtonLabel(
+                    isSaving
+                        ? String(localized: "Saving…", bundle: RockxyLocalization.bundle)
+                        : viewModel.existingID == nil
+                        ? String(localized: "Add", bundle: RockxyLocalization.bundle)
+                        : String(localized: "Save", bundle: RockxyLocalization.bundle)
+                )
+            }
+            .keyboardShortcut(.defaultAction)
+            .rockxyGlassButtonStyle(prominent: true)
+            .disabled(!viewModel.isSaveEnabled || isSaving)
+        }
+        .padding(.horizontal, toolMetrics.formHorizontalPadding)
+        .padding(.vertical, toolMetrics.controlSpacing)
+    }
+
+    private func provenanceBanner(_ message: String) -> some View {
+        HStack(spacing: 7) {
+            Image(systemName: "arrow.turn.down.right")
+                .foregroundStyle(.secondary)
+            Text(message)
+                .font(toolMetrics.secondaryFont(monospaced: true))
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+                .truncationMode(.middle)
+                .help(message)
+            Spacer()
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 8)
+        .background(Color.accentColor.opacity(0.08))
+        .clipShape(RoundedRectangle(cornerRadius: 6))
+        .overlay {
+            RoundedRectangle(cornerRadius: 6)
+                .stroke(Color.accentColor.opacity(0.25), lineWidth: 1)
+        }
+    }
+
+    private func menuCheckmarkLabel(_ title: String, isSelected: Bool) -> some View {
+        HStack(spacing: 7) {
+            if isSelected {
+                Image(systemName: "checkmark")
+            }
+            Text(title)
+        }
+    }
+
+    private func dataEntryMenuLabel(_ title: String, width: CGFloat) -> some View {
+        HStack(spacing: 6) {
+            Text(title)
+                .lineLimit(1)
+            Spacer(minLength: 6)
+            Image(systemName: "chevron.up.chevron.down")
+                .font(.system(size: 10, weight: .semibold))
+        }
+        .padding(.horizontal, 7)
+        .frame(width: width, height: toolMetrics.formControlHeight, alignment: .leading)
+        .background(Color(nsColor: .controlBackgroundColor))
+        .clipShape(RoundedRectangle(cornerRadius: 5))
+        .overlay {
+            RoundedRectangle(cornerRadius: 5)
+                .stroke(Color(nsColor: .separatorColor), lineWidth: 1)
+        }
+        .contentShape(RoundedRectangle(cornerRadius: 5))
+    }
+
+    private func inlineField(
+        _ label: String,
+        @ViewBuilder content: () -> some View
+    )
+        -> some View
+    {
+        HStack(alignment: .center, spacing: toolMetrics.controlSpacing) {
+            Text(label)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+                .fixedSize(horizontal: true, vertical: false)
+            content()
+                .font(toolMetrics.font())
+                .controlSize(.regular)
+                .frame(height: toolMetrics.formControlHeight)
+        }
+    }
+
+    private func fieldGroup(
+        _ label: String,
+        @ViewBuilder content: () -> some View
+    )
+        -> some View
+    {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(label)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+            content()
+                .font(toolMetrics.font())
+                .controlSize(.regular)
+                .frame(height: toolMetrics.formControlHeight)
+        }
+    }
+
+    private func footerButtonLabel(_ title: String) -> some View {
+        Text(title)
+            .frame(
+                width: max(64, toolMetrics.footerButtonWidth - toolMetrics.controlSpacing * 3),
+                height: max(16, toolMetrics.footerControlHeight - toolMetrics.controlSpacing)
+            )
+    }
+
+    private func saveAndClose() {
+        guard let rule = viewModel.makeRule() else {
+            return
+        }
+        isSaving = true
+        Task {
+            let outcome: RulePersistenceOutcome
+            if viewModel.existingID == nil {
+                switch await RulePolicyGate.shared.addRulePersisting(rule) {
+                case .quotaExceeded:
+                    viewModel.errorMessage = String(
+                        localized:
+                        "The active Map Local rule limit was reached. Disable another rule and try again.",
+                        bundle: RockxyLocalization.bundle
+                    )
+                    isSaving = false
+                    return
+                case let .loadFailed(message):
+                    // The engine was not mutated. Keep new-rule semantics so a
+                    // retry first reloads the user's existing on-disk rules.
+                    outcome = .failed(message: message)
+                case let .persisted(result):
+                    outcome = result
+                    if case .failed = result {
+                        // The optimistic engine mutation already added this rule under
+                        // `rule.id`. Adopt that identity so the next Save updates the same
+                        // rule (retry-update) instead of adding a duplicate with a new UUID.
+                        viewModel.adoptFailedAddIdentity(rule)
+                    }
+                }
+            } else {
+                outcome = await RulePolicyGate.shared.updateRulePersisting(rule)
+            }
+            isSaving = false
+            // Only dismiss when the change was durably written. A failed save
+            // keeps the editor open with the error visible so the user does not
+            // believe a lost rule was saved.
+            if case let .failed(message) = outcome {
+                viewModel.errorMessage = message
+                return
+            }
+            dismiss()
+        }
+    }
+}
+
+// MARK: - MapLocalExternalEditor
+
+enum MapLocalExternalEditor: String, CaseIterable, Identifiable {
+    case code
+    case cursor
+    case textEdit
+    case xcode
+
+    // MARK: Internal
+
+    var id: String {
+        rawValue
+    }
+
+    var displayName: String {
+        switch self {
+        case .code: "Code"
+        case .cursor: "Cursor"
+        case .textEdit: "TextEdit"
+        case .xcode: "Xcode"
+        }
+    }
+
+    var bundleIdentifier: String? {
+        switch self {
+        case .code: "com.microsoft.VSCode"
+        case .cursor: "com.todesktop.230313mzl4w4u92"
+        case .textEdit: "com.apple.TextEdit"
+        case .xcode: "com.apple.dt.Xcode"
+        }
+    }
+}

--- a/Rockxy/Views/Rules/MapLocalWindowView.swift
+++ b/Rockxy/Views/Rules/MapLocalWindowView.swift
@@ -2,7 +2,8 @@ import AppKit
 import os
 import SwiftUI
 
-// Presents the native Map Local management and editor windows.
+// Presents the native Map Local management window.
+// The rule editor window lives in `MapLocalEditorWindowView.swift`.
 
 // MARK: - MapLocalViewModel
 
@@ -71,15 +72,16 @@ final class MapLocalViewModel {
             return !locals.isEmpty && locals.allSatisfy(\.isEnabled)
         }
         set {
-            var updated = allRules
-            for index in updated.indices {
-                if case .mapLocal = updated[index].action {
-                    updated[index].isEnabled = newValue
+            // Optimistically reflect the toggle on the local Map Local rows only;
+            // the engine stays authoritative. Never rebuild a full snapshot here —
+            // a stale `allRules` would clobber concurrent additions from other windows.
+            for index in allRules.indices {
+                if case .mapLocal = allRules[index].action {
+                    allRules[index].isEnabled = newValue
                 }
             }
-            allRules = updated
             Task {
-                await RulePolicyGate.shared.replaceAllRules(updated)
+                await RulePolicyGate.shared.setMapLocalRulesEnabled(newValue)
                 allRules = await RuleEngine.shared.allRules
             }
         }
@@ -117,6 +119,14 @@ final class MapLocalViewModel {
             selectedRuleIDs = selectedRuleIDs.filter { id in
                 rules.contains { $0.id == id }
             }
+        }
+    }
+
+    /// Surfaces a durable save/load failure posted by `RuleSyncService` so the
+    /// user sees that persistence did not succeed instead of a silent no-op.
+    func handlePersistenceFailure(_ notification: Notification) {
+        if let message = notification.object as? String {
+            errorMessage = message
         }
     }
 
@@ -164,8 +174,13 @@ final class MapLocalViewModel {
         }
         allRules.removeAll { idsToRemove.contains($0.id) }
         selectedRuleIDs.removeAll()
-        let updated = allRules
-        Task { await RulePolicyGate.shared.replaceAllRules(updated) }
+        Task {
+            // Remove only the selected IDs against current engine state instead of
+            // persisting a full stale snapshot, so concurrent additions and other
+            // categories survive.
+            await RulePolicyGate.shared.removeRules(ids: idsToRemove)
+            allRules = await RuleEngine.shared.allRules
+        }
     }
 
     func removeRule(id: UUID) {
@@ -301,13 +316,27 @@ struct MapLocalWindowView: View {
             minWidth: max(860, toolMetrics.bodyFontSize * 28 + 496),
             minHeight: max(620, toolMetrics.bodyFontSize * 18 + 386)
         )
-        .task { await viewModel.refreshFromEngine() }
+        .task {
+            // Ensure persisted rules are loaded even when macOS restored ONLY this
+            // tool window (no main window ran its startup task). Idempotent and
+            // app-scoped — independent of main-window project hydration.
+            if case let .failed(message) = await RuleSyncService.ensureLoaded() {
+                viewModel.errorMessage = message
+            }
+            await viewModel.refreshFromEngine()
+        }
         .onAppear { consumePendingDraftIfNeeded() }
         .onReceive(NotificationCenter.default.publisher(for: .openMapLocalWindow)) { _ in
             consumePendingDraftIfNeeded()
         }
         .onReceive(NotificationCenter.default.publisher(for: .rulesDidChange)) { notification in
             viewModel.handleRulesDidChange(notification)
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .rulePersistenceDidFail)) { notification in
+            viewModel.handlePersistenceFailure(notification)
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .rulesDidFailToLoad)) { notification in
+            viewModel.handlePersistenceFailure(notification)
         }
         .alert(
             String(localized: "Map Local", bundle: RockxyLocalization.bundle),
@@ -339,7 +368,10 @@ struct MapLocalWindowView: View {
 
     private var footerHint: String {
         let countText = isSearching
-            ? String(localized: "\(viewModel.filteredRules.count) of \(viewModel.ruleCount) rules", bundle: RockxyLocalization.bundle)
+            ? String(
+                localized: "\(viewModel.filteredRules.count) of \(viewModel.ruleCount) rules",
+                bundle: RockxyLocalization.bundle
+            )
             : String(localized: "\(viewModel.ruleCount) rules", bundle: RockxyLocalization.bundle)
         return "\(countText) · ⌘N \(String(localized: "New Rule", bundle: RockxyLocalization.bundle)) · ⌘↩ \(String(localized: "Edit", bundle: RockxyLocalization.bundle))"
     }
@@ -361,7 +393,10 @@ struct MapLocalWindowView: View {
                 .toggleStyle(.checkbox)
                 .font(toolMetrics.font(weight: .medium))
 
-                Text(String(localized: "Serve a local file or directory for matching requests.", bundle: RockxyLocalization.bundle))
+                Text(String(
+                    localized: "Serve a local file or directory for matching requests.",
+                    bundle: RockxyLocalization.bundle
+                ))
                 .font(toolMetrics.secondaryFont())
                 .foregroundStyle(.secondary)
             }
@@ -469,8 +504,14 @@ struct MapLocalWindowView: View {
                     systemImage: isSearching ? "magnifyingglass" : "folder.badge.gearshape",
                     description: Text(
                         isSearching
-                            ? String(localized: "Try a different name, method, URL, or local path.", bundle: RockxyLocalization.bundle)
-                            : String(localized: "Click \"+\" or press ⌘N to create a rule.", bundle: RockxyLocalization.bundle)
+                            ? String(
+                                localized: "Try a different name, method, URL, or local path.",
+                                bundle: RockxyLocalization.bundle
+                            )
+                            : String(
+                                localized: "Click \"+\" or press ⌘N to create a rule.",
+                                bundle: RockxyLocalization.bundle
+                            )
                     )
                 )
             }
@@ -668,676 +709,5 @@ struct MapLocalWindowView: View {
             return false
         }
         return viewModel.mapLocalRules.indices.contains(index + offset)
-    }
-}
-
-// MARK: - MapLocalEditorWindowView
-
-struct MapLocalEditorWindowView: View {
-    // MARK: Internal
-
-    @State var viewModel = MapLocalEditorViewModel()
-
-    var body: some View {
-        VStack(spacing: 0) {
-            ScrollView {
-                VStack(alignment: .leading, spacing: toolMetrics.formRowSpacing + 3) {
-                    Text(editorTitle)
-                        .font(.system(size: max(15, toolMetrics.bodyFontSize + 2), weight: .semibold))
-
-                    if let provenance = quickCreateProvenance {
-                        provenanceBanner(provenance)
-                    }
-
-                    ruleDetailsSection
-                    responseSourceSection
-                }
-                .padding(.horizontal, toolMetrics.formHorizontalPadding)
-                .padding(.vertical, toolMetrics.formVerticalPadding)
-            }
-
-            Divider()
-            footer
-        }
-        .font(toolMetrics.font())
-        .frame(minWidth: max(860, toolMetrics.bodyFontSize * 28 + 496))
-        .frame(height: max(680, toolMetrics.bodyFontSize * 20 + 420))
-        .navigationTitle(viewModel.windowTitle)
-        .onAppear { viewModel.load(context: editorStore.context) }
-        .onChange(of: editorStore.draftVersion) { _, _ in
-            viewModel.load(context: editorStore.context)
-        }
-        .alert(
-            String(localized: "Map Local", bundle: RockxyLocalization.bundle),
-            isPresented: Binding(
-                get: { viewModel.errorMessage != nil },
-                set: {
-                    if !$0 {
-                        viewModel.errorMessage = nil
-                    }
-                }
-            )
-        ) {
-            Button(String(localized: "OK", bundle: RockxyLocalization.bundle)) { viewModel.errorMessage = nil }
-        } message: {
-            if let error = viewModel.errorMessage {
-                Text(error)
-            }
-        }
-    }
-
-    // MARK: Private
-
-    @Environment(\.dismiss) private var dismiss
-    @Environment(\.appUIDisplayMetrics) private var appMetrics
-    @State private var editorStore = MapLocalEditorStore.shared
-    @State private var isSaving = false
-
-    private var editorTitle: String {
-        viewModel.existingID == nil
-            ? String(localized: "New Map Local Rule", bundle: RockxyLocalization.bundle)
-            : String(localized: "Edit Map Local Rule", bundle: RockxyLocalization.bundle)
-    }
-
-    private var quickCreateProvenance: String? {
-        guard let draft = viewModel.draft else {
-            return nil
-        }
-        if let sourceURL = draft.sourceURL {
-            return String(localized: "Created from \(draft.sourceMethod ?? "ANY") \(sourceURL.absoluteString)", bundle: RockxyLocalization.bundle)
-        }
-        return String(localized: "Created from domain \(draft.sourceHost)", bundle: RockxyLocalization.bundle)
-    }
-
-    private var fileStatusColor: Color {
-        if viewModel.isCapturedBinary {
-            return .blue
-        }
-        if viewModel.isExternalReference {
-            return viewModel.isSelectedFileAvailable ? .green : .orange
-        }
-        return viewModel.isSelectedFileAvailable ? .green : .secondary
-    }
-
-    private var fileStatusMessage: String {
-        if viewModel.isCapturedBinary {
-            return String(localized: "Captured binary response will be written when the rule is saved.", bundle: RockxyLocalization.bundle)
-        }
-        if viewModel.isExternalReference {
-            if viewModel.isExternalFullHTTPMessage {
-                return String(localized: "Full HTTP response file detected — previewing file-owned status, headers, and body.", bundle: RockxyLocalization.bundle)
-            }
-            return viewModel.isSelectedFileAvailable
-                ? String(localized: "External file available", bundle: RockxyLocalization.bundle)
-                : String(localized: "External file is currently unavailable", bundle: RockxyLocalization.bundle)
-        }
-        return viewModel.isSelectedFileAvailable
-            ? String(localized: "Rockxy-owned response file available", bundle: RockxyLocalization.bundle)
-            : String(localized: "Rockxy will create this response file when the rule is saved.", bundle: RockxyLocalization.bundle)
-    }
-
-    private var toolMetrics: ToolWindowDisplayMetrics {
-        ToolWindowDisplayMetrics(appMetrics: appMetrics)
-    }
-
-    private var localFileResponseDescription: String {
-        if viewModel.isInlineResponseEditable {
-            return String(localized: "Edit the status line, response headers, and body. Rockxy always recalculates Content-Length.", bundle: RockxyLocalization.bundle)
-        }
-        if viewModel.isCapturedBinary {
-            // swiftlint:disable:next line_length
-            return String(localized: "Edit status and headers here. Captured binary body bytes stay preserved and text after the blank line is ignored.", bundle: RockxyLocalization.bundle)
-        }
-        if viewModel.isExternalFullHTTPMessage {
-            if viewModel.externalFullMessageHasBinaryBody {
-                // swiftlint:disable:next line_length
-                return String(localized: "Read-only preview. This file controls the status and headers; its binary body is preserved but not shown.", bundle: RockxyLocalization.bundle)
-            }
-            return String(localized: "Read-only preview. This file controls the status, ordered headers, and body at request time.", bundle: RockxyLocalization.bundle)
-        }
-        // swiftlint:disable:next line_length
-        return String(localized: "Edit status and headers here. The body comes from the user-owned file and text after the blank line is ignored.", bundle: RockxyLocalization.bundle)
-    }
-
-    private var ruleDetailsSection: some View {
-        VStack(alignment: .leading, spacing: 7) {
-            Text(String(localized: "Rule Details", bundle: RockxyLocalization.bundle))
-                .font(toolMetrics.font(weight: .semibold))
-
-            VStack(alignment: .leading, spacing: toolMetrics.formRowSpacing) {
-                HStack(alignment: .top, spacing: toolMetrics.controlSpacing) {
-                    fieldGroup(String(localized: "Name", bundle: RockxyLocalization.bundle)) {
-                        TextField(
-                            String(localized: "Untitled", bundle: RockxyLocalization.bundle),
-                            text: $viewModel.name
-                        )
-                        .textFieldStyle(.roundedBorder)
-                        .accessibilityLabel(String(localized: "Rule name", bundle: RockxyLocalization.bundle))
-                    }
-                    .frame(width: max(250, toolMetrics.fieldWidth(250)))
-
-                    fieldGroup(String(localized: "URL pattern", bundle: RockxyLocalization.bundle)) {
-                        TextField("https://example.com/api/*", text: $viewModel.urlText)
-                            .textFieldStyle(.roundedBorder)
-                            .font(toolMetrics.font(monospaced: true))
-                            .accessibilityLabel(String(localized: "URL pattern", bundle: RockxyLocalization.bundle))
-                    }
-                    .frame(maxWidth: .infinity)
-                }
-
-                if let validationMessage = viewModel.urlValidationMessage {
-                    Label(validationMessage, systemImage: "exclamationmark.triangle.fill")
-                        .font(toolMetrics.secondaryFont())
-                        .foregroundStyle(.red)
-                }
-
-                MapLocalHTTPSPrerequisiteNotice(
-                    isHTTPSPattern: viewModel.isHTTPSPattern,
-                    targetHost: viewModel.httpsTargetHost,
-                    toolMetrics: toolMetrics
-                )
-
-                HStack(alignment: .center, spacing: toolMetrics.controlSpacing * 2) {
-                    inlineField(String(localized: "Method", bundle: RockxyLocalization.bundle)) {
-                        methodMenu
-                    }
-                    inlineField(String(localized: "Match type", bundle: RockxyLocalization.bundle)) {
-                        matchTypeMenu
-                    }
-
-                    if viewModel.matchType == .wildcard {
-                        Text(String(localized: "Supports * and ?.", bundle: RockxyLocalization.bundle))
-                            .font(toolMetrics.secondaryFont())
-                            .foregroundStyle(.secondary)
-                    }
-                    Spacer()
-                }
-
-                if viewModel.matchType == .wildcard {
-                    Toggle(
-                        String(localized: "Include all subpaths of this URL", bundle: RockxyLocalization.bundle),
-                        isOn: $viewModel.includeSubpaths
-                    )
-                    .toggleStyle(.checkbox)
-                }
-
-                if let validationMessage = viewModel.directoryRegexValidationMessage {
-                    Label(validationMessage, systemImage: "exclamationmark.triangle.fill")
-                        .font(toolMetrics.secondaryFont())
-                        .foregroundStyle(.red)
-                }
-
-                MapLocalRuleTesterSection(viewModel: viewModel, toolMetrics: toolMetrics)
-
-                Divider()
-
-                HStack(alignment: .center, spacing: toolMetrics.controlSpacing) {
-                    Text(String(localized: "Response delay", bundle: RockxyLocalization.bundle))
-                        .foregroundStyle(.secondary)
-                    delayMenu
-                    if viewModel.delayPreset == .custom {
-                        Stepper(
-                            String(localized: "\(viewModel.customDelaySeconds) seconds", bundle: RockxyLocalization.bundle),
-                            value: $viewModel.customDelaySeconds,
-                            in: 0 ... 300
-                        )
-                        .frame(width: toolMetrics.fieldWidth(160))
-                    }
-                    Spacer()
-                }
-            }
-            .padding(.horizontal, toolMetrics.formHorizontalPadding - 2)
-            .padding(.vertical, toolMetrics.formVerticalPadding - 2)
-            .background(Color(nsColor: .textBackgroundColor))
-            .clipShape(RoundedRectangle(cornerRadius: 6))
-            .overlay {
-                RoundedRectangle(cornerRadius: 6)
-                    .stroke(Color(nsColor: .separatorColor), lineWidth: 1)
-            }
-        }
-    }
-
-    private var responseSourceSection: some View {
-        VStack(alignment: .leading, spacing: 7) {
-            Text(String(localized: "Response Source", bundle: RockxyLocalization.bundle))
-                .font(toolMetrics.font(weight: .semibold))
-
-            VStack(alignment: .leading, spacing: toolMetrics.formRowSpacing) {
-                Picker(
-                    String(localized: "Source type", bundle: RockxyLocalization.bundle),
-                    selection: $viewModel.targetMode
-                ) {
-                    Text(MapLocalTargetMode.localFile.displayName).tag(MapLocalTargetMode.localFile)
-                    Text(MapLocalTargetMode.localDirectory.displayName).tag(MapLocalTargetMode.localDirectory)
-                }
-                .pickerStyle(.segmented)
-                .labelsHidden()
-                .frame(width: toolMetrics.menuWidth(240))
-                .frame(maxWidth: .infinity, alignment: .center)
-
-                Divider()
-
-                responseStatusRow
-
-                if viewModel.targetMode == .localFile {
-                    localFileSection
-                } else {
-                    localDirectorySection
-                }
-            }
-            .padding(.horizontal, toolMetrics.formHorizontalPadding - 2)
-            .padding(.vertical, toolMetrics.formVerticalPadding - 2)
-            .background(Color(nsColor: .textBackgroundColor))
-            .clipShape(RoundedRectangle(cornerRadius: 6))
-            .overlay {
-                RoundedRectangle(cornerRadius: 6)
-                    .stroke(Color(nsColor: .separatorColor), lineWidth: 1)
-            }
-        }
-    }
-
-    private var localFileSection: some View {
-        VStack(alignment: .leading, spacing: toolMetrics.formRowSpacing) {
-            HStack(alignment: .bottom, spacing: toolMetrics.controlSpacing) {
-                fieldGroup(String(localized: "Local file", bundle: RockxyLocalization.bundle)) {
-                    Text(viewModel.filePath)
-                        .font(toolMetrics.font(monospaced: true))
-                        .foregroundStyle(.secondary)
-                        .lineLimit(1)
-                        .truncationMode(.middle)
-                        .textSelection(.enabled)
-                        .padding(.horizontal, 7)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .background(Color(nsColor: .controlBackgroundColor))
-                        .clipShape(RoundedRectangle(cornerRadius: 5))
-                        .overlay {
-                            RoundedRectangle(cornerRadius: 5)
-                                .stroke(Color(nsColor: .separatorColor), lineWidth: 1)
-                        }
-                        .help(viewModel.filePath)
-                }
-                .frame(maxWidth: .infinity)
-
-                Button(String(localized: "Choose…", bundle: RockxyLocalization.bundle)) { viewModel.choosePath() }
-                    .frame(height: toolMetrics.formControlHeight)
-
-                fileActionsMenu
-            }
-
-            HStack(spacing: 7) {
-                Circle()
-                    .fill(fileStatusColor)
-                    .frame(width: 8, height: 8)
-                Text(fileStatusMessage)
-                    .font(toolMetrics.secondaryFont())
-                    .foregroundStyle(.secondary)
-                Spacer()
-                Text(viewModel.responseContentType)
-                    .font(toolMetrics.metadataFont(monospaced: true))
-                    .foregroundStyle(.secondary)
-                    .help(String(localized: "Configured Content-Type, or the file-extension fallback.", bundle: RockxyLocalization.bundle))
-            }
-
-            if let validationMessage = viewModel.externalFileValidationMessage {
-                Label(validationMessage, systemImage: "exclamationmark.triangle.fill")
-                    .font(toolMetrics.secondaryFont())
-                    .foregroundStyle(.orange)
-            }
-
-            MapLocalHTTPResponseSection(
-                text: $viewModel.httpMessageText,
-                bodyIsEditable: viewModel.isInlineResponseEditable,
-                bodyDescription: localFileResponseDescription,
-                toolMetrics: toolMetrics,
-                messageIsEditable: !viewModel.isExternalFullHTTPMessage
-            )
-        }
-    }
-
-    private var responseStatusRow: some View {
-        HStack(alignment: .center, spacing: toolMetrics.controlSpacing) {
-            Text(String(localized: "Status code", bundle: RockxyLocalization.bundle))
-                .foregroundStyle(.secondary)
-            TextField(
-                "",
-                value: Binding(
-                    get: { viewModel.responseStatusCode },
-                    set: { viewModel.setResponseStatusCode($0) }
-                ),
-                format: .number
-            )
-            .textFieldStyle(.roundedBorder)
-            .frame(width: 84, height: toolMetrics.formControlHeight)
-            .accessibilityLabel(String(localized: "HTTP response status code", bundle: RockxyLocalization.bundle))
-            .disabled(viewModel.isExternalFullHTTPMessage)
-            Text(viewModel.isExternalFullHTTPMessage
-                ? String(localized: "The selected full HTTP response file controls this status code.", bundle: RockxyLocalization.bundle)
-                : String(localized: "Applied to every response from this rule. Valid range: 100–599.", bundle: RockxyLocalization.bundle))
-                .font(toolMetrics.secondaryFont())
-                .foregroundStyle(.secondary)
-            Spacer()
-        }
-    }
-
-    private var localDirectorySection: some View {
-        VStack(alignment: .leading, spacing: toolMetrics.formRowSpacing) {
-            fieldGroup(String(localized: "Local directory", bundle: RockxyLocalization.bundle)) {
-                HStack(spacing: toolMetrics.controlSpacing) {
-                    TextField(
-                        String(localized: "Choose a directory", bundle: RockxyLocalization.bundle),
-                        text: $viewModel.directoryPath
-                    )
-                    .textFieldStyle(.roundedBorder)
-                    .font(toolMetrics.font(monospaced: true))
-                    Button(String(localized: "Choose…", bundle: RockxyLocalization.bundle)) { viewModel.choosePath() }
-                    Button(String(localized: "Show in Finder", bundle: RockxyLocalization.bundle)) {
-                        viewModel.showSelectedPathInFinder()
-                    }
-                    .disabled(!viewModel.isDirectoryValid)
-                }
-            }
-            HStack(spacing: 8) {
-                Circle()
-                    .fill(viewModel.isDirectoryValid ? Color.green : Color.orange)
-                    .frame(width: 8, height: 8)
-                Text(viewModel.isDirectoryValid
-                    ? String(localized: "Directory available", bundle: RockxyLocalization.bundle)
-                    : String(localized: "Choose an available directory to continue.", bundle: RockxyLocalization.bundle))
-                    .font(toolMetrics.secondaryFont())
-                    .foregroundStyle(.secondary)
-            }
-
-            HStack(alignment: .top, spacing: 8) {
-                Image(systemName: "folder")
-                    .foregroundStyle(.secondary)
-                Text(
-                    String(
-                        localized: "Request subpaths resolve to files inside this directory. Root requests and missing files continue to the origin.",
-                        bundle: RockxyLocalization.bundle
-                    )
-                        + " "
-                        + String(localized: "Regex directory rules use the first capture group as the relative file path.", bundle: RockxyLocalization.bundle)
-                )
-                .font(toolMetrics.secondaryFont())
-                .foregroundStyle(.secondary)
-                Spacer()
-            }
-            .padding(10)
-            .background(Color(nsColor: .controlBackgroundColor))
-            .clipShape(RoundedRectangle(cornerRadius: 5))
-
-            MapLocalHTTPResponseSection(
-                text: $viewModel.httpMessageText,
-                bodyIsEditable: false,
-                bodyDescription: String(
-                    localized:
-                    "Edit status and headers here. Response bodies come from the matched file in this directory; text after the blank line is ignored.",
-                    bundle: RockxyLocalization.bundle
-                ),
-                toolMetrics: toolMetrics
-            )
-        }
-    }
-
-    private var methodMenu: some View {
-        Menu {
-            ForEach(Array(MapLocalEditorMenuContent.methodSections.enumerated()), id: \.offset) { index, section in
-                ForEach(section) { method in
-                    Button { viewModel.method = method } label: {
-                        menuCheckmarkLabel(method.rawValue, isSelected: viewModel.method == method)
-                    }
-                }
-                if index < MapLocalEditorMenuContent.methodSections.count - 1 {
-                    Divider()
-                }
-            }
-        } label: {
-            dataEntryMenuLabel(viewModel.method.rawValue, width: toolMetrics.menuWidth(90))
-        }
-        .menuIndicator(.hidden)
-        .buttonStyle(.plain)
-        .frame(width: toolMetrics.menuWidth(90))
-    }
-
-    private var matchTypeMenu: some View {
-        Menu {
-            ForEach(Array(MapLocalEditorMenuContent.matchTypeSections.enumerated()), id: \.offset) { index, section in
-                ForEach(section) { matchType in
-                    Button { viewModel.matchType = matchType } label: {
-                        menuCheckmarkLabel(matchType.displayName, isSelected: viewModel.matchType == matchType)
-                    }
-                }
-                if index < MapLocalEditorMenuContent.matchTypeSections.count - 1 {
-                    Divider()
-                }
-            }
-        } label: {
-            dataEntryMenuLabel(viewModel.matchType.displayName, width: toolMetrics.menuWidth(150))
-        }
-        .menuIndicator(.hidden)
-        .buttonStyle(.plain)
-        .frame(width: toolMetrics.menuWidth(150))
-    }
-
-    private var delayMenu: some View {
-        Menu {
-            ForEach(Array(MapLocalEditorMenuContent.delaySections.enumerated()), id: \.offset) { index, section in
-                ForEach(section) { preset in
-                    Button { viewModel.delayPreset = preset } label: {
-                        menuCheckmarkLabel(preset.displayName, isSelected: viewModel.delayPreset == preset)
-                    }
-                }
-                if index < MapLocalEditorMenuContent.delaySections.count - 1 {
-                    Divider()
-                }
-            }
-        } label: {
-            dataEntryMenuLabel(viewModel.delayPreset.displayName, width: toolMetrics.menuWidth(160))
-        }
-        .menuIndicator(.hidden)
-        .buttonStyle(.plain)
-        .frame(width: toolMetrics.menuWidth(160))
-    }
-
-    private var fileActionsMenu: some View {
-        Menu {
-            Button(String(localized: "Show in Finder", bundle: RockxyLocalization.bundle)) {
-                viewModel.showSelectedPathInFinder()
-            }
-            .disabled(!viewModel.isSelectedFileAvailable)
-            Divider()
-            ForEach(MapLocalExternalEditor.allCases) { editor in
-                Button(String(localized: "Open with \(editor.displayName)", bundle: RockxyLocalization.bundle)) {
-                    viewModel.openSelectedPath(with: editor)
-                }
-                .disabled(!viewModel.isSelectedFileAvailable)
-            }
-        } label: {
-            Image(systemName: "ellipsis.circle")
-                .frame(width: toolMetrics.footerControlHeight, height: toolMetrics.formControlHeight)
-        }
-        .menuIndicator(.hidden)
-        .buttonStyle(.plain)
-        .help(String(localized: "File Actions", bundle: RockxyLocalization.bundle))
-    }
-
-    private var footer: some View {
-        HStack {
-            Spacer()
-            Button {
-                dismiss()
-            } label: {
-                footerButtonLabel(String(localized: "Cancel", bundle: RockxyLocalization.bundle))
-            }
-            .keyboardShortcut(.cancelAction)
-
-            Button {
-                saveAndClose()
-            } label: {
-                footerButtonLabel(
-                    isSaving
-                        ? String(localized: "Saving…", bundle: RockxyLocalization.bundle)
-                        : viewModel.existingID == nil
-                        ? String(localized: "Add", bundle: RockxyLocalization.bundle)
-                        : String(localized: "Save", bundle: RockxyLocalization.bundle)
-                )
-            }
-            .keyboardShortcut(.defaultAction)
-            .rockxyGlassButtonStyle(prominent: true)
-            .disabled(!viewModel.isSaveEnabled || isSaving)
-        }
-        .padding(.horizontal, toolMetrics.formHorizontalPadding)
-        .padding(.vertical, toolMetrics.controlSpacing)
-    }
-
-    private func provenanceBanner(_ message: String) -> some View {
-        HStack(spacing: 7) {
-            Image(systemName: "arrow.turn.down.right")
-                .foregroundStyle(.secondary)
-            Text(message)
-                .font(toolMetrics.secondaryFont(monospaced: true))
-                .foregroundStyle(.secondary)
-                .lineLimit(1)
-                .truncationMode(.middle)
-                .help(message)
-            Spacer()
-        }
-        .padding(.horizontal, 10)
-        .padding(.vertical, 8)
-        .background(Color.accentColor.opacity(0.08))
-        .clipShape(RoundedRectangle(cornerRadius: 6))
-        .overlay {
-            RoundedRectangle(cornerRadius: 6)
-                .stroke(Color.accentColor.opacity(0.25), lineWidth: 1)
-        }
-    }
-
-    private func menuCheckmarkLabel(_ title: String, isSelected: Bool) -> some View {
-        HStack(spacing: 7) {
-            if isSelected {
-                Image(systemName: "checkmark")
-            }
-            Text(title)
-        }
-    }
-
-    private func dataEntryMenuLabel(_ title: String, width: CGFloat) -> some View {
-        HStack(spacing: 6) {
-            Text(title)
-                .lineLimit(1)
-            Spacer(minLength: 6)
-            Image(systemName: "chevron.up.chevron.down")
-                .font(.system(size: 10, weight: .semibold))
-        }
-        .padding(.horizontal, 7)
-        .frame(width: width, height: toolMetrics.formControlHeight, alignment: .leading)
-        .background(Color(nsColor: .controlBackgroundColor))
-        .clipShape(RoundedRectangle(cornerRadius: 5))
-        .overlay {
-            RoundedRectangle(cornerRadius: 5)
-                .stroke(Color(nsColor: .separatorColor), lineWidth: 1)
-        }
-        .contentShape(RoundedRectangle(cornerRadius: 5))
-    }
-
-    private func inlineField(
-        _ label: String,
-        @ViewBuilder content: () -> some View
-    )
-        -> some View
-    {
-        HStack(alignment: .center, spacing: toolMetrics.controlSpacing) {
-            Text(label)
-                .foregroundStyle(.secondary)
-                .lineLimit(1)
-                .fixedSize(horizontal: true, vertical: false)
-            content()
-                .font(toolMetrics.font())
-                .controlSize(.regular)
-                .frame(height: toolMetrics.formControlHeight)
-        }
-    }
-
-    private func fieldGroup(
-        _ label: String,
-        @ViewBuilder content: () -> some View
-    )
-        -> some View
-    {
-        VStack(alignment: .leading, spacing: 4) {
-            Text(label)
-                .foregroundStyle(.secondary)
-                .lineLimit(1)
-            content()
-                .font(toolMetrics.font())
-                .controlSize(.regular)
-                .frame(height: toolMetrics.formControlHeight)
-        }
-    }
-
-    private func footerButtonLabel(_ title: String) -> some View {
-        Text(title)
-            .frame(
-                width: max(64, toolMetrics.footerButtonWidth - toolMetrics.controlSpacing * 3),
-                height: max(16, toolMetrics.footerControlHeight - toolMetrics.controlSpacing)
-            )
-    }
-
-    private func saveAndClose() {
-        guard let rule = viewModel.makeRule() else {
-            return
-        }
-        isSaving = true
-        Task {
-            if viewModel.existingID == nil {
-                let accepted = await RulePolicyGate.shared.addRule(rule)
-                guard accepted else {
-                    viewModel.errorMessage = String(
-                        localized:
-                        "The active Map Local rule limit was reached. Disable another rule and try again.",
-                        bundle: RockxyLocalization.bundle
-                    )
-                    isSaving = false
-                    return
-                }
-            } else {
-                await RulePolicyGate.shared.updateRule(rule)
-            }
-            isSaving = false
-            dismiss()
-        }
-    }
-}
-
-// MARK: - MapLocalExternalEditor
-
-enum MapLocalExternalEditor: String, CaseIterable, Identifiable {
-    case code
-    case cursor
-    case textEdit
-    case xcode
-
-    // MARK: Internal
-
-    var id: String {
-        rawValue
-    }
-
-    var displayName: String {
-        switch self {
-        case .code: "Code"
-        case .cursor: "Cursor"
-        case .textEdit: "TextEdit"
-        case .xcode: "Xcode"
-        }
-    }
-
-    var bundleIdentifier: String? {
-        switch self {
-        case .code: "com.microsoft.VSCode"
-        case .cursor: "com.todesktop.230313mzl4w4u92"
-        case .textEdit: "com.apple.TextEdit"
-        case .xcode: "com.apple.dt.Xcode"
-        }
     }
 }

--- a/Rockxy/Views/Rules/MapRemoteWindowView.swift
+++ b/Rockxy/Views/Rules/MapRemoteWindowView.swift
@@ -133,8 +133,10 @@ final class MapRemoteWindowViewModel {
         }
         allRules.removeAll { idsToRemove.contains($0.id) }
         selectedRuleIDs.removeAll()
-        let updated = allRules
-        pendingRuleSyncTask = Task { await RulePolicyGate.shared.replaceAllRules(updated) }
+        pendingRuleSyncTask = Task {
+            await RulePolicyGate.shared.removeRules(ids: idsToRemove)
+            allRules = await RuleEngine.shared.allRules
+        }
     }
 
     func removeRule(id: UUID) {

--- a/RockxyTests/Core/RuleEngine/MapLocalRulePersistenceTests.swift
+++ b/RockxyTests/Core/RuleEngine/MapLocalRulePersistenceTests.swift
@@ -1,0 +1,702 @@
+import Foundation
+@testable import Rockxy
+import Testing
+
+// Regression tests for Map Local rule persistence (issue #307). These exercise the
+// REAL production save/load path (`RuleSyncService` + `RuleStore`) through the
+// injectable `RuleSyncService.store` seam pointed at a temp directory (not a copied
+// testable store) so a genuine relaunch, save failure, and decode failure are covered.
+
+@Suite(.serialized)
+struct MapLocalRulePersistenceTests {
+    // MARK: Internal
+
+    @Test("Map Local rules survive save → process reset → load with every field intact")
+    func roundTripPreservesAllVariants() async throws {
+        let saved = [Self.fileRule(), Self.directoryRule(), Self.fullResponseRule()]
+        let store = RuleStore(fileURL: Self.tempFileURL)
+        try? FileManager.default.removeItem(at: Self.tempFileURL)
+        defer { try? FileManager.default.removeItem(at: Self.tempFileURL) }
+
+        try store.saveRules(saved)
+
+        // A fresh engine models the next process without sharing mutable singleton
+        // state with the repository's many rule tests that execute in parallel.
+        let relaunchedEngine = RuleEngine()
+        try await relaunchedEngine.loadRules(from: store)
+        let loaded = await relaunchedEngine.allRules
+
+        #expect(loaded.count == 3)
+        #expect(loaded.map(\.id) == saved.map(\.id))
+        for (actual, expected) in zip(loaded, saved) {
+            Self.expectEqualRule(actual, expected)
+        }
+    }
+
+    @Test("Mixed rule categories keep their global slots and order across a reload")
+    @MainActor
+    func mixedCategoriesRetainOrder() async {
+        await withRuleHarness {
+            let block = ProxyRule(
+                name: "Block Ads",
+                matchCondition: RuleMatchCondition(urlPattern: ".*ads\\.example\\.com.*"),
+                action: .block(statusCode: 403)
+            )
+            let modify = ProxyRule(
+                name: "Inject Header",
+                matchCondition: RuleMatchCondition(urlPattern: ".*example\\.com.*"),
+                action: .modifyHeader(operations: [
+                    HeaderOperation(type: .add, headerName: "X-Debug", headerValue: "1"),
+                ])
+            )
+            let saved = [Self.fileRule(), block, Self.directoryRule(), modify]
+
+            await RuleSyncService.replaceAllRules(saved)
+            await RuleEngine.shared.replaceAll([])
+            await RuleSyncService.resetLoadStateForTesting()
+            #expect(await RuleSyncService.ensureLoaded() == .loaded)
+
+            let loaded = await RuleEngine.shared.allRules
+            #expect(loaded.map(\.id) == saved.map(\.id))
+            #expect(loaded.map(\.action.toolCategory) == saved.map(\.action.toolCategory))
+        }
+    }
+
+    @Test("A successful load publishes rules without rewriting the source file")
+    @MainActor
+    func successfulLoadDoesNotRewriteFile() async {
+        await withRuleHarness {
+            // Hand-write a pretty-printed (but valid) rules file; a rewrite would
+            // re-encode compactly and change the bytes.
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+            guard let prettyData = try? encoder.encode([Self.fileRule()]) else {
+                Issue.record("Expected to encode rules fixture")
+                return
+            }
+            try? prettyData.write(to: Self.tempFileURL, options: .atomic)
+
+            await RuleEngine.shared.replaceAll([])
+            await RuleSyncService.resetLoadStateForTesting()
+            #expect(await RuleSyncService.ensureLoaded() == .loaded)
+
+            let afterLoad = try? Data(contentsOf: Self.tempFileURL)
+            #expect(afterLoad == prettyData)
+            #expect(await RuleEngine.shared.allRules.count == 1)
+        }
+    }
+
+    @Test("A save failure is reported and never masquerades as a durable save")
+    @MainActor
+    func saveFailureIsVisible() async {
+        await withRuleHarness {
+            var failureMessage: String?
+            let token = NotificationCenter.default.addObserver(
+                forName: .rulePersistenceDidFail, object: nil, queue: nil
+            ) { note in
+                failureMessage = note.object as? String
+            }
+            defer { NotificationCenter.default.removeObserver(token) }
+
+            // Point the store at an unwritable location to force a real save failure.
+            RuleSyncService.store = RuleStore(
+                fileURL: URL(fileURLWithPath: "/dev/null/rockxy-nested/rules.json")
+            )
+            await RuleEngine.shared.replaceAll([])
+
+            let result = await RuleSyncService.addRuleIfAllowedPersisting(Self.fileRule(), maxPerCategory: 10)
+
+            #expect(!result.isDurablySaved)
+            if case let .persisted(.failed(message)) = result {
+                #expect(!message.isEmpty)
+            } else {
+                Issue.record("Expected a persisted(.failed) result, got \(result)")
+            }
+            #expect(failureMessage != nil)
+            // The optimistic engine mutation is still visible (truthful active state)…
+            #expect(await RuleEngine.shared.allRules.count == 1)
+            // …but nothing was written to disk.
+            #expect(!FileManager.default.fileExists(atPath: "/dev/null/rockxy-nested/rules.json"))
+        }
+    }
+
+    @Test("updateRulePersisting reports a save failure instead of silent success")
+    @MainActor
+    func updateFailureIsVisible() async {
+        await withRuleHarness {
+            let rule = Self.fileRule()
+            await RuleEngine.shared.replaceAll([rule])
+            RuleSyncService.store = RuleStore(
+                fileURL: URL(fileURLWithPath: "/dev/null/rockxy-nested/rules.json")
+            )
+
+            var updated = rule
+            updated.name = "Renamed"
+            let outcome = await RuleSyncService.updateRulePersisting(updated)
+            #expect(outcome.isSaved == false)
+        }
+    }
+
+    @Test("A failed new-rule save retried against a writable store yields exactly one rule")
+    @MainActor
+    func saveFailureRetryIsDuplicateSafe() async {
+        await withRuleHarness {
+            let rule = Self.fileRule()
+            await RuleEngine.shared.replaceAll([])
+
+            // First attempt: the store is unwritable, so the optimistic engine mutation
+            // lands but the durable write fails.
+            RuleSyncService.store = RuleStore(
+                fileURL: URL(fileURLWithPath: "/dev/null/rockxy-nested/rules.json")
+            )
+            let first = await RuleSyncService.addRuleIfAllowedPersisting(rule, maxPerCategory: 10)
+            #expect(!first.isDurablySaved)
+            #expect(await RuleEngine.shared.allRules.count == 1)
+
+            // The editor adopts the attempted identity (see
+            // MapLocalEditorViewModel.adoptFailedAddIdentity), so the retry updates the
+            // same rule instead of adding a second one under a fresh UUID.
+            RuleSyncService.store = RuleStore(fileURL: Self.tempFileURL)
+            var retried = rule
+            retried.name = "Retried"
+            let second = await RuleSyncService.updateRulePersisting(retried)
+            #expect(second.isSaved)
+
+            let engineRules = await RuleEngine.shared.allRules
+            #expect(engineRules.count == 1)
+            #expect(engineRules.first?.id == rule.id)
+            #expect(engineRules.first?.name == "Retried")
+
+            let persisted = (try? RuleStore(fileURL: Self.tempFileURL).loadRules()) ?? []
+            #expect(persisted.count == 1)
+            #expect(persisted.first?.id == rule.id)
+            #expect(persisted.first?.name == "Retried")
+        }
+    }
+
+    @Test("A new rule waits for persisted rules to load before saving the combined set")
+    @MainActor
+    func persistingAddLoadsExistingRulesFirst() async {
+        await withRuleHarness {
+            let existing = Self.directoryRule()
+            let encoder = JSONEncoder()
+            guard let data = try? encoder.encode([existing]) else {
+                Issue.record("Expected to encode rules fixture")
+                return
+            }
+            try? data.write(to: Self.tempFileURL, options: .atomic)
+            await RuleEngine.shared.replaceAll([])
+            await RuleSyncService.resetLoadStateForTesting()
+
+            let added = Self.fileRule()
+            let result = await RuleSyncService.addRuleIfAllowedPersisting(added, maxPerCategory: 10)
+
+            #expect(result.isDurablySaved)
+            let engineRules = await RuleEngine.shared.allRules
+            #expect(engineRules.map(\.id) == [existing.id, added.id])
+            let persisted = (try? RuleStore(fileURL: Self.tempFileURL).loadRules()) ?? []
+            #expect(persisted.map(\.id) == [existing.id, added.id])
+        }
+    }
+
+    @Test("A load failure blocks a new mutation instead of overwriting saved data")
+    @MainActor
+    func loadFailureBlocksPersistingAdd() async {
+        await withRuleHarness {
+            let corrupt = Data(#"{"existing":"unreadable"}"#.utf8)
+            try? corrupt.write(to: Self.tempFileURL, options: .atomic)
+            await RuleEngine.shared.replaceAll([])
+            await RuleSyncService.resetLoadStateForTesting()
+
+            let result = await RuleSyncService.addRuleIfAllowedPersisting(Self.fileRule(), maxPerCategory: 10)
+
+            if case .loadFailed = result {} else {
+                Issue.record("Expected loadFailed, got \(result)")
+            }
+            #expect(await RuleEngine.shared.allRules.isEmpty)
+            #expect((try? Data(contentsOf: Self.tempFileURL)) == corrupt)
+        }
+    }
+
+    @Test("Editor adopts a failed add's identity, switching from add-new to retry-update")
+    @MainActor
+    func editorAdoptsFailedAddIdentity() {
+        let viewModel = MapLocalEditorViewModel()
+        viewModel.load(context: .blank)
+        // A brand-new editor has no identity, so the save path uses add-new semantics.
+        #expect(viewModel.existingID == nil)
+
+        let attempted = Self.fileRule()
+        viewModel.adoptFailedAddIdentity(attempted)
+
+        // After adoption the save path routes through update semantics on the same id.
+        #expect(viewModel.existingID == attempted.id)
+        #expect(viewModel.originalRule?.id == attempted.id)
+    }
+
+    @Test("A corrupt rules file is left untouched, not marked loaded, and remains retryable")
+    @MainActor
+    func decodeFailurePreservesFileAndRetries() async {
+        await withRuleHarness {
+            let corrupt = Data(#"{"not":"a rule list"}"#.utf8)
+            try? corrupt.write(to: Self.tempFileURL, options: .atomic)
+            await RuleEngine.shared.replaceAll([])
+            await RuleSyncService.resetLoadStateForTesting()
+
+            let failed = await RuleSyncService.ensureLoaded()
+            if case .failed = failed {} else {
+                Issue.record("Expected a failed load for corrupt data")
+            }
+            let onDiskAfterFailure = try? Data(contentsOf: Self.tempFileURL)
+            #expect(onDiskAfterFailure == corrupt)
+            #expect(await RuleEngine.shared.allRules.isEmpty)
+
+            // Retry after fixing the file succeeds (failure was not cached).
+            let encoder = JSONEncoder()
+            guard let good = try? encoder.encode([Self.fileRule()]) else {
+                Issue.record("Expected to encode rules fixture")
+                return
+            }
+            try? good.write(to: Self.tempFileURL, options: .atomic)
+            #expect(await RuleSyncService.ensureLoaded() == .loaded)
+            #expect(await RuleEngine.shared.allRules.count == 1)
+        }
+    }
+
+    @Test("Bulk-disabling Map Local rules mutates only Map Local and keeps concurrent additions")
+    @MainActor
+    func bulkDisableRetainsConcurrentAdditionsAndOtherCategories() async {
+        await withRuleHarness {
+            let a = Self.fileRule() // Map Local, enabled
+            let b = Self.fullResponseRule() // Map Local, enabled
+            await RuleSyncService.replaceAllRules([a, b])
+
+            // A Map Local window captured [a, b]. Meanwhile another window adds an
+            // unrelated (enabled) Block rule and a fresh Map Local rule — neither is
+            // present in the window's stale snapshot.
+            let concurrentBlock = Self.blockRule()
+            let concurrentMapLocal = Self.directoryRule() // disabled
+            await RuleSyncService.addRule(concurrentBlock)
+            await RuleSyncService.addRule(concurrentMapLocal)
+
+            // The stale bulk-disable now runs. It must disable only Map Local rules
+            // and never drop the concurrent additions or the Block rule's state.
+            await RuleSyncService.setMapLocalRulesEnabled(false, maxPerCategory: 10)
+
+            let engine = await RuleEngine.shared.allRules
+            #expect(Set(engine.map(\.id)) == Set([a.id, b.id, concurrentBlock.id, concurrentMapLocal.id]))
+            // The Block rule is a different category and must be untouched.
+            #expect(engine.first { $0.id == concurrentBlock.id }?.isEnabled == true)
+            // Every Map Local rule is now disabled.
+            for rule in engine where isMapLocal(rule) {
+                #expect(rule.isEnabled == false)
+            }
+            // The mutation was persisted against current state, not a stale snapshot.
+            let persisted = (try? RuleStore(fileURL: Self.tempFileURL).loadRules()) ?? []
+            #expect(Set(persisted.map(\.id)) == Set([a.id, b.id, concurrentBlock.id, concurrentMapLocal.id]))
+        }
+    }
+
+    @Test("Bulk-enabling Map Local rules respects the per-category quota")
+    @MainActor
+    func bulkEnableHonorsQuota() async {
+        await withRuleHarness {
+            var first = Self.fileRule()
+            first.isEnabled = false
+            var second = Self.fullResponseRule()
+            second.isEnabled = false
+            var third = Self.directoryRule() // already disabled
+            third.name = "Third Map Local"
+            await RuleSyncService.replaceAllRules([first, second, third])
+
+            // Quota of 2 means only two Map Local rules may become active.
+            await RuleSyncService.setMapLocalRulesEnabled(true, maxPerCategory: 2)
+
+            let engine = await RuleEngine.shared.allRules
+            let enabled = engine.filter { isMapLocal($0) && $0.isEnabled }
+            #expect(enabled.count == 2)
+        }
+    }
+
+    @Test("Removing selected Map Local rules keeps concurrent additions and other categories")
+    @MainActor
+    func removeSelectedRetainsConcurrentAdditions() async {
+        await withRuleHarness {
+            let a = Self.fileRule()
+            let b = Self.fullResponseRule()
+            await RuleSyncService.replaceAllRules([a, b])
+
+            // Snapshot captured [a, b]; another window then adds rules before the
+            // stale removal executes.
+            let concurrentBlock = Self.blockRule()
+            let concurrentMapLocal = Self.directoryRule()
+            await RuleSyncService.addRule(concurrentBlock)
+            await RuleSyncService.addRule(concurrentMapLocal)
+
+            // Remove only the originally-selected Map Local IDs.
+            await RuleSyncService.removeRules(ids: [a.id, b.id])
+
+            let engine = await RuleEngine.shared.allRules
+            #expect(Set(engine.map(\.id)) == Set([concurrentBlock.id, concurrentMapLocal.id]))
+            let persisted = (try? RuleStore(fileURL: Self.tempFileURL).loadRules()) ?? []
+            #expect(Set(persisted.map(\.id)) == Set([concurrentBlock.id, concurrentMapLocal.id]))
+        }
+    }
+
+    @Test("Removing selected Map Remote rules via the view model keeps concurrent additions")
+    @MainActor
+    func mapRemoteRemoveSelectedRetainsConcurrentAdditions() async {
+        await withRuleHarness {
+            let remoteA = Self.mapRemoteRule(name: "Remote A")
+            let remoteB = Self.mapRemoteRule(name: "Remote B")
+            await RuleSyncService.replaceAllRules([remoteA, remoteB])
+
+            let viewModel = MapRemoteWindowViewModel()
+            await viewModel.refreshFromEngine()
+            viewModel.selectedRuleIDs = [remoteA.id, remoteB.id]
+
+            // Another window adds unrelated rules after this window took its snapshot.
+            let concurrentBlock = Self.blockRule()
+            let concurrentMapLocal = Self.fileRule()
+            await RuleSyncService.addRule(concurrentBlock)
+            await RuleSyncService.addRule(concurrentMapLocal)
+
+            // Removing the selected Map Remote rules must not touch the concurrent adds.
+            viewModel.removeSelectedRules()
+            await viewModel.waitForPendingRuleSync()
+
+            let engine = await RuleEngine.shared.allRules
+            #expect(Set(engine.map(\.id)) == Set([concurrentBlock.id, concurrentMapLocal.id]))
+            let persisted = (try? RuleStore(fileURL: Self.tempFileURL).loadRules()) ?? []
+            #expect(Set(persisted.map(\.id)) == Set([concurrentBlock.id, concurrentMapLocal.id]))
+        }
+    }
+
+    @Test("Importing Block rules replaces only Block rules and keeps concurrent Map Local additions")
+    @MainActor
+    func blockImportReplacesOnlyBlockCategory() async {
+        await withRuleHarness {
+            let existingBlock = Self.blockRule()
+            let mapLocal = Self.fileRule()
+            await RuleSyncService.replaceAllRules([existingBlock, mapLocal])
+
+            // A concurrent Map Local addition lands after the Block window's snapshot.
+            let concurrentMapLocal = Self.directoryRule()
+            await RuleSyncService.addRule(concurrentMapLocal)
+
+            let importedA = ProxyRule(
+                name: "Imported A",
+                matchCondition: RuleMatchCondition(urlPattern: ".*a\\.example\\.com.*"),
+                action: .block(statusCode: 403)
+            )
+            let importedB = ProxyRule(
+                name: "Imported B",
+                matchCondition: RuleMatchCondition(urlPattern: ".*b\\.example\\.com.*"),
+                action: .block(statusCode: 0)
+            )
+            await RuleSyncService.replaceBlockRules([importedA, importedB], maxPerCategory: 10)
+
+            let engine = await RuleEngine.shared.allRules
+            // Old Block rule gone; both Map Local rules retained (order preserved);
+            // imported Block rules appended after the retained non-Block rules.
+            #expect(engine.map(\.id) == [mapLocal.id, concurrentMapLocal.id, importedA.id, importedB.id])
+            #expect(!engine.contains { $0.id == existingBlock.id })
+            let persisted = (try? RuleStore(fileURL: Self.tempFileURL).loadRules()) ?? []
+            #expect(persisted.map(\.id) == [mapLocal.id, concurrentMapLocal.id, importedA.id, importedB.id])
+        }
+    }
+
+    @Test("Importing Block rules caps enabled imported rules to the per-category quota")
+    @MainActor
+    func blockImportHonorsQuota() async {
+        await withRuleHarness {
+            await RuleSyncService.replaceAllRules([])
+            let imported = (0 ..< 4).map { index in
+                ProxyRule(
+                    name: "Imported \(index)",
+                    matchCondition: RuleMatchCondition(urlPattern: ".*\(index)\\.example\\.com.*"),
+                    action: .block(statusCode: 403)
+                )
+            }
+
+            await RuleSyncService.replaceBlockRules(imported, maxPerCategory: 2)
+
+            let engine = await RuleEngine.shared.allRules
+            #expect(engine.count == 4)
+            let enabledBlock = engine.filter { isBlock($0) && $0.isEnabled }
+            #expect(enabledBlock.count == 2)
+            // The first two imported Block rules stay enabled; the overflow is disabled.
+            #expect(engine[0].isEnabled)
+            #expect(engine[1].isEnabled)
+            #expect(engine.suffix(2).allSatisfy { !$0.isEnabled })
+        }
+    }
+
+    @Test("Concurrent ensureLoaded calls are idempotent")
+    @MainActor
+    func concurrentEnsureLoadIsIdempotent() async {
+        await withRuleHarness {
+            let encoder = JSONEncoder()
+            guard let good = try? encoder.encode([Self.fileRule(), Self.directoryRule()]) else {
+                Issue.record("Expected to encode rules fixture")
+                return
+            }
+            try? good.write(to: Self.tempFileURL, options: .atomic)
+            await RuleEngine.shared.replaceAll([])
+            await RuleSyncService.resetLoadStateForTesting()
+
+            async let first = RuleSyncService.ensureLoaded()
+            async let second = RuleSyncService.ensureLoaded()
+            let outcomes = await [first, second]
+
+            #expect(outcomes.allSatisfy { $0 == .loaded })
+            #expect(await RuleEngine.shared.allRules.count == 2)
+        }
+    }
+
+    @Test("A newer snapshot committed first is never overwritten by an older ticket's stale snapshot")
+    func newerTicketWinsRegardlessOfCommitOrder() async {
+        let url = Self.queueTempFileURL(suffix: "order")
+        try? FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(), withIntermediateDirectories: true
+        )
+        try? FileManager.default.removeItem(at: url)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let store = RuleStore(fileURL: url)
+        let queue = RulePersistenceQueue()
+
+        let older = [Self.fileRule()]
+        let newer = [Self.fileRule(), Self.directoryRule()]
+
+        // Reserve in mutation-completion order: older ticket first, newer second.
+        let oldTicket = await queue.reserveTicket()
+        let newTicket = await queue.reserveTicket()
+
+        // Commit out of order: the newer, encompassing snapshot lands first, the
+        // stale older snapshot second — reproducing the write-order race.
+        let newCommit = await queue.commit(ticket: newTicket, newer, using: store)
+        let oldCommit = await queue.commit(ticket: oldTicket, older, using: store)
+
+        #expect(newCommit.superseded == false)
+        #expect(newCommit.outcome == .saved)
+        // The stale older commit is superseded and never writes.
+        #expect(oldCommit.superseded)
+        #expect(oldCommit.outcome == .saved)
+
+        let persisted = (try? store.loadRules()) ?? []
+        #expect(persisted.map(\.id) == newer.map(\.id))
+    }
+
+    @Test("An older commit after a failed newer attempt inherits the failure and never persists")
+    func olderCommitInheritsFailedNewerOutcome() async {
+        // Newer snapshot targets an unwritable path → a real save failure.
+        let failingStore = RuleStore(
+            fileURL: URL(fileURLWithPath: "/dev/null/rockxy-queue-nested/rules.json")
+        )
+        // Older snapshot targets a writable temp store; it must STILL not write.
+        let url = Self.queueTempFileURL(suffix: "failure")
+        try? FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(), withIntermediateDirectories: true
+        )
+        try? FileManager.default.removeItem(at: url)
+        defer { try? FileManager.default.removeItem(at: url) }
+        let writableStore = RuleStore(fileURL: url)
+
+        let queue = RulePersistenceQueue()
+        let oldTicket = await queue.reserveTicket()
+        let newTicket = await queue.reserveTicket()
+
+        let newCommit = await queue.commit(
+            ticket: newTicket, [Self.fileRule(), Self.directoryRule()], using: failingStore
+        )
+        #expect(newCommit.superseded == false)
+        #expect(newCommit.outcome.isSaved == false)
+
+        let oldCommit = await queue.commit(ticket: oldTicket, [Self.fileRule()], using: writableStore)
+        // The older caller inherits the newer, encompassing attempt's failure so it
+        // cannot falsely report durability, and its stale snapshot is not written.
+        #expect(oldCommit.superseded)
+        #expect(oldCommit.outcome.isSaved == false)
+        #expect(oldCommit.outcome == newCommit.outcome)
+        #expect(!FileManager.default.fileExists(atPath: url.path(percentEncoded: false)))
+    }
+
+    // MARK: Private
+
+    private static let tempFileURL: URL = FileManager.default.temporaryDirectory
+        // Keep a space in the path to mirror production's "Application Support"
+        // directory and catch accidental use of URL.path()'s encoded form. Include
+        // the process ID because Xcode can execute Swift Testing suites in multiple
+        // worker processes that must not delete each other's fixture.
+        .appendingPathComponent(
+            "rockxy maplocal tests \(ProcessInfo.processInfo.processIdentifier)",
+            isDirectory: true
+        )
+        .appendingPathComponent("rules.json")
+
+    /// Isolated temp file for the persistence-queue ordering tests. Kept distinct
+    /// from `tempFileURL` (and per-suffix + per-PID) so a queue test never shares a
+    /// path with the harness-backed tests or a parallel worker process.
+    private static func queueTempFileURL(suffix: String) -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent(
+                "rockxy maplocal queue \(suffix) \(ProcessInfo.processInfo.processIdentifier)",
+                isDirectory: true
+            )
+            .appendingPathComponent("rules.json")
+    }
+
+    private static func fileRule() -> ProxyRule {
+        ProxyRule(
+            id: UUID(),
+            name: "Serve Mock JSON",
+            isEnabled: true,
+            matchCondition: RuleMatchCondition(
+                urlPattern: "https://example.com/api/*",
+                sourceURLPattern: "https://example.com/api/*",
+                method: "GET",
+                matchType: .wildcard,
+                includeSubpaths: false
+            ),
+            action: .mapLocal(
+                filePath: "/tmp/mock/response.json",
+                statusCode: 200,
+                isDirectory: false,
+                delayMs: 0,
+                responseHeaders: [
+                    HTTPHeader(name: "Content-Type", value: "application/json"),
+                    HTTPHeader(name: "X-Order", value: "1"),
+                ]
+            ),
+            priority: 3
+        )
+    }
+
+    private static func directoryRule() -> ProxyRule {
+        ProxyRule(
+            id: UUID(),
+            name: "Serve Assets Dir",
+            isEnabled: false,
+            matchCondition: RuleMatchCondition(
+                urlPattern: "https://cdn\\.example\\.com/assets/(.*)",
+                sourceURLPattern: "https://cdn\\.example\\.com/assets/(.*)",
+                method: "POST",
+                matchType: .regex
+            ),
+            action: .mapLocal(
+                filePath: "/tmp/mock/assets",
+                statusCode: 404,
+                isDirectory: true,
+                delayMs: 1_500,
+                responseHeaders: [HTTPHeader(name: "Cache-Control", value: "no-store")]
+            ),
+            priority: 7
+        )
+    }
+
+    private static func blockRule() -> ProxyRule {
+        ProxyRule(
+            name: "Block Ads",
+            matchCondition: RuleMatchCondition(urlPattern: ".*ads\\.example\\.com.*"),
+            action: .block(statusCode: 403)
+        )
+    }
+
+    private static func mapRemoteRule(name: String) -> ProxyRule {
+        ProxyRule(
+            id: UUID(),
+            name: name,
+            matchCondition: RuleMatchCondition(
+                urlPattern: "https://example.com/api/*",
+                sourceURLPattern: "https://example.com/api/*",
+                matchType: .wildcard
+            ),
+            action: .mapRemote(configuration: MapRemoteConfiguration(host: "staging.example.com"))
+        )
+    }
+
+    private static func fullResponseRule() -> ProxyRule {
+        ProxyRule(
+            id: UUID(),
+            name: "Full HTTP Response",
+            isEnabled: true,
+            matchCondition: RuleMatchCondition(
+                urlPattern: "https://example.com/login*",
+                sourceURLPattern: "https://example.com/login*",
+                matchType: .wildcard,
+                includeSubpaths: true
+            ),
+            action: .mapLocal(
+                filePath: "/tmp/mock/full-response.http",
+                statusCode: 201,
+                isDirectory: false,
+                delayMs: 250,
+                responseHeaders: [
+                    HTTPHeader(name: "Set-Cookie", value: "a=1"),
+                    HTTPHeader(name: "Set-Cookie", value: "b=2"),
+                    HTTPHeader(name: "X-Order", value: "z"),
+                ]
+            ),
+            priority: 1
+        )
+    }
+
+    private static func expectEqualRule(_ actual: ProxyRule, _ expected: ProxyRule) {
+        #expect(actual.id == expected.id)
+        #expect(actual.name == expected.name)
+        #expect(actual.isEnabled == expected.isEnabled)
+        #expect(actual.priority == expected.priority)
+        #expect(actual.matchCondition == expected.matchCondition)
+
+        guard case let .mapLocal(aPath, aStatus, aDir, aDelay, aHeaders) = actual.action,
+              case let .mapLocal(ePath, eStatus, eDir, eDelay, eHeaders) = expected.action else
+        {
+            Issue.record("Expected both actions to be .mapLocal")
+            return
+        }
+        #expect(aPath == ePath)
+        #expect(aStatus == eStatus)
+        #expect(aDir == eDir)
+        #expect(aDelay == eDelay)
+        #expect(aHeaders == eHeaders)
+    }
+
+    private func isMapLocal(_ rule: ProxyRule) -> Bool {
+        if case .mapLocal = rule.action {
+            return true
+        }
+        return false
+    }
+
+    private func isBlock(_ rule: ProxyRule) -> Bool {
+        if case .block = rule.action {
+            return true
+        }
+        return false
+    }
+
+    /// Runs `body` under the shared rule-test lock with `RuleSyncService.store`,
+    /// the engine's rules, and the load-cache all backed up and restored.
+    @MainActor
+    private func withRuleHarness(_ body: () async -> Void) async {
+        await RuleTestLock.shared.acquire()
+        let storeBackup = RuleSyncService.store
+        let engineBackup = await RuleEngine.shared.allRules
+
+        try? FileManager.default.createDirectory(
+            at: Self.tempFileURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try? FileManager.default.removeItem(at: Self.tempFileURL)
+        RuleSyncService.store = RuleStore(fileURL: Self.tempFileURL)
+
+        await body()
+
+        RuleSyncService.store = storeBackup
+        await RuleEngine.shared.replaceAll(engineBackup)
+        await RuleSyncService.resetLoadStateForTesting()
+        try? FileManager.default.removeItem(at: Self.tempFileURL)
+        await RuleTestLock.shared.release()
+    }
+}

--- a/RockxyTests/Views/Rules/MapRemoteModelTests.swift
+++ b/RockxyTests/Views/Rules/MapRemoteModelTests.swift
@@ -123,7 +123,8 @@ struct MapRemoteModelTests {
                 matchCondition: RuleMatchCondition(urlPattern: "https://blocked.example.com/.*"),
                 action: .block(statusCode: 403)
             )
-            vm.allRules = [mapRemote, block]
+            await RuleEngine.shared.replaceAll([mapRemote, block])
+            await vm.refreshFromEngine()
             vm.selectedRuleIDs = [mapRemote.id]
 
             vm.removeSelectedRules()

--- a/RockxyTests/Views/ToolWindowReadabilityTests.swift
+++ b/RockxyTests/Views/ToolWindowReadabilityTests.swift
@@ -448,6 +448,7 @@ struct ToolWindowReadabilityTests {
         let files = [
             "Rockxy/Views/Rules/MapRemoteWindowView.swift",
             "Rockxy/Views/Rules/MapLocalWindowView.swift",
+            "Rockxy/Views/Rules/MapLocalEditorWindowView.swift",
             "Rockxy/Views/Rules/BlockListWindowView.swift",
             "Rockxy/Views/Rules/AllowListWindowView.swift",
             "Rockxy/Views/Rules/AddAllowListRuleSheet.swift",
@@ -556,8 +557,9 @@ struct ToolWindowReadabilityTests {
     @Test("Block and Allow List retain readable table rhythm")
     func blockAndAllowListRetainReadableTableRhythm() throws {
         let blockListFile = "Rockxy/Views/Rules/BlockListWindowView.swift"
+        let blockListTableFile = "Rockxy/Views/Rules/BlockListTableView.swift"
         let allowListFile = "Rockxy/Views/Rules/AllowListWindowView.swift"
-        let files = [blockListFile, allowListFile]
+        let files = [blockListTableFile, allowListFile]
         let forbiddenSnippets = [
             ".frame(width: 1_200, height: 642)",
             ".controlSize(.large)",
@@ -615,6 +617,7 @@ struct ToolWindowReadabilityTests {
             "Rockxy/Views/Rules/ModifyHeaderWindowView.swift",
             "Rockxy/Views/Rules/ModifyHeaderEditorView.swift",
             "Rockxy/Views/Rules/MapLocalWindowView.swift",
+            "Rockxy/Views/Rules/MapLocalEditorWindowView.swift",
             "Rockxy/Views/Rules/MapRemoteWindowView.swift",
             "Rockxy/Views/Rules/NetworkConditionsWindowView.swift",
             "Rockxy/Views/Rules/ProtobufSettingsWindowView.swift",
@@ -892,7 +895,9 @@ struct ToolWindowReadabilityTests {
 
     @Test("Map Local uses the approved native window and editor structure")
     func mapLocalUsesApprovedNativeStructure() throws {
-        let source = try readProjectFile("Rockxy/Views/Rules/MapLocalWindowView.swift")
+        let windowSource = try readProjectFile("Rockxy/Views/Rules/MapLocalWindowView.swift")
+        let editorSource = try readProjectFile("Rockxy/Views/Rules/MapLocalEditorWindowView.swift")
+        let source = windowSource + "\n" + editorSource
 
         #expect(source.contains(#"TextField(String(localized: "Search rules", bundle: RockxyLocalization.bundle)"#))
         #expect(source.contains("minWidth: max(860, toolMetrics.bodyFontSize * 28 + 496)"))


### PR DESCRIPTION
## Summary

- fix persisted rule discovery for Application Support paths containing spaces
- load rules idempotently before Map Local editing and surface save or decode failures without overwriting the on-disk file
- keep failed editor saves retryable with stable rule identity
- serialize whole-rule persistence so stale snapshots cannot overwrite newer mutations
- make Map Local, Map Remote, and Block List bulk operations mutate current engine state without dropping concurrent rules
- add regression coverage for relaunch round trips, supported Map Local fields, ordering, failure recovery, quotas, concurrent mutations, and persisted-state ordering

## Why

Map Local rules could appear to save successfully and then disappear after Rockxy reopened. The persisted file path could be checked in percent-encoded form, startup loading depended too heavily on main-window timing, and persistence failures were not visible to the editor. Concurrent rule windows could also replace the full rule snapshot and lose newer changes.

## Impact

Saved Map Local file, directory, and full-response rules now reload with their enabled state, matching configuration, response settings, priority, and ordering intact. Failed writes remain visible and retryable, corrupt files are preserved for recovery, and unrelated rule categories survive concurrent bulk operations.

## Related issues

Refs #307

## Validation

- `swiftlint lint --strict` — passed with 0 violations
- `swiftformat --lint` on all affected production and regression-test files — passed
- `xcodebuild -project Rockxy.xcodeproj -scheme Rockxy -configuration Debug build` — passed
- focused Map Local persistence, RuleSyncService, Map Remote, Block List, tool-window readability, and Breakpoint Phase D suites — passed
- manual Map Local save, quit, relaunch, and fixture verification — passed
- full test suite: 3,859 passed, 11 skipped; two unrelated existing failures remain:
  - `DeveloperSetupGuideCatalogTests/javaSupportCopyIsConcrete` expects Java support copy to mention `keytool`
  - `BreakpointPhaseDTests/upstreamReceivesEditedRequest` intermittently times out in the full parallel suite; the complete Breakpoint Phase D suite passes when run separately