### PR TITLE
fix: preserve per-service proxy recovery

### DIFF
--- a/Rockxy/Core/TrafficCapture/SystemProxyManager.swift
+++ b/Rockxy/Core/TrafficCapture/SystemProxyManager.swift
@@ -74,9 +74,46 @@ enum ProxyActivationConfirmation {
 /// Persistent on-disk backup of the pre-Rockxy proxy state for all services.
 /// Written before any direct-mode mutation; cleared after successful restore.
 struct DirectProxyBackup: Codable {
+    init(
+        services: [DirectServiceBackup],
+        timestamp: Date,
+        rockxyPort: Int,
+        recoveryPending: Bool = false
+    ) {
+        self.services = services
+        self.timestamp = timestamp
+        self.rockxyPort = rockxyPort
+        self.recoveryPending = recoveryPending
+    }
+
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        services = try container.decode([DirectServiceBackup].self, forKey: .services)
+        timestamp = try container.decode(Date.self, forKey: .timestamp)
+        rockxyPort = try container.decode(Int.self, forKey: .rockxyPort)
+        recoveryPending = try container.decodeIfPresent(Bool.self, forKey: .recoveryPending) ?? false
+    }
+
     let services: [DirectServiceBackup]
     let timestamp: Date
     let rockxyPort: Int
+    let recoveryPending: Bool
+
+    private enum CodingKeys: String, CodingKey {
+        case services
+        case timestamp
+        case rockxyPort
+        case recoveryPending
+    }
+
+    func markedRecoveryPending() -> DirectProxyBackup {
+        DirectProxyBackup(
+            services: services,
+            timestamp: timestamp,
+            rockxyPort: rockxyPort,
+            recoveryPending: true
+        )
+    }
 }
 
 // MARK: - DirectServiceBackup
@@ -807,23 +844,31 @@ final class SystemProxyManager: @unchecked Sendable {
     /// left behind by a crash or force-quit.
     func recoverStaleProxyIfNeeded() async {
         if let backup = loadDirectBackup() {
-            let backedUpServices = backup.services.map(\.service)
+            let residualOwnedServices = recoverableDirectServices(in: backup)
+            // The session that wrote this backup is by definition gone: this app process is the
+            // only one that can own a direct-mode override, and it has just launched.
             switch ProxyBackupRecoveryPolicy.action(
-                proxyStillPointsAtRockxy: currentProxyMatchesRockxy(
-                    port: backup.rockxyPort,
-                    backedUpServices: backedUpServices
-                ),
-                listenerIsReachable: false
+                residualOwnedServicesExist: !residualOwnedServices.isEmpty,
+                ownerSessionIsLive: false
             ) {
             case .restore:
-                Self.logger.info("Recovering stale direct-mode proxy override from crash")
-                do {
-                    try await disableSystemProxy()
-                } catch {
-                    Self.logger.error("Stale direct proxy recovery failed: \(error.localizedDescription)")
+                Self.logger
+                    .info(
+                        "Recovering \(residualOwnedServices.count) stale direct-mode service(s) from a previous session"
+                    )
+                if recoverOwnedDirectServices(backup: backup, ownedServices: residualOwnedServices) {
+                    stopBypassListObserver()
+                    clearInMemoryOverrideState()
+                    NotificationCenter.default.post(
+                        name: .systemProxyDidChange,
+                        object: nil,
+                        userInfo: ["enabled": false]
+                    )
+                } else {
+                    Self.logger.error("Stale direct proxy recovery incomplete — backup preserved for retry")
                 }
             case .clear:
-                Self.logger.info("Proxy no longer Rockxy-owned, clearing stale direct backup")
+                Self.logger.info("No backed-up service is still Rockxy-owned, clearing stale direct backup")
                 clearDirectBackup()
             case .preserve:
                 break
@@ -847,19 +892,19 @@ final class SystemProxyManager: @unchecked Sendable {
         stopBypassListObserver()
 
         if let backup = loadDirectBackup() {
-            let backedUpServices = backup.services.map(\.service)
-            if currentProxyMatchesRockxy(port: backup.rockxyPort, backedUpServices: backedUpServices) {
-                Self.logger.warning("\(reason): restoring direct-mode proxy backup during shutdown")
-                restoreDirectMode(using: backup)
-
-                if anyLoopbackProxyEnabled(on: backedUpServices) {
-                    Self.logger.warning("\(reason): direct restore incomplete, forcing proxy states off")
-                    try? disableSystemProxyViaNetworkSetup()
+            let residualOwnedServices = recoverableDirectServices(in: backup)
+            if !residualOwnedServices.isEmpty {
+                Self.logger
+                    .warning(
+                        "\(reason): restoring \(residualOwnedServices.count) owned direct-mode service(s) during shutdown"
+                    )
+                if !recoverOwnedDirectServices(backup: backup, ownedServices: residualOwnedServices) {
+                    Self.logger.warning("\(reason): direct restore incomplete, leaving the narrowed backup for retry")
                 }
                 return
             }
 
-            Self.logger.info("\(reason): clearing stale direct backup because proxy no longer matches Rockxy")
+            Self.logger.info("\(reason): clearing stale direct backup because no service is still Rockxy-owned")
             clearDirectBackup()
         }
 
@@ -981,10 +1026,18 @@ final class SystemProxyManager: @unchecked Sendable {
 
     /// Shared direct-mode restore routine used by both same-session cleanup and ownership-based cleanup.
     @discardableResult
-    private func restoreDirectMode(using backup: DirectProxyBackup) -> Bool {
+    private func restoreDirectMode(using sourceBackup: DirectProxyBackup) -> Bool {
+        let backup = sourceBackup.markedRecoveryPending()
+        do {
+            try writeDirectBackup(backup)
+        } catch {
+            Self.logger.error("Could not mark direct recovery pending — leaving settings untouched: \(error.localizedDescription)")
+            return false
+        }
         let backedUpServices = backup.services.map(\.service)
 
         var allSucceeded = true
+        var failedServices: Set<String> = []
 
         for entry in backup.services {
             let snapshot = ServiceProxySnapshot(
@@ -1005,21 +1058,26 @@ final class SystemProxyManager: @unchecked Sendable {
                 try restoreServiceProxyState(service: entry.service, snapshot: snapshot)
             } catch {
                 allSucceeded = false
+                failedServices.insert(entry.service)
                 Self.logger.error("Failed to restore proxy state for '\(entry.service)': \(error.localizedDescription)")
             }
             do {
                 try restoreServiceBypassDomains(service: entry.service, domains: entry.bypassDomains)
             } catch {
                 allSucceeded = false
+                failedServices.insert(entry.service)
                 Self.logger.error("Failed to restore bypass for '\(entry.service)': \(error.localizedDescription)")
             }
         }
 
+        // Any service still pointing at Rockxy keeps the backup alive, even when the others
+        // restored cleanly — that service has no other restore point.
+        let stillOwnedServices = allSucceeded
+            ? residualOwnedServicesAfterRestore(port: backup.rockxyPort, backedUpServices: backedUpServices)
+            : residualRockxyOwnedServices(port: backup.rockxyPort, backedUpServices: backedUpServices)
+
         let proxyStillPointsAtRockxy: Bool = if allSucceeded {
-            directProxyStillOwnedAfterRestoreVerification(
-                port: backup.rockxyPort,
-                backedUpServices: backedUpServices
-            )
+            backedUpServices.isEmpty ? anyLoopbackProxyEnabled(on: nil) : !stillOwnedServices.isEmpty
         } else {
             true
         }
@@ -1040,6 +1098,11 @@ final class SystemProxyManager: @unchecked Sendable {
             } else {
                 Self.logger.warning("Partial restore failure — keeping backup on disk for retry")
             }
+            retainUnresolvedDirectBackup(
+                backup: backup,
+                failedServices: failedServices,
+                stillOwnedServices: Set(stillOwnedServices)
+            )
             // directRestorePending stays true for same-session retry
         }
         lock.unlock()
@@ -1463,31 +1526,6 @@ final class SystemProxyManager: @unchecked Sendable {
         }
     }
 
-    private func directProxyStillOwnedAfterRestoreVerification(
-        port: Int,
-        backedUpServices: [String],
-        maxAttempts: Int = 5,
-        pollInterval: TimeInterval = 0.2
-    )
-        -> Bool
-    {
-        guard !backedUpServices.isEmpty else {
-            return anyLoopbackProxyEnabled(on: nil)
-        }
-
-        for attempt in 0 ..< maxAttempts {
-            if !currentProxyMatchesRockxy(port: port, backedUpServices: backedUpServices) {
-                return false
-            }
-
-            if attempt < maxAttempts - 1 {
-                Thread.sleep(forTimeInterval: pollInterval)
-            }
-        }
-
-        return true
-    }
-
     // MARK: - Process Execution
 
     @discardableResult
@@ -1563,6 +1601,153 @@ final class SystemProxyManager: @unchecked Sendable {
             helperBackupExists: helperBackupExists,
             loopbackProxyDetected: loopbackProxyDetected
         )
+    }
+}
+
+// MARK: - Direct-Mode Recovery
+
+/// Ownership and subset-restore behavior for direct-mode backups. Recovery asks a different
+/// question from readiness — which backed-up services still need their restore point — so it
+/// lives apart from the enable/disable flow it supports.
+extension SystemProxyManager {
+    /// Recovery's per-service ownership view of a backup. `currentProxyMatchesRockxy` answers a
+    /// readiness question — is capture actually routed through Rockxy — and deliberately requires
+    /// the routed service, or every backed-up service, to match. Recovery asks something else:
+    /// which backed-up services are still pointing at Rockxy and therefore still need their
+    /// restore point. One service the user re-pointed must not make the rest look unowned.
+    func residualRockxyOwnedServices(port: Int, backedUpServices: [String]) -> [String] {
+        ProxyOverrideOwnership.residualOwnedServices(
+            in: backedUpServices.map(currentOverrideState(for:)),
+            port: port
+        )
+    }
+
+    /// Once a restore has started, every retained entry is known unresolved even if a partial
+    /// command already changed the live shape enough that strict ownership no longer matches.
+    private func recoverableDirectServices(in backup: DirectProxyBackup) -> [String] {
+        if backup.recoveryPending {
+            return backup.services.map(\.service)
+        }
+        return residualRockxyOwnedServices(
+            port: backup.rockxyPort,
+            backedUpServices: backup.services.map(\.service)
+        )
+    }
+
+    /// Reads only the fields ownership depends on for one service.
+    private func currentOverrideState(for service: String) -> ProxyServiceOverrideState {
+        let snapshot = captureProxySnapshot(for: service)
+        let bypassOutput = (try? runNetworkSetup(["-getproxybypassdomains", service])) ?? ""
+        let hasGlobalBypass = bypassOutput.components(separatedBy: "\n").contains {
+            $0.trimmingCharacters(in: .whitespacesAndNewlines) == "*"
+        }
+        return ProxyServiceOverrideState(
+            service: service,
+            httpEnabled: snapshot.httpEnabled,
+            httpHost: snapshot.httpHost,
+            httpPort: snapshot.httpPort,
+            httpsEnabled: snapshot.httpsEnabled,
+            httpsHost: snapshot.httpsHost,
+            httpsPort: snapshot.httpsPort,
+            socksEnabled: snapshot.socksEnabled,
+            pacEnabled: snapshot.pacEnabled,
+            autoDiscoveryEnabled: snapshot.autoDiscoveryEnabled,
+            hasGlobalBypass: hasGlobalBypass
+        )
+    }
+
+    /// Narrows the on-disk backup to the services recovery still owns, then restores exactly
+    /// those. Persisting the reduced backup first is what keeps a later retry from replaying
+    /// stale settings onto a service the user has changed in the meantime; if that write fails,
+    /// the original backup stays put and no setting is touched.
+    @discardableResult
+    private func recoverOwnedDirectServices(backup: DirectProxyBackup, ownedServices: [String]) -> Bool {
+        let ownedBackup = DirectProxyBackup(
+            services: ProxyBackupSubset.select(
+                backup.services,
+                services: Set(ownedServices),
+                serviceName: \.service
+            ),
+            timestamp: backup.timestamp,
+            rockxyPort: backup.rockxyPort,
+            recoveryPending: true
+        )
+        guard !ownedBackup.services.isEmpty else {
+            clearDirectBackup()
+            return true
+        }
+
+        do {
+            try writeDirectBackup(ownedBackup)
+        } catch {
+            Self.logger
+                .error(
+                    "Could not narrow the direct backup — leaving settings untouched: \(error.localizedDescription)"
+                )
+            return false
+        }
+
+        return restoreDirectMode(using: ownedBackup)
+    }
+
+    /// Keeps only the services a restore attempt left unresolved, so the retry cannot write the
+    /// captured settings back onto a service that already restored.
+    private func retainUnresolvedDirectBackup(
+        backup: DirectProxyBackup,
+        failedServices: Set<String>,
+        stillOwnedServices: Set<String>
+    ) {
+        let unresolvedEntries = ProxyBackupSubset.unresolvedEntries(
+            backup.services,
+            failedServices: failedServices,
+            stillOwnedServices: stillOwnedServices,
+            serviceName: \.service
+        )
+        guard !unresolvedEntries.isEmpty, unresolvedEntries.count < backup.services.count else {
+            return
+        }
+
+        do {
+            try writeDirectBackup(DirectProxyBackup(
+                services: unresolvedEntries,
+                timestamp: backup.timestamp,
+                rockxyPort: backup.rockxyPort,
+                recoveryPending: true
+            ))
+        } catch {
+            Self.logger
+                .error("Could not narrow the retained direct backup: \(error.localizedDescription)")
+        }
+    }
+
+    /// Polls the backed-up services after a restore attempt and reports whichever ones are still
+    /// Rockxy-owned. macOS applies `networksetup` writes asynchronously, so a single read right
+    /// after the commands can still show the old override.
+    private func residualOwnedServicesAfterRestore(
+        port: Int,
+        backedUpServices: [String],
+        maxAttempts: Int = 5,
+        pollInterval: TimeInterval = 0.2
+    )
+        -> [String]
+    {
+        guard !backedUpServices.isEmpty else {
+            return []
+        }
+
+        var stillOwnedServices: [String] = []
+        for attempt in 0 ..< maxAttempts {
+            stillOwnedServices = residualRockxyOwnedServices(port: port, backedUpServices: backedUpServices)
+            if stillOwnedServices.isEmpty {
+                return []
+            }
+
+            if attempt < maxAttempts - 1 {
+                Thread.sleep(forTimeInterval: pollInterval)
+            }
+        }
+
+        return stillOwnedServices
     }
 }
 

--- a/RockxyHelperTool/CrashRecovery.swift
+++ b/RockxyHelperTool/CrashRecovery.swift
@@ -1,4 +1,3 @@
-import Darwin
 import Foundation
 import os
 
@@ -101,15 +100,79 @@ enum CrashRecovery {
     }
 
     struct ProxyBackup: Codable {
+        // MARK: Lifecycle
+
+        init(
+            services: [ServiceProxyBackup],
+            timestamp: Date,
+            rockxyPort: Int?,
+            ownerPID: Int32?,
+            ownerStartSignature: String?,
+            recoveryPending: Bool = false
+        ) {
+            self.services = services
+            self.timestamp = timestamp
+            self.rockxyPort = rockxyPort
+            self.ownerPID = ownerPID
+            self.ownerStartSignature = ownerStartSignature
+            self.recoveryPending = recoveryPending
+        }
+
+        /// Backups written before owner identity existed decode with no owner, which recovery
+        /// reads as "the session that took this override is gone".
+        init(from decoder: any Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            services = try container.decode([ServiceProxyBackup].self, forKey: .services)
+            timestamp = try container.decode(Date.self, forKey: .timestamp)
+            rockxyPort = try container.decodeIfPresent(Int.self, forKey: .rockxyPort)
+            ownerPID = try container.decodeIfPresent(Int32.self, forKey: .ownerPID)
+            ownerStartSignature = try container.decodeIfPresent(String.self, forKey: .ownerStartSignature)
+            recoveryPending = try container.decodeIfPresent(Bool.self, forKey: .recoveryPending) ?? false
+        }
+
+        // MARK: Internal
+
         let services: [ServiceProxyBackup]
         let timestamp: Date
         let rockxyPort: Int?
+        /// The Rockxy app process that asked for the override, and the kernel start time that
+        /// tells it apart from a later process which inherited the same PID.
+        let ownerPID: Int32?
+        let ownerStartSignature: String?
+        /// True after recovery has narrowed the backup and before every retained entry has been
+        /// fully restored. Retained entries remain authoritative even after partial commands
+        /// change their live shape enough that strict ownership no longer matches.
+        let recoveryPending: Bool
+
+        // MARK: Private
+
+        private enum CodingKeys: String, CodingKey {
+            case services
+            case timestamp
+            case rockxyPort
+            case ownerPID
+            case ownerStartSignature
+            case recoveryPending
+        }
+    }
+
+    /// What launch-time recovery did with the backup it found.
+    enum StartupRecoveryOutcome: Equatable {
+        case noBackup
+        case cleared
+        case restored
+        case restoreIncomplete
+        /// The recorded owner is still alive and still passes caller validation, so its override
+        /// stays in place. The PID is handed back so the helper can re-arm its owner watchdog.
+        case preserved(ownerPID: Int32?)
     }
 
     // MARK: - Public API
 
     /// Save current proxy settings for all specified services before overriding them.
-    static func saveOriginalSettings(services: [String], rockxyPort: Int) throws {
+    /// The owning app process is recorded with the backup so a later helper launch can tell a
+    /// still-running session from a stranded override.
+    static func saveOriginalSettings(services: [String], rockxyPort: Int, ownerPID: Int32) throws {
         let existingBackup = loadBackup()
         let existingServices = Set(existingBackup?.services.map(\.service) ?? [])
         let servicesToCapture = services.filter { !existingServices.contains($0) }
@@ -165,19 +228,14 @@ enum CrashRecovery {
         let backup = ProxyBackup(
             services: (existingBackup?.services ?? []) + serviceBackups,
             timestamp: existingBackup?.timestamp ?? Date(),
-            rockxyPort: rockxyPort
+            rockxyPort: rockxyPort,
+            ownerPID: ownerPID,
+            ownerStartSignature: ProcessStartIdentity.startSignature(for: ownerPID),
+            recoveryPending: false
         )
 
         do {
-            try ensureBackupDirectoryExists()
-            let data = try PropertyListEncoder().encode(backup)
-            for url in backupURLs {
-                try data.write(to: url, options: .atomic)
-                try FileManager.default.setAttributes(
-                    [.posixPermissions: 0o600],
-                    ofItemAtPath: url.path
-                )
-            }
+            try persist(backup)
             logger
                 .info(
                     "Proxy backup saved to \(backupURLs.first?.path ?? "<unknown>") (\(backup.services.count) service(s))"
@@ -188,35 +246,144 @@ enum CrashRecovery {
         }
     }
 
+    /// Writes a backup to every backup location with owner-only permissions.
+    /// Used both for the initial capture and for the reduced backup a subset restore persists
+    /// before it touches any setting.
+    static func persist(_ backup: ProxyBackup) throws {
+        try ensureBackupDirectoryExists()
+        let data = try PropertyListEncoder().encode(backup)
+        for url in backupURLs {
+            try data.write(to: url, options: .atomic)
+            try FileManager.default.setAttributes(
+                [.posixPermissions: 0o600],
+                ofItemAtPath: url.path
+            )
+        }
+    }
+
+    /// Narrows the backup on disk to `services` before a subset restore mutates anything.
+    /// Dropping the entries recovery no longer owns is what stops a later retry from writing
+    /// stale settings over a service the user has since changed.
+    static func reduceBackup(
+        _ backup: ProxyBackup,
+        to services: [String],
+        rockxyPort: Int? = nil
+    )
+        throws -> ProxyBackup
+    {
+        let reduced = ProxyBackup(
+            services: ProxyBackupSubset.select(
+                backup.services,
+                services: Set(services),
+                serviceName: \.service
+            ),
+            timestamp: backup.timestamp,
+            rockxyPort: backup.rockxyPort ?? rockxyPort,
+            ownerPID: nil,
+            ownerStartSignature: nil,
+            recoveryPending: true
+        )
+        try persist(reduced)
+        return reduced
+    }
+
     /// Check for stale backup on daemon launch and restore if found.
-    /// A backup existing at launch time means Rockxy crashed without restoring proxy settings.
-    static func restoreIfNeeded() {
+    /// A backup existing at launch time means the previous session ended without restoring proxy
+    /// settings — unless its owner is still running, which the recorded process identity proves.
+    @discardableResult
+    static func restoreIfNeeded() -> StartupRecoveryOutcome {
         guard hasBackup() else {
             logger.info("No stale proxy backup found — clean startup")
-            return
+            return .noBackup
         }
 
         guard let backup = loadBackup() else {
             logger.warning("Backup file exists but could not be read — clearing")
             clearBackup()
-            return
+            return .cleared
         }
 
-        let status = ProxyConfigurator.getCurrentStatus()
+        // Legacy backups predate the persisted port, so fall back to the port the backed-up
+        // services are still overriding, then to the port the live status reports. With none of
+        // those, nothing can be identified as Rockxy-owned.
+        let overrideStates = ProxyConfigurator.currentOverrideStates(for: backup.services.map(\.service))
+        let fallbackPort: () -> Int? = {
+            if let inferredPort = ProxyOverrideOwnership.inferredOwnedPort(in: overrideStates) {
+                return inferredPort
+            }
+            let status = ProxyConfigurator.getCurrentStatus()
+            return status.isOverridden ? status.port : nil
+        }
+        let ownedPort = backup.rockxyPort ?? fallbackPort()
+        guard backup.recoveryPending || ownedPort != nil else {
+            logger.info("No Rockxy-owned port could be identified — clearing stale backup")
+            clearBackup()
+            return .cleared
+        }
+
+        let residualOwnedServices = if backup.recoveryPending {
+            backup.services.map(\.service)
+        } else {
+            ProxyOverrideOwnership.residualOwnedServices(in: overrideStates, port: ownedPort ?? 0)
+        }
+        let liveOwnerPID = backup.recoveryPending ? nil : liveOwnerPID(for: backup)
+
         switch ProxyBackupRecoveryPolicy.action(
-            proxyStillPointsAtRockxy: status.isOverridden &&
-                (backup.rockxyPort == nil || backup.rockxyPort == status.port),
-            listenerIsReachable: listenerIsReachable(port: status.port)
+            residualOwnedServicesExist: !residualOwnedServices.isEmpty,
+            ownerSessionIsLive: liveOwnerPID != nil
         ) {
         case .restore:
-            logger.warning("Owned proxy backup has no live listener — restoring proxy settings")
-            ProxyConfigurator.restoreProxy()
+            logger
+                .warning(
+                    "Owned proxy backup has no live owner — restoring \(residualOwnedServices.count) residual service(s)"
+                )
+            do {
+                try ProxyConfigurator.restoreOwnedServicesOrThrow(
+                    ownedServices: residualOwnedServices,
+                    port: ownedPort
+                )
+                return .restored
+            } catch {
+                logger.error("Stale proxy restore incomplete: \(error.localizedDescription)")
+                return .restoreIncomplete
+            }
         case .preserve:
-            logger.info("Owned proxy backup belongs to a live listener — preserving the active session")
+            logger.info("Owned proxy backup belongs to a live authenticated owner — preserving the active session")
+            return .preserved(ownerPID: liveOwnerPID)
         case .clear:
-            logger.info("Proxy no longer points at the backed-up Rockxy session — clearing stale backup")
+            logger.info("No backed-up service still points at the Rockxy session — clearing stale backup")
             clearBackup()
+            return .cleared
         }
+    }
+
+    /// The recorded owner, but only when it is still the same live process *and* still passes
+    /// caller validation as the Rockxy app. A recycled PID, a legacy backup with no recorded
+    /// identity, or a process that no longer validates all resolve to nil, which makes recovery
+    /// treat the override as stranded.
+    static func liveOwnerPID(for backup: ProxyBackup) -> Int32? {
+        guard let ownerPID = backup.ownerPID, ownerPID > 0 else {
+            return nil
+        }
+
+        let ownerIsAlive = ProcessStartIdentity.isAlive(ownerPID)
+        let liveStartSignature = ownerIsAlive ? ProcessStartIdentity.startSignature(for: ownerPID) : nil
+        let passesCallerValidation = ownerIsAlive && CallerValidation.validateCaller(
+            pid: ownerPID,
+            allowedIdentifiers: RockxyIdentity.current.allowedCallerIdentifiers
+        )
+
+        guard ProxyBackupOwnerIdentityPolicy.ownerSessionIsLive(
+            recordedOwnerPID: ownerPID,
+            recordedStartSignature: backup.ownerStartSignature,
+            ownerProcessIsAlive: ownerIsAlive,
+            liveStartSignature: liveStartSignature,
+            ownerPassesCallerValidation: passesCallerValidation
+        ) else {
+            return nil
+        }
+
+        return ownerPID
     }
 
     /// Load the backup data from disk.
@@ -290,52 +457,6 @@ enum CrashRecovery {
                 )
             }
         }
-    }
-
-    private static func listenerIsReachable(port: Int) -> Bool {
-        guard let port = UInt16(exactly: port), port > 0 else {
-            return false
-        }
-
-        let descriptor = socket(AF_INET, SOCK_STREAM, 0)
-        guard descriptor >= 0 else {
-            return false
-        }
-        defer { Darwin.close(descriptor) }
-
-        let flags = fcntl(descriptor, F_GETFL, 0)
-        guard flags >= 0, fcntl(descriptor, F_SETFL, flags | O_NONBLOCK) == 0 else {
-            return false
-        }
-
-        var address = sockaddr_in()
-        address.sin_family = sa_family_t(AF_INET)
-        address.sin_port = in_port_t(port).bigEndian
-        address.sin_addr.s_addr = inet_addr("127.0.0.1")
-
-        let result = withUnsafePointer(to: &address) { pointer in
-            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) {
-                Darwin.connect(descriptor, $0, socklen_t(MemoryLayout<sockaddr_in>.size))
-            }
-        }
-        if result == 0 {
-            return true
-        }
-        guard errno == EINPROGRESS else {
-            return false
-        }
-
-        var state = pollfd(fd: descriptor, events: Int16(POLLOUT), revents: 0)
-        guard Darwin.poll(&state, 1, 250) > 0 else {
-            return false
-        }
-
-        var socketError: Int32 = 0
-        var socketErrorLength = socklen_t(MemoryLayout<Int32>.size)
-        guard getsockopt(descriptor, SOL_SOCKET, SO_ERROR, &socketError, &socketErrorLength) == 0 else {
-            return false
-        }
-        return socketError == 0
     }
 
     private static func readBypassDomains(service: String) throws -> [String] {

--- a/RockxyHelperTool/HelperService.swift
+++ b/RockxyHelperTool/HelperService.swift
@@ -47,7 +47,7 @@ final class HelperService: NSObject, RockxyHelperProtocol {
 
         guard let result = Self.mutationGate.withExclusiveAccess({
             Result {
-                try ProxyConfigurator.overrideProxy(port: port)
+                try ProxyConfigurator.overrideProxy(port: port, ownerPID: ownerPID)
                 lastProxyChangeTime = Date()
                 startOwnerWatchdog(for: ownerPID)
             }
@@ -157,6 +157,17 @@ final class HelperService: NSObject, RockxyHelperProtocol {
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
             Foundation.exit(0)
         }
+    }
+
+    /// Re-arms the owner watchdog for a session that survived a helper relaunch.
+    /// Without this, an override preserved at startup would have no observer left, so the owner
+    /// dying later would strand the user's proxy settings with nothing to restore them.
+    func resumeOwnerWatchdog(for pid: Int32) {
+        guard pid > 0 else {
+            return
+        }
+        Self.logger.info("Re-arming owner watchdog for preserved session pid \(pid)")
+        startOwnerWatchdog(for: pid)
     }
 
     func handleConnectionInvalidated(processID: Int32) {

--- a/RockxyHelperTool/ProxyConfigurator.swift
+++ b/RockxyHelperTool/ProxyConfigurator.swift
@@ -27,7 +27,7 @@ enum ProxyConfigurator {
 
     /// Override system HTTP and HTTPS proxy to 127.0.0.1 on the given port.
     /// Saves current settings via CrashRecovery before making changes.
-    static func overrideProxy(port: Int) throws {
+    static func overrideProxy(port: Int, ownerPID: Int32) throws {
         let services = try detectAllEnabledServices()
         guard !services.isEmpty else {
             throw ProxyConfiguratorError.noActiveService
@@ -35,7 +35,7 @@ enum ProxyConfigurator {
 
         // Existing service snapshots are preserved, while newly enabled services are added
         // before they are mutated so every touched route has an exact restore point.
-        try CrashRecovery.saveOriginalSettings(services: services, rockxyPort: port)
+        try CrashRecovery.saveOriginalSettings(services: services, rockxyPort: port, ownerPID: ownerPID)
 
         logger.info("Setting system proxy to 127.0.0.1:\(port) for \(services.count) service(s)")
 
@@ -77,22 +77,27 @@ enum ProxyConfigurator {
 
     /// Restore proxy settings from CrashRecovery backup. Throws on failure.
     static func restoreProxyOrThrow() throws {
-        guard let backup = CrashRecovery.loadBackup() else {
+        guard let sourceBackup = CrashRecovery.loadBackup() else {
             logger.info("No proxy backup exists, so there is no owned proxy state to restore")
             return
         }
+        let backedUpServices = sourceBackup.services.map(\.service)
+        let inferredPort = ProxyOverrideOwnership.inferredOwnedPort(
+            in: currentOverrideStates(for: backedUpServices)
+        )
+        let backup = try CrashRecovery.reduceBackup(
+            sourceBackup,
+            to: backedUpServices,
+            rockxyPort: inferredPort
+        )
 
-        var allSucceeded = true
+        var failedServices: Set<String> = []
         for service in backup.services.map(\.service) {
             do {
-                try runNetworkSetup(["-setwebproxystate", service, "off"])
-                try runNetworkSetup(["-setsecurewebproxystate", service, "off"])
-                try runNetworkSetup(["-setsocksfirewallproxystate", service, "off"])
-                try runNetworkSetup(["-setautoproxystate", service, "off"])
-                try runNetworkSetup(["-setproxyautodiscovery", service, "off"])
+                try disableProxyStates(for: service)
                 logger.debug("Disabled proxy on '\(service)'")
             } catch {
-                allSucceeded = false
+                failedServices.insert(service)
                 logger.debug("Failed to disable proxy for '\(service)': \(error.localizedDescription)")
             }
         }
@@ -100,67 +105,167 @@ enum ProxyConfigurator {
         logger.info("Restoring original proxy settings for \(backup.services.count) service(s)")
 
         for serviceBackup in backup.services {
-            let service = serviceBackup.service
-            logger.info("Restoring proxy settings for '\(service)'")
+            logger.info("Restoring proxy settings for '\(serviceBackup.service)'")
 
             do {
-                if !serviceBackup.httpHost.isEmpty, serviceBackup.httpPort > 0 {
-                    try runNetworkSetup([
-                        "-setwebproxy", service, serviceBackup.httpHost,
-                        String(serviceBackup.httpPort),
-                    ])
-                    try runNetworkSetup([
-                        "-setwebproxystate", service, serviceBackup.httpEnabled ? "on" : "off",
-                    ])
-                }
-
-                if !serviceBackup.httpsHost.isEmpty, serviceBackup.httpsPort > 0 {
-                    try runNetworkSetup([
-                        "-setsecurewebproxy", service, serviceBackup.httpsHost,
-                        String(serviceBackup.httpsPort),
-                    ])
-                    try runNetworkSetup([
-                        "-setsecurewebproxystate", service, serviceBackup.httpsEnabled ? "on" : "off",
-                    ])
-                }
-
-                if !serviceBackup.socksHost.isEmpty, serviceBackup.socksPort > 0 {
-                    try runNetworkSetup([
-                        "-setsocksfirewallproxy", service, serviceBackup.socksHost,
-                        String(serviceBackup.socksPort),
-                    ])
-                    try runNetworkSetup([
-                        "-setsocksfirewallproxystate", service, serviceBackup.socksEnabled ? "on" : "off",
-                    ])
-                }
-
-                if serviceBackup.pacEnabled {
-                    if !serviceBackup.pacURL.isEmpty {
-                        try runNetworkSetup(["-setautoproxyurl", service, serviceBackup.pacURL])
-                    }
-                    try runNetworkSetup(["-setautoproxystate", service, "on"])
-                }
-
-                if serviceBackup.autoDiscoveryEnabled {
-                    try runNetworkSetup(["-setproxyautodiscovery", service, "on"])
-                }
-
-                try restoreBypassDomains(service: service, domains: serviceBackup.bypassDomains)
+                try applyServiceBackup(serviceBackup)
             } catch {
-                allSucceeded = false
-                logger.error("Failed to restore proxy for '\(service)': \(error.localizedDescription)")
+                failedServices.insert(serviceBackup.service)
+                logger
+                    .error(
+                        "Failed to restore proxy for '\(serviceBackup.service)': \(error.localizedDescription)"
+                    )
             }
         }
 
-        guard allSucceeded else {
+        let stillOwnedServices = Set(backup.rockxyPort.map { port in
+            ProxyOverrideOwnership.residualOwnedServices(
+                in: currentOverrideStates(for: backup.services.map(\.service)),
+                port: port
+            )
+        } ?? [])
+        let unresolvedEntries = ProxyBackupSubset.unresolvedEntries(
+            backup.services,
+            failedServices: failedServices,
+            stillOwnedServices: stillOwnedServices,
+            serviceName: \.service
+        )
+
+        guard unresolvedEntries.isEmpty else {
+            do {
+                _ = try CrashRecovery.reduceBackup(backup, to: unresolvedEntries.map(\.service))
+            } catch {
+                logger.error("Could not narrow the retained proxy backup: \(error.localizedDescription)")
+            }
             throw ProxyConfiguratorError.executionFailed(
                 command: "restore proxy",
-                reason: "One or more network services could not be restored; the recovery backup was preserved"
+                reason: "\(unresolvedEntries.count) network service(s) could not be restored; the recovery backup was preserved"
             )
         }
 
         CrashRecovery.clearBackup()
         logger.info("Proxy settings restored successfully")
+    }
+
+    /// Restores only the backed-up services that still carry Rockxy's override, leaving any
+    /// service the user (or another tool) has since re-pointed exactly as it is.
+    ///
+    /// The backup is narrowed to those services *before* the first setting is written, so a
+    /// retry after a partial failure can never replay stale settings onto a service that is no
+    /// longer Rockxy's. If that reduced backup cannot be persisted, the original backup stays
+    /// on disk and nothing is mutated — losing the restore point is worse than a stranded
+    /// override that can still be recovered later.
+    static func restoreOwnedServicesOrThrow(ownedServices: [String], port: Int?) throws {
+        guard let backup = CrashRecovery.loadBackup() else {
+            logger.info("No proxy backup exists, so there is no owned proxy state to restore")
+            return
+        }
+
+        let ownedEntries = ProxyBackupSubset.select(
+            backup.services,
+            services: Set(ownedServices),
+            serviceName: \.service
+        )
+        guard !ownedEntries.isEmpty else {
+            logger.info("No backed-up service is still Rockxy-owned — clearing the stale backup")
+            CrashRecovery.clearBackup()
+            return
+        }
+
+        let reducedBackup: CrashRecovery.ProxyBackup
+        do {
+            reducedBackup = try CrashRecovery.reduceBackup(
+                backup,
+                to: ownedEntries.map(\.service),
+                rockxyPort: port
+            )
+        } catch {
+            logger
+                .error(
+                    "Could not persist the reduced proxy backup — leaving settings untouched: \(error.localizedDescription)"
+                )
+            throw error
+        }
+
+        logger.info("Restoring original proxy settings for \(reducedBackup.services.count) owned service(s)")
+
+        var failedServices: Set<String> = []
+        for serviceBackup in reducedBackup.services {
+            do {
+                try disableProxyStates(for: serviceBackup.service)
+                try applyServiceBackup(serviceBackup)
+            } catch {
+                failedServices.insert(serviceBackup.service)
+                logger
+                    .error(
+                        "Failed to restore proxy for '\(serviceBackup.service)': \(error.localizedDescription)"
+                    )
+            }
+        }
+
+        let stillOwnedServices = Set(port.map { ownedPort in
+            ProxyOverrideOwnership.residualOwnedServices(
+                in: currentOverrideStates(for: reducedBackup.services.map(\.service)),
+                port: ownedPort
+            )
+        } ?? [])
+        let unresolvedEntries = ProxyBackupSubset.unresolvedEntries(
+            reducedBackup.services,
+            failedServices: failedServices,
+            stillOwnedServices: stillOwnedServices,
+            serviceName: \.service
+        )
+
+        guard unresolvedEntries.isEmpty else {
+            // Keep exactly the services that still need recovery so a retry has a restore point
+            // for them and only them.
+            do {
+                _ = try CrashRecovery.reduceBackup(reducedBackup, to: unresolvedEntries.map(\.service))
+            } catch {
+                logger
+                    .error(
+                        "Could not narrow the retained proxy backup: \(error.localizedDescription)"
+                    )
+            }
+            throw ProxyConfiguratorError.executionFailed(
+                command: "restore owned proxy services",
+                reason: "\(unresolvedEntries.count) network service(s) could not be restored; the recovery backup was preserved"
+            )
+        }
+
+        CrashRecovery.clearBackup()
+        logger.info("Owned proxy settings restored successfully")
+    }
+
+    /// Reads the ownership-relevant proxy fields for each service. Services that cannot be read
+    /// report as not overridden, which keeps recovery from claiming ownership it cannot prove.
+    static func currentOverrideStates(for services: [String]) -> [ProxyServiceOverrideState] {
+        services.map { service in
+            let http = parseProxyOutput((try? runNetworkSetup(["-getwebproxy", service])) ?? "")
+            let https = parseProxyOutput((try? runNetworkSetup(["-getsecurewebproxy", service])) ?? "")
+            let socks = parseProxyOutput((try? runNetworkSetup(["-getsocksfirewallproxy", service])) ?? "")
+            let pac = parsePACOutput((try? runNetworkSetup(["-getautoproxyurl", service])) ?? "")
+            let autoDiscovery = parseAutoDiscoveryOutput(
+                (try? runNetworkSetup(["-getproxyautodiscovery", service])) ?? ""
+            )
+            let bypassOutput = (try? runNetworkSetup(["-getproxybypassdomains", service])) ?? ""
+            let hasGlobalBypass = bypassOutput.components(separatedBy: "\n").contains {
+                $0.trimmingCharacters(in: .whitespacesAndNewlines) == "*"
+            }
+            return ProxyServiceOverrideState(
+                service: service,
+                httpEnabled: http.enabled,
+                httpHost: http.host,
+                httpPort: http.port,
+                httpsEnabled: https.enabled,
+                httpsHost: https.host,
+                httpsPort: https.port,
+                socksEnabled: socks.enabled,
+                pacEnabled: pac.enabled,
+                autoDiscoveryEnabled: autoDiscovery,
+                hasGlobalBypass: hasGlobalBypass
+            )
+        }
     }
 
     /// Set bypass domains on all enabled network services.
@@ -328,6 +433,64 @@ enum ProxyConfigurator {
     private static let logger = Logger(subsystem: RockxyIdentity.current.logSubsystem, category: "ProxyConfigurator")
     private static let networkSetupPath = "/usr/sbin/networksetup"
     private static let routePath = "/sbin/route"
+
+    /// Turns every proxy mode off for one service before its snapshot is written back, so a
+    /// mode the snapshot does not mention cannot survive the restore.
+    private static func disableProxyStates(for service: String) throws {
+        try runNetworkSetup(["-setwebproxystate", service, "off"])
+        try runNetworkSetup(["-setsecurewebproxystate", service, "off"])
+        try runNetworkSetup(["-setsocksfirewallproxystate", service, "off"])
+        try runNetworkSetup(["-setautoproxystate", service, "off"])
+        try runNetworkSetup(["-setproxyautodiscovery", service, "off"])
+    }
+
+    /// Writes one service's captured pre-Rockxy proxy configuration back verbatim.
+    private static func applyServiceBackup(_ serviceBackup: CrashRecovery.ServiceProxyBackup) throws {
+        let service = serviceBackup.service
+
+        if !serviceBackup.httpHost.isEmpty, serviceBackup.httpPort > 0 {
+            try runNetworkSetup([
+                "-setwebproxy", service, serviceBackup.httpHost,
+                String(serviceBackup.httpPort),
+            ])
+            try runNetworkSetup([
+                "-setwebproxystate", service, serviceBackup.httpEnabled ? "on" : "off",
+            ])
+        }
+
+        if !serviceBackup.httpsHost.isEmpty, serviceBackup.httpsPort > 0 {
+            try runNetworkSetup([
+                "-setsecurewebproxy", service, serviceBackup.httpsHost,
+                String(serviceBackup.httpsPort),
+            ])
+            try runNetworkSetup([
+                "-setsecurewebproxystate", service, serviceBackup.httpsEnabled ? "on" : "off",
+            ])
+        }
+
+        if !serviceBackup.socksHost.isEmpty, serviceBackup.socksPort > 0 {
+            try runNetworkSetup([
+                "-setsocksfirewallproxy", service, serviceBackup.socksHost,
+                String(serviceBackup.socksPort),
+            ])
+            try runNetworkSetup([
+                "-setsocksfirewallproxystate", service, serviceBackup.socksEnabled ? "on" : "off",
+            ])
+        }
+
+        if serviceBackup.pacEnabled {
+            if !serviceBackup.pacURL.isEmpty {
+                try runNetworkSetup(["-setautoproxyurl", service, serviceBackup.pacURL])
+            }
+            try runNetworkSetup(["-setautoproxystate", service, "on"])
+        }
+
+        if serviceBackup.autoDiscoveryEnabled {
+            try runNetworkSetup(["-setproxyautodiscovery", service, "on"])
+        }
+
+        try restoreBypassDomains(service: service, domains: serviceBackup.bypassDomains)
+    }
 
     private static func validateBinary(_ path: String) throws {
         guard BinaryValidator.validateAppleSignedBinary(at: path) else {

--- a/RockxyHelperTool/main.swift
+++ b/RockxyHelperTool/main.swift
@@ -9,15 +9,43 @@ private let logger = Logger(subsystem: identity.logSubsystem, category: "Main")
 
 // MARK: - DirectProxyBackup
 
-private struct DirectProxyBackup: Decodable {
+private struct DirectProxyBackup: Codable {
+    init(
+        services: [DirectServiceBackup],
+        timestamp: Date,
+        rockxyPort: Int,
+        recoveryPending: Bool = false
+    ) {
+        self.services = services
+        self.timestamp = timestamp
+        self.rockxyPort = rockxyPort
+        self.recoveryPending = recoveryPending
+    }
+
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        services = try container.decode([DirectServiceBackup].self, forKey: .services)
+        timestamp = try container.decode(Date.self, forKey: .timestamp)
+        rockxyPort = try container.decode(Int.self, forKey: .rockxyPort)
+        recoveryPending = try container.decodeIfPresent(Bool.self, forKey: .recoveryPending) ?? false
+    }
+
     let services: [DirectServiceBackup]
     let timestamp: Date
     let rockxyPort: Int
+    let recoveryPending: Bool
+
+    private enum CodingKeys: String, CodingKey {
+        case services
+        case timestamp
+        case rockxyPort
+        case recoveryPending
+    }
 }
 
 // MARK: - DirectServiceBackup
 
-private struct DirectServiceBackup: Decodable {
+private struct DirectServiceBackup: Codable {
     init(from decoder: any Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         service = try container.decode(String.self, forKey: .service)
@@ -125,22 +153,52 @@ private enum DirectProxyWatchdog {
 
     private static let networkSetupPath = "/usr/sbin/networksetup"
 
+    /// Restores only the backed-up services that still carry Rockxy's override. A service the
+    /// user re-pointed after the crash is left alone, and its absence never justifies deleting
+    /// the restore point the remaining owned services still depend on.
     private static func restoreIfNeeded(from backupURL: URL) {
         guard let backup = loadBackup(from: backupURL) else {
             return
         }
 
-        let backedUpServices = backup.services.map(\.service)
-        guard currentProxyMatchesRockxy(port: backup.rockxyPort, services: backedUpServices) else {
-            logger.info("Direct proxy watchdog clearing stale backup because proxy no longer points at Rockxy")
+        let ownedServices = backup.recoveryPending
+            ? backup.services.map(\.service)
+            : residualOwnedServices(in: backup)
+        guard !ownedServices.isEmpty else {
+            logger.info("Direct proxy watchdog clearing stale backup because no service still points at Rockxy")
             try? FileManager.default.removeItem(at: backupURL)
             return
         }
 
-        logger.warning("Direct proxy watchdog restoring proxy settings after parent exit")
-        var allSucceeded = true
+        // Narrow the backup before mutating anything: if this write fails, the original backup
+        // and the current settings both stay exactly as they are.
+        let ownedBackup = DirectProxyBackup(
+            services: ProxyBackupSubset.select(
+                backup.services,
+                services: Set(ownedServices),
+                serviceName: \.service
+            ),
+            timestamp: backup.timestamp,
+            rockxyPort: backup.rockxyPort,
+            recoveryPending: true
+        )
+        do {
+            try write(ownedBackup, to: backupURL)
+        } catch {
+            logger
+                .error(
+                    "Direct proxy watchdog could not narrow the backup — leaving settings untouched: \(error.localizedDescription)"
+                )
+            return
+        }
 
-        for entry in backup.services {
+        logger
+            .warning(
+                "Direct proxy watchdog restoring \(ownedBackup.services.count) owned service(s) after parent exit"
+            )
+        var failedServices: Set<String> = []
+
+        for entry in ownedBackup.services {
             let snapshot = DirectProxySnapshot(
                 httpEnabled: entry.httpEnabled,
                 httpHost: entry.httpHost,
@@ -159,7 +217,7 @@ private enum DirectProxyWatchdog {
             do {
                 try restoreProxyState(for: entry.service, snapshot: snapshot)
             } catch {
-                allSucceeded = false
+                failedServices.insert(entry.service)
                 logger
                     .error(
                         "Direct proxy watchdog failed to restore proxy state for '\(entry.service)': \(error.localizedDescription)"
@@ -169,7 +227,7 @@ private enum DirectProxyWatchdog {
             do {
                 try restoreBypassDomains(for: entry.service, domains: entry.bypassDomains)
             } catch {
-                allSucceeded = false
+                failedServices.insert(entry.service)
                 logger
                     .error(
                         "Direct proxy watchdog failed to restore bypass domains for '\(entry.service)': \(error.localizedDescription)"
@@ -177,11 +235,42 @@ private enum DirectProxyWatchdog {
             }
         }
 
-        if allSucceeded {
+        let unresolvedEntries = ProxyBackupSubset.unresolvedEntries(
+            ownedBackup.services,
+            failedServices: failedServices,
+            stillOwnedServices: Set(residualOwnedServices(in: ownedBackup)),
+            serviceName: \.service
+        )
+
+        guard !unresolvedEntries.isEmpty else {
             try? FileManager.default.removeItem(at: backupURL)
-        } else {
-            logger.warning("Direct proxy watchdog left backup on disk for later recovery")
+            return
         }
+
+        let retainedBackup = DirectProxyBackup(
+            services: unresolvedEntries,
+            timestamp: ownedBackup.timestamp,
+            rockxyPort: ownedBackup.rockxyPort,
+            recoveryPending: true
+        )
+        do {
+            try write(retainedBackup, to: backupURL)
+        } catch {
+            logger.error("Direct proxy watchdog could not narrow the retained backup: \(error.localizedDescription)")
+        }
+        logger
+            .warning(
+                "Direct proxy watchdog left \(unresolvedEntries.count) service(s) in the backup for later recovery"
+            )
+    }
+
+    private static func write(_ backup: DirectProxyBackup, to backupURL: URL) throws {
+        let data = try PropertyListEncoder().encode(backup)
+        try data.write(to: backupURL, options: .atomic)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o600],
+            ofItemAtPath: backupURL.path
+        )
     }
 
     private static func loadBackup(from backupURL: URL) -> DirectProxyBackup? {
@@ -195,29 +284,29 @@ private enum DirectProxyWatchdog {
         }
     }
 
-    private static func currentProxyMatchesRockxy(port: Int, services: [String]) -> Bool {
-        for service in services {
-            let snapshot = captureProxySnapshot(for: service)
-            let httpMatch = snapshot.httpEnabled
-                && snapshot.httpHost == "127.0.0.1"
-                && snapshot.httpPort == port
-            let httpsMatch = snapshot.httpsEnabled
-                && snapshot.httpsHost == "127.0.0.1"
-                && snapshot.httpsPort == port
-            if httpMatch, httpsMatch {
-                return true
-            }
-        }
-
-        return false
+    /// The backed-up services that still carry Rockxy's override on the persisted port.
+    private static func residualOwnedServices(in backup: DirectProxyBackup) -> [String] {
+        ProxyOverrideOwnership.residualOwnedServices(
+            in: backup.services.map { currentOverrideState(for: $0.service) },
+            port: backup.rockxyPort
+        )
     }
 
-    private static func captureProxySnapshot(for service: String) -> DirectProxySnapshot {
+    private static func currentOverrideState(for service: String) -> ProxyServiceOverrideState {
         let http = parseProxyOutput((try? runNetworkSetup(["-getwebproxy", service])) ?? "")
         let https = parseProxyOutput((try? runNetworkSetup(["-getsecurewebproxy", service])) ?? "")
         let socks = parseProxyOutput((try? runNetworkSetup(["-getsocksfirewallproxy", service])) ?? "")
+        let pac = parsePACOutput((try? runNetworkSetup(["-getautoproxyurl", service])) ?? "")
+        let autoDiscovery = parseAutoDiscoveryOutput(
+            (try? runNetworkSetup(["-getproxyautodiscovery", service])) ?? ""
+        )
+        let bypassOutput = (try? runNetworkSetup(["-getproxybypassdomains", service])) ?? ""
+        let hasGlobalBypass = bypassOutput.components(separatedBy: "\n").contains {
+            $0.trimmingCharacters(in: .whitespacesAndNewlines) == "*"
+        }
 
-        return DirectProxySnapshot(
+        return ProxyServiceOverrideState(
+            service: service,
             httpEnabled: http.enabled,
             httpHost: http.host,
             httpPort: http.port,
@@ -225,11 +314,9 @@ private enum DirectProxyWatchdog {
             httpsHost: https.host,
             httpsPort: https.port,
             socksEnabled: socks.enabled,
-            socksHost: socks.host,
-            socksPort: socks.port,
-            pacEnabled: false,
-            pacURL: "",
-            autoDiscoveryEnabled: false
+            pacEnabled: pac.enabled,
+            autoDiscoveryEnabled: autoDiscovery,
+            hasGlobalBypass: hasGlobalBypass
         )
     }
 
@@ -296,6 +383,38 @@ private enum DirectProxyWatchdog {
         return (enabled, host, port)
     }
 
+    private static func parsePACOutput(_ output: String) -> (enabled: Bool, url: String) {
+        var enabled = false
+        var url = ""
+        for line in output.components(separatedBy: "\n") {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            if trimmed.hasPrefix("Enabled:") {
+                enabled = trimmed.replacingOccurrences(of: "Enabled:", with: "")
+                    .trimmingCharacters(in: .whitespaces)
+                    .lowercased() == "yes"
+            } else if trimmed.hasPrefix("URL:") {
+                let value = trimmed.replacingOccurrences(of: "URL:", with: "")
+                    .trimmingCharacters(in: .whitespaces)
+                if value != "(null)" {
+                    url = value
+                }
+            }
+        }
+        return (enabled, url)
+    }
+
+    private static func parseAutoDiscoveryOutput(_ output: String) -> Bool {
+        output.components(separatedBy: "\n").contains { line in
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            guard trimmed.hasPrefix("Auto Proxy Discovery:") else {
+                return false
+            }
+            return trimmed.replacingOccurrences(of: "Auto Proxy Discovery:", with: "")
+                .trimmingCharacters(in: .whitespaces)
+                .lowercased() == "on"
+        }
+    }
+
     @discardableResult
     private static func runNetworkSetup(_ arguments: [String]) throws -> String {
         guard BinaryValidator.validateAppleSignedBinary(at: networkSetupPath) else {
@@ -343,8 +462,12 @@ if DirectProxyWatchdog.run(arguments: ProcessInfo.processInfo.arguments) {
 
 logger.info("RockxyHelperTool starting up")
 
-// Check for stale proxy settings from a previous crash
-CrashRecovery.restoreIfNeeded()
+// Check for stale proxy settings from a previous crash. A session whose owner is still alive
+// and still validates keeps its override, and its watchdog is re-armed before this helper takes
+// any new work, so a later owner death still restores the user's settings.
+if case let .preserved(ownerPID) = CrashRecovery.restoreIfNeeded(), let ownerPID {
+    HelperService.shared.resumeOwnerWatchdog(for: ownerPID)
+}
 
 let delegate = HelperDelegate()
 let machServiceName = identity.helperMachServiceName

--- a/RockxyTests/Core/ProxyEngine/HelperProxyBackupOwnerIdentityTests.swift
+++ b/RockxyTests/Core/ProxyEngine/HelperProxyBackupOwnerIdentityTests.swift
@@ -1,0 +1,189 @@
+import Foundation
+@testable import Rockxy
+import Testing
+
+// Regression tests for the helper proxy backup's owner identity in the core proxy engine layer.
+
+// MARK: - HelperProxyBackupOwnerIdentityTests
+
+/// Verifies the owner-identity fields the helper writes alongside a proxy backup, and that
+/// backups written before those fields existed still decode. Uses mirror structs matching the
+/// helper's `CrashRecovery` types, since the helper tool target is not linked to the test target.
+struct HelperProxyBackupOwnerIdentityTests {
+    // MARK: Internal
+
+    @Test("Helper backups written before owner identity existed decode with no owner")
+    func legacyBackupDecodesWithoutOwnerIdentity() throws {
+        let legacy = LegacyProxyBackupMirror(
+            services: [makeServiceBackup()],
+            timestamp: Date(),
+            rockxyPort: 9_090
+        )
+
+        let data = try PropertyListEncoder().encode(legacy)
+        let decoded = try PropertyListDecoder().decode(ProxyBackupMirror.self, from: data)
+
+        #expect(decoded.services.map(\.service) == ["Wi-Fi"])
+        #expect(decoded.rockxyPort == 9_090)
+        #expect(decoded.ownerPID == nil)
+        #expect(decoded.ownerStartSignature == nil)
+        #expect(decoded.recoveryPending == false)
+    }
+
+    @Test("Helper backups predating the persisted port still decode")
+    func legacyBackupWithoutPortDecodes() throws {
+        let legacy = LegacyProxyBackupMirror(
+            services: [makeServiceBackup()],
+            timestamp: Date(),
+            rockxyPort: nil
+        )
+
+        let data = try PropertyListEncoder().encode(legacy)
+        let decoded = try PropertyListDecoder().decode(ProxyBackupMirror.self, from: data)
+
+        #expect(decoded.rockxyPort == nil)
+        #expect(decoded.ownerPID == nil)
+    }
+
+    @Test("A legacy backup with residual ownership is restored rather than preserved")
+    func legacyBackupIsRestoredWhenServicesAreStillOwned() throws {
+        let legacy = LegacyProxyBackupMirror(
+            services: [makeServiceBackup()],
+            timestamp: Date(),
+            rockxyPort: 9_090
+        )
+        let data = try PropertyListEncoder().encode(legacy)
+        let decoded = try PropertyListDecoder().decode(ProxyBackupMirror.self, from: data)
+
+        let ownerSessionIsLive = ProxyBackupOwnerIdentityPolicy.ownerSessionIsLive(
+            recordedOwnerPID: decoded.ownerPID,
+            recordedStartSignature: decoded.ownerStartSignature,
+            ownerProcessIsAlive: true,
+            liveStartSignature: "1788787973.748707",
+            ownerPassesCallerValidation: true
+        )
+
+        #expect(!ownerSessionIsLive)
+        #expect(ProxyBackupRecoveryPolicy.action(
+            residualOwnedServicesExist: true,
+            ownerSessionIsLive: ownerSessionIsLive
+        ) == .restore)
+    }
+
+    @Test("Owner identity survives a plist roundtrip")
+    func ownerIdentityRoundtrips() throws {
+        let backup = ProxyBackupMirror(
+            services: [makeServiceBackup()],
+            timestamp: Date(),
+            rockxyPort: 9_090,
+            ownerPID: 4_242,
+            ownerStartSignature: "1788787973.748707",
+            recoveryPending: true
+        )
+
+        let data = try PropertyListEncoder().encode(backup)
+        let decoded = try PropertyListDecoder().decode(ProxyBackupMirror.self, from: data)
+
+        #expect(decoded.ownerPID == 4_242)
+        #expect(decoded.ownerStartSignature == "1788787973.748707")
+        #expect(decoded.recoveryPending)
+    }
+
+    // MARK: Private
+
+    /// Mirror of CrashRecovery.ServiceProxyBackup — must match the helper tool's struct layout.
+    private struct ServiceProxyBackupMirror: Codable {
+        let service: String
+        let httpEnabled: Bool
+        let httpHost: String
+        let httpPort: Int
+        let httpsEnabled: Bool
+        let httpsHost: String
+        let httpsPort: Int
+        let socksEnabled: Bool
+        let socksHost: String
+        let socksPort: Int
+        let pacEnabled: Bool
+        let pacURL: String
+        let autoDiscoveryEnabled: Bool
+        let bypassDomains: [String]
+    }
+
+    /// Mirror of the helper's proxy backup shape before owner identity was recorded.
+    private struct LegacyProxyBackupMirror: Codable {
+        let services: [ServiceProxyBackupMirror]
+        let timestamp: Date
+        let rockxyPort: Int?
+    }
+
+    /// Mirror of CrashRecovery.ProxyBackup — must match the helper tool's struct layout,
+    /// including its tolerance for missing optional keys.
+    private struct ProxyBackupMirror: Codable {
+        // MARK: Lifecycle
+
+        init(
+            services: [ServiceProxyBackupMirror],
+            timestamp: Date,
+            rockxyPort: Int?,
+            ownerPID: Int32?,
+            ownerStartSignature: String?,
+            recoveryPending: Bool = false
+        ) {
+            self.services = services
+            self.timestamp = timestamp
+            self.rockxyPort = rockxyPort
+            self.ownerPID = ownerPID
+            self.ownerStartSignature = ownerStartSignature
+            self.recoveryPending = recoveryPending
+        }
+
+        init(from decoder: any Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            services = try container.decode([ServiceProxyBackupMirror].self, forKey: .services)
+            timestamp = try container.decode(Date.self, forKey: .timestamp)
+            rockxyPort = try container.decodeIfPresent(Int.self, forKey: .rockxyPort)
+            ownerPID = try container.decodeIfPresent(Int32.self, forKey: .ownerPID)
+            ownerStartSignature = try container.decodeIfPresent(String.self, forKey: .ownerStartSignature)
+            recoveryPending = try container.decodeIfPresent(Bool.self, forKey: .recoveryPending) ?? false
+        }
+
+        // MARK: Internal
+
+        let services: [ServiceProxyBackupMirror]
+        let timestamp: Date
+        let rockxyPort: Int?
+        let ownerPID: Int32?
+        let ownerStartSignature: String?
+        let recoveryPending: Bool
+
+        // MARK: Private
+
+        private enum CodingKeys: String, CodingKey {
+            case services
+            case timestamp
+            case rockxyPort
+            case ownerPID
+            case ownerStartSignature
+            case recoveryPending
+        }
+    }
+
+    private func makeServiceBackup(service: String = "Wi-Fi") -> ServiceProxyBackupMirror {
+        ServiceProxyBackupMirror(
+            service: service,
+            httpEnabled: false,
+            httpHost: "",
+            httpPort: 0,
+            httpsEnabled: false,
+            httpsHost: "",
+            httpsPort: 0,
+            socksEnabled: false,
+            socksHost: "",
+            socksPort: 0,
+            pacEnabled: false,
+            pacURL: "",
+            autoDiscoveryEnabled: false,
+            bypassDomains: []
+        )
+    }
+}

--- a/RockxyTests/Core/TrafficCapture/ProxyOverrideOwnershipTests.swift
+++ b/RockxyTests/Core/TrafficCapture/ProxyOverrideOwnershipTests.swift
@@ -1,0 +1,185 @@
+import Foundation
+@testable import Rockxy
+import Testing
+
+// Regression tests for `ProxyOverrideOwnership` and its contrast with the readiness predicate
+// in the core traffic capture layer.
+
+struct ProxyOverrideOwnershipTests {
+    // MARK: Internal
+
+    @Test("Readiness requires every snapshot to match while recovery ownership is per service")
+    func readinessAllMatchVersusRecoveryAnyMatch() {
+        let port = 9_090
+        let ownedSnapshot = makeSnapshot(host: "127.0.0.1", port: port)
+        let userChangedSnapshot = makeSnapshot(host: "proxy.corp.com", port: 8_080)
+
+        // Readiness answers "is capture actually routed through Rockxy" and must stay all-match.
+        #expect(SystemProxyManager.proxySnapshotsMatchRockxy(
+            port: port,
+            snapshots: [ownedSnapshot, ownedSnapshot]
+        ))
+        #expect(!SystemProxyManager.proxySnapshotsMatchRockxy(
+            port: port,
+            snapshots: [ownedSnapshot, userChangedSnapshot]
+        ))
+
+        // Recovery answers "which services still need their restore point" and must be any-match.
+        let states = [
+            makeState(service: "Wi-Fi", host: "127.0.0.1", port: port),
+            makeState(service: "Ethernet", host: "proxy.corp.com", port: 8_080),
+        ]
+        #expect(ProxyOverrideOwnership.residualOwnedServices(in: states, port: port) == ["Wi-Fi"])
+        #expect(ProxyOverrideOwnership.hasResidualOwnedService(in: states, port: port))
+    }
+
+    @Test("Ownership requires both loopback protocols on the persisted port")
+    func ownershipRequiresStrictLoopbackOverride() {
+        let port = 9_090
+
+        #expect(ProxyOverrideOwnership.isOwnedByRockxy(
+            makeState(service: "Wi-Fi", host: "127.0.0.1", port: port),
+            port: port
+        ))
+        #expect(!ProxyOverrideOwnership.isOwnedByRockxy(
+            makeState(service: "Wi-Fi", host: "127.0.0.1", port: 9_091),
+            port: port
+        ))
+        #expect(!ProxyOverrideOwnership.isOwnedByRockxy(
+            makeState(service: "Wi-Fi", host: "10.0.0.2", port: port),
+            port: port
+        ))
+        #expect(!ProxyOverrideOwnership.isOwnedByRockxy(
+            makeState(service: "Wi-Fi", host: "127.0.0.1", port: port, httpsEnabled: false),
+            port: port
+        ))
+        #expect(!ProxyOverrideOwnership.isOwnedByRockxy(
+            makeState(service: "Wi-Fi", host: "127.0.0.1", port: port, httpEnabled: false),
+            port: port
+        ))
+    }
+
+    @Test("An unusable persisted port never claims ownership")
+    func ownershipRejectsUnusablePort() {
+        let states = [makeState(service: "Wi-Fi", host: "127.0.0.1", port: 0)]
+
+        #expect(!ProxyOverrideOwnership.hasResidualOwnedService(in: states, port: 0))
+        #expect(ProxyOverrideOwnership.residualOwnedServices(in: states, port: 0).isEmpty)
+    }
+
+    @Test("Alternative proxy modes and global bypass invalidate recovery ownership")
+    func ownershipRejectsConflictingRoutingModes() {
+        let port = 9_090
+        let base = makeState(service: "Wi-Fi", host: "127.0.0.1", port: port)
+
+        #expect(!ProxyOverrideOwnership.isOwnedByRockxy(
+            replacing(base, socksEnabled: true),
+            port: port
+        ))
+        #expect(!ProxyOverrideOwnership.isOwnedByRockxy(
+            replacing(base, pacEnabled: true),
+            port: port
+        ))
+        #expect(!ProxyOverrideOwnership.isOwnedByRockxy(
+            replacing(base, autoDiscoveryEnabled: true),
+            port: port
+        ))
+        #expect(!ProxyOverrideOwnership.isOwnedByRockxy(
+            replacing(base, hasGlobalBypass: true),
+            port: port
+        ))
+    }
+
+    @Test("A backup without a persisted port infers it from the services still overridden")
+    func inferredPortComesFromResidualOverride() {
+        let states = [
+            makeState(service: "Ethernet", host: "proxy.corp.com", port: 8_080),
+            makeState(service: "Wi-Fi", host: "127.0.0.1", port: 9_090),
+        ]
+
+        #expect(ProxyOverrideOwnership.inferredOwnedPort(in: states) == 9_090)
+    }
+
+    @Test("No inferred port when nothing carries a complete loopback override")
+    func inferredPortIsNilWithoutLoopbackOverride() {
+        #expect(ProxyOverrideOwnership.inferredOwnedPort(in: [
+            makeState(service: "Wi-Fi", host: "127.0.0.1", port: 9_090, httpsEnabled: false),
+            makeState(service: "Ethernet", host: "10.0.0.2", port: 3_128),
+            makeState(service: "USB LAN", host: "127.0.0.1", port: 0),
+        ]) == nil)
+    }
+
+    @Test("Residual ownership keeps the supplied service order")
+    func residualOwnershipPreservesOrder() {
+        let port = 9_090
+        let states = [
+            makeState(service: "Ethernet", host: "127.0.0.1", port: port),
+            makeState(service: "Wi-Fi", host: "192.168.0.1", port: 3_128),
+            makeState(service: "USB LAN", host: "127.0.0.1", port: port),
+        ]
+
+        #expect(ProxyOverrideOwnership.residualOwnedServices(in: states, port: port) == ["Ethernet", "USB LAN"])
+    }
+
+    // MARK: Private
+
+    private func makeSnapshot(host: String, port: Int) -> ServiceProxySnapshot {
+        ServiceProxySnapshot(
+            httpEnabled: true,
+            httpHost: host,
+            httpPort: port,
+            httpsEnabled: true,
+            httpsHost: host,
+            httpsPort: port,
+            socksEnabled: false,
+            socksHost: "",
+            socksPort: 0,
+            pacEnabled: false,
+            pacURL: "",
+            autoDiscoveryEnabled: false
+        )
+    }
+
+    private func makeState(
+        service: String,
+        host: String,
+        port: Int,
+        httpEnabled: Bool = true,
+        httpsEnabled: Bool = true,
+        httpsPort: Int? = nil
+    )
+        -> ProxyServiceOverrideState
+    {
+        ProxyServiceOverrideState(
+            service: service,
+            httpEnabled: httpEnabled,
+            httpHost: host,
+            httpPort: port,
+            httpsEnabled: httpsEnabled,
+            httpsHost: host,
+            httpsPort: httpsPort ?? port
+        )
+    }
+
+    private func replacing(
+        _ state: ProxyServiceOverrideState,
+        socksEnabled: Bool = false,
+        pacEnabled: Bool = false,
+        autoDiscoveryEnabled: Bool = false,
+        hasGlobalBypass: Bool = false
+    ) -> ProxyServiceOverrideState {
+        ProxyServiceOverrideState(
+            service: state.service,
+            httpEnabled: state.httpEnabled,
+            httpHost: state.httpHost,
+            httpPort: state.httpPort,
+            httpsEnabled: state.httpsEnabled,
+            httpsHost: state.httpsHost,
+            httpsPort: state.httpsPort,
+            socksEnabled: socksEnabled,
+            pacEnabled: pacEnabled,
+            autoDiscoveryEnabled: autoDiscoveryEnabled,
+            hasGlobalBypass: hasGlobalBypass
+        )
+    }
+}

--- a/RockxyTests/Core/TrafficCapture/SystemProxyBackupCompatibilityTests.swift
+++ b/RockxyTests/Core/TrafficCapture/SystemProxyBackupCompatibilityTests.swift
@@ -69,17 +69,32 @@ struct SystemProxyBackupCompatibilityTests {
     @Test("Backup recovery follows live ownership instead of backup age")
     func backupRecoveryUsesLiveOwnership() {
         #expect(ProxyBackupRecoveryPolicy.action(
-            proxyStillPointsAtRockxy: true,
-            listenerIsReachable: true
+            residualOwnedServicesExist: true,
+            ownerSessionIsLive: true
         ) == .preserve)
         #expect(ProxyBackupRecoveryPolicy.action(
-            proxyStillPointsAtRockxy: true,
-            listenerIsReachable: false
+            residualOwnedServicesExist: true,
+            ownerSessionIsLive: false
         ) == .restore)
         #expect(ProxyBackupRecoveryPolicy.action(
-            proxyStillPointsAtRockxy: false,
-            listenerIsReachable: false
+            residualOwnedServicesExist: false,
+            ownerSessionIsLive: false
         ) == .clear)
+    }
+
+    @Test("Direct backups written before recovery markers decode as not pending")
+    func decodesLegacyDirectBackupWithoutRecoveryMarker() throws {
+        let legacy = OldDirectProxyBackup(
+            services: [],
+            timestamp: Date(),
+            rockxyPort: 9_090
+        )
+
+        let data = try PropertyListEncoder().encode(legacy)
+        let decoded = try PropertyListDecoder().decode(DirectProxyBackup.self, from: data)
+
+        #expect(decoded.rockxyPort == 9_090)
+        #expect(decoded.recoveryPending == false)
     }
 
     // MARK: Private
@@ -93,5 +108,11 @@ struct SystemProxyBackupCompatibilityTests {
         let httpsHost: String
         let httpsPort: Int
         let bypassDomains: [String]
+    }
+
+    private struct OldDirectProxyBackup: Codable {
+        let services: [DirectServiceBackup]
+        let timestamp: Date
+        let rockxyPort: Int
     }
 }

--- a/RockxyTests/Shared/ProcessStartIdentityTests.swift
+++ b/RockxyTests/Shared/ProcessStartIdentityTests.swift
@@ -1,0 +1,96 @@
+import Darwin
+import Foundation
+@testable import Rockxy
+import Testing
+
+// Regression tests for `ProcessStartIdentity` in the shared recovery layer.
+
+struct ProcessStartIdentityTests {
+    @Test("The current process is alive and reports a stable start signature")
+    func currentProcessHasStableSignature() {
+        let pid = ProcessInfo.processInfo.processIdentifier
+
+        #expect(ProcessStartIdentity.isAlive(pid))
+
+        let firstReading = ProcessStartIdentity.startSignature(for: pid)
+        let secondReading = ProcessStartIdentity.startSignature(for: pid)
+
+        #expect(firstReading != nil)
+        #expect(firstReading == secondReading)
+    }
+
+    @Test("Invalid process identifiers are never alive and have no signature")
+    func invalidIdentifiersHaveNoIdentity() {
+        for pid in [Int32(0), -1] {
+            #expect(!ProcessStartIdentity.isAlive(pid))
+            #expect(ProcessStartIdentity.startSignature(for: pid) == nil)
+        }
+    }
+
+    @Test("A process that has exited no longer matches its recorded identity")
+    func exitedProcessDoesNotMatchRecordedIdentity() throws {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/cat")
+        process.standardInput = Pipe()
+        process.standardOutput = Pipe()
+        process.standardError = Pipe()
+        try process.run()
+
+        let pid = process.processIdentifier
+        let recordedSignature = ProcessStartIdentity.startSignature(for: pid)
+        #expect(recordedSignature != nil)
+        #expect(ProcessStartIdentity.isAlive(pid))
+        #expect(ProcessStartIdentity.identifiesSameProcess(
+            recordedPID: pid,
+            recordedStartSignature: recordedSignature,
+            liveStartSignature: ProcessStartIdentity.startSignature(for: pid)
+        ))
+
+        process.terminate()
+        process.waitUntilExit()
+
+        // Either the PID is gone, or it was handed to a different process — neither is the
+        // session that was recorded.
+        #expect(!ProcessStartIdentity.identifiesSameProcess(
+            recordedPID: pid,
+            recordedStartSignature: recordedSignature,
+            liveStartSignature: ProcessStartIdentity.startSignature(for: pid)
+        ))
+    }
+
+    @Test("Signature formatting uses the kernel start time verbatim")
+    func signatureFormatsStartTime() {
+        let startTime = timeval(tv_sec: 1_788_787_973, tv_usec: 748_707)
+
+        #expect(ProcessStartIdentity.signature(startTime: startTime) == "1788787973.748707")
+    }
+
+    @Test("Identity comparison rejects missing, empty, and mismatched signatures")
+    func identityComparisonRejectsIncompleteRecords() {
+        #expect(!ProcessStartIdentity.identifiesSameProcess(
+            recordedPID: nil,
+            recordedStartSignature: "1.2",
+            liveStartSignature: "1.2"
+        ))
+        #expect(!ProcessStartIdentity.identifiesSameProcess(
+            recordedPID: 0,
+            recordedStartSignature: "1.2",
+            liveStartSignature: "1.2"
+        ))
+        #expect(!ProcessStartIdentity.identifiesSameProcess(
+            recordedPID: 4_242,
+            recordedStartSignature: "",
+            liveStartSignature: ""
+        ))
+        #expect(!ProcessStartIdentity.identifiesSameProcess(
+            recordedPID: 4_242,
+            recordedStartSignature: "1.2",
+            liveStartSignature: nil
+        ))
+        #expect(ProcessStartIdentity.identifiesSameProcess(
+            recordedPID: 4_242,
+            recordedStartSignature: "1.2",
+            liveStartSignature: "1.2"
+        ))
+    }
+}

--- a/RockxyTests/Shared/ProxyBackupRecoveryPolicyTests.swift
+++ b/RockxyTests/Shared/ProxyBackupRecoveryPolicyTests.swift
@@ -1,0 +1,164 @@
+import Foundation
+@testable import Rockxy
+import Testing
+
+// Regression tests for `ProxyBackupRecoveryPolicy`, owner identity, and subset selection in the
+// shared recovery layer.
+
+// MARK: - ProxyBackupRecoveryPolicyTests
+
+struct ProxyBackupRecoveryPolicyTests {
+    @Test("Recovery keeps the backup while any backed-up service is still Rockxy-owned")
+    func recoveryFollowsResidualOwnership() {
+        #expect(ProxyBackupRecoveryPolicy.action(
+            residualOwnedServicesExist: true,
+            ownerSessionIsLive: true
+        ) == .preserve)
+        #expect(ProxyBackupRecoveryPolicy.action(
+            residualOwnedServicesExist: true,
+            ownerSessionIsLive: false
+        ) == .restore)
+        #expect(ProxyBackupRecoveryPolicy.action(
+            residualOwnedServicesExist: false,
+            ownerSessionIsLive: false
+        ) == .clear)
+    }
+
+    @Test("A live owner cannot keep a backup that no service still needs")
+    func liveOwnerDoesNotPreserveAnUnownedBackup() {
+        #expect(ProxyBackupRecoveryPolicy.action(
+            residualOwnedServicesExist: false,
+            ownerSessionIsLive: true
+        ) == .clear)
+    }
+}
+
+// MARK: - ProxyBackupOwnerIdentityPolicyTests
+
+struct ProxyBackupOwnerIdentityPolicyTests {
+    @Test("A live, signature-matched, validated owner keeps its session")
+    func authenticatedOwnerIsLive() {
+        #expect(ProxyBackupOwnerIdentityPolicy.ownerSessionIsLive(
+            recordedOwnerPID: 4_242,
+            recordedStartSignature: "1788787973.748707",
+            ownerProcessIsAlive: true,
+            liveStartSignature: "1788787973.748707",
+            ownerPassesCallerValidation: true
+        ))
+    }
+
+    @Test("An owner that fails caller validation is treated as gone")
+    func untrustedOwnerIsNotLive() {
+        #expect(!ProxyBackupOwnerIdentityPolicy.ownerSessionIsLive(
+            recordedOwnerPID: 4_242,
+            recordedStartSignature: "1788787973.748707",
+            ownerProcessIsAlive: true,
+            liveStartSignature: "1788787973.748707",
+            ownerPassesCallerValidation: false
+        ))
+    }
+
+    @Test("A recycled PID does not inherit the recorded session")
+    func recycledPIDIsNotLive() {
+        #expect(!ProxyBackupOwnerIdentityPolicy.ownerSessionIsLive(
+            recordedOwnerPID: 4_242,
+            recordedStartSignature: "1788787973.748707",
+            ownerProcessIsAlive: true,
+            liveStartSignature: "1788799999.100000",
+            ownerPassesCallerValidation: true
+        ))
+    }
+
+    @Test("A legacy backup without recorded identity is never live")
+    func legacyIdentityIsNotLive() {
+        #expect(!ProxyBackupOwnerIdentityPolicy.ownerSessionIsLive(
+            recordedOwnerPID: nil,
+            recordedStartSignature: nil,
+            ownerProcessIsAlive: true,
+            liveStartSignature: "1788787973.748707",
+            ownerPassesCallerValidation: true
+        ))
+        #expect(!ProxyBackupOwnerIdentityPolicy.ownerSessionIsLive(
+            recordedOwnerPID: 4_242,
+            recordedStartSignature: nil,
+            ownerProcessIsAlive: true,
+            liveStartSignature: "1788787973.748707",
+            ownerPassesCallerValidation: true
+        ))
+    }
+
+    @Test("A dead owner is never live even when everything else lines up")
+    func deadOwnerIsNotLive() {
+        #expect(!ProxyBackupOwnerIdentityPolicy.ownerSessionIsLive(
+            recordedOwnerPID: 4_242,
+            recordedStartSignature: "1788787973.748707",
+            ownerProcessIsAlive: false,
+            liveStartSignature: nil,
+            ownerPassesCallerValidation: true
+        ))
+    }
+}
+
+// MARK: - ProxyBackupSubsetTests
+
+struct ProxyBackupSubsetTests {
+    // MARK: Internal
+
+    @Test("Subset selection keeps only the owned services, in backup order")
+    func selectionKeepsOwnedServicesInOrder() {
+        let entries = [entry("Wi-Fi"), entry("Ethernet"), entry("USB LAN")]
+
+        let selected = ProxyBackupSubset.select(
+            entries,
+            services: ["USB LAN", "Wi-Fi"],
+            serviceName: \.service
+        )
+
+        #expect(selected.map(\.service) == ["Wi-Fi", "USB LAN"])
+    }
+
+    @Test("Subset selection of nothing owned is empty")
+    func selectionOfNoOwnedServicesIsEmpty() {
+        let entries = [entry("Wi-Fi"), entry("Ethernet")]
+
+        #expect(ProxyBackupSubset.select(entries, services: [], serviceName: \.service).isEmpty)
+    }
+
+    @Test("Unresolved entries cover both failed commands and services still pointing at Rockxy")
+    func unresolvedEntriesUnionFailuresAndResidualOwnership() {
+        let entries = [entry("Wi-Fi"), entry("Ethernet"), entry("USB LAN")]
+
+        let unresolved = ProxyBackupSubset.unresolvedEntries(
+            entries,
+            failedServices: ["Ethernet"],
+            stillOwnedServices: ["USB LAN"],
+            serviceName: \.service
+        )
+
+        #expect(unresolved.map(\.service) == ["Ethernet", "USB LAN"])
+    }
+
+    @Test("A fully resolved restore attempt leaves nothing to retry")
+    func resolvedRestoreLeavesNoEntries() {
+        let entries = [entry("Wi-Fi"), entry("Ethernet")]
+
+        let unresolved = ProxyBackupSubset.unresolvedEntries(
+            entries,
+            failedServices: [],
+            stillOwnedServices: [],
+            serviceName: \.service
+        )
+
+        #expect(unresolved.isEmpty)
+    }
+
+    // MARK: Private
+
+    private struct BackupEntry {
+        let service: String
+    }
+
+    private func entry(_ service: String) -> BackupEntry {
+        BackupEntry(service: service)
+    }
+}

--- a/Shared/ProcessStartIdentity.swift
+++ b/Shared/ProcessStartIdentity.swift
@@ -1,0 +1,67 @@
+import Darwin
+import Foundation
+
+// Identifies a specific running process across a relaunch of an observer process.
+
+// MARK: - ProcessStartIdentity
+
+/// A PID on its own does not identify a process: the kernel recycles process identifiers, so a
+/// recorded PID can name an unrelated process minutes later. Pairing the PID with the kernel's
+/// process start time gives an identity that a recycled PID cannot forge.
+enum ProcessStartIdentity {
+    // MARK: Internal
+
+    /// Whether a process with this identifier currently exists.
+    /// `EPERM` still means the process is there — it just belongs to another user.
+    static func isAlive(_ pid: Int32) -> Bool {
+        guard pid > 0 else {
+            return false
+        }
+        if kill(pid, 0) == 0 {
+            return true
+        }
+        return errno == EPERM
+    }
+
+    /// Reads the kernel start time of a live process and formats it as a stable signature.
+    /// Returns nil when the process no longer exists or the kernel refuses the query.
+    static func startSignature(for pid: Int32) -> String? {
+        guard pid > 0 else {
+            return nil
+        }
+
+        var mib: [Int32] = [CTL_KERN, KERN_PROC, KERN_PROC_PID, pid]
+        var info = kinfo_proc()
+        var size = MemoryLayout<kinfo_proc>.stride
+        let result = sysctl(&mib, u_int(mib.count), &info, &size, nil, 0)
+        guard result == 0, size > 0, info.kp_proc.p_pid == pid else {
+            return nil
+        }
+
+        return signature(startTime: info.kp_proc.p_un.__p_starttime)
+    }
+
+    /// Formats a kernel start time into the signature stored alongside a backup.
+    static func signature(startTime: timeval) -> String {
+        "\(startTime.tv_sec).\(startTime.tv_usec)"
+    }
+
+    /// Pure comparison used by recovery: a recorded identity names the same process only when
+    /// the PID is positive, a signature was recorded, and the live process reports that exact
+    /// signature. A missing recorded signature is a legacy record, never a match.
+    static func identifiesSameProcess(
+        recordedPID: Int32?,
+        recordedStartSignature: String?,
+        liveStartSignature: String?
+    )
+        -> Bool
+    {
+        guard let recordedPID, recordedPID > 0,
+              let recordedStartSignature, !recordedStartSignature.isEmpty,
+              let liveStartSignature, !liveStartSignature.isEmpty else
+        {
+            return false
+        }
+        return recordedStartSignature == liveStartSignature
+    }
+}

--- a/Shared/ProxyBackupRecoveryPolicy.swift
+++ b/Shared/ProxyBackupRecoveryPolicy.swift
@@ -1,20 +1,198 @@
+import Foundation
+
+// Decides what happens to a proxy backup that outlived the session that wrote it.
+
+// MARK: - ProxyBackupRecoveryAction
+
 enum ProxyBackupRecoveryAction: Equatable {
     case restore
     case preserve
     case clear
 }
 
-/// Decides backup lifetime from live ownership instead of elapsed wall-clock time.
-/// A healthy listener means the capture session still owns the override; an unreachable
-/// listener means the owned override was stranded and must be restored immediately.
+// MARK: - ProxyServiceOverrideState
+
+/// The proxy fields recovery reads to decide whether one backed-up network service still
+/// carries Rockxy's override. Readiness reporting inspects more fields and answers for the
+/// routed service; ownership only asks whether this service still points at Rockxy.
+struct ProxyServiceOverrideState: Equatable {
+    init(
+        service: String,
+        httpEnabled: Bool,
+        httpHost: String,
+        httpPort: Int,
+        httpsEnabled: Bool,
+        httpsHost: String,
+        httpsPort: Int,
+        socksEnabled: Bool = false,
+        pacEnabled: Bool = false,
+        autoDiscoveryEnabled: Bool = false,
+        hasGlobalBypass: Bool = false
+    ) {
+        self.service = service
+        self.httpEnabled = httpEnabled
+        self.httpHost = httpHost
+        self.httpPort = httpPort
+        self.httpsEnabled = httpsEnabled
+        self.httpsHost = httpsHost
+        self.httpsPort = httpsPort
+        self.socksEnabled = socksEnabled
+        self.pacEnabled = pacEnabled
+        self.autoDiscoveryEnabled = autoDiscoveryEnabled
+        self.hasGlobalBypass = hasGlobalBypass
+    }
+
+    let service: String
+    let httpEnabled: Bool
+    let httpHost: String
+    let httpPort: Int
+    let httpsEnabled: Bool
+    let httpsHost: String
+    let httpsPort: Int
+    let socksEnabled: Bool
+    let pacEnabled: Bool
+    let autoDiscoveryEnabled: Bool
+    let hasGlobalBypass: Bool
+}
+
+// MARK: - ProxyOverrideOwnership
+
+/// Per-service ownership for recovery. This is deliberately an *any* predicate: a backup covers
+/// several network services, and one service the user has since re-pointed must not make the
+/// remaining Rockxy-owned services look unowned — that is how a stranded override survives with
+/// its only restore point deleted.
+enum ProxyOverrideOwnership {
+    // MARK: Internal
+
+    static let loopbackHost = "127.0.0.1"
+
+    /// True when this service still carries Rockxy's strict HTTP+HTTPS loopback override on the
+    /// persisted port. Both protocols must match: a half-configured service belongs to whoever
+    /// changed it, not to Rockxy.
+    static func isOwnedByRockxy(_ state: ProxyServiceOverrideState, port: Int) -> Bool {
+        guard port > 0 else {
+            return false
+        }
+        return state.httpEnabled
+            && state.httpHost == loopbackHost
+            && state.httpPort == port
+            && state.httpsEnabled
+            && state.httpsHost == loopbackHost
+            && state.httpsPort == port
+            && !state.socksEnabled
+            && !state.pacEnabled
+            && !state.autoDiscoveryEnabled
+            && !state.hasGlobalBypass
+    }
+
+    /// The backed-up services Rockxy still owns right now, in the order they were supplied.
+    /// Restoring these and only these leaves a user-changed or foreign service untouched.
+    static func residualOwnedServices(in states: [ProxyServiceOverrideState], port: Int) -> [String] {
+        states.filter { isOwnedByRockxy($0, port: port) }.map(\.service)
+    }
+
+    static func hasResidualOwnedService(in states: [ProxyServiceOverrideState], port: Int) -> Bool {
+        states.contains { isOwnedByRockxy($0, port: port) }
+    }
+
+    /// The loopback port a backup without a persisted port is still overriding, taken from the
+    /// first backed-up service that carries a complete HTTP+HTTPS loopback override. Backups
+    /// written before the port was recorded have nothing to compare against otherwise, and an
+    /// unidentifiable port means the restore point gets thrown away.
+    static func inferredOwnedPort(in states: [ProxyServiceOverrideState]) -> Int? {
+        for state in states where state.httpEnabled
+            && state.httpsEnabled
+            && state.httpHost == loopbackHost
+            && state.httpsHost == loopbackHost
+            && state.httpPort == state.httpsPort
+            && state.httpPort > 0
+            && !state.socksEnabled
+            && !state.pacEnabled
+            && !state.autoDiscoveryEnabled
+            && !state.hasGlobalBypass
+        {
+            return state.httpPort
+        }
+        return nil
+    }
+}
+
+// MARK: - ProxyBackupRecoveryPolicy
+
+/// Decides backup lifetime from live ownership instead of elapsed wall-clock time or a loopback
+/// probe. Any process can answer on a loopback port, so reachability never proved that the
+/// capture session which took the override was still the one running.
 enum ProxyBackupRecoveryPolicy {
     static func action(
-        proxyStillPointsAtRockxy: Bool,
-        listenerIsReachable: Bool
-    ) -> ProxyBackupRecoveryAction {
-        guard proxyStillPointsAtRockxy else {
+        residualOwnedServicesExist: Bool,
+        ownerSessionIsLive: Bool
+    )
+        -> ProxyBackupRecoveryAction
+    {
+        guard residualOwnedServicesExist else {
             return .clear
         }
-        return listenerIsReachable ? .preserve : .restore
+        return ownerSessionIsLive ? .preserve : .restore
+    }
+}
+
+// MARK: - ProxyBackupOwnerIdentityPolicy
+
+/// Decides whether the process recorded in a backup is still the live, trusted Rockxy session
+/// that took the override. Every clause has to hold: a recycled PID, a legacy record with no
+/// identity, or a process that no longer satisfies caller validation all mean the session is
+/// gone and its residual services must be restored.
+enum ProxyBackupOwnerIdentityPolicy {
+    static func ownerSessionIsLive(
+        recordedOwnerPID: Int32?,
+        recordedStartSignature: String?,
+        ownerProcessIsAlive: Bool,
+        liveStartSignature: String?,
+        ownerPassesCallerValidation: Bool
+    )
+        -> Bool
+    {
+        guard ownerProcessIsAlive, ownerPassesCallerValidation else {
+            return false
+        }
+        return ProcessStartIdentity.identifiesSameProcess(
+            recordedPID: recordedOwnerPID,
+            recordedStartSignature: recordedStartSignature,
+            liveStartSignature: liveStartSignature
+        )
+    }
+}
+
+// MARK: - ProxyBackupSubset
+
+/// Pure selection helpers that make subset restore deterministic and testable without touching
+/// system state.
+enum ProxyBackupSubset {
+    /// Keeps the backup entries naming one of `services`, preserving the backup's order.
+    static func select<Entry>(
+        _ entries: [Entry],
+        services: Set<String>,
+        serviceName: (Entry) -> String
+    )
+        -> [Entry]
+    {
+        entries.filter { services.contains(serviceName($0)) }
+    }
+
+    /// The entries a restore attempt did not resolve: the services whose commands failed, plus
+    /// the services still pointing at Rockxy afterwards. While this is non-empty the backup has
+    /// to survive, because those services have no other restore point.
+    static func unresolvedEntries<Entry>(
+        _ entries: [Entry],
+        failedServices: Set<String>,
+        stillOwnedServices: Set<String>,
+        serviceName: (Entry) -> String
+    )
+        -> [Entry]
+    {
+        entries.filter { entry in
+            let service = serviceName(entry)
+            return failedServices.contains(service) || stillOwnedServices.contains(service)
+        }
     }
 }


### PR DESCRIPTION
## Summary

- recover stale proxy backups per service instead of treating the primary route as the whole ownership state
- preserve only authenticated process ownership across helper relaunches and reject unauthenticated loopback listeners as proof of liveness
- narrow recovery backups before mutation so partial restores remain retryable without overwriting user-changed services
- restore alternative proxy modes and bypass settings from the original snapshot while retaining unresolved entries for recovery
- re-arm helper owner monitoring after a verified live-session recovery

## Validation

- `swiftlint lint --strict`
- 79 focused recovery, ownership, compatibility, process-identity, and system-proxy tests
- app and helper targets compiled as part of the focused test run
- `git diff --check`

Related promotion: #329

Refs #319
Refs #310