### PR TITLE
fix(ci): support release test toolchains

### DIFF
--- a/RockxyTests/Helpers/RuleTestLock.swift
+++ b/RockxyTests/Helpers/RuleTestLock.swift
@@ -70,10 +70,26 @@ actor RuleTestLock {
 struct SharedPolicyStateTrait: SuiteTrait, TestScoping {
     let isRecursive = false
 
+#if compiler(>=6.2)
     func provideScope(
         for _: Test,
         testCase _: Test.Case?,
         performing function: @concurrent @Sendable () async throws -> Void
+    ) async throws {
+        try await withSharedPolicyState(performing: function)
+    }
+#else
+    func provideScope(
+        for _: Test,
+        testCase _: Test.Case?,
+        performing function: @Sendable () async throws -> Void
+    ) async throws {
+        try await withSharedPolicyState(performing: function)
+    }
+#endif
+
+    private func withSharedPolicyState(
+        performing function: @Sendable () async throws -> Void
     ) async throws {
         await RuleTestLock.shared.acquire()
         do {


### PR DESCRIPTION
## Summary

- use the current TestScoping closure annotation on Swift 6.2 and newer
- retain the compatible Sendable-only signature for the Xcode 16 CI compiler
- preserve the shared-policy suite lock behavior on both toolchain generations

## Why

The release head compiled and passed locally with Swift 6.3, but the Xcode 16 CI compiler treats concurrent as the legacy spelling of Sendable. Combining both annotations therefore produced a duplicate-attribute build error before tests could run.

## Validation

- git diff --check
- swiftlint lint --strict
- RequestTableRefreshTests: 65 tests passed on Swift 6.3
- Xcode 16 compatibility branch selected at compile time for CI

Refs #314