### PR TITLE
fix(proxy): harden developer capture and trust recovery

### DIFF
--- a/Rockxy/AppDelegate.swift
+++ b/Rockxy/AppDelegate.swift
@@ -22,22 +22,65 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSUserInterfaceValidat
             )
         }
         Self.logger.info("Rockxy launched")
-        if !RockxyIdentity.isRunningTests {
-            AppUpdater.shared.startIfConfigured()
-        }
         Task {
+            // Restore network reachability before any updater or startup service can create a
+            // request through a proxy left behind by a previous abnormal termination.
+            await SystemProxyStartupRecovery.task.value
+            if !RockxyIdentity.isRunningTests {
+                AppUpdater.shared.startIfConfigured()
+            }
             let applicationSupportURL = FileManager.default.urls(
                 for: .applicationSupportDirectory,
                 in: .userDomainMask
             ).first
             if !RockxyIdentity.isRunningTests, let applicationSupportURL {
-                await Task.detached(priority: .utility) {
+                let runningApplicationProcesses = Dictionary(
+                    NSWorkspace.shared.runningApplications.compactMap { application -> (String, Int32)? in
+                        guard !application.isTerminated,
+                              application.processIdentifier > 0,
+                              let bundleIdentifier = application.bundleIdentifier,
+                              let bundleURL = application.bundleURL
+                        else {
+                            return nil
+                        }
+                        return (
+                            Self.developerApplicationIdentityKey(
+                                bundleIdentifier: bundleIdentifier,
+                                bundleURL: bundleURL
+                            ),
+                            application.processIdentifier
+                        )
+                    },
+                    uniquingKeysWith: { first, _ in first }
+                )
+                Task.detached(priority: .utility) {
                     DeveloperApplicationCaptureConfigurator.reconcileOutstandingPreparations(
-                        applicationSupportURL: applicationSupportURL
+                        applicationSupportURL: applicationSupportURL,
+                        recordedApplicationProcessIdentifier: { bundleIdentifier, bundlePath in
+                            runningApplicationProcesses[
+                                Self.developerApplicationIdentityKey(
+                                    bundleIdentifier: bundleIdentifier,
+                                    bundleURL: URL(fileURLWithPath: bundlePath)
+                                )
+                            ]
+                        },
+                        livePreparationHandler: { processIdentifier, preparation in
+                            Task { @MainActor in
+                                do {
+                                    try DeveloperApplicationSettingsRestorationMonitor.shared.startMonitoring(
+                                        processIdentifier: processIdentifier,
+                                        preparation: preparation
+                                    )
+                                } catch {
+                                    Self.logger.error(
+                                        "Could not resume a developer-application settings restoration monitor: \(error.localizedDescription)"
+                                    )
+                                }
+                            }
+                        }
                     )
-                }.value
+                }
             }
-            await SystemProxyManager.shared.recoverStaleProxyIfNeeded()
             if !RockxyIdentity.isRunningTests {
                 do {
                     try await CertificateManager.shared.ensureRootCA()
@@ -148,6 +191,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSUserInterfaceValidat
     private static let identity = RockxyIdentity.current
 
     private static let logger = Logger(subsystem: identity.logSubsystem, category: "AppDelegate")
+
+    nonisolated private static func developerApplicationIdentityKey(
+        bundleIdentifier: String,
+        bundleURL: URL
+    ) -> String {
+        let normalizedIdentifier = bundleIdentifier.trimmingCharacters(in: .whitespacesAndNewlines)
+        let normalizedPath = bundleURL.standardizedFileURL.resolvingSymlinksInPath().path
+        return "\(normalizedIdentifier)|\(normalizedPath)"
+    }
 
     private var skipNextQuitConfirmation = false
 

--- a/Rockxy/ContentView.swift
+++ b/Rockxy/ContentView.swift
@@ -157,6 +157,9 @@ struct ContentView: View {
             }
             coordinator.readiness.startObserving()
             coordinator.setupSSLProxyingObserver()
+            // Share the app-level recovery barrier so startup cannot restore an old proxy after
+            // this view has already enabled a new capture session.
+            await SystemProxyStartupRecovery.task.value
             coordinator.refreshProxyOverrideStatus()
             coordinator.startProxyOnLaunchIfNeeded()
             nearbyTransferReceiver.start(coordinator: coordinator)

--- a/Rockxy/Core/Certificate/CertificateManager.swift
+++ b/Rockxy/Core/Certificate/CertificateManager.swift
@@ -421,6 +421,12 @@ actor CertificateManager {
         // `ensureRootCA` runs without suspending, so no other call can interleave with it.
         try ensureRootCA()
 
+        // Another Rockxy process can share this certificate namespace while retaining a
+        // different root in memory. Never ask macOS to trust material that is no longer the
+        // certificate/key pair this process would load after a relaunch. Reconcile before the
+        // authorization prompt so the one prompt applies to the durable identity.
+        try reconcilePersistedRootIdentityBeforeTrust()
+
         guard let certificate = rootCACertificate else {
             throw CertificateManagerError.noRootCA
         }
@@ -492,6 +498,23 @@ actor CertificateManager {
             throw error
         }
         Self.logger.info("Root CA trusted app-side (fingerprint: \(fingerprint))")
+
+        // The authorization dialog suspends this actor while another process remains free to
+        // replace the shared certificate or key. A successful trust write is not a successful
+        // Rockxy setup if that identity will disappear on the next launch. Detect the race,
+        // report it, and never raise an automatic second prompt or delete either identity.
+        do {
+            guard try activeRootMatchesPersistedStorage() else {
+                throw CertificateManagerError.persistedRootIdentityChanged
+            }
+        } catch let error as CertificateManagerError {
+            lastValidationErrorMessage = error.localizedDescription
+            throw error
+        } catch {
+            let wrapped = CertificateManagerError.trustStateUnavailable(error.localizedDescription)
+            lastValidationErrorMessage = wrapped.localizedDescription
+            throw wrapped
+        }
 
         try Task.checkCancellation()
         activeRootFingerprint = fingerprint
@@ -1008,6 +1031,69 @@ actor CertificateManager {
         return try certToDER(certificate)
     }
 
+    /// Makes the in-memory root agree with the identity that will survive a process restart.
+    ///
+    /// This is intentionally limited to trust installation. Routine status reads stay
+    /// non-mutating, while the explicit install action may already generate a missing root. If
+    /// another process replaced either persisted half since this actor adopted its root, reload
+    /// the complete persisted pair or follow the existing one-time regeneration policy before
+    /// asking the user for administrator approval.
+    private func reconcilePersistedRootIdentityBeforeTrust() throws {
+        let matches: Bool
+        do {
+            matches = try activeRootMatchesPersistedStorage()
+        } catch {
+            throw CertificateManagerError.trustStateUnavailable(error.localizedDescription)
+        }
+        guard !matches else {
+            return
+        }
+
+        Self.logger.warning(
+            "Active root CA differs from persisted certificate/key identity — reloading before trust"
+        )
+        rootCACertificate = nil
+        rootCAPrivateKey = nil
+        try ensureRootCA()
+
+        do {
+            guard try activeRootMatchesPersistedStorage() else {
+                throw CertificateManagerError.persistedRootIdentityChanged
+            }
+        } catch let error as CertificateManagerError {
+            throw error
+        } catch {
+            throw CertificateManagerError.trustStateUnavailable(error.localizedDescription)
+        }
+    }
+
+    /// Exact certificate bytes plus the private key are the durable root identity. A key that is
+    /// decodable but belongs to another certificate is a mismatch, not proof of corruption.
+    private func activeRootMatchesPersistedStorage(migrateLegacyKey: Bool = true) throws -> Bool {
+        guard let activeCertificate = rootCACertificate,
+              let activePrivateKey = rootCAPrivateKey,
+              let persistedCertificate = try CertificateStore.loadRootCACertificate() else
+        {
+            return false
+        }
+
+        let persistedPublicKey = persistedCertificate.publicKey.subjectPublicKeyInfoBytes
+        let matchesPersistedCertificate: (P256.Signing.PrivateKey) -> Bool = { candidate in
+            Certificate.PublicKey(candidate.publicKey).subjectPublicKeyInfoBytes == persistedPublicKey
+        }
+        let persistedPrivateKey = if migrateLegacyKey {
+            try CertificateStore.loadRootCAPrivateKey(matching: matchesPersistedCertificate)
+        } else {
+            try CertificateStore.loadRootCAPrivateKeyWithoutMigration(matching: matchesPersistedCertificate)
+        }
+        guard let persistedPrivateKey else {
+            return false
+        }
+
+        return try certToDER(activeCertificate) == certToDER(persistedCertificate)
+            && activePrivateKey.rawRepresentation == persistedPrivateKey.rawRepresentation
+    }
+
     /// Rejects any operation that would replace or destroy the material another privileged
     /// operation is currently suspended inside.
     ///
@@ -1327,13 +1413,34 @@ actor CertificateManager {
     /// validation diagnostic instead of being read as "no CA exists", which would silently
     /// invalidate the fingerprint the user already approved.
     private func loadPersistedRootCAIfNeeded() -> PersistedRootLoadOutcome {
-        guard rootCACertificate == nil || rootCAPrivateKey == nil else {
-            return .resolved
-        }
-
         #if DEBUG
         persistedRootLoadAttemptsForTests += 1
         #endif
+
+        if rootCACertificate != nil, rootCAPrivateKey != nil {
+            // A privileged mutation owns this identity across an await. Its post-operation check
+            // and notification will publish the final state; a concurrent status read must not
+            // adopt or diagnose the half-finished storage transition.
+            if isInstallingTrust || isRemovingRootMaterial {
+                return .resolved
+            }
+
+            do {
+                guard try activeRootMatchesPersistedStorage(migrateLegacyKey: false) else {
+                    throw CertificateManagerError.persistedRootIdentityDrift
+                }
+                return .resolved
+            } catch {
+                Self.logger.error(
+                    "Persisted root CA no longer matches the active certificate/key identity: \(error.localizedDescription)"
+                )
+                // A cached green answer belongs to the in-memory CA. It cannot describe the CA a
+                // relaunch would use after another process changed either persisted half.
+                lastTrustValidationResult = nil
+                lastValidationErrorMessage = error.localizedDescription
+                return .failed(error.localizedDescription)
+            }
+        }
 
         do {
             _ = try loadExistingRootCA()
@@ -1573,6 +1680,8 @@ nonisolated enum CertificateManagerError: LocalizedError, Equatable {
     case rootCANotTrusted
     case trustValidationFailed
     case trustInstallationInProgress
+    case persistedRootIdentityChanged
+    case persistedRootIdentityDrift
     case rootRemovalInProgress
     case rootRemovalIncomplete(String)
     case helperInstallUnavailable(String)
@@ -1592,6 +1701,12 @@ nonisolated enum CertificateManagerError: LocalizedError, Equatable {
             "macOS has not validated the certificate for TLS. Your certificate and key were kept. Recheck the certificate status in Settings."
         case .trustInstallationInProgress:
             "A certificate trust installation is already in progress. Wait for it to finish, then try again."
+        case .persistedRootIdentityChanged:
+            "Rockxy's persisted root CA changed while trust was being prepared. Quit other running copies of Rockxy, then try again. No second trust prompt was requested."
+        case .persistedRootIdentityDrift:
+            "Rockxy's active root CA no longer matches its saved certificate and private key. " +
+                "This can happen after another Rockxy copy or a Keychain restore changed certificate storage. " +
+                "Use Install & Trust Certificate to reconcile it before HTTPS interception."
         case .rootRemovalInProgress:
             "A certificate removal is already in progress. Wait for it to finish, then try again."
         case let .trustStateUnavailable(detail):

--- a/Rockxy/Core/Certificate/CertificateStore.swift
+++ b/Rockxy/Core/Certificate/CertificateStore.swift
@@ -246,6 +246,44 @@ nonisolated enum CertificateStore {
         return nil
     }
 
+    /// Reads every persisted private-key source without migrating or rewriting any of them.
+    ///
+    /// Status and readiness checks use this to prove that the in-memory certificate/key pair is
+    /// still the pair a relaunch would recover. Going through `loadRootCAPrivateKey(matching:)`
+    /// here would turn a read-only status refresh into a Keychain migration and legacy-file
+    /// cleanup opportunity. A rejected source remains untouched so an explicit recovery or trust
+    /// action can still reconcile it later.
+    static func loadRootCAPrivateKeyWithoutMigration(
+        matching isExpectedKey: (P256.Signing.PrivateKey) -> Bool
+    )
+        throws -> P256.Signing.PrivateKey?
+    {
+        if let keyData = try KeychainHelper.loadPrivateKeyWithoutMigration(
+            label: keychainKeyLabel,
+            isUsable: { data in
+                guard let candidate = try? P256.Signing.PrivateKey(x963Representation: data) else {
+                    return false
+                }
+                return isExpectedKey(candidate)
+            }
+        ) {
+            return try P256.Signing.PrivateKey(x963Representation: keyData)
+        }
+
+        let legacyPaths = [
+            storageDirectory.appendingPathComponent(rootCAKeyFilename),
+            storageDirectory.appendingPathComponent(rootCAKeyFilename + ".bak")
+        ]
+        for path in legacyPaths {
+            if let key = try loadPrivateKeyPEM(at: path, sourceDescription: "legacy disk recovery"),
+               isExpectedKey(key)
+            {
+                return key
+            }
+        }
+        return nil
+    }
+
     /// Reads only the Keychain copy of the root CA private key.
     ///
     /// Used where a caller needs the currently persisted key as a value — capturing the

--- a/Rockxy/Core/Certificate/KeychainHelper.swift
+++ b/Rockxy/Core/Certificate/KeychainHelper.swift
@@ -111,7 +111,9 @@ nonisolated enum KeychainHelper {
             if isUsable(data) {
                 return data
             }
-            logger.error("Root CA private key in generic-password storage is unusable — trying recovery sources")
+            logger.error(
+                "Root CA private key in generic-password storage is invalid or does not match the requested certificate — trying recovery sources"
+            )
         }
 
         for shape in PrivateKeyShape.migrationSources {
@@ -130,6 +132,27 @@ nonisolated enum KeychainHelper {
             return data
         }
 
+        return nil
+    }
+
+    /// Reads every historical Keychain shape without rewriting or deleting any of them.
+    ///
+    /// Readiness and status checks use this path so observing whether the active root still
+    /// matches durable storage cannot opportunistically migrate a legacy item. Explicit setup
+    /// and recovery actions continue to use `loadPrivateKey(label:isUsable:)`, which owns that
+    /// mutation after it has selected a usable source.
+    static func loadPrivateKeyWithoutMigration(
+        label: String,
+        isUsable: (Data) -> Bool
+    )
+        throws -> Data?
+    {
+        let shapes = [PrivateKeyShape.genericPassword] + PrivateKeyShape.migrationSources
+        for shape in shapes {
+            if let data = try readPrivateKeyItem(label: label, shape: shape), isUsable(data) {
+                return data
+            }
+        }
         return nil
     }
 

--- a/Rockxy/Core/ProxyEngine/ClientIdentityResolution.swift
+++ b/Rockxy/Core/ProxyEngine/ClientIdentityResolution.swift
@@ -259,11 +259,11 @@ private actor SnapshotCoordinator {
 
 // MARK: - ClientIdentityHandle
 
-/// Per-connection handle retaining the descriptor and a lazily started resolution Task. The
+/// Per-connection handle retaining the descriptor and a single shared resolution Task. The
 /// resolved identity is retained for the connection lifetime: `currentIdentity` provides a
 /// non-blocking snapshot for transaction stamping, while `awaitIdentity()` bounds the TLS
-/// decision. Laziness avoids running `lsof` for plain HTTP and raw tunnels whose policy cannot
-/// depend on application identity.
+/// decision. The proxy starts resolution at accept time so short-lived sockets remain observable;
+/// later policy and stamping reads reuse that work without launching another OS lookup.
 final class ClientIdentityHandle: @unchecked Sendable {
     // MARK: Lifecycle
 
@@ -279,6 +279,13 @@ final class ClientIdentityHandle: @unchecked Sendable {
     /// Non-blocking snapshot of the resolved identity (nil until resolution completes).
     var currentIdentity: ClientApplicationIdentity? {
         state.get()
+    }
+
+    /// Starts resolution without waiting for it. The proxy calls this as soon as a local
+    /// connection is accepted so short-lived raw tunnels can still be attributed after their
+    /// client socket disappears from the OS connection table.
+    func startResolution() {
+        _ = resolutionTask()
     }
 
     /// Starts resolution once, then awaits the same bounded result for every caller.
@@ -309,12 +316,17 @@ final class ClientIdentityHandle: @unchecked Sendable {
                 }
                 Task {
                     try? await Task.sleep(for: .milliseconds(850))
-                    if gate.resolve(nil, continuation: continuation) {
-                        resolverTask.cancel()
-                    }
+                    _ = gate.resolve(nil, continuation: continuation)
                 }
             }
             state.set(identity)
+            if identity == nil {
+                Task {
+                    if let lateIdentity = await resolverTask.value {
+                        state.set(lateIdentity)
+                    }
+                }
+            }
             return identity
         }
         task = created

--- a/Rockxy/Core/ProxyEngine/ConnectionLimiter.swift
+++ b/Rockxy/Core/ProxyEngine/ConnectionLimiter.swift
@@ -2,15 +2,17 @@ import Foundation
 
 /// Limits concurrent upstream connections per destination to prevent file descriptor exhaustion.
 ///
-/// Modeled after mitmproxy's `max_conns` semaphore pattern: each (host, port) pair gets at most
-/// `maxPerDestination` concurrent connections. Callers must `acquire` before opening a connection
-/// and `release` when the connection closes.
+/// Each normalized (host, port) pair gets at most `maxPerDestination` concurrent connections.
+/// The default accommodates parallel browser and IDE startup bursts while retaining a hard bound
+/// against one destination consuming an unbounded number of file descriptors. Callers must
+/// `acquire` before opening a connection and `release` when the connection closes.
 ///
 /// Thread-safe via `NSLock` for use from NIO event loops.
 final class ConnectionLimiter: @unchecked Sendable {
     // MARK: Lifecycle
 
-    init(maxPerDestination: Int = 6) {
+    init(maxPerDestination: Int = 64) {
+        precondition(maxPerDestination > 0)
         self.maxPerDestination = maxPerDestination
     }
 
@@ -18,7 +20,7 @@ final class ConnectionLimiter: @unchecked Sendable {
 
     /// Attempts to reserve a connection slot. Returns `true` if allowed, `false` if at capacity.
     func acquire(host: String, port: Int) -> Bool {
-        let dest = Destination(host: host, port: port)
+        let dest = destination(host: host, port: port)
         lock.lock()
         defer { lock.unlock() }
         let current = counts[dest, default: 0]
@@ -31,11 +33,15 @@ final class ConnectionLimiter: @unchecked Sendable {
 
     /// Releases a connection slot when the upstream channel closes.
     func release(host: String, port: Int) {
-        let dest = Destination(host: host, port: port)
+        let dest = destination(host: host, port: port)
         lock.lock()
         defer { lock.unlock() }
         let current = counts[dest, default: 0]
-        counts[dest] = max(0, current - 1)
+        if current <= 1 {
+            counts.removeValue(forKey: dest)
+        } else {
+            counts[dest] = current - 1
+        }
     }
 
     // MARK: Private
@@ -48,4 +54,12 @@ final class ConnectionLimiter: @unchecked Sendable {
     private let maxPerDestination: Int
     private var counts: [Destination: Int] = [:]
     private let lock = NSLock()
+
+    private func destination(host: String, port: Int) -> Destination {
+        var normalizedHost = host.lowercased()
+        if normalizedHost.hasSuffix(".") {
+            normalizedHost.removeLast()
+        }
+        return Destination(host: normalizedHost, port: port)
+    }
 }

--- a/Rockxy/Core/ProxyEngine/ProcessResolver.swift
+++ b/Rockxy/Core/ProxyEngine/ProcessResolver.swift
@@ -1,4 +1,5 @@
 import AppKit
+import Darwin
 import Foundation
 import os
 
@@ -12,6 +13,26 @@ final class ProcessResolver: @unchecked Sendable {
     // MARK: Lifecycle
 
     init() {
+        processMapProvider = nil
+        minimumRefreshInterval = 0.5
+        identityResolver = ClientIdentityResolver(
+            connectionTableProvider: { proxyPort, deadline in
+                ProcessResolver.runLsofConnectionTable(proxyPort: proxyPort, deadline: deadline)
+            },
+            identityProvider: { pid, command in
+                ProcessResolver.applicationIdentity(forPID: pid, command: command)
+            },
+            excludePID: getpid()
+        )
+    }
+
+    init(
+        processMapProvider: @escaping @Sendable (_ proxyPort: Int) -> [UInt16: String],
+        minimumRefreshInterval: Double = 0.5
+    ) {
+        precondition(minimumRefreshInterval >= 0)
+        self.processMapProvider = processMapProvider
+        self.minimumRefreshInterval = minimumRefreshInterval
         identityResolver = ClientIdentityResolver(
             connectionTableProvider: { proxyPort, deadline in
                 ProcessResolver.runLsofConnectionTable(proxyPort: proxyPort, deadline: deadline)
@@ -32,25 +53,53 @@ final class ProcessResolver: @unchecked Sendable {
     let identityResolver: ClientIdentityResolver
 
     /// Runs a single `lsof` call against the proxy port and returns a mapping of
-    /// client source port → human-readable app name. Cached for 2 seconds to avoid
-    /// shelling out on every batch.
-    func resolveProcesses(proxyPort: Int) -> [UInt16: String] {
+    /// client source port → human-readable app name. Missing source ports can request an early
+    /// refresh, but refreshes are globally coalesced so closed or remote sockets cannot cause an
+    /// `lsof` process on every delivery flush.
+    func resolveProcesses(proxyPort: Int, requiring sourcePorts: Set<UInt16> = []) -> [UInt16: String] {
         let now = DispatchTime.now()
         lock.lock()
-        if let cached = cachedResult,
-           let cacheTime = cacheTimestamp,
-           Double(now.uptimeNanoseconds - cacheTime.uptimeNanoseconds) / 1_000_000_000 < cacheTTL
+        if let inFlightQuery = inFlightQueries[proxyPort] {
+            lock.unlock()
+            _ = inFlightQuery.wait(timeout: .now() + .seconds(1))
+            lock.lock()
+            let result = cachedProcessMaps[proxyPort]?.result ?? [:]
+            lock.unlock()
+            return result
+        }
+        if let cachedEntry = cachedProcessMaps[proxyPort],
+           Double(now.uptimeNanoseconds - cachedEntry.timestamp.uptimeNanoseconds) / 1_000_000_000 < cacheTTL
         {
+            let cached = cachedEntry.result
+            let containsRequiredPorts = sourcePorts.allSatisfy { cached[$0] != nil }
+            let refreshAge = lastQueryStartedAt[proxyPort].map {
+                Double(now.uptimeNanoseconds - $0.uptimeNanoseconds) / 1_000_000_000
+            } ?? .infinity
+            if containsRequiredPorts || refreshAge < minimumRefreshInterval {
+                lock.unlock()
+                return cached
+            }
+        }
+        if let lastQueryStartedAt = lastQueryStartedAt[proxyPort],
+           Double(now.uptimeNanoseconds - lastQueryStartedAt.uptimeNanoseconds) / 1_000_000_000
+               < minimumRefreshInterval
+        {
+            let cached = cachedProcessMaps[proxyPort]?.result ?? [:]
             lock.unlock()
             return cached
         }
+        lastQueryStartedAt[proxyPort] = now
+        let inFlightQuery = DispatchGroup()
+        inFlightQuery.enter()
+        inFlightQueries[proxyPort] = inFlightQuery
         lock.unlock()
 
         let result = queryLsof(proxyPort: proxyPort)
 
         lock.lock()
-        cachedResult = result
-        cacheTimestamp = now
+        cachedProcessMaps[proxyPort] = CachedProcessMap(result: result, timestamp: .now())
+        inFlightQueries.removeValue(forKey: proxyPort)
+        inFlightQuery.leave()
         lock.unlock()
 
         return result
@@ -58,36 +107,18 @@ final class ProcessResolver: @unchecked Sendable {
 
     /// Async version that dispatches the blocking lsof call off the cooperative thread pool.
     /// Safe to call from Swift actors without blocking their executor.
-    func resolveProcessesAsync(proxyPort: Int) async -> [UInt16: String] {
-        let now = DispatchTime.now()
-        lock.lock()
-        if let cached = cachedResult,
-           let cacheTime = cacheTimestamp,
-           Double(now.uptimeNanoseconds - cacheTime.uptimeNanoseconds) / 1_000_000_000 < cacheTTL
-        {
-            lock.unlock()
-            return cached
-        }
-        lock.unlock()
-
-        return await withCheckedContinuation { continuation in
+    func resolveProcessesAsync(proxyPort: Int, requiring sourcePorts: Set<UInt16> = []) async -> [UInt16: String] {
+        await withCheckedContinuation { continuation in
             DispatchQueue.global(qos: .utility).async {
-                let result = self.resolveProcesses(proxyPort: proxyPort)
+                let result = self.resolveProcesses(proxyPort: proxyPort, requiring: sourcePorts)
                 continuation.resume(returning: result)
             }
         }
     }
 
-    /// Resolves a single source port to an app name using `proc_pidinfo`-style lookup.
-    /// Used as a fallback when `lsof` batch hasn't run yet.
+    /// Resolves a single source port to an app name without consulting proxy-port-specific caches.
+    /// Used as a fallback when the caller does not have the corresponding proxy listener port.
     func resolveAppName(remotePort: UInt16) -> String? {
-        lock.lock()
-        if let cached = cachedResult, let name = cached[remotePort] {
-            lock.unlock()
-            return name
-        }
-        lock.unlock()
-
         guard let pid = findPIDForLocalPort(remotePort) else {
             return nil
         }
@@ -97,39 +128,38 @@ final class ProcessResolver: @unchecked Sendable {
     // MARK: Private
 
     private static let logger = Logger(subsystem: RockxyIdentity.current.logSubsystem, category: "ProcessResolver")
+    private struct CachedProcessMap {
+        let result: [UInt16: String]
+        let timestamp: DispatchTime
+    }
+
     private let lock = NSLock()
-    private var cachedResult: [UInt16: String]?
-    private var cacheTimestamp: DispatchTime?
+    private let processMapProvider: (@Sendable (_ proxyPort: Int) -> [UInt16: String])?
+    private var cachedProcessMaps: [Int: CachedProcessMap] = [:]
+    private var lastQueryStartedAt: [Int: DispatchTime] = [:]
+    private var inFlightQueries: [Int: DispatchGroup] = [:]
     private let cacheTTL: Double = 5.0
+    private let minimumRefreshInterval: Double
 
     /// Runs `lsof -i TCP:PORT -n -P -F pcn` and parses the output into a port→appName map.
     /// The `-F` flag produces machine-parseable output:
     ///   `p<pid>` lines, `c<command>` lines, `n<connection>` lines.
     private func queryLsof(proxyPort: Int) -> [UInt16: String] {
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/usr/sbin/lsof")
-        process.arguments = ["-i", "TCP:\(proxyPort)", "-n", "-P", "-F", "pcn"]
-
-        let pipe = Pipe()
-        process.standardOutput = pipe
-        process.standardError = Pipe()
-
-        do {
-            try process.run()
-        } catch {
-            Self.logger.warning("Failed to launch lsof: \(error.localizedDescription)")
+        if let processMapProvider {
+            return processMapProvider(proxyPort)
+        }
+        guard let execution = Self.runBoundedLsof(
+            arguments: ["-i", "TCP:\(proxyPort)", "-n", "-P", "-F", "pcn"],
+            deadline: .now() + .milliseconds(700)
+        ) else {
             return [:]
         }
-
-        let data = pipe.fileHandleForReading.readDataToEndOfFile()
-        process.waitUntilExit()
-
-        guard process.terminationStatus == 0 else {
-            return [:]
+        let output = String(data: execution.data, encoding: .utf8) ?? ""
+        let parsed = parseLsofOutput(output, proxyPort: proxyPort)
+        if execution.status != 0, parsed.isEmpty {
+            Self.logger.debug("lsof process map exited with status \(execution.status)")
         }
-
-        let output = String(data: data, encoding: .utf8) ?? ""
-        return parseLsofOutput(output, proxyPort: proxyPort)
+        return parsed
     }
 
     private func parseLsofOutput(_ output: String, proxyPort: Int) -> [UInt16: String] {
@@ -242,7 +272,7 @@ final class ProcessResolver: @unchecked Sendable {
 
         let pipe = Pipe()
         process.standardOutput = pipe
-        process.standardError = Pipe()
+        process.standardError = FileHandle.nullDevice
 
         do {
             try process.run()
@@ -365,45 +395,18 @@ extension ProcessResolver {
     /// watchdog deadline. Reads the pipe on a background queue to avoid a full-pipe deadlock,
     /// and terminates the process if it overruns the deadline (returning an empty table).
     static func runLsofConnectionTable(proxyPort: Int, deadline: DispatchTime) -> [ProxyConnectionRecord] {
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/usr/sbin/lsof")
-        process.arguments = ["-nP", "-iTCP:\(proxyPort)", "-Fpcn"]
-
-        let pipe = Pipe()
-        process.standardOutput = pipe
-        process.standardError = Pipe()
-
-        do {
-            try process.run()
-        } catch {
-            Self.logger.warning("Failed to launch lsof for connection table: \(error.localizedDescription)")
+        guard let execution = runBoundedLsof(
+            arguments: ["-nP", "-iTCP:\(proxyPort)", "-Fpcn"],
+            deadline: deadline
+        ) else {
             return []
         }
-
-        let handle = pipe.fileHandleForReading
-        let outputBox = LsofOutputBox()
-        let completion = DispatchSemaphore(value: 0)
-        Self.lsofReadQueue.async {
-            let data = handle.readDataToEndOfFile()
-            outputBox.set(data)
-            completion.signal()
+        let output = String(data: execution.data, encoding: .utf8) ?? ""
+        let parsed = parseConnectionTable(output)
+        if execution.status != 0, parsed.isEmpty {
+            Self.logger.debug("lsof connection table exited with status \(execution.status)")
         }
-
-        let waitDeadline = deadline > DispatchTime.now() ? deadline : DispatchTime.now()
-        if completion.wait(timeout: waitDeadline) == .timedOut {
-            process.terminate()
-            _ = completion.wait(timeout: .now() + .milliseconds(200))
-            Self.logger.debug("lsof connection table timed out for port \(proxyPort)")
-            return []
-        }
-
-        process.waitUntilExit()
-        guard process.terminationStatus == 0 else {
-            return []
-        }
-
-        let output = String(data: outputBox.get(), encoding: .utf8) ?? ""
-        return parseConnectionTable(output)
+        return parsed
     }
 
     /// Parses `lsof -Fpcn` output into directional connection records. Kept pure and internal
@@ -436,7 +439,57 @@ extension ProcessResolver {
         return records
     }
 
-    private static let lsofReadQueue = DispatchQueue(label: "rockxy.client-identity.lsof", qos: .utility)
+    private struct LsofExecution {
+        let data: Data
+        let status: Int32
+    }
+
+    private static let lsofReadQueue = DispatchQueue(
+        label: "rockxy.client-identity.lsof",
+        qos: .utility,
+        attributes: .concurrent
+    )
+
+    private static func runBoundedLsof(
+        arguments: [String],
+        deadline: DispatchTime
+    ) -> LsofExecution? {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/sbin/lsof")
+        process.arguments = arguments
+
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = FileHandle.nullDevice
+
+        do {
+            try process.run()
+        } catch {
+            logger.warning("Failed to launch lsof: \(error.localizedDescription)")
+            return nil
+        }
+
+        let outputBox = LsofOutputBox()
+        let completion = DispatchSemaphore(value: 0)
+        lsofReadQueue.async {
+            outputBox.set(pipe.fileHandleForReading.readDataToEndOfFile())
+            completion.signal()
+        }
+
+        let waitDeadline = deadline > DispatchTime.now() ? deadline : DispatchTime.now()
+        guard completion.wait(timeout: waitDeadline) == .success else {
+            process.terminate()
+            if completion.wait(timeout: .now() + .milliseconds(200)) == .timedOut {
+                Darwin.kill(process.processIdentifier, SIGKILL)
+                _ = completion.wait(timeout: .now() + .milliseconds(200))
+            }
+            logger.debug("lsof timed out")
+            return nil
+        }
+
+        process.waitUntilExit()
+        return LsofExecution(data: outputBox.get(), status: process.terminationStatus)
+    }
 
     private static func parseConnectionLine(
         _ value: String,

--- a/Rockxy/Core/ProxyEngine/ProxyServer.swift
+++ b/Rockxy/Core/ProxyEngine/ProxyServer.swift
@@ -494,6 +494,7 @@ actor ProxyServer {
                     proxyPort: proxyPort
                 )
                 let identityHandle = identityProvider(descriptor)
+                identityHandle?.startResolution()
                 let decoratedCallback = ProxyServer.makeIdentityStampingCallback(
                     handle: identityHandle,
                     downstream: callback

--- a/Rockxy/Core/Services/ReadinessCoordinator.swift
+++ b/Rockxy/Core/Services/ReadinessCoordinator.swift
@@ -205,16 +205,25 @@ final class ReadinessCoordinator {
 
     /// Pure decision function: returns the warning that Priority 2 (cert-not-trusted)
     /// would produce, or nil if the cert is trusted. Extracted for deterministic testing.
+    ///
+    /// Each readable state names the step that is actually missing. Reporting "not trusted" for
+    /// a root that was never generated, or for one that is not in any keychain, describes a
+    /// trust decision the user never made and hides which recovery step is outstanding. The
+    /// unreadable state stays separate: it is a failed read, so it offers a recheck instead of
+    /// asking for administrator approval.
     nonisolated static func certNotTrustedWarning(
         certReadiness: CertReadiness,
         isCaptureActive: Bool
     )
         -> ReadinessWarning?
     {
-        guard isCaptureActive, certReadiness != .trusted else {
+        guard isCaptureActive else {
             return nil
         }
-        if certReadiness == .unknown {
+        switch certReadiness {
+        case .trusted:
+            return nil
+        case .unknown:
             // Nothing is known to be wrong with the certificate, so the offer is a status check
             // rather than a reinstall that would ask for administrator approval on the strength
             // of a failed read. HTTPS interception stays paused either way.
@@ -228,17 +237,40 @@ final class ReadinessCoordinator {
                 action: .openGeneralSettings,
                 isDismissible: false
             )
+        case .notGenerated:
+            return ReadinessWarning(
+                message: String(
+                    localized: """
+                    HTTPS interception is unavailable because the Rockxy Root CA has not been generated yet. \
+                    HTTP traffic and logs are still captured.
+                    """, bundle: RockxyLocalization.bundle
+                ),
+                action: .reinstallAndTrust,
+                isDismissible: false
+            )
+        case .generatedNotInstalled:
+            return ReadinessWarning(
+                message: String(
+                    localized: """
+                    HTTPS interception is unavailable because the Rockxy Root CA is not installed in the \
+                    login or System keychain. HTTP traffic and logs are still captured.
+                    """, bundle: RockxyLocalization.bundle
+                ),
+                action: .reinstallAndTrust,
+                isDismissible: false
+            )
+        case .installedNotTrusted:
+            return ReadinessWarning(
+                message: String(
+                    localized: """
+                    HTTPS interception is unavailable because the Rockxy Root CA is installed but not \
+                    trusted for SSL. HTTP traffic and logs are still captured.
+                    """, bundle: RockxyLocalization.bundle
+                ),
+                action: .reinstallAndTrust,
+                isDismissible: false
+            )
         }
-        return ReadinessWarning(
-            message: String(
-                localized: """
-                HTTPS interception is unavailable because the Rockxy Root CA is not trusted. \
-                HTTP traffic and logs are still captured.
-                """, bundle: RockxyLocalization.bundle
-            ),
-            action: .reinstallAndTrust,
-            isDismissible: false
-        )
     }
 
     nonisolated static func shouldPerformActivationDeepRefresh(
@@ -380,6 +412,22 @@ final class ReadinessCoordinator {
         await refreshCertState()
         refreshHelperState()
         await refreshProxyMode(isEnabled: systemProxyEnabledProbe())
+        recomputeWarning()
+    }
+
+    /// Forced certificate revalidation: re-snapshots certificate state and, when positive trust
+    /// metadata exists, runs a real `SecTrust` evaluation instead of reusing the last cached
+    /// validation result. Known-absent trust metadata still fails closed without the expensive
+    /// evaluation.
+    ///
+    /// `refresh()` is deliberately cheap and may answer from a cached negative that a trust
+    /// approval since then has already invalidated. Capture start decides HTTPS passthrough for
+    /// a whole session from this answer, so it evaluates trust for real. Narrower than
+    /// `deepRefresh()` on purpose: no helper XPC probe and no system-proxy read, because neither
+    /// participates in the passthrough decision. This never requests certificate installation or
+    /// changes trust settings.
+    func refreshCertificateTrustValidation() async {
+        await refreshCertState(performValidation: true)
         recomputeWarning()
     }
 

--- a/Rockxy/Core/TrafficCapture/SystemProxyManager.swift
+++ b/Rockxy/Core/TrafficCapture/SystemProxyManager.swift
@@ -11,6 +11,7 @@ import os
 enum SystemProxyError: LocalizedError {
     case networkSetupFailed(command: String, output: String, exitCode: Int32)
     case noActiveNetworkService
+    case proxyActivationNotConfirmed(port: Int)
     case unexpectedOutput(String)
 
     // MARK: Internal
@@ -21,6 +22,8 @@ enum SystemProxyError: LocalizedError {
             "networksetup \(command) failed (exit \(exitCode)): \(output)"
         case .noActiveNetworkService:
             "Could not detect an active network service"
+        case let .proxyActivationNotConfirmed(port):
+            "macOS did not confirm the Rockxy system proxy on port \(port)"
         case let .unexpectedOutput(output):
             "Unexpected networksetup output: \(output)"
         }
@@ -132,6 +135,16 @@ enum DirectProxyWatchdogAction {
     case exit
 }
 
+// MARK: - SystemProxyStartupRecovery
+
+/// One process-wide recovery barrier shared by app services and the capture UI. A single task
+/// prevents launch-time restore from racing a new proxy enable when both surfaces appear together.
+enum SystemProxyStartupRecovery {
+    static let task = Task.detached(priority: .userInitiated) {
+        await SystemProxyManager.shared.recoverStaleProxyIfNeeded()
+    }
+}
+
 // MARK: - ServiceProxySnapshot
 
 /// Snapshot of a network service's proxy configuration before Rockxy modifies it.
@@ -215,6 +228,18 @@ final class SystemProxyManager: @unchecked Sendable {
         -> Bool
     {
         commandsSucceeded && !proxyStillPointsAtRockxy
+    }
+
+    nonisolated static func helperOverrideIsConfirmed(
+        requestedPort: Int,
+        status: (isOverridden: Bool, port: Int)?
+    )
+        -> Bool
+    {
+        guard let status else {
+            return false
+        }
+        return status.isOverridden && status.port == requestedPort
     }
 
     @discardableResult
@@ -325,6 +350,12 @@ final class SystemProxyManager: @unchecked Sendable {
             Self.logger
                 .info("Helper not installed (status: \(String(describing: helperStatus))), using networksetup directly")
             try enableSystemProxyViaNetworkSetup(port: port)
+        }
+
+        guard await activeOverrideMatches(port: port) else {
+            await rollbackUnconfirmedOverride()
+            clearInMemoryOverrideState()
+            throw SystemProxyError.proxyActivationNotConfirmed(port: port)
         }
 
         await applyBypassDomains()
@@ -480,19 +511,17 @@ final class SystemProxyManager: @unchecked Sendable {
     /// Determines who currently owns the system proxy override by checking
     /// on-disk backup (direct mode) and helper status.
     func effectiveOverrideOwner() async -> ProxyOverrideOwner {
-        // Check in-memory state first for fast path
+        // In-memory ownership is only a hint. The proxy can be changed outside
+        // Rockxy, or a helper watchdog can restore it after an app restart.
+        // Always reconcile against live state before exposing an active override.
         lock.lock()
         let wasEnabled = isEnabled
         let wasUsingHelper = usingHelper
         lock.unlock()
 
-        if wasEnabled, wasUsingHelper {
-            return .helper(port: 0)
-        }
-
         if let backup = loadDirectBackup() {
             let backedUpServices = backup.services.map(\.service)
-            if wasEnabled || currentProxyMatchesRockxy(port: backup.rockxyPort, backedUpServices: backedUpServices) {
+            if currentProxyMatchesRockxy(port: backup.rockxyPort, backedUpServices: backedUpServices) {
                 return .direct(backup: backup)
             }
         }
@@ -503,7 +532,54 @@ final class SystemProxyManager: @unchecked Sendable {
             return .helper(port: helperStatus.port)
         }
 
+        if wasEnabled || wasUsingHelper {
+            clearInMemoryOverrideState()
+        }
+
         return .none
+    }
+
+    private func activeOverrideMatches(port: Int) async -> Bool {
+        lock.lock()
+        let helper = usingHelper
+        let services = activeServices
+        lock.unlock()
+
+        if helper {
+            let status = try? await HelperConnection.shared.getProxyStatus()
+            return Self.helperOverrideIsConfirmed(requestedPort: port, status: status)
+        }
+
+        return !services.isEmpty && currentProxyMatchesRockxy(port: port, backedUpServices: services)
+    }
+
+    private func clearInMemoryOverrideState() {
+        lock.lock()
+        isEnabled = false
+        usingHelper = false
+        activeServices = []
+        lock.unlock()
+    }
+
+    private func rollbackUnconfirmedOverride() async {
+        lock.lock()
+        let helper = usingHelper
+        lock.unlock()
+
+        if helper {
+            do {
+                try await HelperConnection.shared.restoreSystemProxy()
+            } catch {
+                Self.logger.error(
+                    "Could not roll back an unconfirmed helper proxy override: \(error.localizedDescription)"
+                )
+            }
+            return
+        }
+
+        if let backup = loadDirectBackup() {
+            restoreDirectMode(using: backup)
+        }
     }
 
     /// Checks whether the system proxy on any backed-up service currently points to Rockxy.

--- a/Rockxy/Core/TrafficCapture/TrafficSessionManager.swift
+++ b/Rockxy/Core/TrafficCapture/TrafficSessionManager.swift
@@ -152,7 +152,13 @@ actor TrafficSessionManager {
         let port = proxyPort
         let enrichCallback = onClientAppEnriched
         Task {
-            let portMap = await ProcessResolver.shared.resolveProcessesAsync(proxyPort: port)
+            let unresolvedSourcePorts = Set(batch.compactMap { transaction in
+                transaction.clientApp == nil ? transaction.sourcePort : nil
+            })
+            let portMap = await ProcessResolver.shared.resolveProcessesAsync(
+                proxyPort: port,
+                requiring: unresolvedSourcePorts
+            )
             var enrichedTransactions: [HTTPTransaction] = []
             for transaction in batch where transaction.clientApp == nil {
                 if let srcPort = transaction.sourcePort, let app = portMap[srcPort] {

--- a/Rockxy/Localizable.xcstrings
+++ b/Rockxy/Localizable.xcstrings
@@ -15793,12 +15793,32 @@
         }
       }
     },
-    "HTTPS interception is unavailable because the Rockxy Root CA is not trusted. HTTP traffic and logs are still captured.": {
+    "HTTPS interception is unavailable because the Rockxy Root CA has not been generated yet. HTTP traffic and logs are still captured.": {
       "localizations": {
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "Rockxy 根 CA 不受信任，因此 HTTPS 拦截不可用。HTTP 流量和日志仍会被捕获。"
+            "value": "尚未生成 Rockxy 根 CA，因此 HTTPS 拦截不可用。HTTP 流量和日志仍会被捕获。"
+          }
+        }
+      }
+    },
+    "HTTPS interception is unavailable because the Rockxy Root CA is installed but not trusted for SSL. HTTP traffic and logs are still captured.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rockxy 根 CA 已安装但未被信任用于 SSL，因此 HTTPS 拦截不可用。HTTP 流量和日志仍会被捕获。"
+          }
+        }
+      }
+    },
+    "HTTPS interception is unavailable because the Rockxy Root CA is not installed in the login or System keychain. HTTP traffic and logs are still captured.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rockxy 根 CA 未安装到登录钥匙串或系统钥匙串，因此 HTTPS 拦截不可用。HTTP 流量和日志仍会被捕获。"
           }
         }
       }
@@ -18455,6 +18475,26 @@
           "stringUnit": {
             "state": "translated",
             "value": "macOS 在 Rockxy 完成安装辅助工具之前阻止了其注册。请打开“系统设置”>“登录项”，如果其中出现 Rockxy，请予以批准。如果未列出 Rockxy，请清除过期的 Rockxy 辅助工具注册并再次尝试安装。"
+          }
+        }
+      }
+    },
+    "macOS accepted the request to open %@, but the application is still completing first-launch checks. Follow any macOS prompt and wait for it to open.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macOS 已接受打开 %@ 的请求，但该应用仍在完成首次启动检查。请按提示处理任何 macOS 对话框，并等待应用打开。"
+          }
+        }
+      }
+    },
+    "macOS accepted the request to open %@, but the application is still completing first-launch checks. Follow any macOS prompt and wait for it to open. Temporary settings recovery remains active.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macOS 已接受打开 %@ 的请求，但该应用仍在完成首次启动检查。请按提示处理任何 macOS 对话框，并等待应用打开。临时设置恢复仍处于活动状态。"
           }
         }
       }

--- a/Rockxy/Models/UI/DeveloperApplicationCapture.swift
+++ b/Rockxy/Models/UI/DeveloperApplicationCapture.swift
@@ -1,11 +1,6 @@
 import AppKit
+import Darwin
 import Foundation
-import os
-
-nonisolated private let developerApplicationCaptureLogger = Logger(
-    subsystem: RockxyIdentity.current.logSubsystem,
-    category: "DeveloperApplicationCapture"
-)
 
 // MARK: - DeveloperApplicationInstallation
 
@@ -16,6 +11,7 @@ struct DeveloperApplicationInstallation: Equatable, Identifiable, Sendable {
     let displayName: String
     let settingsAdapter: DeveloperApplicationSettingsAdapter?
     let launchAdapter: DeveloperApplicationLaunchAdapter?
+    let runtimeCapabilities: Set<DeveloperApplicationRuntimeCapability>
 
     var id: String {
         "\(bundleIdentifier)|\(appURL.standardizedFileURL.path)"
@@ -27,6 +23,8 @@ struct DeveloperApplicationInstallation: Equatable, Identifiable, Sendable {
 /// A runtime capability that can be prepared through documented launch arguments.
 enum DeveloperApplicationLaunchAdapter: Equatable, Sendable {
     case chromiumProxy
+
+    // MARK: Internal
 
     func arguments(context: RockxySetupScriptContext) -> [String] {
         switch self {
@@ -47,6 +45,8 @@ enum DeveloperApplicationLaunchAdapter: Equatable, Sendable {
 enum DeveloperApplicationSettingsAdapter: Equatable, Sendable {
     case xmlHTTPProxyAutoDetect(vendorDirectory: String, dataDirectoryName: String)
 
+    // MARK: Internal
+
     var requiresSystemProxy: Bool {
         switch self {
         case .xmlHTTPProxyAutoDetect:
@@ -62,114 +62,27 @@ enum DeveloperApplicationSettingsAdapter: Equatable, Sendable {
     }
 }
 
-// MARK: - DeveloperApplicationLaunching
-
-@MainActor
-protocol DeveloperApplicationLaunching {
-    @discardableResult
-    func launch(
-        _ installation: DeveloperApplicationInstallation,
-        arguments: [String],
-        environment: [String: String],
-        onTermination: (@MainActor @Sendable () -> Void)?
-    ) async throws -> Int32
-}
-
-// MARK: - DeveloperApplicationWorkspaceLauncher
-
-private final class DeveloperApplicationTerminationObserver: @unchecked Sendable {
-    var token: NSObjectProtocol?
-}
-
-/// Launches a fresh application instance with a scoped environment via LaunchServices.
-@MainActor
-struct DeveloperApplicationWorkspaceLauncher: DeveloperApplicationLaunching {
-    @discardableResult
-    func launch(
-        _ installation: DeveloperApplicationInstallation,
-        arguments: [String],
-        environment: [String: String],
-        onTermination: (@MainActor @Sendable () -> Void)?
-    ) async throws -> Int32 {
-        let configuration = NSWorkspace.OpenConfiguration()
-        configuration.createsNewApplicationInstance = true
-        configuration.allowsRunningApplicationSubstitution = false
-        configuration.arguments = arguments
-        configuration.environment = environment
-
-        let launchedApplication: NSRunningApplication = try await withCheckedThrowingContinuation { continuation in
-            NSWorkspace.shared.openApplication(
-                at: installation.appURL,
-                configuration: configuration
-            ) { application, error in
-                if let error {
-                    continuation.resume(throwing: error)
-                } else if let application {
-                    continuation.resume(returning: application)
-                } else {
-                    continuation.resume(
-                        throwing: DeveloperSetupLaunchError.processFailed(
-                            command: installation.displayName,
-                            status: -1,
-                            message: nil
-                        )
-                    )
-                }
-            }
-        }
-
-        let processIdentifier = launchedApplication.processIdentifier
-        guard let onTermination else {
-            return processIdentifier
-        }
-        let notificationCenter = NSWorkspace.shared.notificationCenter
-        let observer = DeveloperApplicationTerminationObserver()
-        observer.token = notificationCenter.addObserver(
-            forName: NSWorkspace.didTerminateApplicationNotification,
-            object: nil,
-            queue: .main
-        ) { notification in
-            guard let terminated = notification
-                .userInfo?[NSWorkspace.applicationUserInfoKey] as? NSRunningApplication,
-                terminated.processIdentifier == processIdentifier
-            else {
-                return
-            }
-            if let token = observer.token {
-                notificationCenter.removeObserver(token)
-                observer.token = nil
-            }
-            Task { @MainActor in
-                onTermination()
-            }
-        }
-        if launchedApplication.isTerminated {
-            if let token = observer.token {
-                notificationCenter.removeObserver(token)
-                observer.token = nil
-            }
-            onTermination()
-        }
-        return processIdentifier
-    }
-}
-
 // MARK: - DeveloperApplicationSettingsPreparation
 
-/// A reversible settings transaction. The backup is stored beside the settings file so a later
-/// setup attempt can recover it even if Rockxy stopped before observing application termination.
+/// A reversible settings transaction. Recovery artifacts are stored in Rockxy's Application
+/// Support ledger directory so an IDE update cannot remove the only copy of the original settings.
 struct DeveloperApplicationSettingsPreparation: Equatable, Sendable {
     let settingsURL: URL
     let backupURL: URL
     let absenceMarkerURL: URL
     let preparedSnapshotURL: URL
     let recoveryRecordURL: URL
+    /// Resolved application bundle path retained only as generic process-identity evidence for
+    /// restart detection. It is never used as a filesystem mutation target.
+    let applicationBundlePath: String?
 }
 
 // MARK: - DeveloperApplicationPreparationRegistry
 
 /// Prevents two setup windows from preparing the same third-party settings file concurrently.
 final class DeveloperApplicationPreparationRegistry: @unchecked Sendable {
+    // MARK: Internal
+
     static let shared = DeveloperApplicationPreparationRegistry()
 
     func begin(_ key: String) -> Bool {
@@ -188,89 +101,10 @@ final class DeveloperApplicationPreparationRegistry: @unchecked Sendable {
         lock.unlock()
     }
 
+    // MARK: Private
+
     private let lock = NSLock()
     private var activeKeys: Set<String> = []
-}
-
-// MARK: - DeveloperApplicationSettingsRestorationMonitoring
-
-@MainActor
-protocol DeveloperApplicationSettingsRestorationMonitoring {
-    func startMonitoring(
-        processIdentifier: Int32,
-        preparation: DeveloperApplicationSettingsPreparation
-    ) throws
-}
-
-/// Runs a bounded, exact-path restoration monitor outside Rockxy's process. This closes the gap
-/// where Rockxy exits before the prepared application. The monitor restores only when the live
-/// settings still match Rockxy's prepared snapshot, so user edits made during the session win.
-@MainActor
-final class DeveloperApplicationSettingsRestorationMonitor: DeveloperApplicationSettingsRestorationMonitoring {
-    static let shared = DeveloperApplicationSettingsRestorationMonitor()
-
-    nonisolated static let script = """
-    remaining=120960
-    started=$(/bin/ps -p "$1" -o lstart= 2>/dev/null)
-    while [ -n "$started" ] && /bin/kill -0 "$1" 2>/dev/null && [ "$remaining" -gt 0 ]; do
-      current=$(/bin/ps -p "$1" -o lstart= 2>/dev/null)
-      if [ "$current" != "$started" ]; then
-        break
-      fi
-      /bin/sleep 5
-      remaining=$((remaining - 1))
-    done
-    current=$(/bin/ps -p "$1" -o lstart= 2>/dev/null)
-    if [ -n "$started" ] && /bin/kill -0 "$1" 2>/dev/null && [ "$current" = "$started" ]; then
-      exit 0
-    fi
-    settings=$2
-    backup=$3
-    absent=$4
-    prepared=$5
-    recovery_record=$6
-    if [ ! -f "$prepared" ]; then
-      exit 0
-    fi
-    if [ ! -f "$settings" ] || ! /usr/bin/cmp -s "$settings" "$prepared"; then
-      # A byte-level mismatch may be an application rewrite that preserved Rockxy's proxy
-      # selector while changing unrelated settings. Keep the recovery transaction for Rockxy's
-      # semantic reconciler instead of deleting the user's original configuration.
-      exit 0
-    fi
-    if [ -f "$absent" ]; then
-      /bin/rm -f "$settings" "$backup" "$absent" "$prepared" "$recovery_record"
-    elif [ -f "$backup" ]; then
-      /bin/mv -f "$backup" "$settings"
-      /bin/rm -f "$absent" "$prepared" "$recovery_record"
-    else
-      /bin/rm -f "$prepared" "$recovery_record"
-    fi
-    """
-
-    func startMonitoring(
-        processIdentifier: Int32,
-        preparation: DeveloperApplicationSettingsPreparation
-    ) throws {
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/bin/sh")
-        process.arguments = [
-            "-c",
-            Self.script,
-            "rockxy-settings-restoration-monitor",
-            String(processIdentifier),
-            preparation.settingsURL.path,
-            preparation.backupURL.path,
-            preparation.absenceMarkerURL.path,
-            preparation.preparedSnapshotURL.path,
-            preparation.recoveryRecordURL.path,
-        ]
-        process.environment = ["PATH": "/usr/bin:/bin"]
-        process.standardOutput = FileHandle.nullDevice
-        process.standardError = FileHandle.nullDevice
-
-        try process.run()
-    }
 }
 
 // MARK: - DeveloperApplicationCaptureError
@@ -285,27 +119,47 @@ enum DeveloperApplicationCaptureError: LocalizedError, Equatable {
     case preparationInProgress(String)
     case systemProxyRequired(String)
 
+    // MARK: Internal
+
     var errorDescription: String? {
         switch self {
         case .invalidApplication:
             String(localized: "Choose a valid macOS application.", bundle: RockxyLocalization.bundle)
         case .invalidApplicationMetadata:
-            String(localized: "The selected application's proxy metadata could not be read safely.", bundle: RockxyLocalization.bundle)
+            String(
+                localized: "The selected application's proxy metadata could not be read safely.",
+                bundle: RockxyLocalization.bundle
+            )
         case .unsafeSettingsLocation:
-            String(localized: "The selected application reported an unsafe settings location. Rockxy left it unchanged.", bundle: RockxyLocalization.bundle)
+            String(
+                localized: "The selected application reported an unsafe settings location. Rockxy left it unchanged.",
+                bundle: RockxyLocalization.bundle
+            )
         case .malformedProxySettings:
-            String(localized: "The application's HTTP Proxy settings file is malformed. Rockxy left it unchanged.", bundle: RockxyLocalization.bundle)
+            String(
+                localized: "The application's HTTP Proxy settings file is malformed. Rockxy left it unchanged.",
+                bundle: RockxyLocalization.bundle
+            )
         case let .settingsRecoveryConflict(path):
             String(
-                localized: "The application rewrote its temporary proxy settings into an unreadable form. Rockxy restored the original settings and preserved the unreadable copy at \(path). Review it, then try again.",
+                localized: "Rockxy could not safely compare the application's current proxy settings with its recovery snapshot. Rockxy restored the original settings and preserved the current file at \(path). Review it, then try again.",
                 bundle: RockxyLocalization.bundle
             )
         case let .applicationIsRunning(name):
-            String(localized: "Quit \(name) completely, then try again so its proxy state and launch environment cannot be stale.", bundle: RockxyLocalization.bundle)
+            String(
+                localized: "Quit \(name) completely, then try again so its proxy state and launch environment cannot be stale.",
+                bundle: RockxyLocalization.bundle
+            )
         case let .preparationInProgress(name):
-            String(localized: "Rockxy is already preparing \(name). Wait for that launch to finish, then try again.", bundle: RockxyLocalization.bundle)
+            String(
+                localized: "Rockxy is already preparing \(name). Wait for that launch to finish, then try again.",
+                bundle: RockxyLocalization.bundle
+            )
         case let .systemProxyRequired(name):
-            String(localized: "Enable macOS System Proxy in Rockxy before opening \(name).", bundle: RockxyLocalization.bundle)
+            String(
+                localized: "Enable macOS System Proxy in Rockxy before opening \(name).",
+                bundle: RockxyLocalization.bundle
+            )
         }
     }
 }
@@ -330,13 +184,19 @@ enum DeveloperApplicationCaptureConfigurator {
         fileManager: FileManager = .default,
         preparationRegistry: DeveloperApplicationPreparationRegistry = .shared,
         recordedProcessIsAlive: (Int32, String?) -> Bool = DeveloperApplicationRecoveryLedger
-            .isRecordedProcessAlive
-    ) -> Int {
+            .isRecordedProcessAlive,
+        recordedApplicationProcessIdentifier: ((String, String) -> Int32?)? = nil,
+        livePreparationHandler: ((Int32, DeveloperApplicationSettingsPreparation) -> Void)? = nil
+    )
+        -> Int
+    {
         DeveloperApplicationRecoveryLedger.reconcileOutstandingPreparations(
             applicationSupportURL: applicationSupportURL,
             fileManager: fileManager,
             preparationRegistry: preparationRegistry,
-            recordedProcessIsAlive: recordedProcessIsAlive
+            recordedProcessIsAlive: recordedProcessIsAlive,
+            recordedApplicationProcessIdentifier: recordedApplicationProcessIdentifier,
+            livePreparationHandler: livePreparationHandler
         )
     }
 
@@ -346,13 +206,28 @@ enum DeveloperApplicationCaptureConfigurator {
         with preparation: DeveloperApplicationSettingsPreparation,
         applicationSupportURL: URL,
         fileManager: FileManager = .default
-    ) throws {
+    )
+        throws
+    {
         try DeveloperApplicationRecoveryLedger.associateRunningProcess(
             processIdentifier: processIdentifier,
             processStartSignature: processStartSignature,
             with: preparation,
             applicationSupportURL: applicationSupportURL,
             fileManager: fileManager
+        )
+    }
+
+    static func recoveryArtifactURLs(for recoveryRecordURL: URL) -> (
+        backupURL: URL,
+        absenceMarkerURL: URL,
+        preparedSnapshotURL: URL
+    ) {
+        let artifactBaseURL = recoveryRecordURL.deletingPathExtension()
+        return (
+            artifactBaseURL.appendingPathExtension("backup"),
+            artifactBaseURL.appendingPathExtension("absent"),
+            artifactBaseURL.appendingPathExtension("prepared")
         )
     }
 
@@ -365,8 +240,8 @@ enum DeveloperApplicationCaptureConfigurator {
         guard standardizedURL.pathExtension.caseInsensitiveCompare("app") == .orderedSame,
               let bundle = Bundle(url: standardizedURL),
               let bundleIdentifier = bundle.bundleIdentifier,
-              !bundleIdentifier.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-        else {
+              !bundleIdentifier.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else
+        {
             throw DeveloperApplicationCaptureError.invalidApplication
         }
 
@@ -374,12 +249,16 @@ enum DeveloperApplicationCaptureConfigurator {
             ?? (bundle.object(forInfoDictionaryKey: "CFBundleName") as? String)
             ?? standardizedURL.deletingPathExtension().lastPathComponent
 
-        return DeveloperApplicationInstallation(
+        return try DeveloperApplicationInstallation(
             appURL: standardizedURL,
             bundleIdentifier: bundleIdentifier,
             displayName: displayName,
-            settingsAdapter: try detectedSettingsAdapter(in: standardizedURL),
-            launchAdapter: detectedLaunchAdapter(in: standardizedURL)
+            settingsAdapter: detectedSettingsAdapter(in: standardizedURL),
+            launchAdapter: detectedLaunchAdapter(in: standardizedURL),
+            runtimeCapabilities: DeveloperApplicationRuntimeDetector.capabilities(
+                in: standardizedURL,
+                bundle: bundle
+            )
         )
     }
 
@@ -387,7 +266,9 @@ enum DeveloperApplicationCaptureConfigurator {
         for adapter: DeveloperApplicationSettingsAdapter,
         applicationSupportURL: URL,
         fileManager: FileManager = .default
-    ) throws -> URL {
+    )
+        throws -> URL
+    {
         let vendorDirectory: String
         let dataDirectoryName: String
         switch adapter {
@@ -397,8 +278,8 @@ enum DeveloperApplicationCaptureConfigurator {
         }
 
         guard isSafeDirectoryComponent(vendorDirectory),
-              isSafeDirectoryComponent(dataDirectoryName)
-        else {
+              isSafeDirectoryComponent(dataDirectoryName) else
+        {
             throw DeveloperApplicationCaptureError.unsafeSettingsLocation
         }
 
@@ -416,7 +297,9 @@ enum DeveloperApplicationCaptureConfigurator {
         for installation: DeveloperApplicationInstallation,
         applicationSupportURL: URL,
         fileManager: FileManager = .default
-    ) throws -> DeveloperApplicationSettingsPreparation? {
+    )
+        throws -> DeveloperApplicationSettingsPreparation?
+    {
         guard let adapter = installation.settingsAdapter else {
             return nil
         }
@@ -425,6 +308,7 @@ enum DeveloperApplicationCaptureConfigurator {
         case .xmlHTTPProxyAutoDetect:
             return try configureXMLAutoDetect(
                 adapter: adapter,
+                installation: installation,
                 applicationSupportURL: applicationSupportURL,
                 fileManager: fileManager
             )
@@ -435,7 +319,9 @@ enum DeveloperApplicationCaptureConfigurator {
         _ preparation: DeveloperApplicationSettingsPreparation,
         applicationSupportURL: URL,
         fileManager: FileManager = .default
-    ) throws {
+    )
+        throws
+    {
         try validateContainedPath(
             preparation.settingsURL,
             rootURL: applicationSupportURL,
@@ -469,46 +355,112 @@ enum DeveloperApplicationCaptureConfigurator {
                 preparedSnapshotURL: preparation.preparedSnapshotURL,
                 fileManager: fileManager
             )
-            try removeIfPresent(preparation.recoveryRecordURL, fileManager: fileManager)
+            try settleRecoveryRecord(preparation.recoveryRecordURL, fileManager: fileManager)
         } catch {
             // A malformed live file is preserved as a conflict while the original is restored.
             // Once no transaction artifacts remain, the record is settled even though the
             // caller still receives the conflict location for user-facing recovery guidance.
-            if !hasRecoveryArtifacts(preparation, fileManager: fileManager) {
-                try? removeIfPresent(preparation.recoveryRecordURL, fileManager: fileManager)
+            if case DeveloperApplicationCaptureError.settingsRecoveryConflict = error {
+                try? settleRecoveryRecord(preparation.recoveryRecordURL, fileManager: fileManager)
             }
             throw error
         }
     }
 
+    /// Identity of one installed application and the settings scope Rockxy would prepare for it.
+    static func scopeIdentity(
+        for installation: DeveloperApplicationInstallation
+    )
+        -> DeveloperApplicationScopeIdentity
+    {
+        DeveloperApplicationScopeIdentity(
+            bundlePath: installation.appURL.standardizedFileURL.resolvingSymlinksInPath().path,
+            settingsAdapter: installation.settingsAdapter
+        )
+    }
+
+    /// Resolves the same identity for an arbitrary installed bundle, such as one reported by a
+    /// running application. Adapter detection is skipped when the caller only needs path identity.
+    static func scopeIdentity(
+        forBundleAt bundleURL: URL,
+        resolvingSettingsAdapter: Bool = true,
+        fileManager: FileManager = .default
+    )
+        -> DeveloperApplicationScopeIdentity
+    {
+        let standardizedURL = bundleURL.standardizedFileURL
+        let adapter: DeveloperApplicationSettingsAdapter? = resolvingSettingsAdapter
+            ? ((try? detectedSettingsAdapter(in: standardizedURL, fileManager: fileManager)) ?? nil)
+            : nil
+        return DeveloperApplicationScopeIdentity(
+            bundlePath: standardizedURL.resolvingSymlinksInPath().path,
+            settingsAdapter: adapter
+        )
+    }
+
+    /// Rejects preparation while any running installation owns the same settings scope. Two
+    /// installations of one application family share a single settings directory, so an
+    /// exact bundle-path comparison alone would let Rockxy mutate settings underneath a
+    /// running process. Applications without a recognized adapter keep exact-path behavior.
     @MainActor
     static func isRunning(
         _ installation: DeveloperApplicationInstallation,
         workspace: NSWorkspace = .shared
-    ) -> Bool {
-        workspace.runningApplications.contains { application in
-            guard let bundleURL = application.bundleURL else {
-                return false
-            }
-            return bundleURL.standardizedFileURL.resolvingSymlinksInPath()
-                == installation.appURL.standardizedFileURL.resolvingSymlinksInPath()
+    )
+        -> Bool
+    {
+        let candidate = scopeIdentity(for: installation)
+        let runningInstances = DeveloperApplicationWorkspaceScopeProvider.runningInstances(
+            resolvingSettingsAdapters: candidate.settingsAdapter != nil,
+            workspace: workspace
+        )
+        return DeveloperApplicationScopeResolution.blockingInstance(
+            candidate: candidate,
+            runningInstances: runningInstances
+        ) != nil
+    }
+
+    static func validateContainedPath(
+        _ candidateURL: URL,
+        rootURL: URL,
+        fileManager: FileManager
+    )
+        throws
+    {
+        let root = try canonicalizedURLPreservingMissingSuffix(rootURL, fileManager: fileManager)
+        let candidate = try canonicalizedURLPreservingMissingSuffix(candidateURL, fileManager: fileManager)
+        let rootPath = root.path.hasSuffix("/") ? root.path : root.path + "/"
+        guard candidate.path.hasPrefix(rootPath), candidate.path != root.path else {
+            throw DeveloperApplicationCaptureError.unsafeSettingsLocation
         }
+    }
+
+    static func fileSize(at url: URL, fileManager: FileManager) throws -> UInt64 {
+        let attributes = try fileManager.attributesOfItem(atPath: url.path)
+        guard let size = attributes[.size] as? NSNumber else {
+            throw DeveloperApplicationCaptureError.invalidApplicationMetadata
+        }
+        return size.uint64Value
     }
 
     // MARK: Private
 
-    private struct ApplicationProxyMetadata: Decodable {
-        let productVendor: String
-        let dataDirectoryName: String
-    }
+    private static let proxySelectionOptionNames: Set<String> = [
+        "USE_PROXY_PAC",
+        "USE_HTTP_PROXY",
+        "USE_PAC_URL",
+        "PROXY_TYPE_IS_SOCKS",
+    ]
 
     /// Detects an application-level proxy schema from metadata shipped inside the app bundle.
-    /// Absence is a supported outcome. A file that declares this schema but is malformed fails
-    /// closed because silently launching would misrepresent the preparation Rockxy can perform.
+    /// Absence and partial metadata are supported outcomes: they fall back to the scoped launch
+    /// environment rather than preventing an otherwise valid application from opening.
     private static func detectedSettingsAdapter(
         in appURL: URL,
         fileManager: FileManager = .default
-    ) throws -> DeveloperApplicationSettingsAdapter? {
+    )
+        throws -> DeveloperApplicationSettingsAdapter?
+    {
         let metadataURL = appURL
             .appendingPathComponent("Contents/Resources/product-info.json", isDirectory: false)
         guard fileManager.fileExists(atPath: metadataURL.path) else {
@@ -525,37 +477,49 @@ enum DeveloperApplicationCaptureConfigurator {
             return nil
         }
 
-        let metadata: ApplicationProxyMetadata
-        do {
-            guard let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-                  object["productVendor"] != nil,
-                  object["dataDirectoryName"] != nil
-            else {
-                // `product-info.json` is not a universal schema. An unrelated file with the
-                // same basename is not evidence that this adapter applies.
-                return nil
-            }
-            metadata = try JSONDecoder().decode(ApplicationProxyMetadata.self, from: data)
-        } catch {
-            throw DeveloperApplicationCaptureError.invalidApplicationMetadata
+        guard let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let productVendor = object["productVendor"] as? String,
+              let dataDirectoryName = object["dataDirectoryName"] as? String,
+              let launchEntries = object["launch"] as? [[String: Any]] else
+        {
+            // `product-info.json` is not a universal or version-stable schema. Entries that do
+            // not prove this adapter applies must not block the generic environment-only path.
+            return nil
         }
 
-        guard isSafeDirectoryComponent(metadata.productVendor),
-              isSafeDirectoryComponent(metadata.dataDirectoryName)
-        else {
+        guard isSafeDirectoryComponent(productVendor),
+              isSafeDirectoryComponent(dataDirectoryName) else
+        {
             throw DeveloperApplicationCaptureError.unsafeSettingsLocation
+        }
+        guard launchEntries.contains(where: { entry in
+            guard entry["os"] as? String == "macOS",
+                  let javaExecutablePath = entry["javaExecutablePath"] as? String else
+            {
+                return false
+            }
+            return DeveloperApplicationRuntimeDetector.isContainedExecutable(
+                relativePath: javaExecutablePath,
+                relativeTo: metadataURL.deletingLastPathComponent(),
+                bundleURL: appURL,
+                fileManager: fileManager
+            )
+        }) else {
+            return nil
         }
 
         return .xmlHTTPProxyAutoDetect(
-            vendorDirectory: metadata.productVendor,
-            dataDirectoryName: metadata.dataDirectoryName
+            vendorDirectory: productVendor,
+            dataDirectoryName: dataDirectoryName
         )
     }
 
     private static func detectedLaunchAdapter(
         in appURL: URL,
         fileManager: FileManager = .default
-    ) -> DeveloperApplicationLaunchAdapter? {
+    )
+        -> DeveloperApplicationLaunchAdapter?
+    {
         let frameworksURL = appURL.appendingPathComponent("Contents/Frameworks", isDirectory: true)
         let knownRuntimeFrameworks = [
             "Electron Framework.framework",
@@ -571,30 +535,59 @@ enum DeveloperApplicationCaptureConfigurator {
 
     private static func configureXMLAutoDetect(
         adapter: DeveloperApplicationSettingsAdapter,
+        installation: DeveloperApplicationInstallation,
         applicationSupportURL: URL,
         fileManager: FileManager
-    ) throws -> DeveloperApplicationSettingsPreparation {
+    )
+        throws -> DeveloperApplicationSettingsPreparation
+    {
         let settingsURL = try proxySettingsURL(
             for: adapter,
             applicationSupportURL: applicationSupportURL,
             fileManager: fileManager
         )
-        let backupURL = settingsURL.appendingPathExtension("rockxy-backup")
-        let absenceMarkerURL = settingsURL.appendingPathExtension("rockxy-originally-absent")
-        let preparedSnapshotURL = settingsURL.appendingPathExtension("rockxy-prepared")
         let recoveryRecordURL = try DeveloperApplicationRecoveryLedger.recordURL(
             for: settingsURL,
             applicationSupportURL: applicationSupportURL,
             fileManager: fileManager
         )
+        let recoveryArtifactURLs = recoveryArtifactURLs(for: recoveryRecordURL)
+        let backupURL = recoveryArtifactURLs.backupURL
+        let absenceMarkerURL = recoveryArtifactURLs.absenceMarkerURL
+        let preparedSnapshotURL = recoveryArtifactURLs.preparedSnapshotURL
+        let recoveryDirectoryURL = recoveryRecordURL.deletingLastPathComponent()
+        try fileManager.createDirectory(at: recoveryDirectoryURL, withIntermediateDirectories: true)
         try validateContainedPath(backupURL, rootURL: applicationSupportURL, fileManager: fileManager)
         try validateContainedPath(absenceMarkerURL, rootURL: applicationSupportURL, fileManager: fileManager)
         try validateContainedPath(preparedSnapshotURL, rootURL: applicationSupportURL, fileManager: fileManager)
 
+        // Migrate a transaction created by Rockxy 0.38.x, whose artifacts lived beside the
+        // third-party settings file. New transactions keep their only recovery copy under Rockxy.
+        let legacyBackupURL = settingsURL.appendingPathExtension("rockxy-backup")
+        let legacyAbsenceMarkerURL = settingsURL.appendingPathExtension("rockxy-originally-absent")
+        let legacyPreparedSnapshotURL = settingsURL.appendingPathExtension("rockxy-prepared")
+        if fileManager.fileExists(atPath: legacyBackupURL.path)
+            || fileManager.fileExists(atPath: legacyAbsenceMarkerURL.path)
+            || fileManager.fileExists(atPath: legacyPreparedSnapshotURL.path)
+        {
+            try restoreBackup(
+                settingsURL: settingsURL,
+                backupURL: legacyBackupURL,
+                absenceMarkerURL: legacyAbsenceMarkerURL,
+                preparedSnapshotURL: legacyPreparedSnapshotURL,
+                fileManager: fileManager
+            )
+            try settleRecoveryRecord(recoveryRecordURL, fileManager: fileManager)
+        }
+
         if fileManager.fileExists(atPath: backupURL.path)
             || fileManager.fileExists(atPath: absenceMarkerURL.path)
             || fileManager.fileExists(atPath: preparedSnapshotURL.path)
+            || fileManager.fileExists(atPath: recoveryRecordURL.path)
         {
+            // A record can outlive its artifacts when a completed restore was interrupted before
+            // the ledger entry was removed. `restoreBackup` settles that case without touching
+            // the live settings file, so preparation continues instead of failing permanently.
             try restoreBackup(
                 settingsURL: settingsURL,
                 backupURL: backupURL,
@@ -602,7 +595,7 @@ enum DeveloperApplicationCaptureConfigurator {
                 preparedSnapshotURL: preparedSnapshotURL,
                 fileManager: fileManager
             )
-            try removeIfPresent(recoveryRecordURL, fileManager: fileManager)
+            try settleRecoveryRecord(recoveryRecordURL, fileManager: fileManager)
         }
 
         let document: XMLDocument
@@ -649,8 +642,10 @@ enum DeveloperApplicationCaptureConfigurator {
         try validateContainedPath(settingsURL, rootURL: applicationSupportURL, fileManager: fileManager)
         if let originalData {
             try originalData.write(to: backupURL, options: .atomic)
+            try fileManager.setAttributes([.posixPermissions: 0o600], ofItemAtPath: backupURL.path)
         } else {
             try Data().write(to: absenceMarkerURL, options: .atomic)
+            try fileManager.setAttributes([.posixPermissions: 0o600], ofItemAtPath: absenceMarkerURL.path)
         }
         let preparedData = document.xmlData(options: [.nodePrettyPrint])
         do {
@@ -659,22 +654,29 @@ enum DeveloperApplicationCaptureConfigurator {
             try DeveloperApplicationRecoveryLedger.writeRecord(
                 settingsURL: settingsURL,
                 recordURL: recoveryRecordURL,
+                bundleIdentifier: installation.bundleIdentifier,
+                applicationBundlePath: installation.appURL.path,
                 applicationSupportURL: applicationSupportURL,
                 fileManager: fileManager
             )
             try preparedData.write(to: settingsURL, options: .atomic)
             try preparedData.write(to: preparedSnapshotURL, options: .atomic)
+            try fileManager.setAttributes([.posixPermissions: 0o600], ofItemAtPath: preparedSnapshotURL.path)
         } catch {
             // Once the backup marker exists, preparation is a transaction. A partial disk or
             // permission failure must not leave the selected application on Rockxy's settings.
-            try? restoreBackup(
-                settingsURL: settingsURL,
-                backupURL: backupURL,
-                absenceMarkerURL: absenceMarkerURL,
-                preparedSnapshotURL: preparedSnapshotURL,
-                fileManager: fileManager
-            )
-            try? removeIfPresent(recoveryRecordURL, fileManager: fileManager)
+            do {
+                try restoreBackup(
+                    settingsURL: settingsURL,
+                    backupURL: backupURL,
+                    absenceMarkerURL: absenceMarkerURL,
+                    preparedSnapshotURL: preparedSnapshotURL,
+                    fileManager: fileManager
+                )
+                try settleRecoveryRecord(recoveryRecordURL, fileManager: fileManager)
+            } catch {
+                // Keep every remaining artifact and the durable record for startup recovery.
+            }
             throw error
         }
         return DeveloperApplicationSettingsPreparation(
@@ -682,7 +684,9 @@ enum DeveloperApplicationCaptureConfigurator {
             backupURL: backupURL,
             absenceMarkerURL: absenceMarkerURL,
             preparedSnapshotURL: preparedSnapshotURL,
-            recoveryRecordURL: recoveryRecordURL
+            recoveryRecordURL: recoveryRecordURL,
+            applicationBundlePath: installation.appURL.standardizedFileURL
+                .resolvingSymlinksInPath().path
         )
     }
 
@@ -692,7 +696,22 @@ enum DeveloperApplicationCaptureConfigurator {
         absenceMarkerURL: URL,
         preparedSnapshotURL: URL,
         fileManager: FileManager
-    ) throws {
+    )
+        throws
+    {
+        guard hasAnyRecoveryArtifact(
+            backupURL: backupURL,
+            absenceMarkerURL: absenceMarkerURL,
+            preparedSnapshotURL: preparedSnapshotURL,
+            fileManager: fileManager
+        ) else {
+            // A completed restore already removed every recovery artifact and only the ledger
+            // entry survived, typically because Rockxy was terminated between the two steps.
+            // That entry owns nothing: the caller settles it and the live settings file stays
+            // exactly as the application and the user left it.
+            return
+        }
+
         if fileManager.fileExists(atPath: preparedSnapshotURL.path) {
             guard fileManager.fileExists(atPath: settingsURL.path) else {
                 // The application or user removed the file. That newer choice wins.
@@ -705,12 +724,27 @@ enum DeveloperApplicationCaptureConfigurator {
                 return
             }
 
-            let preparedDocument = try readProxySettingsDocument(at: preparedSnapshotURL, fileManager: fileManager)
+            let preparedDocument: XMLDocument
+            do {
+                preparedDocument = try readProxySettingsDocument(
+                    at: preparedSnapshotURL,
+                    fileManager: fileManager
+                )
+            } catch {
+                let conflictURL = try recoverConflictingLiveSettings(
+                    settingsURL: settingsURL,
+                    backupURL: backupURL,
+                    absenceMarkerURL: absenceMarkerURL,
+                    preparedSnapshotURL: preparedSnapshotURL,
+                    fileManager: fileManager
+                )
+                throw DeveloperApplicationCaptureError.settingsRecoveryConflict(conflictURL.path)
+            }
             let liveDocument: XMLDocument
             do {
                 liveDocument = try readProxySettingsDocument(at: settingsURL, fileManager: fileManager)
             } catch {
-                let conflictURL = try recoverMalformedLiveSettings(
+                let conflictURL = try recoverConflictingLiveSettings(
                     settingsURL: settingsURL,
                     backupURL: backupURL,
                     absenceMarkerURL: absenceMarkerURL,
@@ -776,8 +810,12 @@ enum DeveloperApplicationCaptureConfigurator {
             let originalData = try Data(contentsOf: backupURL, options: [.mappedIfSafe])
             try originalData.write(to: settingsURL, options: .atomic)
             try fileManager.removeItem(at: backupURL)
+            return
         }
-        try removeIfPresent(preparedSnapshotURL, fileManager: fileManager)
+        // A transaction that still owns artifacts but has lost its original/absence artifact
+        // cannot be settled safely. Keep the record and the live settings intact so a later
+        // repair or diagnostic can recover them.
+        throw DeveloperApplicationCaptureError.malformedProxySettings
     }
 
     private static func removeIfPresent(_ url: URL, fileManager: FileManager) throws {
@@ -787,17 +825,20 @@ enum DeveloperApplicationCaptureConfigurator {
         try fileManager.removeItem(at: url)
     }
 
-    /// Resolves a stale transaction whose live file is no longer parseable. The newer bytes are
+    /// Resolves a stale transaction whose snapshots can no longer be compared safely. The live
+    /// bytes are
     /// never discarded: they are moved beside the settings file under a unique conflict name.
     /// Rockxy then restores the exact original (or its original absence) and stops the current
     /// preparation so the user can inspect the conflict before explicitly trying again.
-    private static func recoverMalformedLiveSettings(
+    private static func recoverConflictingLiveSettings(
         settingsURL: URL,
         backupURL: URL,
         absenceMarkerURL: URL,
         preparedSnapshotURL: URL,
         fileManager: FileManager
-    ) throws -> URL {
+    )
+        throws -> URL
+    {
         let originalData: Data?
         if fileManager.fileExists(atPath: backupURL.path) {
             // Validate the recovery source before moving the only live copy out of place.
@@ -830,17 +871,12 @@ enum DeveloperApplicationCaptureConfigurator {
         }
     }
 
-    private static let proxySelectionOptionNames: Set<String> = [
-        "USE_PROXY_PAC",
-        "USE_HTTP_PROXY",
-        "USE_PAC_URL",
-        "PROXY_TYPE_IS_SOCKS",
-    ]
-
     private static func readProxySettingsDocument(
         at url: URL,
         fileManager: FileManager
-    ) throws -> XMLDocument {
+    )
+        throws -> XMLDocument
+    {
         do {
             guard try fileSize(at: url, fileManager: fileManager) <= maximumProxySettingsBytes else {
                 throw DeveloperApplicationCaptureError.malformedProxySettings
@@ -868,8 +904,8 @@ enum DeveloperApplicationCaptureConfigurator {
         var result: [String: Set<String>] = [:]
         for option in component.elements(forName: "option") {
             guard let name = option.attribute(forName: "name")?.stringValue,
-                  proxySelectionOptionNames.contains(name)
-            else {
+                  proxySelectionOptionNames.contains(name) else
+            {
                 continue
             }
             let value = option.attribute(forName: "value")?.stringValue?
@@ -886,7 +922,9 @@ enum DeveloperApplicationCaptureConfigurator {
     private static func restoreProxySelection(
         from originalDocument: XMLDocument,
         into liveDocument: XMLDocument
-    ) throws {
+    )
+        throws
+    {
         try removeProxySelectionOptions(from: liveDocument)
         guard let originalComponent = proxyComponent(in: originalDocument) else {
             return
@@ -895,8 +933,8 @@ enum DeveloperApplicationCaptureConfigurator {
         for option in originalComponent.elements(forName: "option") {
             guard let name = option.attribute(forName: "name")?.stringValue,
                   proxySelectionOptionNames.contains(name),
-                  let copy = option.copy() as? XMLNode
-            else {
+                  let copy = option.copy() as? XMLNode else
+            {
                 continue
             }
             liveComponent?.addChild(copy)
@@ -909,8 +947,8 @@ enum DeveloperApplicationCaptureConfigurator {
         }
         for option in component.elements(forName: "option") {
             guard let name = option.attribute(forName: "name")?.stringValue,
-                  proxySelectionOptionNames.contains(name)
-            else {
+                  proxySelectionOptionNames.contains(name) else
+            {
                 continue
             }
             option.detach()
@@ -927,7 +965,9 @@ enum DeveloperApplicationCaptureConfigurator {
     private static func proxyComponent(
         in document: XMLDocument,
         createIfMissing: Bool = false
-    ) -> XMLElement? {
+    )
+        -> XMLElement?
+    {
         guard let application = document.rootElement() else {
             return nil
         }
@@ -959,45 +999,73 @@ enum DeveloperApplicationCaptureConfigurator {
         absenceMarkerURL: URL,
         preparedSnapshotURL: URL,
         fileManager: FileManager
-    ) throws {
+    )
+        throws
+    {
         try removeIfPresent(backupURL, fileManager: fileManager)
         try removeIfPresent(absenceMarkerURL, fileManager: fileManager)
         try removeIfPresent(preparedSnapshotURL, fileManager: fileManager)
     }
 
-    private static func hasRecoveryArtifacts(
-        _ preparation: DeveloperApplicationSettingsPreparation,
+    private static func hasAnyRecoveryArtifact(
+        backupURL: URL,
+        absenceMarkerURL: URL,
+        preparedSnapshotURL: URL,
         fileManager: FileManager
-    ) -> Bool {
-        [
-            preparation.backupURL,
-            preparation.absenceMarkerURL,
-            preparation.preparedSnapshotURL,
-        ].contains { fileManager.fileExists(atPath: $0.path) }
+    )
+        -> Bool
+    {
+        [backupURL, absenceMarkerURL, preparedSnapshotURL]
+            .contains { fileManager.fileExists(atPath: $0.path) }
     }
 
-    static func validateContainedPath(
-        _ candidateURL: URL,
-        rootURL: URL,
+    /// Removes a ledger entry that no longer owns any recovery artifact, together with the
+    /// bounded restoration-monitor marker derived from it.
+    private static func settleRecoveryRecord(
+        _ recoveryRecordURL: URL,
         fileManager: FileManager
-    ) throws {
-        let root = rootURL.standardizedFileURL.resolvingSymlinksInPath()
-        let candidate = candidateURL.standardizedFileURL.resolvingSymlinksInPath()
-        let rootPath = root.path.hasSuffix("/") ? root.path : root.path + "/"
-        guard candidate.path.hasPrefix(rootPath), candidate.path != root.path else {
-            throw DeveloperApplicationCaptureError.unsafeSettingsLocation
+    )
+        throws
+    {
+        try removeIfPresent(recoveryRecordURL, fileManager: fileManager)
+        DeveloperApplicationRestorationMonitorLedger.removeMarker(
+            for: recoveryRecordURL,
+            fileManager: fileManager
+        )
+    }
+
+    /// Canonicalizes every existing path component while retaining a not-yet-created suffix.
+    /// Foundation can return `/private/var` URLs from directory enumeration but leave a missing
+    /// sibling under `/var`; treating those aliases lexically would reject a valid recovery file.
+    /// Broken symbolic links remain unsafe because a later target could escape the trusted root.
+    private static func canonicalizedURLPreservingMissingSuffix(
+        _ url: URL,
+        fileManager: FileManager
+    )
+        throws -> URL
+    {
+        var existingURL = url.standardizedFileURL
+        var missingComponents: [String] = []
+
+        while !fileManager.fileExists(atPath: existingURL.path) {
+            var information = stat()
+            if lstat(existingURL.path, &information) == 0,
+               information.st_mode & S_IFMT == S_IFLNK
+            {
+                throw DeveloperApplicationCaptureError.unsafeSettingsLocation
+            }
+            guard existingURL.path != "/" else {
+                break
+            }
+            missingComponents.append(existingURL.lastPathComponent)
+            existingURL.deleteLastPathComponent()
         }
 
-        var existingAncestor = candidateURL.deletingLastPathComponent()
-        while existingAncestor.path != rootURL.path,
-              !fileManager.fileExists(atPath: existingAncestor.path)
-        {
-            existingAncestor.deleteLastPathComponent()
+        var canonicalURL = existingURL.resolvingSymlinksInPath().standardizedFileURL
+        for component in missingComponents.reversed() {
+            canonicalURL.appendPathComponent(component, isDirectory: false)
         }
-        let resolvedAncestor = existingAncestor.standardizedFileURL.resolvingSymlinksInPath()
-        guard resolvedAncestor.path == root.path || resolvedAncestor.path.hasPrefix(rootPath) else {
-            throw DeveloperApplicationCaptureError.unsafeSettingsLocation
-        }
+        return canonicalURL.standardizedFileURL
     }
 
     private static func isSafeDirectoryComponent(_ value: String) -> Bool {
@@ -1011,14 +1079,6 @@ enum DeveloperApplicationCaptureConfigurator {
             && !trimmed.contains(":")
             && !trimmed.contains("\0")
             && trimmed.rangeOfCharacter(from: .controlCharacters) == nil
-    }
-
-    static func fileSize(at url: URL, fileManager: FileManager) throws -> UInt64 {
-        let attributes = try fileManager.attributesOfItem(atPath: url.path)
-        guard let size = attributes[.size] as? NSNumber else {
-            throw DeveloperApplicationCaptureError.invalidApplicationMetadata
-        }
-        return size.uint64Value
     }
 
     private static func setOption(name: String, value: String, in component: XMLElement) {
@@ -1052,204 +1112,6 @@ enum DeveloperApplicationCaptureConfigurator {
             option.attribute(forName: "name")?.stringValue == name
         {
             option.detach()
-        }
-    }
-}
-
-// MARK: - DeveloperApplicationCaptureWorkflow
-
-enum DeveloperApplicationCaptureOutcome: Equatable {
-    case prepared(displayName: String, restorationMonitorActive: Bool)
-    case explicitProxyLaunch(displayName: String)
-    case environmentOnly(displayName: String)
-}
-
-/// Coordinates one reversible application preparation and launch. Keeping this workflow outside
-/// the setup view model makes the capability boundary independently testable and keeps UI state
-/// updates separate from filesystem and process lifecycle work.
-@MainActor
-struct DeveloperApplicationCaptureWorkflow {
-    let launcher: DeveloperApplicationLaunching
-    let restorationMonitor: DeveloperApplicationSettingsRestorationMonitoring
-    let preparationRegistry: DeveloperApplicationPreparationRegistry
-    let applicationIsRunning: @MainActor (DeveloperApplicationInstallation) -> Bool
-    let applicationSupportURL: URL
-
-    func open(
-        appURL: URL,
-        context: RockxySetupScriptContext,
-        systemProxyConfigured: Bool
-    ) async throws -> DeveloperApplicationCaptureOutcome {
-        let installation = try DeveloperApplicationCaptureConfigurator.installation(at: appURL)
-        try validate(installation, systemProxyConfigured: systemProxyConfigured)
-
-        let preparationKey = try settingsURL(for: installation)?.standardizedFileURL.path
-        if let preparationKey, !preparationRegistry.begin(preparationKey) {
-            throw DeveloperApplicationCaptureError.preparationInProgress(installation.displayName)
-        }
-        defer {
-            if let preparationKey {
-                preparationRegistry.end(preparationKey)
-            }
-        }
-
-        let preparation = try await prepareSettings(for: installation)
-        return try await launch(installation, preparation: preparation, context: context)
-    }
-
-    private func validate(
-        _ installation: DeveloperApplicationInstallation,
-        systemProxyConfigured: Bool
-    ) throws {
-        guard !applicationIsRunning(installation) else {
-            throw DeveloperApplicationCaptureError.applicationIsRunning(installation.displayName)
-        }
-        if installation.settingsAdapter?.requiresSystemProxy == true, !systemProxyConfigured {
-            throw DeveloperApplicationCaptureError.systemProxyRequired(installation.displayName)
-        }
-    }
-
-    private func settingsURL(for installation: DeveloperApplicationInstallation) throws -> URL? {
-        try installation.settingsAdapter.map {
-            try DeveloperApplicationCaptureConfigurator.proxySettingsURL(
-                for: $0,
-                applicationSupportURL: applicationSupportURL
-            )
-        }
-    }
-
-    private func prepareSettings(
-        for installation: DeveloperApplicationInstallation
-    ) async throws -> DeveloperApplicationSettingsPreparation? {
-        let applicationSupportURL = self.applicationSupportURL
-        return try await Task.detached {
-            try DeveloperApplicationCaptureConfigurator.prepareRecognizedSettings(
-                for: installation,
-                applicationSupportURL: applicationSupportURL
-            )
-        }.value
-    }
-
-    private func launch(
-        _ installation: DeveloperApplicationInstallation,
-        preparation: DeveloperApplicationSettingsPreparation?,
-        context: RockxySetupScriptContext
-    ) async throws -> DeveloperApplicationCaptureOutcome {
-        let arguments = installation.launchAdapter?.arguments(context: context) ?? []
-        let environment = DeveloperCaptureEnvironmentBuilder.environment(
-            context: context,
-            baseEnvironment: DeveloperCaptureEnvironmentBuilder.safeInheritedEnvironment(),
-            includeJavaProxyProperties: installation.settingsAdapter?.requiresJavaProxyProperties
-        )
-        let applicationSupportURL = self.applicationSupportURL
-        let terminationCallback = preparation.map {
-            Self.settingsRestorationCallback(
-                $0,
-                applicationSupportURL: applicationSupportURL
-            )
-        }
-
-        do {
-            let processIdentifier = try await launcher.launch(
-                installation,
-                arguments: arguments,
-                environment: environment,
-                onTermination: terminationCallback
-            )
-            guard let preparation else {
-                if installation.launchAdapter != nil {
-                    return .explicitProxyLaunch(displayName: installation.displayName)
-                }
-                return .environmentOnly(displayName: installation.displayName)
-            }
-            await associateRunningProcess(
-                processIdentifier: processIdentifier,
-                preparation: preparation
-            )
-            let monitorActive = startRestorationMonitor(
-                processIdentifier: processIdentifier,
-                preparation: preparation
-            )
-            return .prepared(
-                displayName: installation.displayName,
-                restorationMonitorActive: monitorActive
-            )
-        } catch {
-            if let preparation {
-                await Task.detached(priority: .utility) {
-                    Self.restoreSettings(preparation, applicationSupportURL: applicationSupportURL)
-                }.value
-            }
-            throw error
-        }
-    }
-
-    private func startRestorationMonitor(
-        processIdentifier: Int32,
-        preparation: DeveloperApplicationSettingsPreparation
-    ) -> Bool {
-        do {
-            try restorationMonitor.startMonitoring(
-                processIdentifier: processIdentifier,
-                preparation: preparation
-            )
-            return true
-        } catch {
-            developerApplicationCaptureLogger.error(
-                "Could not start the developer-application settings restoration monitor: \(error.localizedDescription)"
-            )
-            return false
-        }
-    }
-
-    private func associateRunningProcess(
-        processIdentifier: Int32,
-        preparation: DeveloperApplicationSettingsPreparation
-    ) async {
-        let applicationSupportURL = self.applicationSupportURL
-        do {
-            try await Task.detached(priority: .utility) {
-                let startSignature = DeveloperApplicationCaptureConfigurator.processStartSignature(
-                    processIdentifier: processIdentifier
-                )
-                try DeveloperApplicationCaptureConfigurator.associateRunningProcess(
-                    processIdentifier: processIdentifier,
-                    processStartSignature: startSignature,
-                    with: preparation,
-                    applicationSupportURL: applicationSupportURL
-                )
-            }.value
-        } catch {
-            developerApplicationCaptureLogger.error(
-                "Could not associate the launched application with its recovery record: \(error.localizedDescription)"
-            )
-        }
-    }
-
-    nonisolated private static func settingsRestorationCallback(
-        _ preparation: DeveloperApplicationSettingsPreparation,
-        applicationSupportURL: URL
-    ) -> @MainActor @Sendable () -> Void {
-        {
-            Task.detached {
-                restoreSettings(preparation, applicationSupportURL: applicationSupportURL)
-            }
-        }
-    }
-
-    nonisolated private static func restoreSettings(
-        _ preparation: DeveloperApplicationSettingsPreparation,
-        applicationSupportURL: URL
-    ) {
-        do {
-            try DeveloperApplicationCaptureConfigurator.restoreRecognizedSettings(
-                preparation,
-                applicationSupportURL: applicationSupportURL
-            )
-        } catch {
-            developerApplicationCaptureLogger.error(
-                "Could not restore temporary developer-application proxy settings: \(error.localizedDescription)"
-            )
         }
     }
 }

--- a/Rockxy/Models/UI/DeveloperApplicationCaptureWorkflow.swift
+++ b/Rockxy/Models/UI/DeveloperApplicationCaptureWorkflow.swift
@@ -1,0 +1,435 @@
+import Foundation
+import os
+
+// One reversible developer-application preparation and launch, plus the restart-aware settlement
+// that decides whether an exited application should be restored or followed to its successor.
+
+nonisolated private let developerApplicationWorkflowLogger = Logger(
+    subsystem: RockxyIdentity.current.logSubsystem,
+    category: "DeveloperApplicationCaptureWorkflow"
+)
+
+// MARK: - DeveloperApplicationCaptureOutcome
+
+enum DeveloperApplicationCaptureOutcome: Equatable {
+    case prepared(displayName: String, restorationMonitorActive: Bool)
+    case explicitProxyLaunch(displayName: String)
+    case environmentOnly(displayName: String)
+    case launchPending(displayName: String, restorationMonitorActive: Bool)
+}
+
+// MARK: - DeveloperApplicationTransactionSettlement
+
+enum DeveloperApplicationTransactionSettlement: Equatable, Sendable {
+    case restored
+    case reboundToSuccessor(processIdentifier: Int32)
+}
+
+// MARK: - DeveloperApplicationTransactionSettler
+
+/// Decides what happens to one durable settings transaction once the launched application exits.
+///
+/// A normal quit restores the original settings exactly as before. An in-place restart or self
+/// update is different: the application replaces itself and a successor keeps running from the
+/// same bundle or settings scope. Restoring then would strip the settings the user asked Rockxy
+/// to prepare, so the transaction is rebound to the successor and monitored there instead.
+///
+/// Ownership is explicit. This in-process settlement runs first with a short bounded window and
+/// is the only writer during that window; the out-of-process monitor waits strictly longer, so it
+/// observes the result of this decision — a removed prepared snapshot or a rebound record — and
+/// never settles the same transaction a second time.
+@MainActor
+final class DeveloperApplicationTransactionSettler {
+    // MARK: Lifecycle
+
+    init(
+        scope: DeveloperApplicationScopeIdentity,
+        preparation: DeveloperApplicationSettingsPreparation,
+        applicationSupportURL: URL,
+        restorationMonitor: any DeveloperApplicationSettingsRestorationMonitoring,
+        runningInstances: (@MainActor () -> [DeveloperApplicationRunningInstance])? = nil,
+        successorScanAttempts: Int = 16,
+        successorScanInterval: Duration = .milliseconds(250)
+    ) {
+        self.scope = scope
+        self.preparation = preparation
+        self.applicationSupportURL = applicationSupportURL
+        self.restorationMonitor = restorationMonitor
+        if let runningInstances {
+            self.runningInstances = runningInstances
+        } else {
+            let resolvesSettingsAdapters = scope.settingsAdapter != nil
+            self.runningInstances = {
+                DeveloperApplicationWorkspaceScopeProvider.runningInstances(
+                    resolvingSettingsAdapters: resolvesSettingsAdapters
+                )
+            }
+        }
+        self.successorScanAttempts = max(1, successorScanAttempts)
+        self.successorScanInterval = successorScanInterval
+    }
+
+    // MARK: Internal
+
+    private(set) var settlement: DeveloperApplicationTransactionSettlement?
+
+    /// Restores the original settings without any successor handling.
+    nonisolated static func restoreSettings(
+        _ preparation: DeveloperApplicationSettingsPreparation,
+        applicationSupportURL: URL
+    ) {
+        do {
+            try DeveloperApplicationCaptureConfigurator.restoreRecognizedSettings(
+                preparation,
+                applicationSupportURL: applicationSupportURL
+            )
+        } catch {
+            developerApplicationWorkflowLogger.error(
+                "Could not restore temporary developer-application proxy settings: \(error.localizedDescription)"
+            )
+        }
+    }
+
+    /// Records the process identity of the launched instance, so a stale listing of that exact
+    /// process can never be mistaken for its successor.
+    func bindLaunchedProcess(_ processIdentifier: Int32) {
+        guard processIdentifier > 0 else {
+            return
+        }
+        launchedProcessIdentifier = processIdentifier
+    }
+
+    /// Settles the transaction after the launch supervisor reported a clean application exit.
+    func settleAfterApplicationExit() async {
+        guard settlement == nil, !isSettling else {
+            return
+        }
+        isSettling = true
+        defer { isSettling = false }
+
+        if let successor = await waitForSuccessor() {
+            await rebind(to: successor)
+            settlement = .reboundToSuccessor(processIdentifier: successor.processIdentifier)
+            return
+        }
+
+        let preparation = self.preparation
+        let applicationSupportURL = self.applicationSupportURL
+        await Task.detached(priority: .utility) {
+            Self.restoreSettings(preparation, applicationSupportURL: applicationSupportURL)
+        }.value
+        settlement = .restored
+    }
+
+    // MARK: Private
+
+    private let scope: DeveloperApplicationScopeIdentity
+    private let preparation: DeveloperApplicationSettingsPreparation
+    private let applicationSupportURL: URL
+    private let restorationMonitor: any DeveloperApplicationSettingsRestorationMonitoring
+    private let runningInstances: @MainActor () -> [DeveloperApplicationRunningInstance]
+    private let successorScanAttempts: Int
+    private let successorScanInterval: Duration
+    private var launchedProcessIdentifier: Int32?
+    private var isSettling = false
+
+    /// Bounded wait so a self update that takes a moment to relaunch is still recognized while a
+    /// normal quit is never delayed indefinitely.
+    private func waitForSuccessor() async -> DeveloperApplicationRunningInstance? {
+        for attempt in 0 ..< successorScanAttempts {
+            if let successor = DeveloperApplicationScopeResolution.successor(
+                candidate: scope,
+                excludingProcessIdentifier: launchedProcessIdentifier,
+                runningInstances: runningInstances()
+            ) {
+                return successor
+            }
+            if attempt < successorScanAttempts - 1 {
+                try? await Task.sleep(for: successorScanInterval)
+            }
+        }
+        return nil
+    }
+
+    private func rebind(to successor: DeveloperApplicationRunningInstance) async {
+        let preparation = self.preparation
+        let applicationSupportURL = self.applicationSupportURL
+        let processIdentifier = successor.processIdentifier
+        do {
+            try await Task.detached(priority: .utility) {
+                // The start signature keeps identity exact: `associateRunningProcess` records the
+                // successor's identifier only when that signature can be proven.
+                let startSignature = DeveloperApplicationCaptureConfigurator.processStartSignature(
+                    processIdentifier: processIdentifier
+                )
+                try DeveloperApplicationCaptureConfigurator.associateRunningProcess(
+                    processIdentifier: processIdentifier,
+                    processStartSignature: startSignature,
+                    with: preparation,
+                    applicationSupportURL: applicationSupportURL
+                )
+            }.value
+        } catch {
+            developerApplicationWorkflowLogger.error(
+                "Could not rebind a developer-application settings transaction to the successor process: \(error.localizedDescription)"
+            )
+        }
+        do {
+            try restorationMonitor.startMonitoring(
+                processIdentifier: processIdentifier,
+                preparation: preparation
+            )
+        } catch {
+            developerApplicationWorkflowLogger.error(
+                "Could not monitor the successor of a prepared developer application: \(error.localizedDescription)"
+            )
+        }
+    }
+}
+
+// MARK: - DeveloperApplicationCaptureWorkflow
+
+/// Coordinates one reversible application preparation and launch. Keeping this workflow outside
+/// the setup view model makes the capability boundary independently testable and keeps UI state
+/// updates separate from filesystem and process lifecycle work.
+@MainActor
+struct DeveloperApplicationCaptureWorkflow {
+    // MARK: Internal
+
+    let launcher: DeveloperApplicationLaunching
+    let restorationMonitor: DeveloperApplicationSettingsRestorationMonitoring
+    let preparationRegistry: DeveloperApplicationPreparationRegistry
+    let applicationIsRunning: @MainActor (DeveloperApplicationInstallation) -> Bool
+    let applicationSupportURL: URL
+
+    func open(
+        appURL: URL,
+        context: RockxySetupScriptContext,
+        systemProxyConfigured: Bool
+    )
+        async throws -> DeveloperApplicationCaptureOutcome
+    {
+        let installation = try DeveloperApplicationCaptureConfigurator.installation(at: appURL)
+        try validate(installation, systemProxyConfigured: systemProxyConfigured)
+
+        let preparationKey = try settingsURL(for: installation)?.standardizedFileURL.path
+        if let preparationKey, !preparationRegistry.begin(preparationKey) {
+            throw DeveloperApplicationCaptureError.preparationInProgress(installation.displayName)
+        }
+        defer {
+            if let preparationKey {
+                preparationRegistry.end(preparationKey)
+            }
+        }
+
+        let preparation = try await prepareSettings(for: installation)
+        return try await launch(installation, preparation: preparation, context: context)
+    }
+
+    // MARK: Private
+
+    private func validate(
+        _ installation: DeveloperApplicationInstallation,
+        systemProxyConfigured: Bool
+    )
+        throws
+    {
+        guard !applicationIsRunning(installation) else {
+            throw DeveloperApplicationCaptureError.applicationIsRunning(installation.displayName)
+        }
+        if installation.settingsAdapter?.requiresSystemProxy == true, !systemProxyConfigured {
+            throw DeveloperApplicationCaptureError.systemProxyRequired(installation.displayName)
+        }
+    }
+
+    private func settingsURL(for installation: DeveloperApplicationInstallation) throws -> URL? {
+        try installation.settingsAdapter.map {
+            try DeveloperApplicationCaptureConfigurator.proxySettingsURL(
+                for: $0,
+                applicationSupportURL: applicationSupportURL
+            )
+        }
+    }
+
+    private func prepareSettings(
+        for installation: DeveloperApplicationInstallation
+    )
+        async throws -> DeveloperApplicationSettingsPreparation?
+    {
+        let applicationSupportURL = self.applicationSupportURL
+        return try await Task.detached {
+            try DeveloperApplicationCaptureConfigurator.prepareRecognizedSettings(
+                for: installation,
+                applicationSupportURL: applicationSupportURL
+            )
+        }.value
+    }
+
+    private func launch(
+        _ installation: DeveloperApplicationInstallation,
+        preparation: DeveloperApplicationSettingsPreparation?,
+        context: RockxySetupScriptContext
+    )
+        async throws -> DeveloperApplicationCaptureOutcome
+    {
+        let arguments = installation.launchAdapter?.arguments(context: context) ?? []
+        let environment = DeveloperCaptureEnvironmentBuilder.environment(
+            context: context,
+            baseEnvironment: DeveloperCaptureEnvironmentBuilder.safeInheritedEnvironment(),
+            includeJavaProxyProperties: context.targetID == .javaVMs
+                || installation.runtimeCapabilities.contains(.javaVirtualMachine)
+        )
+        let applicationSupportURL = self.applicationSupportURL
+        let settler = makeSettler(for: preparation, installation: installation)
+        let terminationCallback = makeTerminationCallback(for: settler)
+
+        do {
+            let receipt = try await launcher.launch(
+                installation,
+                arguments: arguments,
+                environment: environment,
+                onTermination: terminationCallback
+            )
+            guard let preparation else {
+                if receipt.registrationState == .pending {
+                    return .launchPending(
+                        displayName: installation.displayName,
+                        restorationMonitorActive: false
+                    )
+                }
+                if installation.launchAdapter != nil {
+                    return .explicitProxyLaunch(displayName: installation.displayName)
+                }
+                return .environmentOnly(displayName: installation.displayName)
+            }
+            guard let processIdentifier = receipt.registeredProcessIdentifier else {
+                // LaunchServices accepted the request but macOS has not registered the app yet.
+                // `/usr/bin/open -W` remains alive for the launched app's lifetime, so bind the
+                // durable transaction to that exact supervisor identity until startup recovery
+                // can discover the real bundle process. This closes the crash window between a
+                // slow first launch and application registration without guessing by app name.
+                let lifecycleProcessIdentifier = receipt.lifecycleProcessIdentifier
+                settler?.bindLaunchedProcess(lifecycleProcessIdentifier)
+                await associateRunningProcess(
+                    processIdentifier: lifecycleProcessIdentifier,
+                    preparation: preparation
+                )
+                let monitorActive = startRestorationMonitor(
+                    processIdentifier: lifecycleProcessIdentifier,
+                    preparation: preparation
+                )
+                return .launchPending(
+                    displayName: installation.displayName,
+                    restorationMonitorActive: monitorActive
+                )
+            }
+            settler?.bindLaunchedProcess(processIdentifier)
+            await associateRunningProcess(
+                processIdentifier: processIdentifier,
+                preparation: preparation
+            )
+            let monitorActive = startRestorationMonitor(
+                processIdentifier: processIdentifier,
+                preparation: preparation
+            )
+            if receipt.registrationState == .pending {
+                return .launchPending(
+                    displayName: installation.displayName,
+                    restorationMonitorActive: monitorActive
+                )
+            }
+            return .prepared(
+                displayName: installation.displayName,
+                restorationMonitorActive: monitorActive
+            )
+        } catch {
+            if let preparation {
+                await Task.detached(priority: .utility) {
+                    DeveloperApplicationTransactionSettler.restoreSettings(
+                        preparation,
+                        applicationSupportURL: applicationSupportURL
+                    )
+                }.value
+            }
+            throw error
+        }
+    }
+
+    private func makeSettler(
+        for preparation: DeveloperApplicationSettingsPreparation?,
+        installation: DeveloperApplicationInstallation
+    )
+        -> DeveloperApplicationTransactionSettler?
+    {
+        guard let preparation else {
+            return nil
+        }
+        return DeveloperApplicationTransactionSettler(
+            scope: DeveloperApplicationCaptureConfigurator.scopeIdentity(for: installation),
+            preparation: preparation,
+            applicationSupportURL: applicationSupportURL,
+            restorationMonitor: restorationMonitor
+        )
+    }
+
+    private func makeTerminationCallback(
+        for settler: DeveloperApplicationTransactionSettler?
+    )
+        -> (@MainActor @Sendable () -> Void)?
+    {
+        guard let settler else {
+            return nil
+        }
+        return {
+            Task { @MainActor in
+                await settler.settleAfterApplicationExit()
+            }
+        }
+    }
+
+    private func startRestorationMonitor(
+        processIdentifier: Int32,
+        preparation: DeveloperApplicationSettingsPreparation
+    )
+        -> Bool
+    {
+        do {
+            try restorationMonitor.startMonitoring(
+                processIdentifier: processIdentifier,
+                preparation: preparation
+            )
+            return true
+        } catch {
+            developerApplicationWorkflowLogger.error(
+                "Could not start the developer-application settings restoration monitor: \(error.localizedDescription)"
+            )
+            return false
+        }
+    }
+
+    private func associateRunningProcess(
+        processIdentifier: Int32,
+        preparation: DeveloperApplicationSettingsPreparation
+    )
+        async
+    {
+        let applicationSupportURL = self.applicationSupportURL
+        do {
+            try await Task.detached(priority: .utility) {
+                let startSignature = DeveloperApplicationCaptureConfigurator.processStartSignature(
+                    processIdentifier: processIdentifier
+                )
+                try DeveloperApplicationCaptureConfigurator.associateRunningProcess(
+                    processIdentifier: processIdentifier,
+                    processStartSignature: startSignature,
+                    with: preparation,
+                    applicationSupportURL: applicationSupportURL
+                )
+            }.value
+        } catch {
+            developerApplicationWorkflowLogger.error(
+                "Could not associate the launched application with its recovery record: \(error.localizedDescription)"
+            )
+        }
+    }
+}

--- a/Rockxy/Models/UI/DeveloperApplicationLaunchErrorCapture.swift
+++ b/Rockxy/Models/UI/DeveloperApplicationLaunchErrorCapture.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+/// Drains a long-lived LaunchServices supervisor's stderr without allowing it to block on a full
+/// pipe. Only a bounded prefix is retained for a useful failure message.
+final class DeveloperApplicationLaunchErrorCapture: @unchecked Sendable {
+    var capturedData: Data {
+        lock.lock()
+        defer { lock.unlock() }
+        return data
+    }
+
+    func startDraining(_ handle: FileHandle) {
+        completion.enter()
+        DispatchQueue.global(qos: .utility).async { [self] in
+            defer { completion.leave() }
+            while true {
+                let chunk = handle.readData(ofLength: 4_096)
+                guard !chunk.isEmpty else {
+                    return
+                }
+                lock.lock()
+                if data.count < Self.maximumCapturedBytes {
+                    data.append(contentsOf: chunk.prefix(Self.maximumCapturedBytes - data.count))
+                }
+                lock.unlock()
+            }
+        }
+    }
+
+    func waitForDrain() {
+        _ = completion.wait(timeout: .now() + .seconds(1))
+    }
+
+    private static let maximumCapturedBytes = 4_096
+    private let lock = NSLock()
+    private let completion = DispatchGroup()
+    private var data = Data()
+}

--- a/Rockxy/Models/UI/DeveloperApplicationLaunchLifecycle.swift
+++ b/Rockxy/Models/UI/DeveloperApplicationLaunchLifecycle.swift
@@ -1,0 +1,162 @@
+import AppKit
+import Foundation
+
+// Launch lifecycle for user-selected developer applications: how Rockxy opens a fresh instance
+// with a scoped environment and how it learns that the instance registered with macOS or exited.
+
+// MARK: - DeveloperApplicationRegistrationState
+
+enum DeveloperApplicationRegistrationState: Equatable, Sendable {
+    case registered
+    case pending
+}
+
+// MARK: - DeveloperApplicationLaunchReceipt
+
+struct DeveloperApplicationLaunchReceipt: Equatable, Sendable {
+    let lifecycleProcessIdentifier: Int32
+    let registeredProcessIdentifier: Int32?
+    let registrationState: DeveloperApplicationRegistrationState
+}
+
+// MARK: - DeveloperApplicationLaunching
+
+@MainActor
+protocol DeveloperApplicationLaunching {
+    @discardableResult
+    func launch(
+        _ installation: DeveloperApplicationInstallation,
+        arguments: [String],
+        environment: [String: String],
+        onTermination: (@MainActor @Sendable () -> Void)?
+    )
+        async throws -> DeveloperApplicationLaunchReceipt
+}
+
+// MARK: - DeveloperApplicationWorkspaceLauncher
+
+/// Launches a fresh application instance with a scoped environment via LaunchServices.
+///
+/// `NSWorkspace.OpenConfiguration.environment` is additive to the caller's environment. Running
+/// `/usr/bin/open` with an explicit `Process.environment` first prevents unrelated credentials and
+/// developer-shell state from leaking into the selected application while retaining normal macOS
+/// application registration and activation.
+@MainActor
+struct DeveloperApplicationWorkspaceLauncher: DeveloperApplicationLaunching {
+    // MARK: Internal
+
+    @discardableResult
+    func launch(
+        _ installation: DeveloperApplicationInstallation,
+        arguments: [String],
+        environment: [String: String],
+        onTermination: (@MainActor @Sendable () -> Void)?
+    )
+        async throws -> DeveloperApplicationLaunchReceipt
+    {
+        let launchStartedAt = Date()
+        let process = Process()
+        let errorPipe = Pipe()
+        let environmentArguments = environment.keys.sorted().flatMap { key in
+            ["--env", "\(key)=\(environment[key] ?? "")"]
+        }
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/open")
+        process.arguments = ["-W", "-n"] + environmentArguments + [installation.appURL.path]
+            + (arguments.isEmpty ? [] : ["--args"] + arguments)
+        process.environment = environment
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = errorPipe
+
+        try process.run()
+        errorPipe.fileHandleForWriting.closeFile()
+        let errorCapture = DeveloperApplicationLaunchErrorCapture()
+        errorCapture.startDraining(errorPipe.fileHandleForReading)
+        let registration = try await registration(
+            installation: installation,
+            launchStartedAt: launchStartedAt,
+            supervisor: process,
+            errorCapture: errorCapture
+        )
+        let processIdentifier = process.processIdentifier
+        if let onTermination {
+            installTerminationHandler(on: process, callback: onTermination)
+        }
+        return DeveloperApplicationLaunchReceipt(
+            lifecycleProcessIdentifier: processIdentifier,
+            registeredProcessIdentifier: registration.processIdentifier,
+            registrationState: registration.state
+        )
+    }
+
+    // MARK: Private
+
+    private struct Registration {
+        let state: DeveloperApplicationRegistrationState
+        let processIdentifier: Int32?
+    }
+
+    private func registration(
+        installation: DeveloperApplicationInstallation,
+        launchStartedAt: Date,
+        supervisor: Process,
+        errorCapture: DeveloperApplicationLaunchErrorCapture
+    )
+        async throws -> Registration
+    {
+        let expectedURL = installation.appURL.standardizedFileURL.resolvingSymlinksInPath()
+        for _ in 0 ..< 200 {
+            if let application = NSWorkspace.shared.runningApplications.first(where: { application in
+                guard !application.isTerminated,
+                      let bundleURL = application.bundleURL,
+                      bundleURL.standardizedFileURL.resolvingSymlinksInPath() == expectedURL else
+                {
+                    return false
+                }
+                return application.launchDate.map { $0 >= launchStartedAt.addingTimeInterval(-1) } ?? true
+            }) {
+                return Registration(state: .registered, processIdentifier: application.processIdentifier)
+            }
+            if !supervisor.isRunning {
+                supervisor.waitUntilExit()
+                errorCapture.waitForDrain()
+                let message = String(data: errorCapture.capturedData, encoding: .utf8)?
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+                throw DeveloperSetupLaunchError.processFailed(
+                    command: installation.displayName,
+                    status: supervisor.terminationStatus,
+                    message: message?.isEmpty == false
+                        ? message
+                        : "The application exited before registering with macOS."
+                )
+            }
+            try? await Task.sleep(for: .milliseconds(50))
+        }
+        // Gatekeeper, first-run verification, and remote filesystems can legitimately take longer
+        // than the bounded UI wait. The workflow binds durable recovery to this still-running
+        // `open -W` lifecycle supervisor until startup reconciliation can discover the app itself.
+        return Registration(state: .pending, processIdentifier: nil)
+    }
+
+    private func installTerminationHandler(
+        on process: Process,
+        callback: @escaping @MainActor @Sendable () -> Void
+    ) {
+        process.terminationHandler = { [process] _ in
+            process.terminationHandler = nil
+            guard process.terminationReason == .exit, process.terminationStatus == 0 else {
+                // A killed or failed supervisor is not proof that the launched application quit.
+                // Preserve the durable record for app-identity reconciliation on next startup.
+                return
+            }
+            Task { @MainActor in
+                callback()
+            }
+        }
+        if !process.isRunning {
+            process.terminationHandler = nil
+            if process.terminationReason == .exit, process.terminationStatus == 0 {
+                callback()
+            }
+        }
+    }
+}

--- a/Rockxy/Models/UI/DeveloperApplicationRecoveryLedger.swift
+++ b/Rockxy/Models/UI/DeveloperApplicationRecoveryLedger.swift
@@ -1,4 +1,5 @@
 import Crypto
+import Darwin
 import Foundation
 import os
 
@@ -7,9 +8,12 @@ nonisolated private let developerApplicationRecoveryLogger = Logger(
     category: "DeveloperApplicationRecovery"
 )
 
+// MARK: - DeveloperApplicationRecoveryLedger
+
 /// Durable transaction index for third-party settings temporarily prepared by Rockxy.
-/// Record paths are derived from a relative Application Support path and bound to its digest;
-/// the ledger never accepts an absolute or escaping recovery target.
+/// Recovery targets are derived from a relative Application Support path and bound to its digest.
+/// An absolute application-bundle path is retained only as process identity evidence and is never
+/// used as a filesystem mutation target.
 enum DeveloperApplicationRecoveryLedger {
     // MARK: Internal
 
@@ -21,8 +25,12 @@ enum DeveloperApplicationRecoveryLedger {
         applicationSupportURL: URL,
         fileManager: FileManager,
         preparationRegistry: DeveloperApplicationPreparationRegistry,
-        recordedProcessIsAlive: (Int32, String?) -> Bool
-    ) -> Int {
+        recordedProcessIsAlive: (Int32, String?) -> Bool,
+        recordedApplicationProcessIdentifier: ((String, String) -> Int32?)? = nil,
+        livePreparationHandler: ((Int32, DeveloperApplicationSettingsPreparation) -> Void)? = nil
+    )
+        -> Int
+    {
         let directoryURL = recoveryDirectoryURL(applicationSupportURL: applicationSupportURL)
         do {
             try DeveloperApplicationCaptureConfigurator.validateContainedPath(
@@ -45,8 +53,8 @@ enum DeveloperApplicationRecoveryLedger {
                 )
             }
             let recordURLs = allRecordURLs
-            .sorted { $0.lastPathComponent < $1.lastPathComponent }
-            .prefix(maximumRecords)
+                .sorted { $0.lastPathComponent < $1.lastPathComponent }
+                .prefix(maximumRecords)
 
             var reconciledCount = 0
             for recordURL in recordURLs {
@@ -63,12 +71,36 @@ enum DeveloperApplicationRecoveryLedger {
                         continue
                     }
                     defer { preparationRegistry.end(key) }
-                    if let processIdentifier = outstanding.record.processIdentifier,
-                       recordedProcessIsAlive(
-                           processIdentifier,
-                           outstanding.record.processStartSignature
-                       )
+                    let recordedProcessIdentifier = outstanding.record.processIdentifier
+                    let recordedProcessIsStillAlive = recordedProcessIdentifier.map {
+                        recordedProcessIsAlive($0, outstanding.record.processStartSignature)
+                    } ?? false
+                    var relaunchedProcessIdentifier: Int32?
+                    if !recordedProcessIsStillAlive,
+                       let bundleIdentifier = outstanding.record.bundleIdentifier,
+                       let applicationBundlePath = outstanding.record.applicationBundlePath
                     {
+                        relaunchedProcessIdentifier = recordedApplicationProcessIdentifier?(
+                            bundleIdentifier,
+                            applicationBundlePath
+                        )
+                    }
+                    if let liveProcessIdentifier = recordedProcessIsStillAlive
+                        ? recordedProcessIdentifier
+                        : relaunchedProcessIdentifier
+                    {
+                        if !recordedProcessIsStillAlive {
+                            try associateRunningProcess(
+                                processIdentifier: liveProcessIdentifier,
+                                processStartSignature: processStartSignature(
+                                    processIdentifier: liveProcessIdentifier
+                                ),
+                                with: preparation,
+                                applicationSupportURL: applicationSupportURL,
+                                fileManager: fileManager
+                            )
+                        }
+                        livePreparationHandler?(liveProcessIdentifier, preparation)
                         continue
                     }
                     try DeveloperApplicationCaptureConfigurator.restoreRecognizedSettings(
@@ -98,7 +130,9 @@ enum DeveloperApplicationRecoveryLedger {
         with preparation: DeveloperApplicationSettingsPreparation,
         applicationSupportURL: URL,
         fileManager: FileManager
-    ) throws {
+    )
+        throws
+    {
         guard processIdentifier > 0 else {
             return
         }
@@ -109,12 +143,16 @@ enum DeveloperApplicationRecoveryLedger {
             recoveryDirectoryURL: directoryURL,
             fileManager: fileManager
         )
+        let normalizedStartSignature = processStartSignature?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let hasStableIdentity = normalizedStartSignature?.isEmpty == false
         let record = RecoveryRecord(
             schemaVersion: outstanding.record.schemaVersion,
             settingsRelativePath: outstanding.record.settingsRelativePath,
-            processIdentifier: processIdentifier,
-            processStartSignature: processStartSignature?
-                .trimmingCharacters(in: .whitespacesAndNewlines)
+            bundleIdentifier: outstanding.record.bundleIdentifier,
+            applicationBundlePath: outstanding.record.applicationBundlePath,
+            processIdentifier: hasStableIdentity ? processIdentifier : nil,
+            processStartSignature: hasStableIdentity ? normalizedStartSignature : nil
         )
         try JSONEncoder().encode(record).write(to: preparation.recoveryRecordURL, options: .atomic)
     }
@@ -123,7 +161,9 @@ enum DeveloperApplicationRecoveryLedger {
         for settingsURL: URL,
         applicationSupportURL: URL,
         fileManager: FileManager
-    ) throws -> URL {
+    )
+        throws -> URL
+    {
         let relativePath = try relativeSettingsPath(
             for: settingsURL,
             applicationSupportURL: applicationSupportURL,
@@ -139,9 +179,13 @@ enum DeveloperApplicationRecoveryLedger {
     static func writeRecord(
         settingsURL: URL,
         recordURL: URL,
+        bundleIdentifier: String,
+        applicationBundlePath: String,
         applicationSupportURL: URL,
         fileManager: FileManager
-    ) throws {
+    )
+        throws
+    {
         let directoryURL = recoveryDirectoryURL(applicationSupportURL: applicationSupportURL)
         try DeveloperApplicationCaptureConfigurator.validateContainedPath(
             directoryURL,
@@ -159,13 +203,24 @@ enum DeveloperApplicationRecoveryLedger {
             rootURL: directoryURL,
             fileManager: fileManager
         )
-        let record = RecoveryRecord(
-            schemaVersion: 1,
-            settingsRelativePath: try relativeSettingsPath(
+        let normalizedBundleIdentifier = bundleIdentifier.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !normalizedBundleIdentifier.isEmpty else {
+            throw DeveloperApplicationCaptureError.invalidApplicationMetadata
+        }
+        let normalizedApplicationBundlePath = URL(fileURLWithPath: applicationBundlePath)
+            .standardizedFileURL.resolvingSymlinksInPath().path
+        guard normalizedApplicationBundlePath.hasPrefix("/") else {
+            throw DeveloperApplicationCaptureError.invalidApplicationMetadata
+        }
+        let record = try RecoveryRecord(
+            schemaVersion: 3,
+            settingsRelativePath: relativeSettingsPath(
                 for: settingsURL,
                 applicationSupportURL: applicationSupportURL,
                 fileManager: fileManager
             ),
+            bundleIdentifier: normalizedBundleIdentifier,
+            applicationBundlePath: normalizedApplicationBundlePath,
             processIdentifier: nil,
             processStartSignature: nil
         )
@@ -176,38 +231,35 @@ enum DeveloperApplicationRecoveryLedger {
         guard processIdentifier > 0 else {
             return nil
         }
-        let outputPipe = Pipe()
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/bin/ps")
-        process.arguments = ["-p", String(processIdentifier), "-o", "lstart="]
-        process.standardOutput = outputPipe
-        process.standardError = FileHandle.nullDevice
-        do {
-            try process.run()
-            process.waitUntilExit()
-            guard process.terminationStatus == 0 else {
-                return nil
-            }
-            let data = outputPipe.fileHandleForReading.readDataToEndOfFile()
-            let signature = String(data: data, encoding: .utf8)?
-                .trimmingCharacters(in: .whitespacesAndNewlines)
-            return signature?.isEmpty == false ? signature : nil
-        } catch {
+        var info = proc_bsdinfo()
+        let expectedSize = MemoryLayout<proc_bsdinfo>.size
+        let result = proc_pidinfo(
+            processIdentifier,
+            PROC_PIDTBSDINFO,
+            0,
+            &info,
+            Int32(expectedSize)
+        )
+        guard result == expectedSize else {
             return nil
         }
+        return "proc-v1:\(info.pbi_start_tvsec):\(info.pbi_start_tvusec)"
     }
 
     nonisolated static func isRecordedProcessAlive(
         processIdentifier: Int32,
         expectedStartSignature: String?
-    ) -> Bool {
+    )
+        -> Bool
+    {
         guard let currentStartSignature = processStartSignature(processIdentifier: processIdentifier) else {
             return false
         }
-        guard let expectedStartSignature, !expectedStartSignature.isEmpty else {
-            return true
+        guard let expectedStartSignature else {
+            return false
         }
-        return currentStartSignature == expectedStartSignature
+        let normalizedExpected = expectedStartSignature.trimmingCharacters(in: .whitespacesAndNewlines)
+        return !normalizedExpected.isEmpty && currentStartSignature == normalizedExpected
     }
 
     // MARK: Private
@@ -215,6 +267,8 @@ enum DeveloperApplicationRecoveryLedger {
     private struct RecoveryRecord: Codable {
         let schemaVersion: Int
         let settingsRelativePath: String
+        let bundleIdentifier: String?
+        let applicationBundlePath: String?
         let processIdentifier: Int32?
         let processStartSignature: String?
     }
@@ -234,7 +288,9 @@ enum DeveloperApplicationRecoveryLedger {
         for settingsURL: URL,
         applicationSupportURL: URL,
         fileManager: FileManager
-    ) throws -> String {
+    )
+        throws -> String
+    {
         try DeveloperApplicationCaptureConfigurator.validateContainedPath(
             settingsURL,
             rootURL: applicationSupportURL,
@@ -251,8 +307,8 @@ enum DeveloperApplicationRecoveryLedger {
               !relativePath.hasPrefix("/"),
               relativePath.split(separator: "/", omittingEmptySubsequences: false).allSatisfy({
                   !$0.isEmpty && $0 != "." && $0 != ".."
-              })
-        else {
+              }) else
+        {
             throw DeveloperApplicationCaptureError.unsafeSettingsLocation
         }
         return relativePath
@@ -263,7 +319,9 @@ enum DeveloperApplicationRecoveryLedger {
         applicationSupportURL: URL,
         recoveryDirectoryURL: URL,
         fileManager: FileManager
-    ) throws -> OutstandingPreparation {
+    )
+        throws -> OutstandingPreparation
+    {
         try DeveloperApplicationCaptureConfigurator.validateContainedPath(
             recordURL,
             rootURL: recoveryDirectoryURL,
@@ -275,21 +333,33 @@ enum DeveloperApplicationRecoveryLedger {
               try DeveloperApplicationCaptureConfigurator.fileSize(
                   at: recordURL,
                   fileManager: fileManager
-              ) <= maximumRecordBytes
-        else {
+              ) <= maximumRecordBytes else
+        {
             throw DeveloperApplicationCaptureError.unsafeSettingsLocation
         }
         let record = try JSONDecoder().decode(
             RecoveryRecord.self,
             from: Data(contentsOf: recordURL, options: [.mappedIfSafe])
         )
-        guard record.schemaVersion == 1,
+        guard (1 ... 3).contains(record.schemaVersion),
               !record.settingsRelativePath.hasPrefix("/"),
               record.settingsRelativePath.split(separator: "/", omittingEmptySubsequences: false).allSatisfy({
                   !$0.isEmpty && $0 != "." && $0 != ".."
-              })
-        else {
+              }) else
+        {
             throw DeveloperApplicationCaptureError.unsafeSettingsLocation
+        }
+        if record.schemaVersion >= 2 {
+            guard let bundleIdentifier = record.bundleIdentifier,
+                  bundleIdentifier == bundleIdentifier.trimmingCharacters(in: .whitespacesAndNewlines),
+                  !bundleIdentifier.isEmpty,
+                  let applicationBundlePath = record.applicationBundlePath,
+                  applicationBundlePath.hasPrefix("/"),
+                  URL(fileURLWithPath: applicationBundlePath)
+                  .standardizedFileURL.resolvingSymlinksInPath().path == applicationBundlePath else
+            {
+                throw DeveloperApplicationCaptureError.unsafeSettingsLocation
+            }
         }
         let settingsURL = applicationSupportURL.appendingPathComponent(
             record.settingsRelativePath,
@@ -305,16 +375,30 @@ enum DeveloperApplicationRecoveryLedger {
             applicationSupportURL: applicationSupportURL,
             fileManager: fileManager
         )
-        guard expectedRecordURL.standardizedFileURL == recordURL.standardizedFileURL else {
+        guard expectedRecordURL.standardizedFileURL.resolvingSymlinksInPath()
+            == recordURL.standardizedFileURL.resolvingSymlinksInPath() else
+        {
             throw DeveloperApplicationCaptureError.unsafeSettingsLocation
+        }
+        let artifacts: (backupURL: URL, absenceMarkerURL: URL, preparedSnapshotURL: URL) = if record
+            .schemaVersion >= 3
+        {
+            DeveloperApplicationCaptureConfigurator.recoveryArtifactURLs(for: recordURL)
+        } else {
+            (
+                settingsURL.appendingPathExtension("rockxy-backup"),
+                settingsURL.appendingPathExtension("rockxy-originally-absent"),
+                settingsURL.appendingPathExtension("rockxy-prepared")
+            )
         }
         return OutstandingPreparation(
             preparation: DeveloperApplicationSettingsPreparation(
                 settingsURL: settingsURL,
-                backupURL: settingsURL.appendingPathExtension("rockxy-backup"),
-                absenceMarkerURL: settingsURL.appendingPathExtension("rockxy-originally-absent"),
-                preparedSnapshotURL: settingsURL.appendingPathExtension("rockxy-prepared"),
-                recoveryRecordURL: recordURL
+                backupURL: artifacts.backupURL,
+                absenceMarkerURL: artifacts.absenceMarkerURL,
+                preparedSnapshotURL: artifacts.preparedSnapshotURL,
+                recoveryRecordURL: recordURL,
+                applicationBundlePath: record.applicationBundlePath
             ),
             record: record
         )

--- a/Rockxy/Models/UI/DeveloperApplicationRuntimeDetector.swift
+++ b/Rockxy/Models/UI/DeveloperApplicationRuntimeDetector.swift
@@ -1,0 +1,144 @@
+import Foundation
+
+/// Runtime behavior detected from bounded, structural evidence inside an application bundle.
+/// Capabilities are intentionally independent from settings formats and product identities.
+enum DeveloperApplicationRuntimeCapability: Hashable, Sendable {
+    case javaVirtualMachine
+}
+
+enum DeveloperApplicationRuntimeDetector {
+    static func capabilities(
+        in appURL: URL,
+        bundle: Bundle,
+        fileManager: FileManager = .default
+    ) -> Set<DeveloperApplicationRuntimeCapability> {
+        if productMetadataDeclaresJavaRuntime(in: appURL, fileManager: fileManager)
+            || isJPackageApplication(appURL, bundle: bundle, fileManager: fileManager)
+            || isLegacyJavaApplication(appURL, bundle: bundle, fileManager: fileManager)
+        {
+            return [.javaVirtualMachine]
+        }
+        return []
+    }
+
+    static func isContainedExecutable(
+        relativePath: String,
+        relativeTo baseURL: URL,
+        bundleURL: URL,
+        fileManager: FileManager
+    ) -> Bool {
+        guard !relativePath.isEmpty, !relativePath.hasPrefix("/") else {
+            return false
+        }
+        return isContainedExecutable(
+            baseURL.appendingPathComponent(relativePath),
+            bundleURL: bundleURL,
+            fileManager: fileManager
+        )
+    }
+
+    private static let maximumMetadataBytes: UInt64 = 1_048_576
+
+    private static func productMetadataDeclaresJavaRuntime(
+        in appURL: URL,
+        fileManager: FileManager
+    ) -> Bool {
+        let metadataURL = appURL
+            .appendingPathComponent("Contents/Resources/product-info.json", isDirectory: false)
+        guard fileManager.fileExists(atPath: metadataURL.path),
+              let attributes = try? fileManager.attributesOfItem(atPath: metadataURL.path),
+              let fileSize = attributes[.size] as? NSNumber,
+              fileSize.uint64Value <= maximumMetadataBytes,
+              let data = try? Data(contentsOf: metadataURL, options: [.mappedIfSafe]),
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let launchEntries = object["launch"] as? [[String: Any]]
+        else {
+            return false
+        }
+        let baseURL = metadataURL.deletingLastPathComponent()
+        return launchEntries.contains { entry in
+            guard entry["os"] as? String == "macOS",
+                  let relativePath = entry["javaExecutablePath"] as? String
+            else {
+                return false
+            }
+            return isContainedExecutable(
+                relativePath: relativePath,
+                relativeTo: baseURL,
+                bundleURL: appURL,
+                fileManager: fileManager
+            )
+        }
+    }
+
+    private static func isJPackageApplication(
+        _ appURL: URL,
+        bundle: Bundle,
+        fileManager: FileManager
+    ) -> Bool {
+        guard let executable = bundle.object(forInfoDictionaryKey: "CFBundleExecutable") as? String,
+              isSafeDirectoryComponent(executable)
+        else {
+            return false
+        }
+        let runtimeURL = appURL.appendingPathComponent(
+            "Contents/runtime/Contents/Home/bin/java",
+            isDirectory: false
+        )
+        let configurationURL = appURL.appendingPathComponent(
+            "Contents/app/\(executable).cfg",
+            isDirectory: false
+        )
+        return isContainedExecutable(
+            runtimeURL,
+            bundleURL: appURL,
+            fileManager: fileManager
+        ) && fileManager.isReadableFile(atPath: configurationURL.path)
+    }
+
+    private static func isLegacyJavaApplication(
+        _ appURL: URL,
+        bundle: Bundle,
+        fileManager: FileManager
+    ) -> Bool {
+        guard bundle.object(forInfoDictionaryKey: "CFBundleExecutable") as? String == "JavaApplicationStub"
+        else {
+            return false
+        }
+        let mainClass = bundle.object(forInfoDictionaryKey: "JVMMainClassName") as? String
+        let executableURL = appURL.appendingPathComponent(
+            "Contents/MacOS/JavaApplicationStub",
+            isDirectory: false
+        )
+        return mainClass?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
+            && isContainedExecutable(executableURL, bundleURL: appURL, fileManager: fileManager)
+    }
+
+    private static func isContainedExecutable(
+        _ executableURL: URL,
+        bundleURL: URL,
+        fileManager: FileManager
+    ) -> Bool {
+        let resolvedBundleURL = bundleURL.standardizedFileURL.resolvingSymlinksInPath()
+        let resolvedExecutableURL = executableURL.standardizedFileURL.resolvingSymlinksInPath()
+        let prefix = resolvedBundleURL.path.hasSuffix("/")
+            ? resolvedBundleURL.path
+            : resolvedBundleURL.path + "/"
+        guard resolvedExecutableURL.path.hasPrefix(prefix) else {
+            return false
+        }
+        var isDirectory: ObjCBool = false
+        return fileManager.fileExists(atPath: resolvedExecutableURL.path, isDirectory: &isDirectory)
+            && !isDirectory.boolValue
+            && fileManager.isExecutableFile(atPath: resolvedExecutableURL.path)
+    }
+
+    private static func isSafeDirectoryComponent(_ component: String) -> Bool {
+        !component.isEmpty
+            && component != "."
+            && component != ".."
+            && !component.contains("/")
+            && !component.contains(":")
+            && !component.contains("\0")
+    }
+}

--- a/Rockxy/Models/UI/DeveloperApplicationScopeIdentity.swift
+++ b/Rockxy/Models/UI/DeveloperApplicationScopeIdentity.swift
@@ -1,0 +1,107 @@
+import AppKit
+import Foundation
+
+// Generic identity for developer-application installations and the settings scope Rockxy would
+// prepare for them. The comparison seam is pure so preparation guards and restart detection can
+// be verified deterministically without launching or inspecting real applications.
+
+// MARK: - DeveloperApplicationScopeIdentity
+
+/// One installed application described only by evidence Rockxy can verify: the resolved bundle
+/// path and the recognized settings adapter detected inside that bundle. No product, vendor, or
+/// process-name knowledge is encoded here.
+struct DeveloperApplicationScopeIdentity: Equatable, Sendable {
+    let bundlePath: String
+    let settingsAdapter: DeveloperApplicationSettingsAdapter?
+}
+
+// MARK: - DeveloperApplicationRunningInstance
+
+/// A running process paired with the installation identity it resolves to.
+struct DeveloperApplicationRunningInstance: Equatable, Sendable {
+    let processIdentifier: Int32
+    let scope: DeveloperApplicationScopeIdentity
+}
+
+// MARK: - DeveloperApplicationScopeResolution
+
+enum DeveloperApplicationScopeResolution {
+    /// Two installations conflict when they are the same bundle, or when both resolve to the same
+    /// recognized settings adapter. Adapter identity *is* settings-scope identity: the adapter
+    /// payload determines the single settings file Rockxy would prepare, so two installations
+    /// sharing it also share the transaction. Installations without a recognized adapter keep
+    /// exact-path semantics because Rockxy never mutates settings for them.
+    static func sharesSettingsScope(
+        _ candidate: DeveloperApplicationScopeIdentity,
+        _ other: DeveloperApplicationScopeIdentity
+    )
+        -> Bool
+    {
+        if !candidate.bundlePath.isEmpty, candidate.bundlePath == other.bundlePath {
+            return true
+        }
+        guard let candidateAdapter = candidate.settingsAdapter,
+              let otherAdapter = other.settingsAdapter else
+        {
+            return false
+        }
+        return candidateAdapter == otherAdapter
+    }
+
+    /// The running instance that must block a new preparation, if any.
+    static func blockingInstance(
+        candidate: DeveloperApplicationScopeIdentity,
+        runningInstances: [DeveloperApplicationRunningInstance]
+    )
+        -> DeveloperApplicationRunningInstance?
+    {
+        runningInstances.first { sharesSettingsScope(candidate, $0.scope) }
+    }
+
+    /// The running instance that took over from an application that just exited. The exited
+    /// process identifier is excluded so a stale listing of the original process can never be
+    /// mistaken for its successor.
+    static func successor(
+        candidate: DeveloperApplicationScopeIdentity,
+        excludingProcessIdentifier: Int32?,
+        runningInstances: [DeveloperApplicationRunningInstance]
+    )
+        -> DeveloperApplicationRunningInstance?
+    {
+        runningInstances.first { instance in
+            instance.processIdentifier > 0
+                && instance.processIdentifier != excludingProcessIdentifier
+                && sharesSettingsScope(candidate, instance.scope)
+        }
+    }
+}
+
+// MARK: - DeveloperApplicationWorkspaceScopeProvider
+
+/// Resolves the identity of every running application from LaunchServices.
+@MainActor
+enum DeveloperApplicationWorkspaceScopeProvider {
+    /// - Parameter resolvingSettingsAdapters: Detecting an adapter reads bounded metadata inside
+    ///   each running bundle. Callers that only need path identity skip that work entirely.
+    static func runningInstances(
+        resolvingSettingsAdapters: Bool,
+        workspace: NSWorkspace = .shared,
+        fileManager: FileManager = .default
+    )
+        -> [DeveloperApplicationRunningInstance]
+    {
+        workspace.runningApplications.compactMap { application in
+            guard !application.isTerminated, let bundleURL = application.bundleURL else {
+                return nil
+            }
+            return DeveloperApplicationRunningInstance(
+                processIdentifier: application.processIdentifier,
+                scope: DeveloperApplicationCaptureConfigurator.scopeIdentity(
+                    forBundleAt: bundleURL,
+                    resolvingSettingsAdapter: resolvingSettingsAdapters,
+                    fileManager: fileManager
+                )
+            )
+        }
+    }
+}

--- a/Rockxy/Models/UI/DeveloperApplicationSettingsRestorationMonitor.swift
+++ b/Rockxy/Models/UI/DeveloperApplicationSettingsRestorationMonitor.swift
@@ -1,0 +1,321 @@
+import Darwin
+import Foundation
+import os
+
+// Out-of-process restoration for developer-application settings transactions, plus the bounded
+// durable marker that keeps one monitor per transaction across Rockxy relaunches.
+
+nonisolated private let developerApplicationMonitorLogger = Logger(
+    subsystem: RockxyIdentity.current.logSubsystem,
+    category: "DeveloperApplicationRestorationMonitor"
+)
+
+// MARK: - DeveloperApplicationSettingsRestorationMonitoring
+
+@MainActor
+protocol DeveloperApplicationSettingsRestorationMonitoring {
+    func startMonitoring(
+        processIdentifier: Int32,
+        preparation: DeveloperApplicationSettingsPreparation
+    )
+        throws
+}
+
+// MARK: - DeveloperApplicationRestorationMonitorMarker
+
+/// Durable evidence that one restoration monitor already owns a settings transaction.
+struct DeveloperApplicationRestorationMonitorMarker: Codable, Equatable, Sendable {
+    let schemaVersion: Int
+    let monitorProcessIdentifier: Int32
+    let monitorStartSignature: String
+    let monitoredProcessIdentifier: Int32
+}
+
+// MARK: - DeveloperApplicationRestorationMonitorLedger
+
+/// Prevents an orphaned but still valid monitor from being multiplied on every Rockxy relaunch.
+/// Reuse requires exact process identity: the recorded monitor process must still be alive with
+/// the same start signature and must still watch the same application process. Anything weaker —
+/// a missing, corrupt, stale, or differently targeted marker — starts a fresh monitor, so a
+/// damaged marker can never cost the user their recovery transaction.
+enum DeveloperApplicationRestorationMonitorLedger {
+    nonisolated static let schemaVersion = 1
+    nonisolated static let maximumMarkerBytes: UInt64 = 4_096
+
+    static func markerURL(for recoveryRecordURL: URL) -> URL {
+        recoveryRecordURL.deletingPathExtension().appendingPathExtension("monitor")
+    }
+
+    /// Pure decision seam shared by production and tests.
+    static func shouldStartMonitor(
+        marker: DeveloperApplicationRestorationMonitorMarker?,
+        monitoredProcessIdentifier: Int32,
+        monitorIsAlive: (Int32, String) -> Bool
+    )
+        -> Bool
+    {
+        guard let marker,
+              marker.schemaVersion == schemaVersion,
+              marker.monitorProcessIdentifier > 0,
+              marker.monitoredProcessIdentifier == monitoredProcessIdentifier,
+              !marker.monitorStartSignature.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              monitorIsAlive(marker.monitorProcessIdentifier, marker.monitorStartSignature) else
+        {
+            return true
+        }
+        return false
+    }
+
+    static func shouldStartMonitor(
+        markerURL: URL,
+        monitoredProcessIdentifier: Int32,
+        fileManager: FileManager = .default,
+        monitorIsAlive: (Int32, String) -> Bool = { processIdentifier, startSignature in
+            DeveloperApplicationRecoveryLedger.isRecordedProcessAlive(
+                processIdentifier: processIdentifier,
+                expectedStartSignature: startSignature
+            )
+        }
+    )
+        -> Bool
+    {
+        shouldStartMonitor(
+            marker: marker(at: markerURL, fileManager: fileManager),
+            monitoredProcessIdentifier: monitoredProcessIdentifier,
+            monitorIsAlive: monitorIsAlive
+        )
+    }
+
+    /// Reads a bounded marker. Oversized, unreadable, or malformed markers read as absent.
+    static func marker(
+        at markerURL: URL,
+        fileManager: FileManager = .default
+    )
+        -> DeveloperApplicationRestorationMonitorMarker?
+    {
+        guard fileManager.fileExists(atPath: markerURL.path),
+              let size = try? DeveloperApplicationCaptureConfigurator.fileSize(
+                  at: markerURL,
+                  fileManager: fileManager
+              ),
+              size <= maximumMarkerBytes,
+              let data = try? Data(contentsOf: markerURL, options: [.mappedIfSafe]) else
+        {
+            return nil
+        }
+        return try? JSONDecoder().decode(
+            DeveloperApplicationRestorationMonitorMarker.self,
+            from: data
+        )
+    }
+
+    static func writeMarker(
+        monitorProcessIdentifier: Int32,
+        monitorStartSignature: String,
+        monitoredProcessIdentifier: Int32,
+        to markerURL: URL,
+        fileManager: FileManager = .default
+    )
+        throws
+    {
+        let marker = DeveloperApplicationRestorationMonitorMarker(
+            schemaVersion: schemaVersion,
+            monitorProcessIdentifier: monitorProcessIdentifier,
+            monitorStartSignature: monitorStartSignature,
+            monitoredProcessIdentifier: monitoredProcessIdentifier
+        )
+        try JSONEncoder().encode(marker).write(to: markerURL, options: .atomic)
+        try? fileManager.setAttributes([.posixPermissions: 0o600], ofItemAtPath: markerURL.path)
+    }
+
+    static func removeMarker(for recoveryRecordURL: URL, fileManager: FileManager = .default) {
+        let url = markerURL(for: recoveryRecordURL)
+        guard fileManager.fileExists(atPath: url.path) else {
+            return
+        }
+        try? fileManager.removeItem(at: url)
+    }
+}
+
+// MARK: - DeveloperApplicationSettingsRestorationMonitor
+
+/// Runs a bounded, exact-path restoration monitor outside Rockxy's process. This closes the gap
+/// where Rockxy exits before the prepared application. The monitor restores only when the live
+/// settings still match Rockxy's prepared snapshot, so user edits made during the session win.
+///
+/// The monitor is also restart-aware. An application that replaces itself in place — a self
+/// update or an internal restart — leaves a successor process running from the exact same
+/// application bundle. Restoring underneath that successor would silently strip the proxy
+/// settings the user asked Rockxy to prepare, so the monitor stands down and leaves the durable
+/// transaction to Rockxy's semantic reconciler instead.
+///
+/// Ownership is deliberate: the in-process termination callback decides first with a short
+/// window, and this monitor only acts after a strictly longer window, by which time the
+/// callback's decision is already visible on disk as a removed snapshot or a rebound record.
+@MainActor
+final class DeveloperApplicationSettingsRestorationMonitor: DeveloperApplicationSettingsRestorationMonitoring {
+    // MARK: Internal
+
+    static let shared = DeveloperApplicationSettingsRestorationMonitor()
+
+    /// One scan per second, long enough to outlast the in-process successor window.
+    nonisolated static let successorScanAttempts = 12
+
+    nonisolated static let script = """
+    remaining=120960
+    ps_command=${7:-/bin/ps}
+    bundle_path=$8
+    successor_attempts=${9:-12}
+    started=$("$ps_command" -p "$1" -o lstart= 2>/dev/null)
+    if [ -z "$started" ] && /bin/kill -0 "$1" 2>/dev/null; then
+      # An unavailable identity is not proof that the process exited. Leave the durable
+      # transaction for Rockxy's semantic reconciler instead of restoring prematurely.
+      exit 0
+    fi
+    successor_present() {
+      "$ps_command" -A -ww -o pid= -o comm= 2>/dev/null | /usr/bin/awk -v monitored="$1" -v prefix="$2" '
+        {
+          candidate = $1
+          sub(/^[[:space:]]*[0-9]+[[:space:]]+/, "")
+          if (candidate != monitored && index($0, prefix) == 1) { found = 1; exit }
+        }
+        END { exit(found ? 0 : 1) }
+      '
+    }
+    identity_changed=0
+    while /bin/kill -0 "$1" 2>/dev/null && [ "$remaining" -gt 0 ]; do
+      current=$("$ps_command" -p "$1" -o lstart= 2>/dev/null)
+      if [ -z "$current" ]; then
+        /bin/sleep 5
+        remaining=$((remaining - 1))
+        continue
+      fi
+      if [ "$current" != "$started" ]; then
+        identity_changed=1
+        break
+      fi
+      /bin/sleep 5
+      remaining=$((remaining - 1))
+    done
+    current=$("$ps_command" -p "$1" -o lstart= 2>/dev/null)
+    if /bin/kill -0 "$1" 2>/dev/null; then
+      if [ "$identity_changed" -eq 0 ] || [ -z "$current" ] || [ "$current" = "$started" ]; then
+        exit 0
+      fi
+    fi
+    settings=$2
+    backup=$3
+    absent=$4
+    prepared=$5
+    recovery_record=$6
+    monitor_marker="${recovery_record%.json}.monitor"
+    if [ ! -f "$prepared" ]; then
+      /bin/rm -f "$monitor_marker"
+      exit 0
+    fi
+    # An in-place restart or self update leaves a successor executing from the exact same
+    # application bundle. Identity is that executable path, never a process name.
+    if [ -n "$bundle_path" ]; then
+      attempts=$successor_attempts
+      while [ "$attempts" -gt 0 ]; do
+        if successor_present "$1" "$bundle_path/Contents/MacOS/"; then
+          exit 0
+        fi
+        attempts=$((attempts - 1))
+        if [ "$attempts" -gt 0 ]; then
+          /bin/sleep 1
+        fi
+      done
+    fi
+    if [ ! -f "$settings" ] || ! /usr/bin/cmp -s "$settings" "$prepared"; then
+      # A byte-level mismatch may be an application rewrite that preserved Rockxy's proxy
+      # selector while changing unrelated settings. Keep the recovery transaction for Rockxy's
+      # semantic reconciler instead of deleting the user's original configuration.
+      exit 0
+    fi
+    if [ -f "$absent" ]; then
+      /bin/rm -f "$settings" "$backup" "$absent" "$prepared" "$recovery_record" "$monitor_marker"
+    elif [ -f "$backup" ]; then
+      /bin/mv -f "$backup" "$settings"
+      /bin/rm -f "$absent" "$prepared" "$recovery_record" "$monitor_marker"
+    else
+      # Never discard the ledger when the original recovery artifact is missing.
+      # Rockxy's semantic reconciler may still diagnose or repair this transaction.
+      exit 0
+    fi
+    """
+
+    func startMonitoring(
+        processIdentifier: Int32,
+        preparation: DeveloperApplicationSettingsPreparation
+    )
+        throws
+    {
+        let markerURL = DeveloperApplicationRestorationMonitorLedger.markerURL(
+            for: preparation.recoveryRecordURL
+        )
+        guard DeveloperApplicationRestorationMonitorLedger.shouldStartMonitor(
+            markerURL: markerURL,
+            monitoredProcessIdentifier: processIdentifier
+        ) else {
+            // A live monitor already owns this transaction. Starting another one would add a
+            // duplicate on every Rockxy relaunch without improving recovery.
+            return
+        }
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/sh")
+        process.arguments = [
+            "-c",
+            Self.script,
+            "rockxy-settings-restoration-monitor",
+            String(processIdentifier),
+            preparation.settingsURL.path,
+            preparation.backupURL.path,
+            preparation.absenceMarkerURL.path,
+            preparation.preparedSnapshotURL.path,
+            preparation.recoveryRecordURL.path,
+            "/bin/ps",
+            preparation.applicationBundlePath ?? "",
+            String(Self.successorScanAttempts),
+        ]
+        process.environment = ["PATH": "/usr/bin:/bin"]
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
+
+        try process.run()
+        recordMarker(
+            monitorProcessIdentifier: process.processIdentifier,
+            monitoredProcessIdentifier: processIdentifier,
+            markerURL: markerURL
+        )
+    }
+
+    // MARK: Private
+
+    private func recordMarker(
+        monitorProcessIdentifier: Int32,
+        monitoredProcessIdentifier: Int32,
+        markerURL: URL
+    ) {
+        guard let startSignature = DeveloperApplicationRecoveryLedger.processStartSignature(
+            processIdentifier: monitorProcessIdentifier
+        ) else {
+            // A monitor whose identity cannot be proven is never recorded as the owner, so the
+            // next Rockxy launch starts a fresh monitor rather than trusting a bare identifier.
+            return
+        }
+        do {
+            try DeveloperApplicationRestorationMonitorLedger.writeMarker(
+                monitorProcessIdentifier: monitorProcessIdentifier,
+                monitorStartSignature: startSignature,
+                monitoredProcessIdentifier: monitoredProcessIdentifier,
+                to: markerURL
+            )
+        } catch {
+            developerApplicationMonitorLogger.error(
+                "Could not record the developer-application restoration monitor marker: \(error.localizedDescription)"
+            )
+        }
+    }
+}

--- a/Rockxy/Models/UI/DeveloperSetupSessionSetup.swift
+++ b/Rockxy/Models/UI/DeveloperSetupSessionSetup.swift
@@ -443,6 +443,7 @@ final class DeveloperSetupSessionSetupViewModel {
         applicationIsRunning: @escaping @MainActor (DeveloperApplicationInstallation) -> Bool = {
             DeveloperApplicationCaptureConfigurator.isRunning($0)
         },
+        systemProxyConfiguredProvider: (@MainActor () async -> Bool)? = nil,
         applicationSupportURL: URL = FileManager.default.urls(
             for: .applicationSupportDirectory,
             in: .userDomainMask
@@ -459,6 +460,7 @@ final class DeveloperSetupSessionSetupViewModel {
             ?? DeveloperApplicationSettingsRestorationMonitor.shared
         self.preparationRegistry = preparationRegistry ?? .shared
         self.applicationIsRunning = applicationIsRunning
+        self.systemProxyConfiguredProvider = systemProxyConfiguredProvider
         self.applicationSupportURL = applicationSupportURL
         context = Self.makeContext(coordinator: coordinator, targetID: targetID, generatedAt: generatedAt())
     }
@@ -678,6 +680,11 @@ final class DeveloperSetupSessionSetupViewModel {
         }
         refresh()
         do {
+            let systemProxyConfigured = if let systemProxyConfiguredProvider {
+                await systemProxyConfiguredProvider()
+            } else {
+                await coordinator.reconcileProxyOverrideStatus()
+            }
             let workflow = DeveloperApplicationCaptureWorkflow(
                 launcher: applicationLauncher,
                 restorationMonitor: settingsRestorationMonitor,
@@ -688,7 +695,7 @@ final class DeveloperSetupSessionSetupViewModel {
             let outcome = try await workflow.open(
                 appURL: appURL,
                 context: context,
-                systemProxyConfigured: coordinator.isSystemProxyConfigured
+                systemProxyConfigured: systemProxyConfigured
             )
             switch outcome {
             case let .prepared(displayName, restorationMonitorActive):
@@ -713,6 +720,18 @@ final class DeveloperSetupSessionSetupViewModel {
                     localized: "\(displayName) was opened with Rockxy's scoped environment. If it overrides macOS or environment proxy settings, configure that app-level proxy separately.",
                     bundle: RockxyLocalization.bundle
                 )
+            case let .launchPending(displayName, restorationMonitorActive):
+                if restorationMonitorActive {
+                    statusMessage = String(
+                        localized: "macOS accepted the request to open \(displayName), but the application is still completing first-launch checks. Follow any macOS prompt and wait for it to open. Temporary settings recovery remains active.",
+                        bundle: RockxyLocalization.bundle
+                    )
+                } else {
+                    statusMessage = String(
+                        localized: "macOS accepted the request to open \(displayName), but the application is still completing first-launch checks. Follow any macOS prompt and wait for it to open.",
+                        bundle: RockxyLocalization.bundle
+                    )
+                }
             }
         } catch {
             statusMessage = launchFailureMessage(
@@ -764,6 +783,7 @@ final class DeveloperSetupSessionSetupViewModel {
     private let settingsRestorationMonitor: DeveloperApplicationSettingsRestorationMonitoring
     private let preparationRegistry: DeveloperApplicationPreparationRegistry
     private let applicationIsRunning: @MainActor (DeveloperApplicationInstallation) -> Bool
+    private let systemProxyConfiguredProvider: (@MainActor () async -> Bool)?
     private let applicationSupportURL: URL
     private var lastAppliedRouteGeneration = 0
 

--- a/Rockxy/Views/Main/Extensions/MainContentCoordinator+ProxyControl.swift
+++ b/Rockxy/Views/Main/Extensions/MainContentCoordinator+ProxyControl.swift
@@ -3,6 +3,14 @@ import os
 
 // Extends `MainContentCoordinator` with proxy control behavior for the main workspace.
 
+// MARK: - ProxyOverrideReconciliation
+
+/// Result of comparing a live system proxy override with this session's proxy port.
+struct ProxyOverrideReconciliation: Equatable, Sendable {
+    let isOverridden: Bool
+    let matchesActiveProxyPort: Bool
+}
+
 // MARK: - MainContentCoordinator + ProxyControl
 
 /// Coordinator extension for proxy server lifecycle: start, stop, recording toggle,
@@ -39,10 +47,14 @@ extension MainContentCoordinator {
 
                 await certificateManager.validateCertificateChain()
 
-                // Evaluate certificate trust via the readiness layer.
+                // Evaluate certificate trust via the readiness layer, forcing a fresh trust-state
+                // resolution and a real SecTrust evaluation when positive trust metadata exists.
+                // The cheap refresh can answer from a cached negative recorded before the user
+                // approved the root, and that stale answer would pass every HTTPS connection
+                // through for the whole session.
                 // Only new HTTPS connections are affected — existing TLS sessions
                 // are not re-intercepted after trust changes.
-                await readiness.refresh()
+                await readiness.refreshCertificateTrustValidation()
                 SSLProxyingManager.shared.forceGlobalPassthrough = !readiness.canInterceptHTTPS
                 if !readiness.canInterceptHTTPS {
                     Self.logger.warning(
@@ -210,17 +222,50 @@ extension MainContentCoordinator {
 
     func refreshProxyOverrideStatus() {
         Task { @MainActor in
-            let owner = await SystemProxyManager.shared.effectiveOverrideOwner()
-            let overridden = switch owner {
-            case .none:
-                false
-            case .direct,
-                 .helper:
-                true
-            }
-            isProxyOverridden = overridden
-            isSystemProxyConfigured = overridden
+            _ = await reconcileProxyOverrideStatus()
         }
+    }
+
+    @discardableResult
+    func reconcileProxyOverrideStatus() async -> Bool {
+        let owner = await SystemProxyManager.shared.effectiveOverrideOwner()
+        let reconciliation = Self.reconcileProxyOverride(
+            overridePort: Self.proxyOverridePort(for: owner),
+            activeProxyPort: activeProxyPort
+        )
+        isProxyOverridden = reconciliation.isOverridden
+        isSystemProxyConfigured = reconciliation.matchesActiveProxyPort
+        return reconciliation.matchesActiveProxyPort
+    }
+
+    /// The port a live Rockxy override points at, or `nil` when nothing overrides the proxy.
+    nonisolated static func proxyOverridePort(for owner: ProxyOverrideOwner) -> Int? {
+        switch owner {
+        case .none:
+            nil
+        case let .direct(backup):
+            backup.rockxyPort
+        case let .helper(port):
+            port
+        }
+    }
+
+    /// Separates "a Rockxy override exists" from "the override points at this session's proxy".
+    /// A stale override left by an earlier session or a differently ported one still counts as an
+    /// override the user can switch off, but it must never be reported as capture-ready.
+    nonisolated static func reconcileProxyOverride(
+        overridePort: Int?,
+        activeProxyPort: Int
+    )
+        -> ProxyOverrideReconciliation
+    {
+        guard let overridePort else {
+            return ProxyOverrideReconciliation(isOverridden: false, matchesActiveProxyPort: false)
+        }
+        return ProxyOverrideReconciliation(
+            isOverridden: true,
+            matchesActiveProxyPort: overridePort == activeProxyPort
+        )
     }
 
     func switchOffSystemProxyOverride() {

--- a/RockxyTests/Core/Certificate/CertificateInstallNonDestructiveTests.swift
+++ b/RockxyTests/Core/Certificate/CertificateInstallNonDestructiveTests.swift
@@ -168,6 +168,60 @@ struct RootCANonDestructiveInstallTests {
         #expect(try KeychainHelper.isCertificateInstalledStrict(certData: older))
     }
 
+    @Test("trust preflight adopts the persisted identity changed by another process")
+    func trustPreflightAdoptsPersistedIdentity() async throws {
+        let overrides = try await installSharedTestOverrides()
+        defer { overrides.cleanup() }
+
+        let manager = CertificateManager.makeForTesting()
+        try await manager.generateRootCA()
+        let staleDER = try #require(await manager.getRootCADER())
+
+        // Model another Rockxy process replacing the shared pair while this actor still holds
+        // its original root in memory.
+        let replacement = try RootCAGenerator.generate()
+        try CertificateStore.saveRootCAPrivateKey(replacement.privateKey)
+        try CertificateStore.saveRootCACertificate(replacement.certificate)
+        let replacementDER = try nonDestructiveInstallDER(replacement.certificate)
+
+        let recorder = InstallCallRecorder()
+        await manager.setAppInstallOverrideForTests { der in recorder.recordApp(der) }
+
+        await #expect(throws: CertificateManagerError.trustValidationFailed) {
+            try await manager.installAndTrust()
+        }
+
+        #expect(recorder.appPayloads == [replacementDER])
+        #expect(recorder.appPayloads != [staleDER])
+        #expect(try await manager.getRootCADER() == replacementDER)
+    }
+
+    @Test("identity changed during authorization fails without a second prompt")
+    func identityChangedDuringAuthorizationFailsClosed() async throws {
+        let overrides = try await installSharedTestOverrides()
+        defer { overrides.cleanup() }
+
+        let manager = CertificateManager.makeForTesting()
+        try await manager.generateRootCA()
+        let originalDER = try #require(await manager.getRootCADER())
+        let replacement = try RootCAGenerator.generate()
+        let recorder = InstallCallRecorder()
+
+        await manager.setAppInstallOverrideForTests { der in
+            recorder.recordApp(der)
+            try CertificateStore.saveRootCAPrivateKey(replacement.privateKey)
+            try CertificateStore.saveRootCACertificate(replacement.certificate)
+        }
+
+        await #expect(throws: CertificateManagerError.persistedRootIdentityChanged) {
+            try await manager.installAndTrust()
+        }
+
+        #expect(recorder.appPayloads == [originalDER])
+        #expect(try await manager.getRootCADER() == originalDER)
+        #expect(await manager.lastTrustValidationResult == nil)
+    }
+
     @Test("competing mutations are rejected while the authorization dialog is open")
     func mutationsRejectedWhileDialogIsOpen() async throws {
         let overrides = try await installSharedTestOverrides()

--- a/RockxyTests/Core/Certificate/CertificateLifecycleHardeningTests.swift
+++ b/RockxyTests/Core/Certificate/CertificateLifecycleHardeningTests.swift
@@ -482,6 +482,36 @@ struct RootCAStartupReadinessTests {
         let snapshot = await relaunched.rootCAStatusSnapshot()
         #expect(snapshot.fingerprintSHA256 == originalFingerprint)
     }
+
+    @Test("status fails closed when another process replaces the persisted root identity")
+    func statusRejectsPersistedIdentityDrift() async throws {
+        let overrides = try await installSharedTestOverrides()
+        defer { overrides.cleanup() }
+
+        let manager = CertificateManager.makeForTesting()
+        try await manager.generateRootCA()
+        let activeFingerprint = try #require(await manager.getActiveRootFingerprint())
+
+        // Model an older sibling process replacing both persisted halves while this actor still
+        // holds the previously trusted CA and its derived state in memory.
+        let replacement = try RootCAGenerator.generate()
+        try CertificateStore.saveRootCAPrivateKey(replacement.privateKey)
+        try CertificateStore.saveRootCACertificate(replacement.certificate)
+
+        let snapshot = await manager.rootCAStatusSnapshot(performValidation: true)
+
+        #expect(snapshot.isStatusUnavailable)
+        #expect(snapshot.statusReadFailure?.scope == .persistedMaterial)
+        #expect(snapshot.statusReadErrorMessage == CertificateManagerError.persistedRootIdentityDrift.localizedDescription)
+        #expect(snapshot.isSystemTrustValidated == false)
+        #expect(await manager.lastTrustValidationResult == nil)
+        // A status read is fail-closed and non-mutating. The explicit trust action owns adoption.
+        #expect(await manager.getActiveRootFingerprint() == activeFingerprint)
+        #expect(
+            certificateFingerprint(try #require(try CertificateStore.loadRootCACertificate()))
+                == certificateFingerprint(replacement.certificate)
+        )
+    }
 }
 
 // MARK: - RootCATestIsolationTests

--- a/RockxyTests/Core/ProxyEngine/ClientIdentityResolutionTests.swift
+++ b/RockxyTests/Core/ProxyEngine/ClientIdentityResolutionTests.swift
@@ -28,6 +28,69 @@ private final class IntBox: @unchecked Sendable {
     private var value = 0
 }
 
+// MARK: - ProcessMapFixture
+
+private final class ProcessMapFixture: @unchecked Sendable {
+    // MARK: Internal
+
+    func next(proxyPort: Int) -> [UInt16: String] {
+        lock.lock()
+        defer { lock.unlock() }
+        requestedProxyPorts.append(proxyPort)
+        let index = min(requestedProxyPorts.count - 1, snapshots.count - 1)
+        return snapshots[index]
+    }
+
+    func requests() -> [Int] {
+        lock.lock()
+        defer { lock.unlock() }
+        return requestedProxyPorts
+    }
+
+    let snapshots: [[UInt16: String]] = [
+        [51_001: "Existing App"],
+        [51_001: "Existing App", 51_002: "New App"],
+        [52_001: "Other Proxy App"],
+    ]
+
+    // MARK: Private
+
+    private let lock = NSLock()
+    private var requestedProxyPorts: [Int] = []
+}
+
+// MARK: - SlowProcessMapFixture
+
+private final class SlowProcessMapFixture: @unchecked Sendable {
+    // MARK: Internal
+
+    func next(proxyPort _: Int) -> [UInt16: String] {
+        lock.lock()
+        requests += 1
+        lock.unlock()
+        Thread.sleep(forTimeInterval: 0.1)
+        return [53_001: "Burst App"]
+    }
+
+    func requestCount() -> Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return requests
+    }
+
+    // MARK: Private
+
+    private let lock = NSLock()
+    private var requests = 0
+}
+
+private final class ConcurrentProxyMapFixture: @unchecked Sendable {
+    func next(proxyPort: Int) -> [UInt16: String] {
+        Thread.sleep(forTimeInterval: proxyPort == 8_888 ? 0.08 : 0.02)
+        return proxyPort == 8_888 ? [53_101: "First Proxy App"] : [53_102: "Second Proxy App"]
+    }
+}
+
 // MARK: - ClientIdentityResolutionTests
 
 @Suite(.serialized)
@@ -35,6 +98,88 @@ struct ClientIdentityResolutionTests {
     // MARK: Internal
 
     // MARK: - Directional endpoint matching
+
+    @Test("process map cache refreshes for a missing source port and a changed proxy port")
+    func processMapCacheRefreshesForRequiredConnection() {
+        let fixture = ProcessMapFixture()
+        let resolver = ProcessResolver(
+            processMapProvider: { proxyPort in
+                fixture.next(proxyPort: proxyPort)
+            },
+            minimumRefreshInterval: 0
+        )
+
+        let initial = resolver.resolveProcesses(proxyPort: 8_888, requiring: [51_001])
+        let cached = resolver.resolveProcesses(proxyPort: 8_888, requiring: [51_001])
+        let refreshed = resolver.resolveProcesses(proxyPort: 8_888, requiring: [51_002])
+        let otherProxy = resolver.resolveProcesses(proxyPort: 9_090, requiring: [52_001])
+
+        #expect(initial[51_001] == "Existing App")
+        #expect(cached[51_001] == "Existing App")
+        #expect(refreshed[51_002] == "New App")
+        #expect(otherProxy[52_001] == "Other Proxy App")
+        #expect(fixture.requests() == [8_888, 8_888, 9_090])
+    }
+
+    @Test("missing process ports coalesce repeated lsof refreshes")
+    func processMapCacheCoalescesMissingPorts() {
+        let fixture = ProcessMapFixture()
+        let resolver = ProcessResolver { proxyPort in
+            fixture.next(proxyPort: proxyPort)
+        }
+
+        _ = resolver.resolveProcesses(proxyPort: 8_888, requiring: [51_001])
+        let firstMiss = resolver.resolveProcesses(proxyPort: 8_888, requiring: [51_002])
+        let repeatedMiss = resolver.resolveProcesses(proxyPort: 8_888, requiring: [51_003])
+
+        #expect(firstMiss[51_002] == nil)
+        #expect(repeatedMiss[51_003] == nil)
+        #expect(fixture.requests() == [8_888])
+    }
+
+    @Test("first process-map burst coalesces while the initial query is in flight")
+    func initialProcessMapBurstCoalesces() async {
+        let fixture = SlowProcessMapFixture()
+        let resolver = ProcessResolver { proxyPort in
+            fixture.next(proxyPort: proxyPort)
+        }
+
+        let results = await withTaskGroup(of: Bool.self, returning: [Bool].self) { group in
+            for _ in 0 ..< 24 {
+                group.addTask {
+                    let result = await resolver.resolveProcessesAsync(proxyPort: 8_888, requiring: [53_001])
+                    return result[53_001] == "Burst App"
+                }
+            }
+
+            var results: [Bool] = []
+            for await result in group {
+                results.append(result)
+            }
+            return results
+        }
+
+        #expect(fixture.requestCount() == 1)
+        #expect(results.allSatisfy { $0 })
+    }
+
+    @Test("concurrent proxy ports retain independent process maps")
+    func concurrentProxyPortsDoNotOverwriteEachOther() async {
+        let fixture = ConcurrentProxyMapFixture()
+        let resolver = ProcessResolver(
+            processMapProvider: { proxyPort in fixture.next(proxyPort: proxyPort) },
+            minimumRefreshInterval: 0
+        )
+
+        async let first = resolver.resolveProcessesAsync(proxyPort: 8_888, requiring: [53_101])
+        async let second = resolver.resolveProcessesAsync(proxyPort: 9_090, requiring: [53_102])
+        let (firstResult, secondResult) = await (first, second)
+
+        #expect(firstResult[53_101] == "First Proxy App")
+        #expect(secondResult[53_102] == "Second Proxy App")
+        #expect(resolver.resolveProcesses(proxyPort: 8_888)[53_101] == "First Proxy App")
+        #expect(resolver.resolveProcesses(proxyPort: 9_090)[53_102] == "Second Proxy App")
+    }
 
     @Test("matches a local client to its owning pid via exact source endpoint")
     func matchesLocalClient() {
@@ -295,6 +440,37 @@ struct ClientIdentityResolutionTests {
         let descriptor = makeDescriptor(clientHost: "127.0.0.1", clientPort: 54_321, proxyPort: 9_090)
         let identity = await resolver.resolveIdentity(descriptor: descriptor)
         #expect(identity == Self.sampleIdentity)
+    }
+
+    @Test("connection handle can resolve eagerly before a transaction is emitted")
+    func handleResolvesEagerly() async throws {
+        let resolver = makeResolver(records: [Self.matchingRecord])
+        let descriptor = makeDescriptor(clientHost: "127.0.0.1", clientPort: 54_321, proxyPort: 9_090)
+        let handle = ClientIdentityHandle(descriptor: descriptor, resolver: resolver)
+
+        handle.startResolution()
+        try await Task.sleep(for: .milliseconds(50))
+
+        #expect(handle.currentIdentity == Self.sampleIdentity)
+    }
+
+    @Test("connection handle backfills an identity that resolves after the decision deadline")
+    func handleBackfillsLateIdentity() async throws {
+        let resolver = ClientIdentityResolver(
+            connectionTableProvider: { _, _ in
+                Thread.sleep(forTimeInterval: 1.0)
+                return [Self.matchingRecord]
+            },
+            identityProvider: { _, _ in Self.sampleIdentity },
+            excludePID: 999
+        )
+        let descriptor = makeDescriptor(clientHost: "127.0.0.1", clientPort: 54_321, proxyPort: 9_090)
+        let handle = ClientIdentityHandle(descriptor: descriptor, resolver: resolver)
+
+        #expect(await handle.awaitIdentity() == nil)
+        try await Task.sleep(for: .milliseconds(300))
+
+        #expect(handle.currentIdentity == Self.sampleIdentity)
     }
 
     @Test("remote descriptor short-circuits without collecting the table")

--- a/RockxyTests/Core/ProxyEngine/ConnectionLimiterTests.swift
+++ b/RockxyTests/Core/ProxyEngine/ConnectionLimiterTests.swift
@@ -1,0 +1,66 @@
+import Foundation
+@testable import Rockxy
+import Testing
+
+@Suite("Connection limiter")
+struct ConnectionLimiterTests {
+    @Test("default capacity accepts realistic parallel client bursts and remains bounded")
+    func defaultCapacitySupportsParallelClients() {
+        let limiter = ConnectionLimiter()
+
+        for _ in 0 ..< 64 {
+            #expect(limiter.acquire(host: "plugins.jetbrains.com", port: 443))
+        }
+        #expect(!limiter.acquire(host: "plugins.jetbrains.com", port: 443))
+
+        limiter.release(host: "plugins.jetbrains.com", port: 443)
+        #expect(limiter.acquire(host: "plugins.jetbrains.com", port: 443))
+    }
+
+    @Test("destination identity is case-insensitive and ignores a DNS trailing dot")
+    func destinationIsCanonicalized() {
+        let limiter = ConnectionLimiter(maxPerDestination: 1)
+
+        #expect(limiter.acquire(host: "Example.COM.", port: 443))
+        #expect(!limiter.acquire(host: "example.com", port: 443))
+        #expect(limiter.acquire(host: "example.com", port: 8_443))
+    }
+
+    @Test("release below zero does not poison a future acquisition")
+    func unmatchedReleaseIsHarmless() {
+        let limiter = ConnectionLimiter(maxPerDestination: 1)
+
+        limiter.release(host: "example.com", port: 443)
+        #expect(limiter.acquire(host: "example.com", port: 443))
+    }
+
+    @Test("saturating one destination leaves another destination available")
+    func destinationsHaveIndependentCapacity() {
+        let limiter = ConnectionLimiter(maxPerDestination: 1)
+
+        #expect(limiter.acquire(host: "api.example.com", port: 443))
+        #expect(!limiter.acquire(host: "api.example.com", port: 443))
+        #expect(limiter.acquire(host: "assets.example.com", port: 443))
+    }
+
+    @Test("concurrent acquisitions never exceed the configured capacity")
+    func concurrentAcquisitionsRemainBounded() async {
+        let limiter = ConnectionLimiter(maxPerDestination: 8)
+        let results = await withTaskGroup(of: Bool.self, returning: [Bool].self) { group in
+            for _ in 0 ..< 64 {
+                group.addTask {
+                    limiter.acquire(host: "burst.example.com", port: 443)
+                }
+            }
+
+            var outcomes: [Bool] = []
+            for await outcome in group {
+                outcomes.append(outcome)
+            }
+            return outcomes
+        }
+
+        #expect(results.filter(\.self).count == 8)
+        #expect(results.filter { !$0 }.count == 56)
+    }
+}

--- a/RockxyTests/Core/Services/ReadinessCoordinatorTests.swift
+++ b/RockxyTests/Core/Services/ReadinessCoordinatorTests.swift
@@ -460,6 +460,18 @@ struct ReadinessCoordinatorTests {
         }
     }
 
+    @Test("forced trust revalidation refreshes the snapshot and derived capability")
+    @MainActor
+    func forcedTrustRevalidationRefreshesSnapshot() async throws {
+        let coordinator = ReadinessCoordinator.shared
+        // This path never requests installation or changes trust settings. Positive trust
+        // metadata triggers SecTrust evaluation; known absence fails closed before that work.
+        await coordinator.refreshCertificateTrustValidation()
+
+        let snapshot = try #require(coordinator.lastCertSnapshot)
+        #expect(coordinator.canInterceptHTTPS == snapshot.isSystemTrustValidated)
+    }
+
     @Test("mid-capture passthrough matches cert readiness")
     @MainActor
     func midCaptureTrustChangeAffectsFuture() async {
@@ -539,6 +551,82 @@ struct ReadinessWarningTests {
         #expect(!CertReadiness.unknown.localizedDescription.isEmpty)
     }
 
+    @Test("each readable certificate state names the step that is actually missing")
+    func readableCertStatesProduceDistinctWarnings() throws {
+        let notGenerated = try #require(ReadinessCoordinator.certNotTrustedWarning(
+            certReadiness: .notGenerated,
+            isCaptureActive: true
+        ))
+        let generatedNotInstalled = try #require(ReadinessCoordinator.certNotTrustedWarning(
+            certReadiness: .generatedNotInstalled,
+            isCaptureActive: true
+        ))
+        let installedNotTrusted = try #require(ReadinessCoordinator.certNotTrustedWarning(
+            certReadiness: .installedNotTrusted,
+            isCaptureActive: true
+        ))
+        let unknown = try #require(ReadinessCoordinator.certNotTrustedWarning(
+            certReadiness: .unknown,
+            isCaptureActive: true
+        ))
+
+        // Each readable state describes its own missing step. "Not trusted" for a root that was
+        // never generated, or for one that is in no keychain, names a decision the user never made.
+        #expect(notGenerated.message.contains("has not been generated"))
+        #expect(generatedNotInstalled.message.contains("not installed in the login or System keychain"))
+        #expect(installedNotTrusted.message.contains("installed but not trusted"))
+
+        let messages = [
+            notGenerated.message,
+            generatedNotInstalled.message,
+            installedNotTrusted.message,
+            unknown.message,
+        ]
+        #expect(Set(messages).count == messages.count)
+
+        for warning in [notGenerated, generatedNotInstalled, installedNotTrusted, unknown] {
+            // HTTP and log capture keep running in every one of these states, and none of the
+            // warnings may be dismissed away while HTTPS interception is paused.
+            #expect(warning.message.contains("HTTP traffic and logs are still captured"))
+            #expect(warning.isDismissible == false)
+        }
+
+        // The recovery stays as it was: a readable missing step offers the install, an
+        // unreadable status offers only a recheck.
+        #expect(notGenerated.action == .reinstallAndTrust)
+        #expect(generatedNotInstalled.action == .reinstallAndTrust)
+        #expect(installedNotTrusted.action == .reinstallAndTrust)
+        #expect(unknown.action == .openGeneralSettings)
+    }
+
+    @Test("no certificate warning is produced while capture is idle, in any readable state")
+    func certWarningsRequireActiveCaptureInEveryState() {
+        for readiness in [
+            CertReadiness.notGenerated,
+            .generatedNotInstalled,
+            .installedNotTrusted,
+            .trusted,
+            .unknown,
+        ] {
+            #expect(
+                ReadinessCoordinator.certNotTrustedWarning(
+                    certReadiness: readiness,
+                    isCaptureActive: false
+                ) == nil
+            )
+        }
+    }
+
+    @Test("a trusted root produces no certificate warning during capture")
+    func trustedRootProducesNoWarningDuringCapture() {
+        #expect(
+            ReadinessCoordinator.certNotTrustedWarning(
+                certReadiness: .trusted,
+                isCaptureActive: true
+            ) == nil
+        )
+    }
+
     @Test("an unreadable cert status warns that verification failed and offers a status check")
     func unknownCertReadinessOffersStatusCheck() throws {
         let warning = try #require(ReadinessCoordinator.certNotTrustedWarning(
@@ -557,5 +645,84 @@ struct ReadinessWarningTests {
             certReadiness: .installedNotTrusted,
             isCaptureActive: true
         )?.action == .reinstallAndTrust)
+    }
+}
+
+// MARK: - ProxyStartTrustValidationContractTests
+
+/// Source-contract coverage for the Start Capture trust gate.
+///
+/// Starting the real proxy would bind a port, replace the system proxy configuration, and
+/// launch a second capture session on this machine, so the call path is pinned at the source
+/// level instead: capture start must force a fresh trust resolution (including real `SecTrust`
+/// evaluation when trust metadata is present) before it decides global passthrough and before the
+/// server accepts connections. A cached negative recorded before the user approved the root would
+/// otherwise pass every HTTPS connection through for the whole session.
+struct ProxyStartTrustValidationContractTests {
+    // MARK: Internal
+
+    @Test("Start Capture forces certificate revalidation before passthrough and server start")
+    func startProxyForcesFreshTrustValidation() throws {
+        let source = try String(
+            contentsOf: resolveProjectRoot()
+                .appendingPathComponent("Rockxy/Views/Main/Extensions/MainContentCoordinator+ProxyControl.swift"),
+            encoding: .utf8
+        )
+        let startBody = try #require(bodyOfStartProxy(in: source))
+
+        let validation = try #require(startBody.range(of: "await readiness.refreshCertificateTrustValidation()"))
+        let passthrough = try #require(
+            startBody.range(of: "SSLProxyingManager.shared.forceGlobalPassthrough = !readiness.canInterceptHTTPS")
+        )
+        let serverStart = try #require(startBody.range(of: "try await proxyServer.start()"))
+
+        #expect(validation.upperBound <= passthrough.lowerBound)
+        #expect(passthrough.upperBound <= serverStart.lowerBound)
+        // The cheap cached refresh must not be what decides this gate.
+        #expect(!startBody.contains("await readiness.refresh()"))
+    }
+
+    @Test("the forced revalidation entry point requests fresh validation")
+    func forcedRevalidationRequestsRealValidation() throws {
+        let source = try String(
+            contentsOf: resolveProjectRoot()
+                .appendingPathComponent("Rockxy/Core/Services/ReadinessCoordinator.swift"),
+            encoding: .utf8
+        )
+        let declaration = try #require(source.range(of: "func refreshCertificateTrustValidation() async {"))
+        let body = source[declaration.upperBound...].prefix(400)
+
+        #expect(body.contains("refreshCertState(performValidation: true)"))
+    }
+
+    // MARK: Private
+
+    private enum ContractError: Error {
+        case rootNotFound(filePath: String)
+    }
+
+    /// The text of `startProxy()`, bounded by the next function declaration so later lifecycle
+    /// code cannot satisfy or break an ordering assertion about capture start.
+    private func bodyOfStartProxy(in source: String) -> String? {
+        guard let start = source.range(of: "func startProxy() {") else {
+            return nil
+        }
+        let remainder = source[start.upperBound...]
+        guard let end = remainder.range(of: "func stopProxy() {") else {
+            return String(remainder)
+        }
+        return String(remainder[..<end.lowerBound])
+    }
+
+    private func resolveProjectRoot() throws -> URL {
+        var url = URL(fileURLWithPath: #filePath)
+        while url.lastPathComponent != "RockxyTests", url.path != "/" {
+            url.deleteLastPathComponent()
+        }
+        guard url.lastPathComponent == "RockxyTests" else {
+            throw ContractError.rootNotFound(filePath: #filePath)
+        }
+        url.deleteLastPathComponent()
+        return url
     }
 }

--- a/RockxyTests/Core/TrafficCapture/SystemProxyManagerTests.swift
+++ b/RockxyTests/Core/TrafficCapture/SystemProxyManagerTests.swift
@@ -50,6 +50,7 @@ struct SystemProxyManagerTests {
         let cases: [SystemProxyError] = [
             .networkSetupFailed(command: "test", output: "out", exitCode: 42),
             .noActiveNetworkService,
+            .proxyActivationNotConfirmed(port: 8_888),
             .unexpectedOutput("bad"),
         ]
 
@@ -141,6 +142,76 @@ struct SystemProxyManagerTests {
             commandsSucceeded: false,
             proxyStillPointsAtRockxy: false
         ) == false)
+    }
+
+    @Test("helper override confirmation requires active state on the requested port")
+    func helperOverrideConfirmationRequiresExactLiveState() {
+        #expect(SystemProxyManager.helperOverrideIsConfirmed(
+            requestedPort: 8_888,
+            status: (isOverridden: true, port: 8_888)
+        ))
+        #expect(SystemProxyManager.helperOverrideIsConfirmed(
+            requestedPort: 8_888,
+            status: (isOverridden: false, port: 8_888)
+        ) == false)
+        #expect(SystemProxyManager.helperOverrideIsConfirmed(
+            requestedPort: 8_888,
+            status: (isOverridden: true, port: 9_090)
+        ) == false)
+        #expect(SystemProxyManager.helperOverrideIsConfirmed(
+            requestedPort: 8_888,
+            status: nil
+        ) == false)
+    }
+
+    // MARK: - Proxy Override Reconciliation
+
+    @Test("An override on the active proxy port reports both override and capture readiness")
+    func overrideOnActivePortIsCaptureReady() {
+        let reconciliation = MainContentCoordinator.reconcileProxyOverride(
+            overridePort: 8_888,
+            activeProxyPort: 8_888
+        )
+
+        #expect(reconciliation == ProxyOverrideReconciliation(
+            isOverridden: true,
+            matchesActiveProxyPort: true
+        ))
+    }
+
+    @Test("An override on a different port stays an override but is not capture ready")
+    func overrideOnDifferentPortIsNotCaptureReady() {
+        let reconciliation = MainContentCoordinator.reconcileProxyOverride(
+            overridePort: 9_090,
+            activeProxyPort: 8_888
+        )
+
+        #expect(reconciliation.isOverridden)
+        #expect(!reconciliation.matchesActiveProxyPort)
+    }
+
+    @Test("No override reports neither an override nor capture readiness")
+    func absentOverrideReportsNothing() {
+        let reconciliation = MainContentCoordinator.reconcileProxyOverride(
+            overridePort: nil,
+            activeProxyPort: 8_888
+        )
+
+        #expect(!reconciliation.isOverridden)
+        #expect(!reconciliation.matchesActiveProxyPort)
+    }
+
+    @Test("Override ownership resolves the port from direct backups and helper status")
+    func overridePortIsResolvedFromOwnership() {
+        let backup = DirectProxyBackup(
+            services: [],
+            timestamp: Date(timeIntervalSince1970: 0),
+            rockxyPort: 9_090
+        )
+
+        #expect(MainContentCoordinator.proxyOverridePort(for: .none) == nil)
+        #expect(MainContentCoordinator.proxyOverridePort(for: .direct(backup: backup)) == 9_090)
+        #expect(MainContentCoordinator.proxyOverridePort(for: .helper(port: 8_888)) == 8_888)
     }
 
     @Test("direct proxy watchdog launchctl submission uses helper entrypoint and backup path")

--- a/RockxyTests/ViewModels/DeveloperApplicationCaptureRegressionTests.swift
+++ b/RockxyTests/ViewModels/DeveloperApplicationCaptureRegressionTests.swift
@@ -1,0 +1,863 @@
+import Darwin
+import Foundation
+@testable import Rockxy
+import Testing
+
+// MARK: - CapabilityTestLauncher
+
+@MainActor
+private final class CapabilityTestLauncher: DeveloperApplicationLaunching {
+    private(set) var environment: [String: String] = [:]
+    var registrationState: DeveloperApplicationRegistrationState = .registered
+
+    func launch(
+        _: DeveloperApplicationInstallation,
+        arguments _: [String],
+        environment: [String: String],
+        onTermination _: (@MainActor @Sendable () -> Void)?
+    )
+        async throws -> DeveloperApplicationLaunchReceipt
+    {
+        self.environment = environment
+        return DeveloperApplicationLaunchReceipt(
+            lifecycleProcessIdentifier: getpid(),
+            registeredProcessIdentifier: registrationState == .registered ? getpid() : nil,
+            registrationState: registrationState
+        )
+    }
+}
+
+// MARK: - CapabilityTestRestorationMonitor
+
+@MainActor
+private final class CapabilityTestRestorationMonitor: DeveloperApplicationSettingsRestorationMonitoring {
+    private(set) var startCount = 0
+    private(set) var monitoredProcessIdentifiers: [Int32] = []
+
+    func startMonitoring(
+        processIdentifier: Int32,
+        preparation _: DeveloperApplicationSettingsPreparation
+    )
+        throws
+    {
+        startCount += 1
+        monitoredProcessIdentifiers.append(processIdentifier)
+    }
+}
+
+// MARK: - DeveloperApplicationCaptureRegressionTests
+
+@Suite("Developer application capture regressions")
+struct DeveloperApplicationCaptureRegressionTests {
+    // MARK: Internal
+
+    @Test("Metadata-declared JVM receives Java proxy properties from a non-Java setup route")
+    @MainActor
+    func metadataDeclaredJVMUsesJavaProxyProperties() async throws {
+        let fixture = try makeFixture(productMetadataJavaPath: "../jbr/Contents/Home/bin/java")
+        defer { try? FileManager.default.removeItem(at: fixture.rootURL) }
+        try makeExecutable(at: fixture.contentsURL.appendingPathComponent("jbr/Contents/Home/bin/java"))
+        let installation = try DeveloperApplicationCaptureConfigurator.installation(at: fixture.appURL)
+        let launcher = CapabilityTestLauncher()
+        let workflow = workflow(for: fixture, launcher: launcher)
+
+        _ = try await workflow.open(
+            appURL: fixture.appURL,
+            context: setupContext(targetID: .python),
+            systemProxyConfigured: true
+        )
+
+        #expect(installation.runtimeCapabilities.contains(.javaVirtualMachine))
+        #expect(launcher.environment["JAVA_TOOL_OPTIONS"]?.contains("-Dhttp.proxyPort=8888") == true)
+    }
+
+    @Test("jpackage application receives Java proxy properties without product metadata")
+    @MainActor
+    func jPackageApplicationUsesJavaProxyProperties() async throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.rootURL) }
+        try makeExecutable(
+            at: fixture.contentsURL.appendingPathComponent("runtime/Contents/Home/bin/java")
+        )
+        let configURL = fixture.contentsURL.appendingPathComponent("app/developer-app.cfg")
+        try FileManager.default.createDirectory(
+            at: configURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try Data("[Application]\napp.mainclass=com.example.Main\n".utf8).write(to: configURL)
+        let installation = try DeveloperApplicationCaptureConfigurator.installation(at: fixture.appURL)
+        let launcher = CapabilityTestLauncher()
+
+        _ = try await workflow(for: fixture, launcher: launcher).open(
+            appURL: fixture.appURL,
+            context: setupContext(targetID: .python),
+            systemProxyConfigured: false
+        )
+
+        #expect(installation.settingsAdapter == nil)
+        #expect(installation.runtimeCapabilities.contains(.javaVirtualMachine))
+        #expect(launcher.environment["JAVA_TOOL_OPTIONS"] != nil)
+    }
+
+    @Test("Untrusted Java metadata paths do not activate runtime or settings capabilities")
+    func untrustedJavaMetadataIsRejected() throws {
+        let fixture = try makeFixture(productMetadataJavaPath: "../../../../bin/java")
+        defer { try? FileManager.default.removeItem(at: fixture.rootURL) }
+
+        let installation = try DeveloperApplicationCaptureConfigurator.installation(at: fixture.appURL)
+
+        #expect(installation.settingsAdapter == nil)
+        #expect(!installation.runtimeCapabilities.contains(.javaVirtualMachine))
+    }
+
+    @Test("Malformed launch entries do not hide a later valid JVM capability")
+    func partialProductMetadataFallsBackSafely() throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.rootURL) }
+        let javaPath = "../jbr/Contents/Home/bin/java"
+        try makeExecutable(at: fixture.contentsURL.appendingPathComponent("jbr/Contents/Home/bin/java"))
+        let metadata: [String: Any] = [
+            "productVendor": "Example Tools",
+            "dataDirectoryName": "DeveloperIDE2026.2",
+            "launch": [
+                ["os": "macOS", "javaExecutablePath": NSNull()],
+                ["os": "macOS", "javaExecutablePath": javaPath],
+            ],
+        ]
+        let metadataURL = fixture.contentsURL.appendingPathComponent("Resources/product-info.json")
+        try JSONSerialization.data(withJSONObject: metadata, options: [.sortedKeys]).write(to: metadataURL)
+
+        let installation = try DeveloperApplicationCaptureConfigurator.installation(at: fixture.appURL)
+
+        #expect(installation.settingsAdapter != nil)
+        #expect(installation.runtimeCapabilities.contains(.javaVirtualMachine))
+    }
+
+    @Test("A pending first launch binds durable recovery to its lifecycle supervisor")
+    @MainActor
+    func pendingApplicationLaunchMonitorsLifecycleSupervisor() async throws {
+        let fixture = try makeFixture(productMetadataJavaPath: "../jbr/Contents/Home/bin/java")
+        defer { try? FileManager.default.removeItem(at: fixture.rootURL) }
+        try makeExecutable(at: fixture.contentsURL.appendingPathComponent("jbr/Contents/Home/bin/java"))
+        let installation = try DeveloperApplicationCaptureConfigurator.installation(at: fixture.appURL)
+        let adapter = try #require(installation.settingsAdapter)
+        let settingsURL = try DeveloperApplicationCaptureConfigurator.proxySettingsURL(
+            for: adapter,
+            applicationSupportURL: fixture.applicationSupportURL
+        )
+        let launcher = CapabilityTestLauncher()
+        launcher.registrationState = .pending
+        let monitor = CapabilityTestRestorationMonitor()
+        let workflow = DeveloperApplicationCaptureWorkflow(
+            launcher: launcher,
+            restorationMonitor: monitor,
+            preparationRegistry: DeveloperApplicationPreparationRegistry(),
+            applicationIsRunning: { _ in false },
+            applicationSupportURL: fixture.applicationSupportURL
+        )
+
+        let outcome = try await workflow.open(
+            appURL: fixture.appURL,
+            context: setupContext(targetID: .python),
+            systemProxyConfigured: true
+        )
+
+        #expect(outcome == .launchPending(displayName: "Developer App", restorationMonitorActive: true))
+        #expect(monitor.startCount == 1)
+        #expect(monitor.monitoredProcessIdentifiers == [getpid()])
+
+        let reconciled = DeveloperApplicationCaptureConfigurator.reconcileOutstandingPreparations(
+            applicationSupportURL: fixture.applicationSupportURL,
+            recordedProcessIsAlive: { processIdentifier, startSignature in
+                DeveloperApplicationRecoveryLedger.isRecordedProcessAlive(
+                    processIdentifier: processIdentifier,
+                    expectedStartSignature: startSignature
+                )
+            }
+        )
+        #expect(reconciled == 0)
+        #expect(FileManager.default.fileExists(atPath: settingsURL.path))
+    }
+
+    @Test("Recovery process identity requires an exact stable start signature")
+    func recoveryProcessIdentityRejectsMissingAndMismatchedSignatures() throws {
+        let processIdentifier = getpid()
+        let signature = try #require(
+            DeveloperApplicationCaptureConfigurator.processStartSignature(
+                processIdentifier: processIdentifier
+            )
+        )
+
+        #expect(DeveloperApplicationRecoveryLedger.isRecordedProcessAlive(
+            processIdentifier: processIdentifier,
+            expectedStartSignature: signature
+        ))
+        #expect(!DeveloperApplicationRecoveryLedger.isRecordedProcessAlive(
+            processIdentifier: processIdentifier,
+            expectedStartSignature: nil
+        ))
+        #expect(!DeveloperApplicationRecoveryLedger.isRecordedProcessAlive(
+            processIdentifier: processIdentifier,
+            expectedStartSignature: "   "
+        ))
+        #expect(!DeveloperApplicationRecoveryLedger.isRecordedProcessAlive(
+            processIdentifier: processIdentifier,
+            expectedStartSignature: signature + "-different"
+        ))
+        #expect(DeveloperApplicationCaptureConfigurator.processStartSignature(
+            processIdentifier: Int32.max
+        ) == nil)
+    }
+
+    @Test("Out-of-process monitor never restores when process identity is unavailable")
+    func restorationMonitorRetainsRecoveryWhenIdentityProbeIsUnavailable() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("rockxy-restoration-monitor-probe-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let settingsURL = directory.appendingPathComponent("proxy.settings.xml")
+        let backupURL = settingsURL.appendingPathExtension("rockxy-backup")
+        let absenceMarkerURL = settingsURL.appendingPathExtension("rockxy-originally-absent")
+        let preparedSnapshotURL = settingsURL.appendingPathExtension("rockxy-prepared")
+        let recoveryRecordURL = directory.appendingPathComponent("recovery.json")
+        let unavailablePSURL = directory.appendingPathComponent("unavailable-ps")
+        try Data("original".utf8).write(to: backupURL)
+        try Data("prepared".utf8).write(to: settingsURL)
+        try Data("prepared".utf8).write(to: preparedSnapshotURL)
+        try Data("record".utf8).write(to: recoveryRecordURL)
+        try makeExecutable(at: unavailablePSURL)
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/sh")
+        process.arguments = [
+            "-c", DeveloperApplicationSettingsRestorationMonitor.script,
+            "rockxy-settings-restoration-monitor-test", String(getpid()),
+            settingsURL.path, backupURL.path, absenceMarkerURL.path, preparedSnapshotURL.path,
+            recoveryRecordURL.path, unavailablePSURL.path,
+        ]
+        try process.run()
+        process.waitUntilExit()
+
+        #expect(process.terminationStatus == 0)
+        #expect(try Data(contentsOf: settingsURL) == Data("prepared".utf8))
+        #expect(FileManager.default.fileExists(atPath: backupURL.path))
+        #expect(FileManager.default.fileExists(atPath: preparedSnapshotURL.path))
+        #expect(FileManager.default.fileExists(atPath: recoveryRecordURL.path))
+    }
+
+    @Test("A corrupt prepared snapshot restores the validated original and preserves live bytes")
+    func corruptPreparedSnapshotRecoversWithoutDiscardingLiveSettings() throws {
+        let fixture = try makeFixture(productMetadataJavaPath: "../jbr/Contents/Home/bin/java")
+        defer { try? FileManager.default.removeItem(at: fixture.rootURL) }
+        try makeExecutable(at: fixture.contentsURL.appendingPathComponent("jbr/Contents/Home/bin/java"))
+        let installation = try DeveloperApplicationCaptureConfigurator.installation(at: fixture.appURL)
+        let adapter = try #require(installation.settingsAdapter)
+        let settingsURL = try DeveloperApplicationCaptureConfigurator.proxySettingsURL(
+            for: adapter,
+            applicationSupportURL: fixture.applicationSupportURL
+        )
+        try FileManager.default.createDirectory(
+            at: settingsURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        let original = Data(
+            "<application><component name=\"HttpConfigurable\"><option name=\"USE_HTTP_PROXY\" value=\"true\" /></component></application>"
+                .utf8
+        )
+        try original.write(to: settingsURL)
+        let preparation = try #require(try DeveloperApplicationCaptureConfigurator.prepareRecognizedSettings(
+            for: installation,
+            applicationSupportURL: fixture.applicationSupportURL
+        ))
+        let preparedLiveBytes = try Data(contentsOf: settingsURL)
+        try Data("<application><component".utf8).write(
+            to: preparation.preparedSnapshotURL,
+            options: .atomic
+        )
+
+        #expect(throws: DeveloperApplicationCaptureError.self) {
+            try DeveloperApplicationCaptureConfigurator.restoreRecognizedSettings(
+                preparation,
+                applicationSupportURL: fixture.applicationSupportURL
+            )
+        }
+
+        #expect(try Data(contentsOf: settingsURL) == original)
+        #expect(!FileManager.default.fileExists(atPath: preparation.backupURL.path))
+        #expect(!FileManager.default.fileExists(atPath: preparation.preparedSnapshotURL.path))
+        #expect(!FileManager.default.fileExists(atPath: preparation.recoveryRecordURL.path))
+        let conflicts = try FileManager.default.contentsOfDirectory(
+            at: settingsURL.deletingLastPathComponent(),
+            includingPropertiesForKeys: nil
+        ).filter { $0.lastPathComponent.contains("rockxy-conflict-") }
+        #expect(conflicts.count == 1)
+        #expect(try Data(contentsOf: #require(conflicts.first)) == preparedLiveBytes)
+    }
+
+    @Test("Reconciliation rebinds recovery to an already relaunched application")
+    func recoveryRebindsToRelaunchedApplicationIdentity() throws {
+        let fixture = try makeFixture(productMetadataJavaPath: "../jbr/Contents/Home/bin/java")
+        defer { try? FileManager.default.removeItem(at: fixture.rootURL) }
+        try makeExecutable(at: fixture.contentsURL.appendingPathComponent("jbr/Contents/Home/bin/java"))
+        let installation = try DeveloperApplicationCaptureConfigurator.installation(at: fixture.appURL)
+        let preparation = try #require(try DeveloperApplicationCaptureConfigurator.prepareRecognizedSettings(
+            for: installation,
+            applicationSupportURL: fixture.applicationSupportURL
+        ))
+        try DeveloperApplicationCaptureConfigurator.associateRunningProcess(
+            processIdentifier: 42_424,
+            processStartSignature: "old-session",
+            with: preparation,
+            applicationSupportURL: fixture.applicationSupportURL
+        )
+        var reboundProcessIdentifiers: [Int32] = []
+
+        let liveCount = DeveloperApplicationCaptureConfigurator.reconcileOutstandingPreparations(
+            applicationSupportURL: fixture.applicationSupportURL,
+            recordedProcessIsAlive: { _, _ in false },
+            recordedApplicationProcessIdentifier: { bundleIdentifier, bundlePath in
+                #expect(bundleIdentifier == installation.bundleIdentifier)
+                #expect(bundlePath == installation.appURL.resolvingSymlinksInPath().path)
+                return getpid()
+            },
+            livePreparationHandler: { processIdentifier, _ in
+                reboundProcessIdentifiers.append(processIdentifier)
+            }
+        )
+
+        #expect(liveCount == 0)
+        #expect(reboundProcessIdentifiers == [getpid()])
+        #expect(FileManager.default.fileExists(atPath: preparation.recoveryRecordURL.path))
+
+        let restoredCount = DeveloperApplicationCaptureConfigurator.reconcileOutstandingPreparations(
+            applicationSupportURL: fixture.applicationSupportURL,
+            recordedProcessIsAlive: { _, _ in false }
+        )
+        #expect(restoredCount == 1)
+        #expect(!FileManager.default.fileExists(atPath: preparation.recoveryRecordURL.path))
+    }
+
+    @Test("A recovery record left without artifacts is settled instead of blocking preparation")
+    func artifactFreeRecoveryRecordSettlesAndAllowsPreparation() throws {
+        let prepared = try makePreparedFixture()
+        defer { try? FileManager.default.removeItem(at: prepared.fixture.rootURL) }
+        // A completed restore removed every recovery artifact, then Rockxy was terminated before
+        // the ledger entry itself could be removed.
+        try FileManager.default.removeItem(at: prepared.preparation.backupURL)
+        try FileManager.default.removeItem(at: prepared.preparation.preparedSnapshotURL)
+        try prepared.originalData.write(to: prepared.settingsURL, options: .atomic)
+        #expect(FileManager.default.fileExists(atPath: prepared.preparation.recoveryRecordURL.path))
+        #expect(!FileManager.default.fileExists(atPath: prepared.preparation.absenceMarkerURL.path))
+
+        let second = try #require(try DeveloperApplicationCaptureConfigurator.prepareRecognizedSettings(
+            for: prepared.installation,
+            applicationSupportURL: prepared.fixture.applicationSupportURL
+        ))
+
+        // The stale entry must not be reported as malformed settings and must not consume the
+        // current configuration: the new backup is exactly what was on disk before preparation.
+        #expect(try Data(contentsOf: second.backupURL) == prepared.originalData)
+        let live = try String(contentsOf: prepared.settingsURL, encoding: .utf8)
+        #expect(live.contains("USE_PROXY_PAC"))
+        #expect(!live.contains("USE_HTTP_PROXY"))
+        #expect(FileManager.default.fileExists(atPath: second.recoveryRecordURL.path))
+
+        try DeveloperApplicationCaptureConfigurator.restoreRecognizedSettings(
+            second,
+            applicationSupportURL: prepared.fixture.applicationSupportURL
+        )
+        let restored = try String(contentsOf: prepared.settingsURL, encoding: .utf8)
+        #expect(restored.contains("USE_HTTP_PROXY"))
+        #expect(!restored.contains("USE_PROXY_PAC"))
+        #expect(!FileManager.default.fileExists(atPath: second.recoveryRecordURL.path))
+    }
+
+    @Test("A running installation sharing one settings scope blocks preparation of another copy")
+    func sharedSettingsScopeBlocksPreparation() throws {
+        let first = try makeFixture(productMetadataJavaPath: "../jbr/Contents/Home/bin/java")
+        defer { try? FileManager.default.removeItem(at: first.rootURL) }
+        let second = try makeFixture(productMetadataJavaPath: "../jbr/Contents/Home/bin/java")
+        defer { try? FileManager.default.removeItem(at: second.rootURL) }
+        let distinct = try makeFixture(
+            productMetadataJavaPath: "../jbr/Contents/Home/bin/java",
+            dataDirectoryName: "DeveloperIDE2026.3"
+        )
+        defer { try? FileManager.default.removeItem(at: distinct.rootURL) }
+        for fixture in [first, second, distinct] {
+            try makeExecutable(at: fixture.contentsURL.appendingPathComponent("jbr/Contents/Home/bin/java"))
+        }
+
+        let candidate = try DeveloperApplicationCaptureConfigurator.scopeIdentity(
+            for: DeveloperApplicationCaptureConfigurator.installation(at: first.appURL)
+        )
+        let sameScope = DeveloperApplicationCaptureConfigurator.scopeIdentity(
+            forBundleAt: second.appURL
+        )
+        let otherScope = DeveloperApplicationCaptureConfigurator.scopeIdentity(
+            forBundleAt: distinct.appURL
+        )
+
+        #expect(candidate.bundlePath != sameScope.bundlePath)
+        #expect(candidate.settingsAdapter != nil)
+        #expect(sameScope.settingsAdapter == candidate.settingsAdapter)
+        #expect(otherScope.settingsAdapter != candidate.settingsAdapter)
+        #expect(DeveloperApplicationScopeResolution.blockingInstance(
+            candidate: candidate,
+            runningInstances: [
+                DeveloperApplicationRunningInstance(processIdentifier: 4_242, scope: sameScope),
+            ]
+        )?.processIdentifier == 4_242)
+        #expect(DeveloperApplicationScopeResolution.blockingInstance(
+            candidate: candidate,
+            runningInstances: [
+                DeveloperApplicationRunningInstance(processIdentifier: 4_243, scope: otherScope),
+            ]
+        ) == nil)
+    }
+
+    @Test("Applications without a settings adapter keep exact bundle-path running detection")
+    func genericApplicationsKeepExactPathRunningDetection() throws {
+        let first = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: first.rootURL) }
+        let second = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: second.rootURL) }
+
+        let candidate = try DeveloperApplicationCaptureConfigurator.scopeIdentity(
+            for: DeveloperApplicationCaptureConfigurator.installation(at: first.appURL)
+        )
+        let sameInstallation = DeveloperApplicationCaptureConfigurator.scopeIdentity(
+            forBundleAt: first.appURL
+        )
+        let otherInstallation = DeveloperApplicationCaptureConfigurator.scopeIdentity(
+            forBundleAt: second.appURL
+        )
+
+        #expect(candidate.settingsAdapter == nil)
+        #expect(DeveloperApplicationScopeResolution.sharesSettingsScope(candidate, sameInstallation))
+        #expect(!DeveloperApplicationScopeResolution.sharesSettingsScope(candidate, otherInstallation))
+    }
+
+    @Test("An in-place restart rebinds the transaction to the successor instead of restoring")
+    @MainActor
+    func inPlaceRestartRebindsToSuccessor() async throws {
+        let prepared = try makePreparedFixture()
+        defer { try? FileManager.default.removeItem(at: prepared.fixture.rootURL) }
+        let preparedBytes = try Data(contentsOf: prepared.settingsURL)
+        let monitor = CapabilityTestRestorationMonitor()
+        let scope = DeveloperApplicationCaptureConfigurator.scopeIdentity(for: prepared.installation)
+        let settler = makeSettler(
+            for: prepared,
+            monitor: monitor,
+            runningInstances: [
+                DeveloperApplicationRunningInstance(processIdentifier: getpid(), scope: scope),
+            ]
+        )
+        settler.bindLaunchedProcess(42_424)
+
+        await settler.settleAfterApplicationExit()
+
+        #expect(settler.settlement == DeveloperApplicationTransactionSettlement.reboundToSuccessor(
+            processIdentifier: getpid()
+        ))
+        #expect(monitor.monitoredProcessIdentifiers == [getpid()])
+        #expect(try Data(contentsOf: prepared.settingsURL) == preparedBytes)
+        #expect(FileManager.default.fileExists(atPath: prepared.preparation.recoveryRecordURL.path))
+        #expect(FileManager.default.fileExists(atPath: prepared.preparation.backupURL.path))
+    }
+
+    @Test("An ordinary application exit still restores the original settings")
+    @MainActor
+    func ordinaryExitRestoresOriginalSettings() async throws {
+        let prepared = try makePreparedFixture()
+        defer { try? FileManager.default.removeItem(at: prepared.fixture.rootURL) }
+        let monitor = CapabilityTestRestorationMonitor()
+        let settler = makeSettler(for: prepared, monitor: monitor, runningInstances: [])
+        settler.bindLaunchedProcess(42_424)
+
+        await settler.settleAfterApplicationExit()
+
+        #expect(settler.settlement == DeveloperApplicationTransactionSettlement.restored)
+        #expect(monitor.startCount == 0)
+        let restored = try String(contentsOf: prepared.settingsURL, encoding: .utf8)
+        #expect(restored.contains("USE_HTTP_PROXY"))
+        #expect(!restored.contains("USE_PROXY_PAC"))
+        #expect(!FileManager.default.fileExists(atPath: prepared.preparation.recoveryRecordURL.path))
+    }
+
+    @Test("A different application running at exit never claims the transaction")
+    @MainActor
+    func mismatchedRunningIdentityStillRestores() async throws {
+        let prepared = try makePreparedFixture()
+        defer { try? FileManager.default.removeItem(at: prepared.fixture.rootURL) }
+        let unrelated = try makeFixture(
+            productMetadataJavaPath: "../jbr/Contents/Home/bin/java",
+            dataDirectoryName: "DeveloperIDE2026.3"
+        )
+        defer { try? FileManager.default.removeItem(at: unrelated.rootURL) }
+        try makeExecutable(at: unrelated.contentsURL.appendingPathComponent("jbr/Contents/Home/bin/java"))
+        let monitor = CapabilityTestRestorationMonitor()
+        let settler = makeSettler(
+            for: prepared,
+            monitor: monitor,
+            runningInstances: [
+                DeveloperApplicationRunningInstance(
+                    processIdentifier: getpid(),
+                    scope: DeveloperApplicationCaptureConfigurator.scopeIdentity(forBundleAt: unrelated.appURL)
+                ),
+            ]
+        )
+        settler.bindLaunchedProcess(42_424)
+
+        await settler.settleAfterApplicationExit()
+
+        #expect(settler.settlement == DeveloperApplicationTransactionSettlement.restored)
+        #expect(monitor.startCount == 0)
+        let restored = try String(contentsOf: prepared.settingsURL, encoding: .utf8)
+        #expect(restored.contains("USE_HTTP_PROXY"))
+        #expect(!FileManager.default.fileExists(atPath: prepared.preparation.recoveryRecordURL.path))
+    }
+
+    @Test("Out-of-process monitor stands down when a successor runs from the same bundle")
+    func restorationMonitorFollowsInPlaceRestart() throws {
+        let scenario = try makeMonitorScenario(processTable: [
+            "4242 \(monitorBundlePath)/Contents/MacOS/developer-app",
+        ])
+        defer { try? FileManager.default.removeItem(at: scenario.directory) }
+
+        let status = try scenario.run()
+
+        #expect(status == 0)
+        #expect(try Data(contentsOf: scenario.settingsURL) == Data("prepared".utf8))
+        #expect(FileManager.default.fileExists(atPath: scenario.backupURL.path))
+        #expect(FileManager.default.fileExists(atPath: scenario.preparedSnapshotURL.path))
+        #expect(FileManager.default.fileExists(atPath: scenario.recoveryRecordURL.path))
+    }
+
+    @Test("Out-of-process monitor restores after an ordinary exit and clears its marker")
+    func restorationMonitorRestoresWithoutSuccessor() throws {
+        let scenario = try makeMonitorScenario(processTable: [
+            "4242 /Applications/Unrelated.app/Contents/MacOS/unrelated",
+        ])
+        defer { try? FileManager.default.removeItem(at: scenario.directory) }
+
+        let status = try scenario.run()
+
+        #expect(status == 0)
+        #expect(try Data(contentsOf: scenario.settingsURL) == Data("original".utf8))
+        #expect(!FileManager.default.fileExists(atPath: scenario.backupURL.path))
+        #expect(!FileManager.default.fileExists(atPath: scenario.preparedSnapshotURL.path))
+        #expect(!FileManager.default.fileExists(atPath: scenario.recoveryRecordURL.path))
+        #expect(!FileManager.default.fileExists(atPath: scenario.monitorMarkerURL.path))
+    }
+
+    @Test("Out-of-process monitor never treats a matching process name as a successor")
+    func restorationMonitorRejectsProcessNameEvidence() throws {
+        let scenario = try makeMonitorScenario(processTable: [
+            "4242 /Applications/Other App.app/Contents/MacOS/developer-app",
+            "4243 /tmp/wrapper\(monitorBundlePath)/Contents/MacOS/developer-app",
+        ])
+        defer { try? FileManager.default.removeItem(at: scenario.directory) }
+
+        let status = try scenario.run()
+
+        #expect(status == 0)
+        #expect(try Data(contentsOf: scenario.settingsURL) == Data("original".utf8))
+        #expect(!FileManager.default.fileExists(atPath: scenario.recoveryRecordURL.path))
+    }
+
+    @Test("A live restoration monitor marker is reused instead of duplicated on relaunch")
+    func liveRestorationMonitorMarkerIsReused() throws {
+        let directory = try makeTemporaryDirectory(named: "rockxy-monitor-marker")
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let recoveryRecordURL = directory.appendingPathComponent("recovery.json")
+        let markerURL = DeveloperApplicationRestorationMonitorLedger.markerURL(for: recoveryRecordURL)
+        let signature = try #require(
+            DeveloperApplicationCaptureConfigurator.processStartSignature(processIdentifier: getpid())
+        )
+        try DeveloperApplicationRestorationMonitorLedger.writeMarker(
+            monitorProcessIdentifier: getpid(),
+            monitorStartSignature: signature,
+            monitoredProcessIdentifier: 4_242,
+            to: markerURL
+        )
+
+        #expect(markerURL.lastPathComponent == "recovery.monitor")
+        #expect(!DeveloperApplicationRestorationMonitorLedger.shouldStartMonitor(
+            markerURL: markerURL,
+            monitoredProcessIdentifier: 4_242
+        ))
+        // A marker that watches a different application process cannot suppress a new monitor.
+        #expect(DeveloperApplicationRestorationMonitorLedger.shouldStartMonitor(
+            markerURL: markerURL,
+            monitoredProcessIdentifier: 4_243
+        ))
+    }
+
+    @Test("Stale, missing, or corrupt monitor markers always start a fresh monitor")
+    func staleRestorationMonitorMarkerIsReplaced() throws {
+        let directory = try makeTemporaryDirectory(named: "rockxy-monitor-marker-stale")
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let recoveryRecordURL = directory.appendingPathComponent("recovery.json")
+        let markerURL = DeveloperApplicationRestorationMonitorLedger.markerURL(for: recoveryRecordURL)
+
+        #expect(DeveloperApplicationRestorationMonitorLedger.shouldStartMonitor(
+            markerURL: markerURL,
+            monitoredProcessIdentifier: 4_242
+        ))
+
+        try DeveloperApplicationRestorationMonitorLedger.writeMarker(
+            monitorProcessIdentifier: Int32.max,
+            monitorStartSignature: "proc-v1:1:1",
+            monitoredProcessIdentifier: 4_242,
+            to: markerURL
+        )
+        #expect(DeveloperApplicationRestorationMonitorLedger.shouldStartMonitor(
+            markerURL: markerURL,
+            monitoredProcessIdentifier: 4_242
+        ))
+
+        try Data("not a marker".utf8).write(to: markerURL, options: .atomic)
+        #expect(DeveloperApplicationRestorationMonitorLedger.marker(at: markerURL) == nil)
+        #expect(DeveloperApplicationRestorationMonitorLedger.shouldStartMonitor(
+            markerURL: markerURL,
+            monitoredProcessIdentifier: 4_242
+        ))
+    }
+
+    // MARK: Private
+
+    private struct Fixture {
+        let rootURL: URL
+        let appURL: URL
+        let contentsURL: URL
+        let applicationSupportURL: URL
+    }
+
+    private struct PreparedFixture {
+        let fixture: Fixture
+        let installation: DeveloperApplicationInstallation
+        let settingsURL: URL
+        let preparation: DeveloperApplicationSettingsPreparation
+        let originalData: Data
+    }
+
+    private struct MonitorScenario {
+        let directory: URL
+        let settingsURL: URL
+        let backupURL: URL
+        let absenceMarkerURL: URL
+        let preparedSnapshotURL: URL
+        let recoveryRecordURL: URL
+        let monitorMarkerURL: URL
+        let processTableURL: URL
+        let bundlePath: String
+
+        func run() throws -> Int32 {
+            let process = Process()
+            process.executableURL = URL(fileURLWithPath: "/bin/sh")
+            process.arguments = [
+                "-c", DeveloperApplicationSettingsRestorationMonitor.script,
+                "rockxy-settings-restoration-monitor-test", String(Int32.max),
+                settingsURL.path, backupURL.path, absenceMarkerURL.path, preparedSnapshotURL.path,
+                recoveryRecordURL.path, processTableURL.path, bundlePath, "1",
+            ]
+            try process.run()
+            process.waitUntilExit()
+            return process.terminationStatus
+        }
+    }
+
+    /// Bundle path used by the out-of-process monitor scenarios. It never has to exist on disk:
+    /// the monitor compares it against the executable paths reported by the process table.
+    private var monitorBundlePath: String {
+        "/Applications/Developer App.app"
+    }
+
+    private func makeFixture(
+        productMetadataJavaPath: String? = nil,
+        productVendor: String = "Example Tools",
+        dataDirectoryName: String = "DeveloperIDE2026.2"
+    )
+        throws -> Fixture
+    {
+        let rootURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("Rockxy-Capability-App-\(UUID().uuidString)", isDirectory: true)
+        let appURL = rootURL.appendingPathComponent("Developer App.app", isDirectory: true)
+        let contentsURL = appURL.appendingPathComponent("Contents", isDirectory: true)
+        let resourcesURL = contentsURL.appendingPathComponent("Resources", isDirectory: true)
+        try FileManager.default.createDirectory(at: resourcesURL, withIntermediateDirectories: true)
+        let info: [String: Any] = [
+            "CFBundleIdentifier": "com.example.capability-app",
+            "CFBundleName": "Developer App",
+            "CFBundlePackageType": "APPL",
+            "CFBundleExecutable": "developer-app",
+        ]
+        try PropertyListSerialization.data(
+            fromPropertyList: info,
+            format: .xml,
+            options: 0
+        ).write(to: contentsURL.appendingPathComponent("Info.plist"))
+        if let productMetadataJavaPath {
+            let metadata: [String: Any] = [
+                "productVendor": productVendor,
+                "dataDirectoryName": dataDirectoryName,
+                "launch": [[
+                    "os": "macOS",
+                    "javaExecutablePath": productMetadataJavaPath,
+                ]],
+            ]
+            try JSONSerialization.data(withJSONObject: metadata, options: [.sortedKeys])
+                .write(to: resourcesURL.appendingPathComponent("product-info.json"))
+        }
+        return Fixture(
+            rootURL: rootURL,
+            appURL: appURL,
+            contentsURL: contentsURL,
+            applicationSupportURL: rootURL.appendingPathComponent("Application Support", isDirectory: true)
+        )
+    }
+
+    private func makeTemporaryDirectory(named name: String) throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(name)-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        return directory
+    }
+
+    private func makePreparedFixture(
+        dataDirectoryName: String = "DeveloperIDE2026.2"
+    )
+        throws -> PreparedFixture
+    {
+        let fixture = try makeFixture(
+            productMetadataJavaPath: "../jbr/Contents/Home/bin/java",
+            dataDirectoryName: dataDirectoryName
+        )
+        try makeExecutable(at: fixture.contentsURL.appendingPathComponent("jbr/Contents/Home/bin/java"))
+        let installation = try DeveloperApplicationCaptureConfigurator.installation(at: fixture.appURL)
+        let adapter = try #require(installation.settingsAdapter)
+        let settingsURL = try DeveloperApplicationCaptureConfigurator.proxySettingsURL(
+            for: adapter,
+            applicationSupportURL: fixture.applicationSupportURL
+        )
+        try FileManager.default.createDirectory(
+            at: settingsURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        let original = Data(
+            "<application><component name=\"HttpConfigurable\"><option name=\"USE_HTTP_PROXY\" value=\"true\" /></component></application>"
+                .utf8
+        )
+        try original.write(to: settingsURL)
+        let preparation = try #require(try DeveloperApplicationCaptureConfigurator.prepareRecognizedSettings(
+            for: installation,
+            applicationSupportURL: fixture.applicationSupportURL
+        ))
+        return PreparedFixture(
+            fixture: fixture,
+            installation: installation,
+            settingsURL: settingsURL,
+            preparation: preparation,
+            originalData: original
+        )
+    }
+
+    @MainActor
+    private func makeSettler(
+        for prepared: PreparedFixture,
+        monitor: CapabilityTestRestorationMonitor,
+        runningInstances: [DeveloperApplicationRunningInstance]
+    )
+        -> DeveloperApplicationTransactionSettler
+    {
+        DeveloperApplicationTransactionSettler(
+            scope: DeveloperApplicationCaptureConfigurator.scopeIdentity(for: prepared.installation),
+            preparation: prepared.preparation,
+            applicationSupportURL: prepared.fixture.applicationSupportURL,
+            restorationMonitor: monitor,
+            runningInstances: { runningInstances },
+            successorScanAttempts: 1,
+            successorScanInterval: .milliseconds(1)
+        )
+    }
+
+    /// Builds a self-contained transaction on disk plus a deterministic process table, so the
+    /// out-of-process monitor can be exercised without launching or observing a real application.
+    private func makeMonitorScenario(processTable: [String]) throws -> MonitorScenario {
+        let directory = try makeTemporaryDirectory(named: "rockxy-restoration-monitor-restart")
+        let settingsURL = directory.appendingPathComponent("proxy.settings.xml")
+        let recoveryRecordURL = directory.appendingPathComponent("recovery.json")
+        let monitorMarkerURL = DeveloperApplicationRestorationMonitorLedger.markerURL(
+            for: recoveryRecordURL
+        )
+        let processTableURL = directory.appendingPathComponent("process-table")
+        try Data("original".utf8).write(to: settingsURL.appendingPathExtension("rockxy-backup"))
+        try Data("prepared".utf8).write(to: settingsURL)
+        try Data("prepared".utf8).write(to: settingsURL.appendingPathExtension("rockxy-prepared"))
+        try Data("record".utf8).write(to: recoveryRecordURL)
+        try Data("marker".utf8).write(to: monitorMarkerURL)
+        try makeProcessTableCommand(at: processTableURL, entries: processTable)
+        return MonitorScenario(
+            directory: directory,
+            settingsURL: settingsURL,
+            backupURL: settingsURL.appendingPathExtension("rockxy-backup"),
+            absenceMarkerURL: settingsURL.appendingPathExtension("rockxy-originally-absent"),
+            preparedSnapshotURL: settingsURL.appendingPathExtension("rockxy-prepared"),
+            recoveryRecordURL: recoveryRecordURL,
+            monitorMarkerURL: monitorMarkerURL,
+            processTableURL: processTableURL,
+            bundlePath: monitorBundlePath
+        )
+    }
+
+    private func makeProcessTableCommand(at url: URL, entries: [String]) throws {
+        let printedEntries = entries
+            .map { "printf '%s\\n' \"\($0)\"" }
+            .joined(separator: "\n")
+        let script = """
+        #!/bin/sh
+        if [ "$1" = "-A" ]; then
+        \(printedEntries)
+        fi
+        exit 0
+        """
+        try Data(script.utf8).write(to: url)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: url.path)
+    }
+
+    private func makeExecutable(at url: URL) throws {
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try Data("#!/bin/sh\nexit 0\n".utf8).write(to: url)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: url.path)
+    }
+
+    @MainActor
+    private func workflow(
+        for fixture: Fixture,
+        launcher: CapabilityTestLauncher
+    )
+        -> DeveloperApplicationCaptureWorkflow
+    {
+        DeveloperApplicationCaptureWorkflow(
+            launcher: launcher,
+            restorationMonitor: CapabilityTestRestorationMonitor(),
+            preparationRegistry: DeveloperApplicationPreparationRegistry(),
+            applicationIsRunning: { _ in false },
+            applicationSupportURL: fixture.applicationSupportURL
+        )
+    }
+
+    private func setupContext(targetID: SetupTarget.ID) -> RockxySetupScriptContext {
+        RockxySetupScriptContext(
+            proxyHost: "127.0.0.1",
+            proxyPort: 8_888,
+            certificatePath: nil,
+            generatedAt: Date(timeIntervalSince1970: 0),
+            appName: "Rockxy",
+            targetID: targetID
+        )
+    }
+}

--- a/RockxyTests/ViewModels/DeveloperSetupSessionSetupTests.swift
+++ b/RockxyTests/ViewModels/DeveloperSetupSessionSetupTests.swift
@@ -8,6 +8,8 @@ private final class RecordingDeveloperApplicationLauncher: DeveloperApplicationL
     private(set) var terminationHandler: (@MainActor @Sendable () -> Void)?
     var launchError: (any Error)?
     var processIdentifier: Int32 = 42_424
+    var registeredProcessIdentifier: Int32 = 52_424
+    var registrationState: DeveloperApplicationRegistrationState = .registered
 
     @discardableResult
     func launch(
@@ -15,33 +17,41 @@ private final class RecordingDeveloperApplicationLauncher: DeveloperApplicationL
         arguments: [String],
         environment: [String: String],
         onTermination: (@MainActor @Sendable () -> Void)?
-    ) async throws -> Int32 {
+    ) async throws -> DeveloperApplicationLaunchReceipt {
         launches.append((installation, arguments, environment))
         terminationHandler = onTermination
         if let launchError {
             throw launchError
         }
-        return processIdentifier
+        return DeveloperApplicationLaunchReceipt(
+            lifecycleProcessIdentifier: processIdentifier,
+            registeredProcessIdentifier: registrationState == .registered ? registeredProcessIdentifier : nil,
+            registrationState: registrationState
+        )
     }
 }
 
 @MainActor
 private final class SuspendingDeveloperApplicationLauncher: DeveloperApplicationLaunching {
     private(set) var launchCount = 0
-    private var continuation: CheckedContinuation<Int32, Never>?
+    private var continuation: CheckedContinuation<DeveloperApplicationLaunchReceipt, Never>?
 
     func launch(
         _: DeveloperApplicationInstallation,
         arguments _: [String],
         environment _: [String: String],
         onTermination _: (@MainActor @Sendable () -> Void)?
-    ) async throws -> Int32 {
+    ) async throws -> DeveloperApplicationLaunchReceipt {
         launchCount += 1
         return await withCheckedContinuation { continuation = $0 }
     }
 
     func finish() {
-        continuation?.resume(returning: 42_425)
+        continuation?.resume(returning: DeveloperApplicationLaunchReceipt(
+            lifecycleProcessIdentifier: 42_425,
+            registeredProcessIdentifier: 52_425,
+            registrationState: .registered
+        ))
         continuation = nil
     }
 }
@@ -334,15 +344,21 @@ struct DeveloperSetupSessionSetupTests {
             applicationSupportURL: fixture.applicationSupportURL
         )
         let registry = DeveloperApplicationPreparationRegistry()
+        var resumedProcessIdentifiers: [Int32] = []
 
         let liveCount = DeveloperApplicationCaptureConfigurator.reconcileOutstandingPreparations(
             applicationSupportURL: fixture.applicationSupportURL,
             preparationRegistry: registry,
             recordedProcessIsAlive: { processIdentifier, startSignature in
                 processIdentifier == 42_424 && startSignature == "stable-process-start"
+            },
+            livePreparationHandler: { processIdentifier, resumedPreparation in
+                resumedProcessIdentifiers.append(processIdentifier)
+                #expect(resumedPreparation.settingsURL == preparation.settingsURL)
             }
         )
         #expect(liveCount == 0)
+        #expect(resumedProcessIdentifiers == [42_424])
         #expect(FileManager.default.fileExists(atPath: preparation.recoveryRecordURL.path))
 
         #expect(registry.begin(preparation.settingsURL.standardizedFileURL.path))
@@ -609,6 +625,7 @@ struct DeveloperSetupSessionSetupTests {
             targetID: .python,
             applicationLauncher: launcher,
             settingsRestorationMonitor: restorationMonitor,
+            systemProxyConfiguredProvider: { coordinator.isSystemProxyConfigured },
             applicationSupportURL: fixture.applicationSupportURL
         )
 
@@ -629,11 +646,13 @@ struct DeveloperSetupSessionSetupTests {
         #expect(viewModel.statusMessage?.contains("recognized proxy settings") == true)
         #expect(launcher.terminationHandler != nil)
         #expect(restorationMonitor.starts.count == 1)
-        #expect(restorationMonitor.starts[0].0 == launcher.processIdentifier)
+        #expect(restorationMonitor.starts[0].0 == launcher.registeredProcessIdentifier)
         #expect(restorationMonitor.starts[0].1.settingsURL == settingsURL)
 
         launcher.terminationHandler?()
-        for _ in 0 ..< 20 where FileManager.default.fileExists(atPath: settingsURL.path) {
+        // Normal restoration now waits through the bounded in-place-restart window before
+        // settling the transaction. Keep this integration assertion outside that timing race.
+        for _ in 0 ..< 200 where FileManager.default.fileExists(atPath: settingsURL.path) {
             try await Task.sleep(for: .milliseconds(25))
         }
         #expect(!FileManager.default.fileExists(atPath: settingsURL.path))
@@ -653,12 +672,14 @@ struct DeveloperSetupSessionSetupTests {
             coordinator: coordinator,
             applicationLauncher: launcher,
             preparationRegistry: registry,
+            systemProxyConfiguredProvider: { coordinator.isSystemProxyConfigured },
             applicationSupportURL: fixture.applicationSupportURL
         )
         let second = DeveloperSetupSessionSetupViewModel(
             coordinator: coordinator,
             applicationLauncher: launcher,
             preparationRegistry: registry,
+            systemProxyConfiguredProvider: { coordinator.isSystemProxyConfigured },
             applicationSupportURL: fixture.applicationSupportURL
         )
 
@@ -807,6 +828,7 @@ struct DeveloperSetupSessionSetupTests {
         let viewModel = DeveloperSetupSessionSetupViewModel(
             coordinator: coordinator,
             applicationLauncher: launcher,
+            systemProxyConfiguredProvider: { coordinator.isSystemProxyConfigured },
             applicationSupportURL: fixture.applicationSupportURL
         )
 
@@ -831,6 +853,7 @@ struct DeveloperSetupSessionSetupTests {
             coordinator: coordinator,
             targetID: .javaVMs,
             applicationLauncher: launcher,
+            systemProxyConfiguredProvider: { coordinator.isSystemProxyConfigured },
             applicationSupportURL: fixture.applicationSupportURL
         )
 
@@ -859,6 +882,7 @@ struct DeveloperSetupSessionSetupTests {
             coordinator: coordinator,
             applicationLauncher: launcher,
             applicationIsRunning: { _ in true },
+            systemProxyConfiguredProvider: { coordinator.isSystemProxyConfigured },
             applicationSupportURL: fixture.applicationSupportURL
         )
 
@@ -874,19 +898,20 @@ struct DeveloperSetupSessionSetupTests {
         #expect(viewModel.statusMessage?.contains("Quit Developer App completely") == true)
     }
 
-    @Test("Recognized app-level settings require active macOS System Proxy")
+    @Test("Recognized app-level settings use live macOS System Proxy state instead of cached UI state")
     @MainActor
     func recognizedSettingsRequireSystemProxy() async throws {
         let fixture = try makeApplicationFixture(dataDirectoryName: "DeveloperIDE2026.2")
         defer { try? FileManager.default.removeItem(at: fixture.rootURL) }
         let coordinator = MainContentCoordinator()
         coordinator.isProxyRunning = true
-        coordinator.isSystemProxyConfigured = false
+        coordinator.isSystemProxyConfigured = true
         let launcher = RecordingDeveloperApplicationLauncher()
         let viewModel = DeveloperSetupSessionSetupViewModel(
             coordinator: coordinator,
             targetID: .python,
             applicationLauncher: launcher,
+            systemProxyConfiguredProvider: { false },
             applicationSupportURL: fixture.applicationSupportURL
         )
 
@@ -908,6 +933,7 @@ struct DeveloperSetupSessionSetupTests {
             coordinator: coordinator,
             targetID: .python,
             applicationLauncher: launcher,
+            systemProxyConfiguredProvider: { coordinator.isSystemProxyConfigured },
             applicationSupportURL: fixture.applicationSupportURL
         )
 
@@ -933,6 +959,7 @@ struct DeveloperSetupSessionSetupTests {
         let viewModel = DeveloperSetupSessionSetupViewModel(
             coordinator: coordinator,
             applicationLauncher: launcher,
+            systemProxyConfiguredProvider: { coordinator.isSystemProxyConfigured },
             applicationSupportURL: fixture.applicationSupportURL
         )
 
@@ -1043,6 +1070,7 @@ struct DeveloperSetupSessionSetupTests {
         productVendor: String = "Example Tools",
         includeMetadata: Bool = true,
         includeChromiumRuntime: Bool = false,
+        includeJPackageRuntime: Bool = false,
         parseInstallation: Bool = true
     ) throws -> ApplicationFixture {
         let rootURL = FileManager.default.temporaryDirectory
@@ -1052,10 +1080,12 @@ struct DeveloperSetupSessionSetupTests {
         let resourcesURL = contentsURL.appendingPathComponent("Resources", isDirectory: true)
         try FileManager.default.createDirectory(at: resourcesURL, withIntermediateDirectories: true)
 
+        let executableName = "developer-app"
         let info: [String: Any] = [
             "CFBundleIdentifier": "com.example.developer-app",
             "CFBundleName": "Developer App",
             "CFBundlePackageType": "APPL",
+            "CFBundleExecutable": executableName,
         ]
         let infoData = try PropertyListSerialization.data(
             fromPropertyList: info,
@@ -1075,13 +1105,46 @@ struct DeveloperSetupSessionSetupTests {
         }
 
         if includeMetadata {
+            let javaURL = contentsURL.appendingPathComponent("jbr/Contents/Home/bin/java")
+            try FileManager.default.createDirectory(
+                at: javaURL.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            try Data("#!/bin/sh\nexit 0\n".utf8).write(to: javaURL)
+            try FileManager.default.setAttributes(
+                [.posixPermissions: 0o755],
+                ofItemAtPath: javaURL.path
+            )
             let productInfo: [String: Any] = [
                 "name": "Developer App",
                 "productVendor": productVendor,
                 "dataDirectoryName": dataDirectoryName,
+                "launch": [[
+                    "os": "macOS",
+                    "javaExecutablePath": "../jbr/Contents/Home/bin/java",
+                ]],
             ]
             let productInfoData = try JSONSerialization.data(withJSONObject: productInfo, options: [.sortedKeys])
             try productInfoData.write(to: resourcesURL.appendingPathComponent("product-info.json"))
+        }
+
+        if includeJPackageRuntime {
+            let javaURL = contentsURL.appendingPathComponent("runtime/Contents/Home/bin/java")
+            let configURL = contentsURL.appendingPathComponent("app/\(executableName).cfg")
+            try FileManager.default.createDirectory(
+                at: javaURL.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            try FileManager.default.createDirectory(
+                at: configURL.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            try Data("#!/bin/sh\nexit 0\n".utf8).write(to: javaURL)
+            try FileManager.default.setAttributes(
+                [.posixPermissions: 0o755],
+                ofItemAtPath: javaURL.path
+            )
+            try Data("[Application]\napp.mainclass=com.example.Main\n".utf8).write(to: configURL)
         }
 
         let applicationSupportURL = rootURL.appendingPathComponent("Application Support", isDirectory: true)
@@ -1097,7 +1160,10 @@ struct DeveloperSetupSessionSetupTests {
                         dataDirectoryName: dataDirectoryName
                     )
                     : nil,
-                launchAdapter: includeChromiumRuntime ? .chromiumProxy : nil
+                launchAdapter: includeChromiumRuntime ? .chromiumProxy : nil,
+                runtimeCapabilities: includeMetadata || includeJPackageRuntime
+                    ? [.javaVirtualMachine]
+                    : []
             )
         } else {
             installation = try DeveloperApplicationCaptureConfigurator.installation(at: appURL)


### PR DESCRIPTION
## Summary

- preserve temporary developer application settings across delayed launches, in-place restarts, Rockxy relaunches, and abnormal termination
- coalesce bounded process attribution lookups, backfill late identities, and keep connection limits isolated per destination
- verify the live System Proxy port before reporting capture readiness, serialize startup recovery, and roll back unconfirmed overrides
- reconcile the active Root CA with the persisted certificate and private key before trust installation, and fail closed when another app copy changes that identity

## Why

Developer application capture spans application launch, runtime-specific proxy configuration, process attribution, System Proxy ownership, and certificate trust. Recovery gaps across those boundaries could leave settings unrestored, report a stale proxy as ready, or continue presenting an in-memory Root CA as trusted after another Rockxy copy replaced the persisted identity.

This change makes each transition durable and observable. Status checks remain read-only, privileged trust actions reconcile the persisted identity explicitly, and capture startup performs a fresh trust validation before accepting HTTPS connections.

## Impact

- compatible IDE and developer application launches retain reversible proxy configuration across restart and update paths
- stale or mismatched System Proxy overrides are no longer treated as capture-ready
- concurrent attribution queries are bounded and shared without mixing proxy ports or destinations
- HTTPS readiness distinguishes missing, uninstalled, untrusted, and unreadable Root CA states
- a sibling Rockxy copy changing certificate storage cannot leave the current process showing stale trusted state

## Related issues

Refs #319
Refs #302
Refs #11

## Validation

- strict SwiftLint
- localization catalog validation for both catalogs, including required zh-Hans coverage
- 181 focused tests across certificate lifecycle, readiness warnings, System Proxy recovery, process attribution, connection limiting, and developer application capture
- Debug build
- native UI install-and-trust flow followed by an intercepted HTTPS 200 response
- clean relaunch and forced-termination recovery with a stable Root CA fingerprint and both System Proxy protocols restored after termination