### PR TITLE
ci: run CLA gate for release metadata PRs

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -25,8 +25,9 @@ jobs:
     if: >-
       (github.event_name == 'pull_request_target' &&
        github.event.pull_request.base.ref == 'main' &&
-       github.event.pull_request.head.ref == 'develop' &&
-       github.event.pull_request.head.repo.full_name == github.repository) ||
+       github.event.pull_request.head.repo.full_name == github.repository &&
+       (github.event.pull_request.head.ref == 'develop' ||
+        startsWith(github.event.pull_request.head.ref, 'chore/release-public-'))) ||
       (github.event_name == 'issue_comment' &&
        github.event.issue.pull_request &&
        (contains(github.event.comment.body, 'I have read and agree to the Rockxy ICLA v2.0') ||


### PR DESCRIPTION
## Summary
- run the trusted CLA gate for same-repository release metadata pull requests targeting main
- preserve the existing develop-to-main and contributor comment paths
- continue checking out only trusted default-branch gate code

## Validation
- python3 -m unittest discover -s .github/tools/tests -p 'test_*.py'
- workflow YAML parse
- git diff --check

## Issue audit
No directly related open or recent issue was found.