### PR TITLE
fix: harden automatic recovery and TLS fallback

### DIFF
--- a/Rockxy/Core/ProxyEngine/TLSInterceptHandler.swift
+++ b/Rockxy/Core/ProxyEngine/TLSInterceptHandler.swift
@@ -70,6 +70,15 @@ final class RecentFailureTracker: @unchecked Sendable {
         return fresh
     }
 
+    func recordIdentifiedFailure(host: String, clientIdentifier: String?) -> FailureInfo? {
+        guard let clientIdentifier,
+              !clientIdentifier.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        else {
+            return nil
+        }
+        return recordFailure(host: host, clientIdentifier: clientIdentifier)
+    }
+
     func recordSuccess(host: String, clientIdentifier: String? = nil) {
         lock.lock()
         failures.removeValue(forKey: FailureKey(host: host, clientIdentifier: clientIdentifier))
@@ -782,10 +791,12 @@ final class PostHandshakeHandler: ChannelInboundHandler, RemovableChannelHandler
             }
             handshakeResolved = true
             tlsLogger.info("TLS handshake completed for \(self.host) — adding HTTP codecs")
-            Self.recentTLSFailures.recordSuccess(
-                host: host,
-                clientIdentifier: clientIdentifier
-            )
+            if let clientIdentifier {
+                Self.recentTLSFailures.recordSuccess(
+                    host: host,
+                    clientIdentifier: clientIdentifier
+                )
+            }
             var acceptanceUserInfo: [String: String] = [:]
             if let clientIdentifier {
                 acceptanceUserInfo[TLSMITMNotificationUserInfoKey.clientIdentifier] = clientIdentifier
@@ -845,11 +856,11 @@ final class PostHandshakeHandler: ChannelInboundHandler, RemovableChannelHandler
                     "TLS rejection for \(self.host) has no resolved client identity; using one-connection passthrough only"
                 )
             }
-            let failInfo = Self.recentTLSFailures.recordFailure(
+            let failInfo = Self.recentTLSFailures.recordIdentifiedFailure(
                 host: host,
                 clientIdentifier: clientIdentifier
             )
-            if failInfo.count > 1 {
+            if let failInfo, failInfo.count > 1 {
                 tlsLogger.debug(
                     "Suppressing duplicate TLS rejection for \(self.host) and the same client scope (count: \(failInfo.count))"
                 )

--- a/RockxyHelperTool/HelperService.swift
+++ b/RockxyHelperTool/HelperService.swift
@@ -46,15 +46,17 @@ final class HelperService: NSObject, RockxyHelperProtocol {
         }
 
         guard let result = Self.mutationGate.withExclusiveAccess({
-            Result { try ProxyConfigurator.overrideProxy(port: port) }
+            Result {
+                try ProxyConfigurator.overrideProxy(port: port)
+                lastProxyChangeTime = Date()
+                startOwnerWatchdog(for: ownerPID)
+            }
         }) else {
             reply(false, HelperPrivilegedMutationGate.busyMessage)
             return
         }
         switch result {
         case .success:
-            lastProxyChangeTime = Date()
-            startOwnerWatchdog(for: ownerPID)
             reply(true, nil)
         case let .failure(error):
             Self.logger.error("Failed to override proxy: \(error.localizedDescription)")
@@ -67,14 +69,16 @@ final class HelperService: NSObject, RockxyHelperProtocol {
         Self.logger.info("restoreSystemProxy called")
 
         guard let result = Self.mutationGate.withExclusiveAccess({
-            Result { try ProxyConfigurator.restoreProxyOrThrow() }
+            Result {
+                try ProxyConfigurator.restoreProxyOrThrow()
+                stopOwnerWatchdog()
+            }
         }) else {
             reply(false, HelperPrivilegedMutationGate.busyMessage)
             return
         }
         switch result {
         case .success:
-            stopOwnerWatchdog()
             reply(true, nil)
         case let .failure(error):
             Self.logger.error("Failed to restore proxy: \(error.localizedDescription)")
@@ -100,11 +104,12 @@ final class HelperService: NSObject, RockxyHelperProtocol {
         IdleExitMonitor.resetIdleTimer()
         Self.logger.info("prepareForUninstall called")
 
-        guard let _: Void = Self.mutationGate.withExclusiveAccess({
+        let preparation: Void? = Self.mutationGate.withExclusiveAccess {
             stopOwnerWatchdog()
             ProxyConfigurator.restoreProxy()
             CrashRecovery.clearBackup()
-        }) else {
+        }
+        guard preparation != nil else {
             reply(false)
             return
         }
@@ -156,8 +161,10 @@ final class HelperService: NSObject, RockxyHelperProtocol {
 
     func handleConnectionInvalidated(processID: Int32) {
         let action: InvalidationAction
+        let owner = currentOwnerSnapshot()
 
-        if let ownerPID {
+        if let owner {
+            let ownerPID = owner.processIdentifier
             let ownerAlive = isProcessAlive(ownerPID)
             action = Self.invalidationAction(
                 ownerPID: ownerPID,
@@ -173,11 +180,14 @@ final class HelperService: NSObject, RockxyHelperProtocol {
             Self.logger.debug("Ignoring XPC invalidation for pid \(processID)")
         case let .restore(ownerPID):
             Self.logger.warning("XPC owner connection \(ownerPID) vanished — restoring proxy override automatically")
-            stopOwnerWatchdog()
-            ProxyConfigurator.restoreProxy()
+            requestAutomaticProxyRestore(
+                for: ownerPID,
+                ownershipToken: owner?.token,
+                reason: "owner connection invalidation"
+            )
         case let .watchdog(ownerPID):
             Self.logger.info("Owner pid \(ownerPID) still alive after XPC invalidation — deferring to watchdog")
-            scheduleOwnerDisconnectRecheck(for: ownerPID)
+            scheduleOwnerDisconnectRecheck(for: ownerPID, ownershipToken: owner?.token)
         }
     }
 
@@ -424,10 +434,13 @@ final class HelperService: NSObject, RockxyHelperProtocol {
     /// concurrently, so without it an install's verification could read a concurrent removal's
     /// result — or delete the certificate the install had just added.
     private static let mutationGate = HelperPrivilegedMutationGate.shared
+    private static let automaticRestoreRetrier = HelperPrivilegedMutationRetrier(gate: mutationGate)
 
     private var lastProxyChangeTime: Date?
+    private let ownerStateLock = NSLock()
     private var ownerWatchdog: DispatchSourceTimer?
     private var ownerPID: Int32?
+    private var ownerWatchdogToken: UUID?
 
     private static func invalidationAction(
         ownerPID: Int32?,
@@ -448,35 +461,49 @@ final class HelperService: NSObject, RockxyHelperProtocol {
     private func startOwnerWatchdog(for pid: Int32) {
         stopOwnerWatchdog()
 
-        ownerPID = pid
-
+        let ownershipToken = UUID()
         let timer = DispatchSource.makeTimerSource(queue: DispatchQueue.global(qos: .utility))
         timer.schedule(deadline: .now() + Self.ownerWatchdogInterval, repeating: Self.ownerWatchdogInterval)
+
+        ownerStateLock.lock()
+        ownerPID = pid
+        ownerWatchdogToken = ownershipToken
+        ownerWatchdog = timer
+        ownerStateLock.unlock()
         timer.setEventHandler { [weak self] in
             guard let self else {
                 return
             }
-            guard let ownerPID = self.ownerPID else {
+            guard let owner = self.currentOwnerSnapshot(),
+                  owner.token == ownershipToken
+            else {
                 return
             }
+            let ownerPID = owner.processIdentifier
 
             if self.isProcessAlive(ownerPID) {
                 return
             }
 
             Self.logger.warning("Owner app process \(ownerPID) is gone — restoring proxy override automatically")
-            self.stopOwnerWatchdog()
-            ProxyConfigurator.restoreProxy()
+            self.requestAutomaticProxyRestore(
+                for: ownerPID,
+                ownershipToken: ownershipToken,
+                reason: "owner watchdog"
+            )
         }
-        ownerWatchdog = timer
         timer.resume()
         Self.logger.info("Started owner watchdog for app PID \(pid)")
     }
 
     private func stopOwnerWatchdog() {
-        ownerWatchdog?.cancel()
+        ownerStateLock.lock()
+        let watchdog = ownerWatchdog
         ownerWatchdog = nil
         ownerPID = nil
+        ownerWatchdogToken = nil
+        ownerStateLock.unlock()
+        watchdog?.cancel()
     }
 
     private func isProcessAlive(_ pid: Int32) -> Bool {
@@ -486,13 +513,17 @@ final class HelperService: NSObject, RockxyHelperProtocol {
         return errno == EPERM
     }
 
-    private func scheduleOwnerDisconnectRecheck(for pid: Int32) {
+    private func scheduleOwnerDisconnectRecheck(for pid: Int32, ownershipToken: UUID?) {
         let delay = Self.connectionInvalidationGraceInterval
+        guard let ownershipToken else {
+            return
+        }
         DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + delay) { [weak self] in
             guard let self else {
                 return
             }
-            guard let currentOwnerPID = self.ownerPID, currentOwnerPID == pid else {
+            guard self.ownerMatches(processIdentifier: pid, token: ownershipToken)
+            else {
                 return
             }
             guard !self.isProcessAlive(pid) else {
@@ -500,8 +531,64 @@ final class HelperService: NSObject, RockxyHelperProtocol {
             }
 
             Self.logger.warning("Owner pid \(pid) disappeared after XPC invalidation grace period — restoring proxy")
-            self.stopOwnerWatchdog()
-            ProxyConfigurator.restoreProxy()
+            self.requestAutomaticProxyRestore(
+                for: pid,
+                ownershipToken: ownershipToken,
+                reason: "owner disconnect recheck"
+            )
         }
+    }
+
+    private func requestAutomaticProxyRestore(
+        for expectedOwnerPID: Int32,
+        ownershipToken: UUID?,
+        reason: String
+    ) {
+        guard let ownershipToken else {
+            return
+        }
+        let retryKey = ownershipToken.uuidString
+        Self.automaticRestoreRetrier.run(
+            key: retryKey,
+            operation: { [weak self] in
+                guard let self,
+                      self.ownerMatches(processIdentifier: expectedOwnerPID, token: ownershipToken)
+                else {
+                    return true
+                }
+
+                do {
+                    try ProxyConfigurator.restoreProxyOrThrow()
+                    self.stopOwnerWatchdog()
+                    Self.logger.info("Automatic proxy restoration completed after \(reason)")
+                    return true
+                } catch {
+                    Self.logger.error(
+                        "Automatic proxy restoration after \(reason) failed and will retry: \(error.localizedDescription)"
+                    )
+                    return false
+                }
+            },
+            onExhausted: {
+                Self.logger.error(
+                    "Automatic proxy restoration after \(reason) exhausted bounded retries; preserving backup for recovery"
+                )
+            }
+        )
+    }
+
+    private func currentOwnerSnapshot() -> (processIdentifier: Int32, token: UUID)? {
+        ownerStateLock.lock()
+        defer { ownerStateLock.unlock() }
+        guard let ownerPID, let ownerWatchdogToken else {
+            return nil
+        }
+        return (ownerPID, ownerWatchdogToken)
+    }
+
+    private func ownerMatches(processIdentifier: Int32, token: UUID) -> Bool {
+        ownerStateLock.lock()
+        defer { ownerStateLock.unlock() }
+        return ownerPID == processIdentifier && ownerWatchdogToken == token
     }
 }

--- a/RockxyTests/Core/ProxyEngine/RecentFailureTrackerTests.swift
+++ b/RockxyTests/Core/ProxyEngine/RecentFailureTrackerTests.swift
@@ -105,6 +105,15 @@ struct RecentFailureTrackerTests {
         #expect(firstClientAgain.count == 2)
     }
 
+    @Test("unidentified failures never enter duplicate suppression")
+    func unidentifiedFailuresAreNotTracked() {
+        let tracker = RecentFailureTracker()
+
+        #expect(tracker.recordIdentifiedFailure(host: "example.com", clientIdentifier: nil) == nil)
+        #expect(tracker.recordIdentifiedFailure(host: "example.com", clientIdentifier: "  ") == nil)
+        #expect(tracker.trackedEntryCount == 0)
+    }
+
     @Test("success clears only the matching client and host")
     func successIsScopedByClient() {
         var timestamps: [UInt64] = [1_000_000_000, 2_000_000_000, 3_000_000_000, 4_000_000_000]

--- a/RockxyTests/Shared/HelperCertificateMutationGateTests.swift
+++ b/RockxyTests/Shared/HelperCertificateMutationGateTests.swift
@@ -2,6 +2,33 @@ import Foundation
 @testable import Rockxy
 import Testing
 
+private final class MutationGateTestBox<Value>: @unchecked Sendable {
+    init(_ value: Value) {
+        storage = value
+    }
+
+    var value: Value {
+        lock.lock()
+        defer { lock.unlock() }
+        return storage
+    }
+
+    func set(_ value: Value) {
+        lock.lock()
+        storage = value
+        lock.unlock()
+    }
+
+    func mutate(_ body: (inout Value) -> Void) {
+        lock.lock()
+        body(&storage)
+        lock.unlock()
+    }
+
+    private let lock = NSLock()
+    private var storage: Value
+}
+
 // The privileged helper's certificate mutations are read-mutate-verify sequences against one
 // keychain, and XPC delivers messages concurrently. These pin the gate that keeps two of them from
 // interleaving — and, just as importantly, keep it non-blocking: a refused caller must be told so
@@ -118,5 +145,104 @@ struct HelperCertificateMutationGateTests {
 
         gate.release(barrier)
         #expect(gate.tryAcquire() != nil)
+    }
+
+    @Test("automatic recovery waits for the active privileged mutation")
+    func automaticRecoveryRetriesAfterTheGateIsReleased() throws {
+        let gate = HelperPrivilegedMutationGate()
+        let holder = try #require(gate.tryAcquire())
+        let scheduled = MutationGateTestBox<(@Sendable () -> Void)?>(nil)
+        let recoveryCount = MutationGateTestBox(0)
+        let retrier = HelperPrivilegedMutationRetrier(
+            gate: gate,
+            maximumAttempts: 2,
+            scheduler: { _, operation in scheduled.set(operation) }
+        )
+
+        retrier.run(key: "owner-1") {
+            recoveryCount.mutate { $0 += 1 }
+            return true
+        }
+
+        #expect(recoveryCount.value == 0)
+        let retry = try #require(scheduled.value)
+        gate.release(holder)
+        retry()
+        #expect(recoveryCount.value == 1)
+    }
+
+    @Test("duplicate automatic recovery requests share one retry chain")
+    func duplicateAutomaticRecoveryRequestsCoalesce() throws {
+        let gate = HelperPrivilegedMutationGate()
+        let holder = try #require(gate.tryAcquire())
+        defer { gate.release(holder) }
+        let scheduledCount = MutationGateTestBox(0)
+        let retrier = HelperPrivilegedMutationRetrier(
+            gate: gate,
+            maximumAttempts: 2,
+            scheduler: { _, _ in scheduledCount.mutate { $0 += 1 } }
+        )
+
+        retrier.run(key: "owner-1") { true }
+        retrier.run(key: "owner-1") { true }
+
+        #expect(scheduledCount.value == 1)
+    }
+
+    @Test("a superseded owner cancels delayed automatic recovery")
+    func supersededOwnerCancelsRecovery() throws {
+        let gate = HelperPrivilegedMutationGate()
+        let holder = try #require(gate.tryAcquire())
+        let scheduled = MutationGateTestBox<(@Sendable () -> Void)?>(nil)
+        let currentOwner = MutationGateTestBox("owner-1")
+        let recoveryCount = MutationGateTestBox(0)
+        let retrier = HelperPrivilegedMutationRetrier(
+            gate: gate,
+            maximumAttempts: 2,
+            scheduler: { _, operation in scheduled.set(operation) }
+        )
+
+        retrier.run(key: "owner-1") {
+            guard currentOwner.value == "owner-1" else {
+                return true
+            }
+            recoveryCount.mutate { $0 += 1 }
+            return true
+        }
+
+        currentOwner.set("owner-2")
+        gate.release(holder)
+        let retry = try #require(scheduled.value)
+        retry()
+        #expect(recoveryCount.value == 0)
+    }
+
+    @Test("automatic recovery stops after its bounded retry budget")
+    func automaticRecoveryExhaustsItsBudget() throws {
+        let gate = HelperPrivilegedMutationGate()
+        let holder = try #require(gate.tryAcquire())
+        defer { gate.release(holder) }
+        let scheduled = MutationGateTestBox<(@Sendable () -> Void)?>(nil)
+        let exhaustedCount = MutationGateTestBox(0)
+        let retrier = HelperPrivilegedMutationRetrier(
+            gate: gate,
+            maximumAttempts: 3,
+            scheduler: { _, operation in scheduled.set(operation) }
+        )
+
+        retrier.run(
+            key: "owner-1",
+            operation: { true },
+            onExhausted: { exhaustedCount.mutate { $0 += 1 } }
+        )
+
+        for _ in 0 ..< 2 {
+            let retry = try #require(scheduled.value)
+            scheduled.set(nil)
+            retry()
+        }
+
+        #expect(scheduled.value == nil)
+        #expect(exhaustedCount.value == 1)
     }
 }

--- a/RockxyTests/ViewModels/DeveloperSetupSessionSetupTests.swift
+++ b/RockxyTests/ViewModels/DeveloperSetupSessionSetupTests.swift
@@ -105,6 +105,27 @@ struct DeveloperSetupSessionSetupTests {
         #expect(!script.contains("export NODE_OPTIONS="))
     }
 
+    @Test("Certificate hints stay absent until an exported root is available")
+    func missingCertificateOmitsCertificateHints() {
+        let context = RockxySetupScriptContext(
+            proxyHost: "127.0.0.1",
+            proxyPort: 9_090,
+            certificatePath: nil,
+            generatedAt: Date(timeIntervalSince1970: 0),
+            appName: "Rockxy"
+        )
+
+        let script = RockxySetupScriptBuilder.script(context: context)
+        let environment = DeveloperCaptureEnvironmentBuilder.environment(context: context)
+
+        #expect(script.contains("NODE_EXTRA_CA_CERTS") == false)
+        #expect(script.contains("ROCKXY_ROOT_CA_PATH") == false)
+        #expect(script.contains("Export or trust the Rockxy root certificate"))
+        #expect(environment["NODE_EXTRA_CA_CERTS"] == nil)
+        #expect(environment["ROCKXY_ROOT_CA_PATH"] == nil)
+        #expect(environment["HTTP_PROXY"] == "http://127.0.0.1:9090")
+    }
+
     @Test("Java VMs script injects JAVA_TOOL_OPTIONS proxy properties once and preserves the base")
     func javaScriptInjectsProxyPropertiesAndPreservesBase() {
         let context = RockxySetupScriptContext(

--- a/Shared/HelperCertificateMutationGate.swift
+++ b/Shared/HelperCertificateMutationGate.swift
@@ -93,3 +93,95 @@ final class HelperPrivilegedMutationGate: @unchecked Sendable {
     private let lock = NSLock()
     private var heldTicketID: UUID?
 }
+
+// MARK: - HelperPrivilegedMutationRetrier
+
+/// Retries an internal recovery mutation only while the shared privileged gate is busy or the
+/// recovery operation reports a transient failure. Requests with the same key coalesce, keeping
+/// watchdog callbacks from creating overlapping retry chains.
+final class HelperPrivilegedMutationRetrier: @unchecked Sendable {
+    // MARK: Lifecycle
+
+    init(
+        gate: HelperPrivilegedMutationGate,
+        maximumAttempts: Int = 10,
+        retryDelay: TimeInterval = 0.5,
+        scheduler: @escaping Scheduler = { delay, operation in
+            DispatchQueue.global(qos: .utility).asyncAfter(
+                deadline: .now() + delay,
+                execute: operation
+            )
+        }
+    ) {
+        self.gate = gate
+        self.maximumAttempts = max(1, maximumAttempts)
+        self.retryDelay = max(0, retryDelay)
+        self.scheduler = scheduler
+    }
+
+    // MARK: Internal
+
+    typealias Scheduler = @Sendable (TimeInterval, @escaping @Sendable () -> Void) -> Void
+
+    func run(
+        key: String,
+        operation: @escaping @Sendable () -> Bool,
+        onExhausted: @escaping @Sendable () -> Void = {}
+    ) {
+        lock.lock()
+        let inserted = activeKeys.insert(key).inserted
+        lock.unlock()
+        guard inserted else {
+            return
+        }
+
+        attempt(
+            key: key,
+            remainingAttempts: maximumAttempts,
+            operation: operation,
+            onExhausted: onExhausted
+        )
+    }
+
+    // MARK: Private
+
+    private let gate: HelperPrivilegedMutationGate
+    private let maximumAttempts: Int
+    private let retryDelay: TimeInterval
+    private let scheduler: Scheduler
+    private let lock = NSLock()
+    private var activeKeys: Set<String> = []
+
+    private func attempt(
+        key: String,
+        remainingAttempts: Int,
+        operation: @escaping @Sendable () -> Bool,
+        onExhausted: @escaping @Sendable () -> Void
+    ) {
+        if gate.withExclusiveAccess(operation) == true {
+            finish(key: key)
+            return
+        }
+
+        guard remainingAttempts > 1 else {
+            finish(key: key)
+            onExhausted()
+            return
+        }
+
+        scheduler(retryDelay) { [weak self] in
+            self?.attempt(
+                key: key,
+                remainingAttempts: remainingAttempts - 1,
+                operation: operation,
+                onExhausted: onExhausted
+            )
+        }
+    }
+
+    private func finish(key: String) {
+        lock.lock()
+        activeKeys.remove(key)
+        lock.unlock()
+    }
+}

--- a/docs/automatic-setup/automatic-setup.mdx
+++ b/docs/automatic-setup/automatic-setup.mdx
@@ -23,9 +23,9 @@ When those processes do not inherit proxy and certificate settings, Rockxy may b
 
 ## What Rockxy does
 
-Automatic Setup prepares a new session with Rockxy proxy and certificate hints already applied.
+Automatic Setup prepares a new session with Rockxy proxy settings and, when an exported root certificate is available, certificate hints already applied.
 
-For terminal-oriented flows, Rockxy generates a local setup script and launches the selected terminal with that script sourced. The script exports upper- and lower-case proxy variables used by clients that honor them. Node receives an additive CA hint; Java receives explicit proxy properties in the Java workflow. Other runtimes may require their own trust-store configuration.
+For terminal-oriented flows, Rockxy generates a local setup script and launches the selected terminal with that script sourced. The script exports upper- and lower-case proxy variables used by clients that honor them. Node receives an additive CA hint when an exported Rockxy root certificate is available; Java receives explicit proxy properties in the Java workflow. Other runtimes may require their own trust-store configuration.
 
 For developer applications, **Choose & Open Developer App** launches a fresh selected `.app` with the same scoped environment. Rockxy inspects the bundle for a recognized, declarative app-level proxy schema. When one is present, Rockxy temporarily selects automatic proxy discovery so the application can consume the active macOS proxy configuration; unrelated settings are preserved. Unknown application schemas are never edited.
 


### PR DESCRIPTION
## Summary

- serialize helper-owned automatic proxy restoration with every privileged mutation
- retry bounded recovery work without blocking XPC handlers or overlapping watchdog callbacks
- bind delayed restoration to an ownership token so a relaunched session cannot be reverted
- keep TLS rejection fallback per connection when client identity is unavailable
- document and test that certificate environment hints require an exported root certificate

## Validation

- `swiftlint lint --strict`
- focused helper mutation-gate and retry tests, including busy, superseded-owner, coalescing, and exhaustion cases
- focused TLS failure tracker and developer setup environment tests
- helper and application targets built through the focused macOS test run
- `git diff --check`

Related promotion: #329

Refs #319
Refs #310