### PR TITLE
test: isolate developer setup proxy port

### DIFF
--- a/RockxyTests/ViewModels/DeveloperSetupSessionSetupTests.swift
+++ b/RockxyTests/ViewModels/DeveloperSetupSessionSetupTests.swift
@@ -616,6 +616,7 @@ struct DeveloperSetupSessionSetupTests {
         let fixture = try makeApplicationFixture(dataDirectoryName: "DeveloperIDE2026.2")
         defer { try? FileManager.default.removeItem(at: fixture.rootURL) }
         let coordinator = MainContentCoordinator()
+        coordinator.activeProxyPort = 8_888
         coordinator.isProxyRunning = true
         coordinator.isSystemProxyConfigured = true
         let launcher = RecordingDeveloperApplicationLauncher()
@@ -954,6 +955,7 @@ struct DeveloperSetupSessionSetupTests {
         )
         defer { try? FileManager.default.removeItem(at: fixture.rootURL) }
         let coordinator = MainContentCoordinator()
+        coordinator.activeProxyPort = 8_888
         coordinator.isProxyRunning = true
         let launcher = RecordingDeveloperApplicationLauncher()
         let viewModel = DeveloperSetupSessionSetupViewModel(


### PR DESCRIPTION
## Summary

- make the developer application launch tests set their active proxy port explicitly
- prevent persisted runner settings from changing the expected proxy environment and launch arguments

## Why

Promotion CI exposed that two tests expected port 8888 while constructing a coordinator from shared persisted settings. A runner carrying port 9090 therefore exercised valid production behavior but failed nondeterministic test expectations.

The tests now declare the active port they verify, matching the capture state they construct and removing dependence on runner history.

## Impact

- no production behavior changes
- developer setup tests remain deterministic across clean and reused runners
- promotion PR #329 can validate the actual proxy behavior without persisted-state leakage

## Issue audit

No directly related product issue was found.

## Validation

- focused DeveloperSetupSessionSetupTests: 38 tests passed, 0 failed
- strict SwiftLint passed
- git diff validation passed