### PR TITLE
style: satisfy application file length limit

### DIFF
--- a/Rockxy/RockxyApp.swift
+++ b/Rockxy/RockxyApp.swift
@@ -1474,12 +1474,11 @@ struct RockxyMenuCommands: Commands {
     private func showAboutPanel() {
         let version = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "Unknown"
         let build = Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? "Unknown"
-        let homepage = ProjectLinks.repositoryURL
         let credits = NSMutableAttributedString(
             string: String(localized: "The Rockxy Community source edition is licensed under AGPL-3.0-or-later.\n", bundle: RockxyLocalization.bundle)
         )
 
-        if let homepage {
+        if let homepage = ProjectLinks.repositoryURL {
             let linkText = String(localized: "View the public source and license on GitHub", bundle: RockxyLocalization.bundle)
             let link = NSMutableAttributedString(string: linkText)
             link.addAttribute(.link, value: homepage, range: NSRange(location: 0, length: link.length))


### PR DESCRIPTION
## Summary

- keep the existing About panel behavior while reducing RockxyApp.swift below the enforced file-length limit
- bind the optional repository URL directly at its only use site

## Why

The develop-to-main promotion exposed a one-line SwiftLint file-length violation on the protected merge head. The focused cleanup removes that violation without changing application behavior.

## Impact

- no user-facing behavior change
- promotion PR #329 can satisfy the required SwiftLint gate
- the application entry file remains within the configured 1,200-line limit

## Issue audit

No directly related product issue was found.

## Validation

- strict SwiftLint passed across 570 files with 0 violations
- git diff validation passed
- the change is limited to one equivalent optional binding in the About panel