### PR TITLE
fix(release): resolve validation failures

### DIFF
--- a/Rockxy/Localizable.xcstrings
+++ b/Rockxy/Localizable.xcstrings
@@ -28737,12 +28737,12 @@
         }
       }
     },
-    "Automatic Setup prepares a scoped shell that sets JAVA_TOOL_OPTIONS proxy properties for the JVM. HTTPS interception still needs the Rockxy root CA trusted in the exact JVM or JetBrains trust store, plus a Decrypt rule for the target application or host under HTTPS Decryption.": {
+    "Automatic Setup prepares a scoped shell that sets JAVA_TOOL_OPTIONS proxy properties for the JVM. For HTTPS interception, import the Rockxy root CA into the exact JVM or JetBrains trust store with keytool, add a Decrypt rule for the target application or host, then run the HttpClient sample to confirm capture.": {
       "localizations": {
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "自动设置会准备一个限定范围的 shell，为 JVM 设置 JAVA_TOOL_OPTIONS 代理属性。HTTPS 拦截仍需要在对应的 JVM 或 JetBrains 信任库中信任 Rockxy 根 CA，并在 HTTPS 解密中为目标应用或主机添加解密规则。"
+            "value": "自动设置会准备一个限定范围的 shell，为 JVM 设置 JAVA_TOOL_OPTIONS 代理属性。要拦截 HTTPS，请使用 keytool 将 Rockxy 根 CA 导入对应的 JVM 或 JetBrains 信任库，为目标应用或主机添加解密规则，然后运行 HttpClient 示例确认流量已被捕获。"
           }
         }
       }

--- a/Rockxy/Models/UI/DeveloperSetupCatalog.swift
+++ b/Rockxy/Models/UI/DeveloperSetupCatalog.swift
@@ -135,8 +135,9 @@ extension SetupTarget {
             currentSupportSummary: String(
                 localized: """
                 Automatic Setup prepares a scoped shell that sets JAVA_TOOL_OPTIONS proxy properties for the \
-                JVM. HTTPS interception still needs the Rockxy root CA trusted in the exact JVM or JetBrains \
-                trust store, plus a Decrypt rule for the target application or host under HTTPS Decryption.
+                JVM. For HTTPS interception, import the Rockxy root CA into the exact JVM or JetBrains trust \
+                store with keytool, add a Decrypt rule for the target application or host, then run the \
+                HttpClient sample to confirm capture.
                 """, bundle: RockxyLocalization.bundle
             )
         )

--- a/RockxyTests/Views/Main/NativeWorkspaceSplitViewTests.swift
+++ b/RockxyTests/Views/Main/NativeWorkspaceSplitViewTests.swift
@@ -562,9 +562,7 @@ struct NativeWorkspaceSplitViewTests {
         #expect(openCount == 0)
         actionDispatchReturned = true
 
-        for _ in 0 ..< 4 where openCount == 0 {
-            await Task.yield()
-        }
+        try await waitUntil { openCount == 1 }
         #expect(openCount == 1)
     }
 
@@ -602,9 +600,7 @@ struct NativeWorkspaceSplitViewTests {
         #expect(openedWindowID == nil)
         actionDispatchReturned = true
 
-        for _ in 0 ..< 4 where openedWindowID == nil {
-            await Task.yield()
-        }
+        try await waitUntil { openedWindowID != nil }
         #expect(openedWindowID == "mapRemote")
     }
 
@@ -638,9 +634,7 @@ struct NativeWorkspaceSplitViewTests {
         #expect(toggleCount == 0)
         actionDispatchReturned = true
 
-        for _ in 0 ..< 4 where toggleCount == 0 {
-            await Task.yield()
-        }
+        try await waitUntil { toggleCount == 1 }
         #expect(toggleCount == 1)
     }
 
@@ -1104,6 +1098,21 @@ struct NativeWorkspaceSplitViewTests {
         NSToolbar.Identifier("NativeWorkspaceSplitViewTests.Toolbar.\(UUID().uuidString)")
     }
 
+    private func waitUntil(
+        attempts: Int = 500,
+        condition: @MainActor () -> Bool
+    )
+        async throws
+    {
+        for _ in 0 ..< attempts {
+            if condition() {
+                return
+            }
+            try await Task.sleep(nanoseconds: 1_000_000)
+        }
+        throw NativeWorkspaceSplitViewTestTimeout()
+    }
+
     private func expectNonNegativeArrangedGeometry(_ controller: NativeWorkspaceSplitViewController) {
         for item in controller.splitViewItems {
             let frame = item.viewController.view.frame
@@ -1122,3 +1131,5 @@ struct NativeWorkspaceSplitViewTests {
         UserDefaults.standard.removeObject(forKey: "NSToolbar Configuration \(identifier)")
     }
 }
+
+private struct NativeWorkspaceSplitViewTestTimeout: Error {}


### PR DESCRIPTION
## Summary

- restore concrete Java Automatic Setup guidance for `keytool`, Decrypt rules, and `HttpClient` validation
- replace fixed-yield toolbar assertions with bounded condition waits for deferred AppKit actions
- keep the existing main-actor deferral and window identifiers unchanged

## Why

Release PR #314 exposed one stale Java copy contract and one scheduler-sensitive toolbar test. The Java summary no longer named the supported validation path, while the toolbar test assumed four scheduler yields would always be enough under CI load.

## Impact

- Java setup guidance once again describes the complete HTTPS validation sequence.
- Deferred toolbar actions remain asynchronous and are tested reliably under load.
- Simplified Chinese guidance remains aligned with the English source.

## Related issues

Refs #302
Refs #314

## Validation

- `git diff --check` — passed
- `swiftlint lint --strict` — passed
- `python3 .github/tools/validate_xcstrings.py` — passed
- focused Developer Setup and native workspace suites: 59 tests passed
- native workspace suite repeated 10 times: 340 test executions passed
- local full suite excluding the macOS 26-only `Process.waitUntilExit` teardown hang: 3,871 tests passed
- universal build already passed on release PR #314