### PR TITLE
ci: run CLA gate for release metadata PRs

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -25,8 +25,9 @@ jobs:
     if: >-
       (github.event_name == 'pull_request_target' &&
        github.event.pull_request.base.ref == 'main' &&
-       github.event.pull_request.head.ref == 'develop' &&
-       github.event.pull_request.head.repo.full_name == github.repository) ||
+       github.event.pull_request.head.repo.full_name == github.repository &&
+       (github.event.pull_request.head.ref == 'develop' ||
+        startsWith(github.event.pull_request.head.ref, 'chore/release-public-'))) ||
       (github.event_name == 'issue_comment' &&
        github.event.issue.pull_request &&
        (contains(github.event.comment.body, 'I have read and agree to the Rockxy ICLA v2.0') ||


### PR DESCRIPTION
## Summary
- allow same-repository release metadata pull requests to receive the required Rockxy CLA status
- retain the trusted default-branch checkout and existing contributor-signature paths

## Validation
- 50 network-free CLA tests pass
- workflow YAML parses successfully
- develop pull request checks passed

## Issue audit
No directly related open or recent issue was found.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated contribution agreement checks to run for additional same-repository release branch pull requests.
  * Existing checks and workflow behavior remain unchanged for other pull request sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->