### PR TITLE
fix: harden proxy recovery and readiness

### DIFF
--- a/Rockxy/Core/Services/DeveloperSetupProbeServer.swift
+++ b/Rockxy/Core/Services/DeveloperSetupProbeServer.swift
@@ -189,7 +189,13 @@ actor DeveloperSetupProbeServer {
         guard activeSession == session else {
             return
         }
-        await stop()
+        lifecycleGeneration += 1
+        activeSession = nil
+        let channel = serverChannel
+        let group = eventLoopGroup
+        serverChannel = nil
+        eventLoopGroup = nil
+        await close(channel: channel, group: group)
     }
 
     private func close(

--- a/Rockxy/Core/TrafficCapture/SystemProxyManager.swift
+++ b/Rockxy/Core/TrafficCapture/SystemProxyManager.swift
@@ -807,22 +807,26 @@ final class SystemProxyManager: @unchecked Sendable {
     /// left behind by a crash or force-quit.
     func recoverStaleProxyIfNeeded() async {
         if let backup = loadDirectBackup() {
-            if Date().timeIntervalSince(backup.timestamp) > 86_400 {
-                Self.logger.info("Stale direct backup >24h old, clearing without restore")
-                clearDirectBackup()
-            } else {
-                let backedUpServices = backup.services.map(\.service)
-                if currentProxyMatchesRockxy(port: backup.rockxyPort, backedUpServices: backedUpServices) {
-                    Self.logger.info("Recovering stale direct-mode proxy override from crash")
-                    do {
-                        try await disableSystemProxy()
-                    } catch {
-                        Self.logger.error("Stale direct proxy recovery failed: \(error.localizedDescription)")
-                    }
-                } else {
-                    Self.logger.info("Proxy no longer Rockxy-owned, clearing stale direct backup")
-                    clearDirectBackup()
+            let backedUpServices = backup.services.map(\.service)
+            switch ProxyBackupRecoveryPolicy.action(
+                proxyStillPointsAtRockxy: currentProxyMatchesRockxy(
+                    port: backup.rockxyPort,
+                    backedUpServices: backedUpServices
+                ),
+                listenerIsReachable: false
+            ) {
+            case .restore:
+                Self.logger.info("Recovering stale direct-mode proxy override from crash")
+                do {
+                    try await disableSystemProxy()
+                } catch {
+                    Self.logger.error("Stale direct proxy recovery failed: \(error.localizedDescription)")
                 }
+            case .clear:
+                Self.logger.info("Proxy no longer Rockxy-owned, clearing stale direct backup")
+                clearDirectBackup()
+            case .preserve:
+                break
             }
         }
 

--- a/Rockxy/Models/Settings/BypassDomain.swift
+++ b/Rockxy/Models/Settings/BypassDomain.swift
@@ -27,7 +27,9 @@ struct BypassDomain: Identifiable, Codable, Hashable {
         let normalizedHost = host.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         let normalizedDomain = domain.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
 
-        guard !normalizedHost.isEmpty, !normalizedDomain.isEmpty else {
+        guard !normalizedHost.isEmpty,
+              ProxyBypassDomainValidator.isValid(normalizedDomain)
+        else {
             return false
         }
 
@@ -52,7 +54,7 @@ struct BypassDomain: Identifiable, Codable, Hashable {
 
     static func systemProxyPatterns(for domain: String) -> [String] {
         let normalizedDomain = domain.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-        guard !normalizedDomain.isEmpty else {
+        guard ProxyBypassDomainValidator.isValid(normalizedDomain) else {
             return []
         }
 

--- a/Rockxy/Models/UI/DeveloperApplicationCaptureWorkflow.swift
+++ b/Rockxy/Models/UI/DeveloperApplicationCaptureWorkflow.swift
@@ -107,8 +107,7 @@ final class DeveloperApplicationTransactionSettler {
         isSettling = true
         defer { isSettling = false }
 
-        if let successor = await waitForSuccessor() {
-            await rebind(to: successor)
+        if let successor = await waitForSuccessor(), await rebind(to: successor) {
             settlement = .reboundToSuccessor(processIdentifier: successor.processIdentifier)
             return
         }
@@ -151,7 +150,7 @@ final class DeveloperApplicationTransactionSettler {
         return nil
     }
 
-    private func rebind(to successor: DeveloperApplicationRunningInstance) async {
+    private func rebind(to successor: DeveloperApplicationRunningInstance) async -> Bool {
         let preparation = self.preparation
         let applicationSupportURL = self.applicationSupportURL
         let processIdentifier = successor.processIdentifier
@@ -173,6 +172,7 @@ final class DeveloperApplicationTransactionSettler {
             developerApplicationWorkflowLogger.error(
                 "Could not rebind a developer-application settings transaction to the successor process: \(error.localizedDescription)"
             )
+            return false
         }
         do {
             try restorationMonitor.startMonitoring(
@@ -184,6 +184,7 @@ final class DeveloperApplicationTransactionSettler {
                 "Could not monitor the successor of a prepared developer application: \(error.localizedDescription)"
             )
         }
+        return true
     }
 }
 

--- a/Rockxy/Views/Main/Extensions/MainContentCoordinator+ProxyControl.swift
+++ b/Rockxy/Views/Main/Extensions/MainContentCoordinator+ProxyControl.swift
@@ -378,17 +378,16 @@ extension MainContentCoordinator {
             uri: session.url.absoluteString,
             headers: headers
         )
+        let responseHandler = CaptureHealthProbeResponseHandler(
+            requestHead: requestHead,
+            responsePromise: responsePromise
+        )
 
         let bootstrap = ClientBootstrap(group: group)
             .connectTimeout(.seconds(4))
             .channelInitializer { channel in
                 channel.pipeline.addHTTPClientHandlers().flatMap {
-                    channel.pipeline.addHandler(
-                        CaptureHealthProbeResponseHandler(
-                            requestHead: requestHead,
-                            responsePromise: responsePromise
-                        )
-                    )
+                    channel.pipeline.addHandler(responseHandler)
                 }
             }
 
@@ -402,7 +401,7 @@ extension MainContentCoordinator {
         }
 
         let timeout = channel.eventLoop.scheduleTask(in: .seconds(5)) {
-            responsePromise.fail(CaptureHealthProbeError.timeout)
+            responseHandler.timeout()
         }
 
         do {
@@ -973,14 +972,15 @@ extension MainContentCoordinator {
 
 // MARK: - CaptureHealthProbeResponseHandler
 
-private enum CaptureHealthProbeError: Error {
+enum CaptureHealthProbeError: Error {
+    case connectionClosed
     case timeout
 }
 
 /// Sends an absolute-form HTTP request directly to the active proxy listener. Foundation's
 /// URL loading system may bypass configured proxies for loopback destinations, which would
 /// make the readiness check report a false success without traversing Rockxy.
-private final class CaptureHealthProbeResponseHandler: ChannelInboundHandler, @unchecked Sendable {
+final class CaptureHealthProbeResponseHandler: ChannelInboundHandler, @unchecked Sendable {
     typealias InboundIn = HTTPClientResponsePart
     typealias OutboundOut = HTTPClientRequestPart
 
@@ -1004,17 +1004,43 @@ private final class CaptureHealthProbeResponseHandler: ChannelInboundHandler, @u
         case .body:
             break
         case .end:
-            responsePromise.succeed(receivedResponseHead)
+            succeed(receivedResponseHead)
             context.close(promise: nil)
         }
     }
 
     func errorCaught(context: ChannelHandlerContext, error: Error) {
-        responsePromise.fail(error)
+        fail(error)
         context.close(promise: nil)
+    }
+
+    func channelInactive(context: ChannelHandlerContext) {
+        fail(CaptureHealthProbeError.connectionClosed)
+        context.fireChannelInactive()
+    }
+
+    func timeout() {
+        fail(CaptureHealthProbeError.timeout)
     }
 
     private let requestHead: HTTPRequestHead
     private let responsePromise: EventLoopPromise<Bool>
     private var receivedResponseHead = false
+    private var isCompleted = false
+
+    private func succeed(_ value: Bool) {
+        guard !isCompleted else {
+            return
+        }
+        isCompleted = true
+        responsePromise.succeed(value)
+    }
+
+    private func fail(_ error: Error) {
+        guard !isCompleted else {
+            return
+        }
+        isCompleted = true
+        responsePromise.fail(error)
+    }
 }

--- a/Rockxy/Views/RequestList/CenterContentView.swift
+++ b/Rockxy/Views/RequestList/CenterContentView.swift
@@ -38,7 +38,7 @@ struct CenterContentView: View {
                 totalDataSize: coordinator.totalDataSize,
                 uploadSpeed: coordinator.uploadSpeed,
                 downloadSpeed: coordinator.downloadSpeed,
-                isProxyOverridden: coordinator.isSystemProxyConfigured,
+                isProxyOverridden: coordinator.isProxyOverridden,
                 isAllowListActive: allowListManager.isActive,
                 isNoCachingActive: isNoCachingEnabled,
                 activeFilterCount: activeFilterCount,

--- a/RockxyHelperTool/CrashRecovery.swift
+++ b/RockxyHelperTool/CrashRecovery.swift
@@ -1,3 +1,4 @@
+import Darwin
 import Foundation
 import os
 
@@ -102,22 +103,22 @@ enum CrashRecovery {
     struct ProxyBackup: Codable {
         let services: [ServiceProxyBackup]
         let timestamp: Date
+        let rockxyPort: Int?
     }
 
     // MARK: - Public API
 
     /// Save current proxy settings for all specified services before overriding them.
-    static func saveOriginalSettings(services: [String]) throws {
+    static func saveOriginalSettings(services: [String], rockxyPort: Int) throws {
         let existingBackup = loadBackup()
         let existingServices = Set(existingBackup?.services.map(\.service) ?? [])
         let servicesToCapture = services.filter { !existingServices.contains($0) }
 
-        guard !servicesToCapture.isEmpty else {
+        if servicesToCapture.isEmpty {
             logger.info("Preserving the existing proxy backup for \(existingServices.count) service(s)")
-            return
+        } else {
+            logger.info("Saving original proxy settings for \(servicesToCapture.count) new service(s)")
         }
-
-        logger.info("Saving original proxy settings for \(servicesToCapture.count) new service(s)")
 
         var serviceBackups: [ServiceProxyBackup] = []
         for service in servicesToCapture {
@@ -163,7 +164,8 @@ enum CrashRecovery {
 
         let backup = ProxyBackup(
             services: (existingBackup?.services ?? []) + serviceBackups,
-            timestamp: existingBackup?.timestamp ?? Date()
+            timestamp: existingBackup?.timestamp ?? Date(),
+            rockxyPort: rockxyPort
         )
 
         do {
@@ -200,15 +202,21 @@ enum CrashRecovery {
             return
         }
 
-        let maxAge: TimeInterval = 24 * 60 * 60
-        if Date().timeIntervalSince(backup.timestamp) > maxAge {
-            logger.warning("Backup is stale (> 24h old) — discarding rather than restoring")
+        let status = ProxyConfigurator.getCurrentStatus()
+        switch ProxyBackupRecoveryPolicy.action(
+            proxyStillPointsAtRockxy: status.isOverridden &&
+                (backup.rockxyPort == nil || backup.rockxyPort == status.port),
+            listenerIsReachable: listenerIsReachable(port: status.port)
+        ) {
+        case .restore:
+            logger.warning("Owned proxy backup has no live listener — restoring proxy settings")
+            ProxyConfigurator.restoreProxy()
+        case .preserve:
+            logger.info("Owned proxy backup belongs to a live listener — preserving the active session")
+        case .clear:
+            logger.info("Proxy no longer points at the backed-up Rockxy session — clearing stale backup")
             clearBackup()
-            return
         }
-
-        logger.warning("Recent proxy backup found — previous session may have crashed. Restoring proxy settings.")
-        ProxyConfigurator.restoreProxy()
     }
 
     /// Load the backup data from disk.
@@ -282,6 +290,52 @@ enum CrashRecovery {
                 )
             }
         }
+    }
+
+    private static func listenerIsReachable(port: Int) -> Bool {
+        guard let port = UInt16(exactly: port), port > 0 else {
+            return false
+        }
+
+        let descriptor = socket(AF_INET, SOCK_STREAM, 0)
+        guard descriptor >= 0 else {
+            return false
+        }
+        defer { Darwin.close(descriptor) }
+
+        let flags = fcntl(descriptor, F_GETFL, 0)
+        guard flags >= 0, fcntl(descriptor, F_SETFL, flags | O_NONBLOCK) == 0 else {
+            return false
+        }
+
+        var address = sockaddr_in()
+        address.sin_family = sa_family_t(AF_INET)
+        address.sin_port = in_port_t(port).bigEndian
+        address.sin_addr.s_addr = inet_addr("127.0.0.1")
+
+        let result = withUnsafePointer(to: &address) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                Darwin.connect(descriptor, $0, socklen_t(MemoryLayout<sockaddr_in>.size))
+            }
+        }
+        if result == 0 {
+            return true
+        }
+        guard errno == EINPROGRESS else {
+            return false
+        }
+
+        var state = pollfd(fd: descriptor, events: Int16(POLLOUT), revents: 0)
+        guard Darwin.poll(&state, 1, 250) > 0 else {
+            return false
+        }
+
+        var socketError: Int32 = 0
+        var socketErrorLength = socklen_t(MemoryLayout<Int32>.size)
+        guard getsockopt(descriptor, SOL_SOCKET, SO_ERROR, &socketError, &socketErrorLength) == 0 else {
+            return false
+        }
+        return socketError == 0
     }
 
     private static func readBypassDomains(service: String) throws -> [String] {

--- a/RockxyHelperTool/ProxyConfigurator.swift
+++ b/RockxyHelperTool/ProxyConfigurator.swift
@@ -35,7 +35,7 @@ enum ProxyConfigurator {
 
         // Existing service snapshots are preserved, while newly enabled services are added
         // before they are mutated so every touched route has an exact restore point.
-        try CrashRecovery.saveOriginalSettings(services: services)
+        try CrashRecovery.saveOriginalSettings(services: services, rockxyPort: port)
 
         logger.info("Setting system proxy to 127.0.0.1:\(port) for \(services.count) service(s)")
 
@@ -224,7 +224,7 @@ enum ProxyConfigurator {
         guard let services = try? detectAllEnabledServices(), !services.isEmpty else {
             return (false, 0)
         }
-        guard CrashRecovery.hasBackup() else {
+        guard let backup = CrashRecovery.loadBackup() else {
             return (false, 0)
         }
 
@@ -261,6 +261,9 @@ enum ProxyConfigurator {
                 return (false, 0)
             }
             if let matchedPort, matchedPort != http.port {
+                return (false, 0)
+            }
+            if let rockxyPort = backup.rockxyPort, rockxyPort != http.port {
                 return (false, 0)
             }
             matchedPort = http.port

--- a/RockxyTests/Core/ProxyEngine/BypassProxyManagerTests.swift
+++ b/RockxyTests/Core/ProxyEngine/BypassProxyManagerTests.swift
@@ -52,10 +52,11 @@ struct BypassProxyManagerTests {
         #expect(manager.domains.isEmpty)
     }
 
-    @Test("addDomain rejects a global bypass")
+    @Test("addDomain rejects global bypass patterns")
     func addDomainRejectsGlobalBypass() {
         let manager = makeManager()
         manager.addDomain("*")
+        manager.addDomain("0.0.0.0/0")
         #expect(manager.domains.isEmpty)
     }
 
@@ -235,13 +236,14 @@ struct BypassProxyManagerTests {
         #expect(imported.isHostBypassed("169.254.10.20"))
     }
 
-    @Test("import rejects a global bypass")
+    @Test("import rejects global bypass patterns")
     func importRejectsGlobalBypass() throws {
         let manager = makeManager()
-        let data = try JSONEncoder().encode([BypassDomain(domain: "*")])
-
-        #expect(throws: BypassProxyManagerError.self) {
-            try manager.importDomains(from: data)
+        for domain in ["*", "0.0.0.0/0"] {
+            let data = try JSONEncoder().encode([BypassDomain(domain: domain)])
+            #expect(throws: BypassProxyManagerError.self) {
+                try manager.importDomains(from: data)
+            }
         }
         #expect(manager.domains.isEmpty)
     }
@@ -266,27 +268,33 @@ struct BypassProxyManagerTests {
         try? FileManager.default.removeItem(at: url)
     }
 
-    @Test("load preserves but disables a legacy global bypass")
+    @Test("load preserves but disables legacy global bypass patterns")
     func loadDisablesLegacyGlobalBypass() throws {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("rockxy-global-bypass-\(UUID().uuidString).json")
         defer { try? FileManager.default.removeItem(at: url) }
         let data = try JSONEncoder().encode([
             BypassDomain(domain: "*"),
+            BypassDomain(domain: "0.0.0.0/0"),
             BypassDomain(domain: "localhost"),
         ])
         try data.write(to: url, options: .atomic)
 
         let manager = BypassProxyManager(storageURL: url)
 
-        #expect(manager.domains.count == 2)
+        #expect(manager.domains.count == 3)
         #expect(manager.domains.first(where: { $0.domain == "*" })?.isEnabled == false)
+        #expect(manager.domains.first(where: { $0.domain == "0.0.0.0/0" })?.isEnabled == false)
         #expect(manager.domains.first(where: { $0.domain == "localhost" })?.isEnabled == true)
         #expect(!manager.isHostBypassed("example.com"))
 
         let globalBypassID = try #require(manager.domains.first(where: { $0.domain == "*" })?.id)
         manager.toggleDomain(id: globalBypassID)
         #expect(manager.domains.first(where: { $0.domain == "*" })?.isEnabled == false)
+
+        let cidrBypassID = try #require(manager.domains.first(where: { $0.domain == "0.0.0.0/0" })?.id)
+        manager.toggleDomain(id: cidrBypassID)
+        #expect(manager.domains.first(where: { $0.domain == "0.0.0.0/0" })?.isEnabled == false)
     }
 
     // MARK: Private

--- a/RockxyTests/Core/ProxyEngine/ClientIdentityResolutionTests.swift
+++ b/RockxyTests/Core/ProxyEngine/ClientIdentityResolutionTests.swift
@@ -449,7 +449,7 @@ struct ClientIdentityResolutionTests {
         let handle = ClientIdentityHandle(descriptor: descriptor, resolver: resolver)
 
         handle.startResolution()
-        try await Task.sleep(for: .milliseconds(50))
+        _ = await handle.awaitIdentity()
 
         #expect(handle.currentIdentity == Self.sampleIdentity)
     }
@@ -468,7 +468,9 @@ struct ClientIdentityResolutionTests {
         let handle = ClientIdentityHandle(descriptor: descriptor, resolver: resolver)
 
         #expect(await handle.awaitIdentity() == nil)
-        try await Task.sleep(for: .milliseconds(300))
+        for _ in 0 ..< 100 where handle.currentIdentity != Self.sampleIdentity {
+            try await Task.sleep(for: .milliseconds(20))
+        }
 
         #expect(handle.currentIdentity == Self.sampleIdentity)
     }

--- a/RockxyTests/Core/ProxyEngine/ProxyConfiguratorBypassTests.swift
+++ b/RockxyTests/Core/ProxyEngine/ProxyConfiguratorBypassTests.swift
@@ -41,6 +41,8 @@ struct ProxyBackupBypassTests {
             "bad host",
             "bad;host",
             "bad/host",
+            "0.0.0.0/0",
+            "10.0.0.0/-0",
             "10.0.0.0/33",
             "10.0.0/8",
             "10.0.0.0/-1",
@@ -96,7 +98,8 @@ struct ProxyBackupBypassTests {
         )
         let original = ProxyBackupMirror(
             services: [serviceBackup],
-            timestamp: Date(timeIntervalSince1970: 1_700_000_000)
+            timestamp: Date(timeIntervalSince1970: 1_700_000_000),
+            rockxyPort: 8_888
         )
 
         let data = try PropertyListEncoder().encode(original)
@@ -119,6 +122,7 @@ struct ProxyBackupBypassTests {
         #expect(decodedService.autoDiscoveryEnabled == true)
         #expect(decodedService.bypassDomains.count == 3)
         #expect(decodedService.bypassDomains.contains("*.internal.corp.com"))
+        #expect(decoded.rockxyPort == 8_888)
     }
 
     @Test("Old single-service backup format fails to decode with new multi-service struct")
@@ -207,7 +211,8 @@ struct ProxyBackupBypassTests {
         )
         let original = ProxyBackupMirror(
             services: [wifiBackup, ethernetBackup],
-            timestamp: Date()
+            timestamp: Date(),
+            rockxyPort: 9_090
         )
 
         let data = try PropertyListEncoder().encode(original)
@@ -228,6 +233,7 @@ struct ProxyBackupBypassTests {
         #expect(decoded.services[1].pacEnabled == true)
         #expect(decoded.services[1].pacURL == "https://proxy.corp.com/config.pac")
         #expect(decoded.services[1].bypassDomains == ["*.internal.corp.com", "10.0.0.0/8"])
+        #expect(decoded.rockxyPort == 9_090)
     }
 
     // MARK: Private
@@ -254,6 +260,7 @@ struct ProxyBackupBypassTests {
     private struct ProxyBackupMirror: Codable {
         let services: [ServiceProxyBackupMirror]
         let timestamp: Date
+        let rockxyPort: Int?
     }
 
     private func makeServiceBackup(
@@ -289,7 +296,8 @@ struct ProxyBackupBypassTests {
         let services = serviceBackups ?? [makeServiceBackup(bypassDomains: bypassDomains)]
         return ProxyBackupMirror(
             services: services,
-            timestamp: Date()
+            timestamp: Date(),
+            rockxyPort: 8_888
         )
     }
 }

--- a/RockxyTests/Core/Services/DeveloperSetupProbeServerTests.swift
+++ b/RockxyTests/Core/Services/DeveloperSetupProbeServerTests.swift
@@ -114,6 +114,19 @@ struct DeveloperSetupProbeServerTests {
         await server.stop()
     }
 
+    @Test("A stale session cannot stop the newer probe server")
+    func staleSessionStopPreservesNewestServer() async throws {
+        let server = DeveloperSetupProbeServer()
+        let staleSession = try await server.start(targetID: .python)
+        let newestSession = try await server.start(targetID: .ruby)
+
+        await server.stop(ifCurrent: staleSession)
+
+        #expect(await server.activeSession == newestSession)
+        #expect(await server.isRunning)
+        await server.stop()
+    }
+
     @Test("Stop prevents an in-flight start from publishing afterward")
     func stopIsPublicationBarrier() async {
         let server = DeveloperSetupProbeServer()

--- a/RockxyTests/Core/TrafficCapture/SystemProxyBackupCompatibilityTests.swift
+++ b/RockxyTests/Core/TrafficCapture/SystemProxyBackupCompatibilityTests.swift
@@ -66,6 +66,22 @@ struct SystemProxyBackupCompatibilityTests {
         #expect(decoded.bypassDomains == ["*.corp.internal"])
     }
 
+    @Test("Backup recovery follows live ownership instead of backup age")
+    func backupRecoveryUsesLiveOwnership() {
+        #expect(ProxyBackupRecoveryPolicy.action(
+            proxyStillPointsAtRockxy: true,
+            listenerIsReachable: true
+        ) == .preserve)
+        #expect(ProxyBackupRecoveryPolicy.action(
+            proxyStillPointsAtRockxy: true,
+            listenerIsReachable: false
+        ) == .restore)
+        #expect(ProxyBackupRecoveryPolicy.action(
+            proxyStillPointsAtRockxy: false,
+            listenerIsReachable: false
+        ) == .clear)
+    }
+
     // MARK: Private
 
     private struct OldDirectServiceBackup: Codable {

--- a/RockxyTests/Models/BypassDomainTests.swift
+++ b/RockxyTests/Models/BypassDomainTests.swift
@@ -82,6 +82,15 @@ struct BypassDomainTests {
         #expect(BypassDomain.systemProxyPatterns(for: domain.domain) == ["10.0.0.0/8"])
     }
 
+    @Test("Global IPv4 CIDR fails closed")
+    func globalIPv4CIDRFailsClosed() {
+        let domain = TestFixtures.makeBypassDomain(domain: "0.0.0.0/0")
+
+        #expect(!domain.matches("10.0.0.1"))
+        #expect(!domain.matches("192.168.1.10"))
+        #expect(BypassDomain.systemProxyPatterns(for: domain.domain).isEmpty)
+    }
+
     // MARK: - Codable
 
     @Test("Codable roundtrip preserves all fields")

--- a/RockxyTests/ViewModels/DeveloperApplicationCaptureRegressionTests.swift
+++ b/RockxyTests/ViewModels/DeveloperApplicationCaptureRegressionTests.swift
@@ -465,6 +465,33 @@ struct DeveloperApplicationCaptureRegressionTests {
         #expect(FileManager.default.fileExists(atPath: prepared.preparation.backupURL.path))
     }
 
+    @Test("A failed successor association restores instead of reporting a rebound")
+    @MainActor
+    func failedSuccessorAssociationRestores() async throws {
+        let prepared = try makePreparedFixture()
+        defer { try? FileManager.default.removeItem(at: prepared.fixture.rootURL) }
+        let monitor = CapabilityTestRestorationMonitor()
+        let scope = DeveloperApplicationCaptureConfigurator.scopeIdentity(for: prepared.installation)
+        let settler = makeSettler(
+            for: prepared,
+            monitor: monitor,
+            runningInstances: [
+                DeveloperApplicationRunningInstance(processIdentifier: getpid(), scope: scope),
+            ]
+        )
+        settler.bindLaunchedProcess(42_424)
+        try FileManager.default.removeItem(at: prepared.preparation.recoveryRecordURL)
+
+        await settler.settleAfterApplicationExit()
+
+        #expect(settler.settlement == DeveloperApplicationTransactionSettlement.restored)
+        #expect(monitor.startCount == 0)
+        let restored = try String(contentsOf: prepared.settingsURL, encoding: .utf8)
+        #expect(restored.contains("USE_HTTP_PROXY"))
+        #expect(!restored.contains("USE_PROXY_PAC"))
+        #expect(!FileManager.default.fileExists(atPath: prepared.preparation.backupURL.path))
+    }
+
     @Test("An ordinary application exit still restores the original settings")
     @MainActor
     func ordinaryExitRestoresOriginalSettings() async throws {

--- a/RockxyTests/ViewModels/DeveloperSetupSessionSetupTests.swift
+++ b/RockxyTests/ViewModels/DeveloperSetupSessionSetupTests.swift
@@ -34,7 +34,7 @@ private final class RecordingDeveloperApplicationLauncher: DeveloperApplicationL
 @MainActor
 private final class SuspendingDeveloperApplicationLauncher: DeveloperApplicationLaunching {
     private(set) var launchCount = 0
-    private var continuation: CheckedContinuation<DeveloperApplicationLaunchReceipt, Never>?
+    private var continuations: [CheckedContinuation<DeveloperApplicationLaunchReceipt, Never>] = []
 
     func launch(
         _: DeveloperApplicationInstallation,
@@ -43,16 +43,20 @@ private final class SuspendingDeveloperApplicationLauncher: DeveloperApplication
         onTermination _: (@MainActor @Sendable () -> Void)?
     ) async throws -> DeveloperApplicationLaunchReceipt {
         launchCount += 1
-        return await withCheckedContinuation { continuation = $0 }
+        return await withCheckedContinuation { continuations.append($0) }
     }
 
     func finish() {
-        continuation?.resume(returning: DeveloperApplicationLaunchReceipt(
+        let receipt = DeveloperApplicationLaunchReceipt(
             lifecycleProcessIdentifier: 42_425,
             registeredProcessIdentifier: 52_425,
             registrationState: .registered
-        ))
-        continuation = nil
+        )
+        let pending = continuations
+        continuations.removeAll()
+        for continuation in pending {
+            continuation.resume(returning: receipt)
+        }
     }
 }
 
@@ -684,7 +688,11 @@ struct DeveloperSetupSessionSetupTests {
             applicationSupportURL: fixture.applicationSupportURL
         )
 
-        let firstLaunch = Task { await first.openDeveloperApplication(at: fixture.appURL) }
+        var firstLaunchFinished = false
+        let firstLaunch = Task {
+            await first.openDeveloperApplication(at: fixture.appURL)
+            firstLaunchFinished = true
+        }
         while launcher.launchCount == 0 {
             await Task.yield()
         }
@@ -693,7 +701,15 @@ struct DeveloperSetupSessionSetupTests {
         #expect(launcher.launchCount == 1)
         #expect(second.statusMessage?.contains("already preparing") == true)
         launcher.finish()
-        await firstLaunch.value
+        for _ in 0 ..< 200 where !firstLaunchFinished {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        #expect(firstLaunchFinished)
+        if firstLaunchFinished {
+            await firstLaunch.value
+        } else {
+            firstLaunch.cancel()
+        }
     }
 
     @Test("Restoration preserves proxy settings changed by the application during the session")

--- a/RockxyTests/Views/Main/FooterActionDescriptorTests.swift
+++ b/RockxyTests/Views/Main/FooterActionDescriptorTests.swift
@@ -522,4 +522,19 @@ struct ProxyOverrideCommandActionsTests {
         #expect(coordinator.isProxyOverridden == false)
         #expect(coordinator.isSystemProxyConfigured == false)
     }
+
+    @Test("stale proxy override keeps the footer recovery action visible")
+    func staleProxyOverrideKeepsRecoveryActionVisible() {
+        let reconciliation = MainContentCoordinator.reconcileProxyOverride(
+            overridePort: 9_090,
+            activeProxyPort: 8_888
+        )
+        let actions = FooterActionDescriptor.toolingActions(
+            isAllowListActive: false,
+            isProxyOverridden: reconciliation.isOverridden
+        )
+
+        #expect(!reconciliation.matchesActiveProxyPort)
+        #expect(actions.last?.id == .proxyOverride)
+    }
 }

--- a/RockxyTests/Views/Main/ProxyDisplayStateTests.swift
+++ b/RockxyTests/Views/Main/ProxyDisplayStateTests.swift
@@ -1,4 +1,7 @@
 import Foundation
+import NIOCore
+import NIOEmbedded
+import NIOHTTP1
 @testable import Rockxy
 import Testing
 
@@ -217,26 +220,54 @@ struct ProxyDisplayStateTests {
             action: .throttle(delayMs: 10_000)
         )
         await RuleEngine.shared.addRule(broadThrottle)
-        defer {
-            Task {
-                await RuleEngine.shared.removeRule(id: broadThrottle.id)
+        do {
+            try await coordinator.proxyServer.start()
+            coordinator.activeProxyPort = resolution.port
+            coordinator.isProxyRunning = true
+            coordinator.runCaptureHealthCheck()
+            coordinator.runCaptureHealthCheck()
+
+            for _ in 0 ..< 70 where coordinator.readiness.captureHealth == .checking {
+                try await Task.sleep(for: .milliseconds(100))
             }
+            try await Task.sleep(for: .milliseconds(200))
+
+            #expect(coordinator.readiness.captureHealth == .verified)
+            #expect(coordinator.transactions.isEmpty)
+        } catch {
+            await cleanUpCaptureHealthCheck(coordinator, ruleID: broadThrottle.id)
+            throw error
         }
-        try await coordinator.proxyServer.start()
-        coordinator.activeProxyPort = resolution.port
-        coordinator.isProxyRunning = true
-        coordinator.runCaptureHealthCheck()
-        coordinator.runCaptureHealthCheck()
+        await cleanUpCaptureHealthCheck(coordinator, ruleID: broadThrottle.id)
+    }
 
-        for _ in 0 ..< 70 where coordinator.readiness.captureHealth == .checking {
-            try await Task.sleep(for: .milliseconds(100))
+    @Test("Health probe fails promptly when the peer closes before the response ends")
+    func captureHealthProbeHandlesEarlyClose() throws {
+        let channel = EmbeddedChannel()
+        let promise = channel.eventLoop.makePromise(of: Bool.self)
+        let requestHead = HTTPRequestHead(version: .http1_1, method: .GET, uri: "/")
+        let handler = CaptureHealthProbeResponseHandler(
+            requestHead: requestHead,
+            responsePromise: promise
+        )
+        try channel.pipeline.addHandler(handler).wait()
+
+        try channel.close().wait()
+        channel.embeddedEventLoop.run()
+
+        #expect(throws: CaptureHealthProbeError.self) {
+            _ = try promise.futureResult.wait()
         }
-        try await Task.sleep(for: .milliseconds(200))
+        _ = try? channel.finish(acceptAlreadyClosed: true)
+    }
 
-        #expect(coordinator.readiness.captureHealth == .verified)
-        #expect(coordinator.transactions.isEmpty)
-        await RuleEngine.shared.removeRule(id: broadThrottle.id)
+    @Test("Capture listener formats IPv6 endpoints without ambiguity")
+    func ipv6ListenerFormatting() {
+        #expect(CaptureStatusPresentation.listener(address: "::1", port: 8_888) == "[::1]:8888")
+    }
 
+    private func cleanUpCaptureHealthCheck(_ coordinator: MainContentCoordinator, ruleID: UUID) async {
+        await RuleEngine.shared.removeRule(id: ruleID)
         coordinator.captureHealthTask?.cancel()
         await coordinator.captureProbeServer.stop()
         coordinator.captureProbeTracker.cancel()
@@ -244,10 +275,5 @@ struct ProxyDisplayStateTests {
         await coordinator.proxyServer.stop()
         coordinator.isProxyRunning = false
         coordinator.readiness.setCaptureActive(false)
-    }
-
-    @Test("Capture listener formats IPv6 endpoints without ambiguity")
-    func ipv6ListenerFormatting() {
-        #expect(CaptureStatusPresentation.listener(address: "::1", port: 8_888) == "[::1]:8888")
     }
 }

--- a/Shared/ProxyBackupRecoveryPolicy.swift
+++ b/Shared/ProxyBackupRecoveryPolicy.swift
@@ -1,0 +1,20 @@
+enum ProxyBackupRecoveryAction: Equatable {
+    case restore
+    case preserve
+    case clear
+}
+
+/// Decides backup lifetime from live ownership instead of elapsed wall-clock time.
+/// A healthy listener means the capture session still owns the override; an unreachable
+/// listener means the owned override was stranded and must be restored immediately.
+enum ProxyBackupRecoveryPolicy {
+    static func action(
+        proxyStillPointsAtRockxy: Bool,
+        listenerIsReachable: Bool
+    ) -> ProxyBackupRecoveryAction {
+        guard proxyStillPointsAtRockxy else {
+            return .clear
+        }
+        return listenerIsReachable ? .preserve : .restore
+    }
+}

--- a/Shared/ProxyBypassDomainValidator.swift
+++ b/Shared/ProxyBypassDomainValidator.swift
@@ -24,12 +24,12 @@ enum ProxyBypassDomainValidator {
         guard components.count == 2,
               let address = ipv4Address(String(components[0])),
               let prefix = Int(components[1]),
-              (0 ... 32).contains(prefix)
+              (1 ... 32).contains(prefix)
         else {
             return nil
         }
 
-        let mask = prefix == 0 ? UInt32(0) : UInt32.max << UInt32(32 - prefix)
+        let mask = UInt32.max << UInt32(32 - prefix)
         return (address & mask, mask)
     }
 


### PR DESCRIPTION
## Summary

- make developer-app restart settlement restore safely when successor ownership cannot be recorded
- make capture readiness probes complete deterministically on response, timeout, error, or disconnect
- preserve live helper-owned proxy sessions while restoring stranded overrides using exact port ownership
- reject global CIDR bypass entries and keep invalid persisted entries disabled
- surface recovery controls from the actual proxy override state and make async regression tests deterministic

## Validation

- `swiftlint lint --strict`
- focused proxy, helper, developer setup, footer, and readiness regression suites
- helper and application targets built through the focused macOS test run
- `git diff --check`

Related promotion: #329

Refs #319
Refs #310