### PR TITLE
fix: harden proxy recovery ownership and retries

### DIFF
--- a/Rockxy/Core/TrafficCapture/SystemProxyManager.swift
+++ b/Rockxy/Core/TrafficCapture/SystemProxyManager.swift
@@ -17,8 +17,16 @@ enum SystemProxyError: LocalizedError {
     case noActiveNetworkService
     case proxyActivationNotConfirmed(port: Int)
     case proxyRestoreFailed
+    case proxySessionInUse
+    case proxyStateChangedDuringCommit(service: String)
     case previousHelperUnavailable
     case unexpectedOutput(String)
+    /// The direct-mode watchdog could not be armed for this process, so no override was left in
+    /// place without something to restore it.
+    case directProxyWatchdogUnavailable(reason: String)
+    /// An override attempt failed and could not put every service it had already changed back on
+    /// its captured settings. The restore point survives, and the failure says so.
+    case overrideRollbackIncomplete(reason: String)
 
     // MARK: Internal
 
@@ -32,10 +40,18 @@ enum SystemProxyError: LocalizedError {
             "macOS did not confirm the Rockxy system proxy on port \(port)"
         case .proxyRestoreFailed:
             "Rockxy could not restore one or more system proxy settings"
+        case .proxySessionInUse:
+            "Another running Rockxy instance owns the current system proxy session"
+        case let .proxyStateChangedDuringCommit(service):
+            "The proxy settings for \(service) changed before Rockxy could apply its recorded update"
         case .previousHelperUnavailable:
             "Rockxy cannot safely reclaim system routing with the installed helper. Quit and reopen Rockxy, then update or repair the helper in Advanced Proxy Settings."
         case let .unexpectedOutput(output):
             "Unexpected networksetup output: \(output)"
+        case let .directProxyWatchdogUnavailable(reason):
+            "Rockxy could not arm the watchdog that restores your proxy settings, so the system proxy was left unchanged: \(reason)"
+        case let .overrideRollbackIncomplete(reason):
+            "Rockxy could not set the system proxy and could not fully undo the services it had already changed (\(reason)). Your previous settings were kept so they can still be restored."
         }
     }
 }
@@ -69,146 +85,6 @@ enum ProxyActivationConfirmation {
     }
 }
 
-// MARK: - DirectProxyBackup
-
-/// Persistent on-disk backup of the pre-Rockxy proxy state for all services.
-/// Written before any direct-mode mutation; cleared after successful restore.
-struct DirectProxyBackup: Codable {
-    init(
-        services: [DirectServiceBackup],
-        timestamp: Date,
-        rockxyPort: Int,
-        recoveryPending: Bool = false
-    ) {
-        self.services = services
-        self.timestamp = timestamp
-        self.rockxyPort = rockxyPort
-        self.recoveryPending = recoveryPending
-    }
-
-    init(from decoder: any Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        services = try container.decode([DirectServiceBackup].self, forKey: .services)
-        timestamp = try container.decode(Date.self, forKey: .timestamp)
-        rockxyPort = try container.decode(Int.self, forKey: .rockxyPort)
-        recoveryPending = try container.decodeIfPresent(Bool.self, forKey: .recoveryPending) ?? false
-    }
-
-    let services: [DirectServiceBackup]
-    let timestamp: Date
-    let rockxyPort: Int
-    let recoveryPending: Bool
-
-    private enum CodingKeys: String, CodingKey {
-        case services
-        case timestamp
-        case rockxyPort
-        case recoveryPending
-    }
-
-    func markedRecoveryPending() -> DirectProxyBackup {
-        DirectProxyBackup(
-            services: services,
-            timestamp: timestamp,
-            rockxyPort: rockxyPort,
-            recoveryPending: true
-        )
-    }
-}
-
-// MARK: - DirectServiceBackup
-
-/// Per-service proxy configuration captured before Rockxy overrides it.
-struct DirectServiceBackup: Codable {
-    // MARK: Lifecycle
-
-    init(
-        service: String,
-        httpEnabled: Bool,
-        httpHost: String,
-        httpPort: Int,
-        httpsEnabled: Bool,
-        httpsHost: String,
-        httpsPort: Int,
-        socksEnabled: Bool,
-        socksHost: String,
-        socksPort: Int,
-        pacEnabled: Bool,
-        pacURL: String,
-        autoDiscoveryEnabled: Bool,
-        bypassDomains: [String]
-    ) {
-        self.service = service
-        self.httpEnabled = httpEnabled
-        self.httpHost = httpHost
-        self.httpPort = httpPort
-        self.httpsEnabled = httpsEnabled
-        self.httpsHost = httpsHost
-        self.httpsPort = httpsPort
-        self.socksEnabled = socksEnabled
-        self.socksHost = socksHost
-        self.socksPort = socksPort
-        self.pacEnabled = pacEnabled
-        self.pacURL = pacURL
-        self.autoDiscoveryEnabled = autoDiscoveryEnabled
-        self.bypassDomains = bypassDomains
-    }
-
-    init(from decoder: any Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        service = try container.decode(String.self, forKey: .service)
-        httpEnabled = try container.decode(Bool.self, forKey: .httpEnabled)
-        httpHost = try container.decode(String.self, forKey: .httpHost)
-        httpPort = try container.decode(Int.self, forKey: .httpPort)
-        httpsEnabled = try container.decode(Bool.self, forKey: .httpsEnabled)
-        httpsHost = try container.decode(String.self, forKey: .httpsHost)
-        httpsPort = try container.decode(Int.self, forKey: .httpsPort)
-        socksEnabled = try container.decodeIfPresent(Bool.self, forKey: .socksEnabled) ?? false
-        socksHost = try container.decodeIfPresent(String.self, forKey: .socksHost) ?? ""
-        socksPort = try container.decodeIfPresent(Int.self, forKey: .socksPort) ?? 0
-        pacEnabled = try container.decodeIfPresent(Bool.self, forKey: .pacEnabled) ?? false
-        pacURL = try container.decodeIfPresent(String.self, forKey: .pacURL) ?? ""
-        autoDiscoveryEnabled = try container.decodeIfPresent(Bool.self, forKey: .autoDiscoveryEnabled) ?? false
-        bypassDomains = try container.decode([String].self, forKey: .bypassDomains)
-    }
-
-    // MARK: Internal
-
-    let service: String
-    let httpEnabled: Bool
-    let httpHost: String
-    let httpPort: Int
-    let httpsEnabled: Bool
-    let httpsHost: String
-    let httpsPort: Int
-    let socksEnabled: Bool
-    let socksHost: String
-    let socksPort: Int
-    let pacEnabled: Bool
-    let pacURL: String
-    let autoDiscoveryEnabled: Bool
-    let bypassDomains: [String]
-
-    // MARK: Private
-
-    private enum CodingKeys: String, CodingKey {
-        case service
-        case httpEnabled
-        case httpHost
-        case httpPort
-        case httpsEnabled
-        case httpsHost
-        case httpsPort
-        case socksEnabled
-        case socksHost
-        case socksPort
-        case pacEnabled
-        case pacURL
-        case autoDiscoveryEnabled
-        case bypassDomains
-    }
-}
-
 // MARK: - ProxyOverrideOwner
 
 /// Describes who currently owns the system proxy override.
@@ -218,18 +94,85 @@ enum ProxyOverrideOwner {
     case helper(port: Int)
 }
 
-// MARK: - DirectProxyWatchdogAction
+// MARK: - DirectOverrideEnableOutcome
 
-enum DirectProxyWatchdogAction {
-    case wait
-    case restore
-    case exit
+/// How a direct-mode enable attempt ended once every service it touched has been answered.
+enum DirectOverrideEnableOutcome: Equatable {
+    /// The override is applied and a watchdog armed before the first change is watching the
+    /// process that took it.
+    case enabled
+    /// The attempt failed and every service it mutated is back on its captured settings.
+    case rolledBack
+    /// The attempt failed and at least one mutated service is still overridden, so the backup
+    /// survives and the failure is reported rather than swallowed.
+    case rollbackIncomplete
+}
+
+// MARK: - DirectOverrideApplicationStep
+
+/// The three things applying a direct override does, in the only order that leaves nothing
+/// stranded.
+enum DirectOverrideApplicationStep: String, Equatable {
+    /// The restore point is published first, so the watchdog has something to observe from the
+    /// moment it starts.
+    case persistBackup
+    /// The watchdog is armed second — before any setting can change, never after.
+    case armWatchdog
+    /// The proxy commands run last.
+    case mutateServices
+}
+
+// MARK: - DirectOverrideApplication
+
+/// Runs the steps of a direct override in order, and reports the one that stopped it.
+///
+/// The order is the whole guarantee. A failure at `persistBackup` or `armWatchdog` has not
+/// touched a single setting, so there is nothing to roll back; any failure from `mutateServices`
+/// on has, and the watchdog that puts it back is already running by then. Arming the watchdog
+/// after the commands would leave a window in which the process can die with the override applied
+/// and nothing watching it — recoverable only at the next launch, if there is one.
+enum DirectOverrideApplication {
+    static func run(
+        persistBackup: () throws -> Void,
+        armWatchdog: () throws -> Void,
+        mutateServices: () throws -> Void
+    )
+        -> (step: DirectOverrideApplicationStep, error: any Error)?
+    {
+        do {
+            try persistBackup()
+        } catch {
+            return (.persistBackup, error)
+        }
+
+        do {
+            try armWatchdog()
+        } catch {
+            return (.armWatchdog, error)
+        }
+
+        do {
+            try mutateServices()
+        } catch {
+            return (.mutateServices, error)
+        }
+
+        return nil
+    }
 }
 
 enum SystemProxyReclaimMode: Equatable {
     case none
     case direct
     case helper
+}
+
+private enum DirectStaleRecoveryOutcome {
+    case noBackup
+    case preserved
+    case cleared
+    case restored
+    case restoreIncomplete
 }
 
 // MARK: - SystemProxyStartupRecovery
@@ -320,21 +263,40 @@ final class SystemProxyManager: @unchecked Sendable {
         return .none
     }
 
-    nonisolated static func directProxyWatchdogAction(
-        parentAlive: Bool,
-        backupExists: Bool
+    /// Whether a direct override may be applied at all: the watcher that restores it has to be
+    /// resolvable first.
+    ///
+    /// Both halves are required before anything is mutated. An override applied without a live
+    /// watchdog is only recovered at the next launch, and one armed against a bare identifier
+    /// watches whatever process later inherits it — which is the same as not watching at all.
+    nonisolated static func directWatchdogPreflightIsSatisfied(
+        executableIsAvailable: Bool,
+        parentStartSignature: String?
     )
-        -> DirectProxyWatchdogAction
+        -> Bool
     {
-        if !backupExists {
-            return .exit
+        guard executableIsAvailable, let parentStartSignature, !parentStartSignature.isEmpty else {
+            return false
         }
+        return true
+    }
 
-        if parentAlive {
-            return .wait
+    /// What an enable attempt reports once every service it touched has been answered.
+    ///
+    /// The watchdog is armed before the first proxy command, so by the time this is asked the
+    /// only open question is whether the services this attempt changed are back where they
+    /// started. A rollback that did not finish is never reported as a plain failure: the backup
+    /// is still on disk precisely because those services still need it.
+    nonisolated static func directOverrideAttemptOutcome(
+        applySucceeded: Bool,
+        rollbackSucceeded: Bool
+    )
+        -> DirectOverrideEnableOutcome
+    {
+        if applySucceeded {
+            return .enabled
         }
-
-        return .restore
+        return rollbackSucceeded ? .rolledBack : .rollbackIncomplete
     }
 
     nonisolated static func shouldClearDirectBackupAfterRestoreAttempt(
@@ -358,65 +320,62 @@ final class SystemProxyManager: @unchecked Sendable {
         return status.isOverridden && status.port == requestedPort
     }
 
-    @discardableResult
-    nonisolated static func runDirectProxyWatchdogIfRequested(
-        arguments: [String] = ProcessInfo.processInfo.arguments
-    )
-        -> Bool
-    {
-        guard arguments.count >= 3,
-              arguments[1] == "--rockxy-direct-proxy-watchdog",
-              let parentPID = Int32(arguments[2]) else
-        {
-            return false
-        }
-
-        let pollInterval: TimeInterval = 0.5
-        while true {
-            let parentAlive = kill(parentPID, 0) == 0 || errno == EPERM
-            let backupExists = FileManager.default.fileExists(atPath: directBackupURL.path)
-
-            switch directProxyWatchdogAction(parentAlive: parentAlive, backupExists: backupExists) {
-            case .wait:
-                Thread.sleep(forTimeInterval: pollInterval)
-            case .restore:
-                shared.performEmergencyTerminationCleanup(
-                    reason: "direct proxy watchdog observed parent exit"
-                )
-                return true
-            case .exit:
-                return true
-            }
-        }
-    }
-
+    /// The `launchctl submit` invocation for the direct-mode watchdog.
+    ///
+    /// The arguments the watchdog itself reads come from `DirectProxyWatchdogInvocation`, which
+    /// is also what the helper binary parses them back with. Only the `launchctl` wrapper is
+    /// built here: a flag or a field position spelled out twice is one that can disagree, and the
+    /// disagreement would be a watcher silently watching the wrong process.
+    ///
+    /// The parent's kernel start signature travels with its identifier so the watcher can tell
+    /// the process that took the override from whatever later inherits its identifier.
     nonisolated static func directWatchdogSubmitArguments(
         label: String,
         executablePath: String,
         parentPID: pid_t,
+        parentStartSignature: String,
         backupPath: String
     )
         -> [String]
     {
-        [
-            "submit",
-            "-l",
-            label,
-            "--",
-            executablePath,
-            "--rockxy-direct-proxy-watchdog",
-            String(parentPID),
-            backupPath,
-        ]
+        ["submit", "-l", label, "--"] + DirectProxyWatchdogInvocation.watchArguments(
+            executablePath: executablePath,
+            parentPID: parentPID,
+            backupPath: backupPath,
+            parentStartSignature: parentStartSignature
+        )
     }
 
     // MARK: - Public API
 
     func enableSystemProxy(port: Int) async throws {
+        try await Self.lifecycleGate.withOperation { [self] in
+            try await enableSystemProxyLocked(port: port)
+        }
+    }
+
+    private func enableSystemProxyLocked(port: Int) async throws {
         Self.logger.info("enableSystemProxy called for port \(port)")
+
+        let backupAtStart = loadDirectBackup()
+        if directBackupFileExists, backupAtStart == nil {
+            throw SystemProxyError.proxyRestoreFailed
+        }
+        if let backupAtStart, !directBackupBelongsToCurrentProcess(backupAtStart) {
+            switch recoverStaleDirectProxyIfNeeded() {
+            case .noBackup, .cleared, .restored:
+                break
+            case .preserved:
+                throw SystemProxyError.proxySessionInUse
+            case .restoreIncomplete:
+                lock.withLock { directRestorePending = true }
+                throw SystemProxyError.proxyRestoreFailed
+            }
+        }
 
         lock.lock()
         let directRestoreWasPending = directRestorePending
+            || loadDirectBackup().map(directBackupBelongsToCurrentProcess) == true
         let helperWasUsed = usingHelper
         let overrideWasEnabled = isEnabled
         lock.unlock()
@@ -478,20 +437,26 @@ final class SystemProxyManager: @unchecked Sendable {
             usingHelper = true
             lock.unlock()
         } else if helperStatus == .installedCompatible || helperStatus == .installedOutdated {
-            if let info = try? await HelperConnection.shared.getHelperInfo(),
-               HelperCompatibilityPolicy.supportsSafeProxyRouting(protocolVersion: info.protocolVersion)
-            {
-                Self.logger.info("Enabling system proxy via helper tool on port \(port)")
-                try await HelperConnection.shared.overrideSystemProxy(port: port)
-
-                lock.lock()
-                isEnabled = true
-                usingHelper = true
-                lock.unlock()
-            } else {
-                Self.logger.warning("Helper cannot safely own this proxy session, falling back to networksetup")
-                try enableSystemProxyViaNetworkSetup(port: port)
+            let info: HelperInfo
+            do {
+                info = try await HelperConnection.shared.getHelperInfo()
+            } catch {
+                // An installed helper may already own another app instance's live session. A
+                // failed probe is therefore not permission to create an unrelated direct backup
+                // from that helper's loopback override.
+                Self.logger.error("Installed helper could not be verified; refusing direct fallback")
+                throw SystemProxyError.previousHelperUnavailable
             }
+            guard HelperCompatibilityPolicy.supportsSafeProxyRouting(protocolVersion: info.protocolVersion) else {
+                throw SystemProxyError.previousHelperUnavailable
+            }
+            Self.logger.info("Enabling system proxy via helper tool on port \(port)")
+            try await HelperConnection.shared.overrideSystemProxy(port: port)
+
+            lock.lock()
+            isEnabled = true
+            usingHelper = true
+            lock.unlock()
         } else if helperStatus == .requiresApproval {
             Self.logger.warning(
                 "Helper requires approval in System Settings — falling back to networksetup"
@@ -524,15 +489,36 @@ final class SystemProxyManager: @unchecked Sendable {
     }
 
     func disableSystemProxy() async throws {
+        try await Self.lifecycleGate.withOperation { [self] in
+            try await disableSystemProxyLocked()
+        }
+    }
+
+    private func disableSystemProxyLocked() async throws {
         // Same-session shortcut: if we know we own a direct override, skip ownership detection
         lock.lock()
         let pending = directRestorePending
         let helperSession = usingHelper
         lock.unlock()
 
-        if pending, let backup = loadDirectBackup() {
-            Self.logger.info("Direct restore pending — restoring \(backup.services.count) service(s)")
-            guard restoreDirectMode(using: backup) else {
+        if pending {
+            // Serialized against an enable loop and against termination cleanup: the three of
+            // them write the same services and the same backup file from different threads.
+            guard try Self.operationGate.withOperation({
+                try DirectProxySessionLock.withExclusiveAccess(backupURL: Self.directBackupURL) {
+                    invalidateQueuedDirectProxyWork()
+                    guard let currentBackup = loadDirectBackup() else {
+                        return !directBackupFileExists
+                    }
+                    if directBackupOwnerIsLive(currentBackup),
+                       !directBackupBelongsToCurrentProcess(currentBackup)
+                    {
+                        throw SystemProxyError.proxySessionInUse
+                    }
+                    Self.logger.info("Direct restore pending — restoring \(currentBackup.services.count) service(s)")
+                    return restoreDirectMode(using: currentBackup)
+                }
+            }) else {
                 throw SystemProxyError.proxyRestoreFailed
             }
         } else if helperSession {
@@ -553,9 +539,25 @@ final class SystemProxyManager: @unchecked Sendable {
                 Self.logger.info("Disabling system proxy via helper tool")
                 try await HelperConnection.shared.restoreSystemProxy()
 
-            case let .direct(backup):
-                Self.logger.info("Disabling direct-mode system proxy, restoring \(backup.services.count) service(s)")
-                guard restoreDirectMode(using: backup) else {
+            case .direct:
+                guard try Self.operationGate.withOperation({
+                    try DirectProxySessionLock.withExclusiveAccess(backupURL: Self.directBackupURL) {
+                        invalidateQueuedDirectProxyWork()
+                        guard let currentBackup = loadDirectBackup() else {
+                            return !directBackupFileExists
+                        }
+                        if directBackupOwnerIsLive(currentBackup),
+                           !directBackupBelongsToCurrentProcess(currentBackup)
+                        {
+                            throw SystemProxyError.proxySessionInUse
+                        }
+                        Self.logger
+                            .info(
+                                "Disabling direct-mode system proxy, restoring \(currentBackup.services.count) service(s)"
+                            )
+                        return restoreDirectMode(using: currentBackup)
+                    }
+                }) else {
                     throw SystemProxyError.proxyRestoreFailed
                 }
             }
@@ -569,6 +571,7 @@ final class SystemProxyManager: @unchecked Sendable {
         activeServices = []
         originalBypassDomains = [:]
         originalProxyState = [:]
+        sessionGeneration &+= 1
         lock.unlock()
 
         Self.logger.info("System proxy disabled")
@@ -607,17 +610,38 @@ final class SystemProxyManager: @unchecked Sendable {
     /// Apply bypass domains from BypassProxyManager to the system proxy.
     /// Uses helper tool if available, otherwise runs networksetup directly.
     func applyBypassDomains() async throws {
-        let domains = await BypassProxyManager.shared.enabledDomainStringsForSystemProxy()
-
         lock.lock()
-        let currentlyUsingHelper = usingHelper
+        let queuedGeneration = sessionGeneration
+        let queuedForHelper = usingHelper
+        let overrideWasActive = isEnabled
         lock.unlock()
 
-        if currentlyUsingHelper {
+        guard overrideWasActive else {
+            return
+        }
+
+        let domains = await BypassProxyManager.shared.enabledDomainStringsForSystemProxy()
+
+        // Domain calculation may suspend. Re-check the exact session before dispatch so work that
+        // began before a disable cannot become a mutation request after the restore completed.
+        lock.lock()
+        let sessionIsCurrent = ProxyOperationSessionPolicy.mayRun(
+            queuedGeneration: queuedGeneration,
+            currentGeneration: sessionGeneration,
+            overrideIsActive: isEnabled
+        ) && usingHelper == queuedForHelper
+        lock.unlock()
+
+        guard sessionIsCurrent else {
+            Self.logger.info("Skipping a bypass write queued for a proxy session that has already ended")
+            return
+        }
+
+        if queuedForHelper {
             try await HelperConnection.shared.setBypassDomains(domains)
             Self.logger.info("Applied \(domains.count) bypass domain(s) via helper")
         } else {
-            try applyBypassDomainsViaNetworkSetup(domains)
+            try applyBypassDomainsViaNetworkSetup(domains, queuedGeneration: queuedGeneration)
         }
     }
 
@@ -658,8 +682,7 @@ final class SystemProxyManager: @unchecked Sendable {
             let data = try Data(contentsOf: url)
             return try PropertyListDecoder().decode(DirectProxyBackup.self, from: data)
         } catch {
-            Self.logger.warning("Corrupt direct backup, clearing: \(error.localizedDescription)")
-            self.clearDirectBackup()
+            Self.logger.warning("Direct backup is temporarily unreadable, preserving it: \(error.localizedDescription)")
             return nil
         }
     }
@@ -684,7 +707,7 @@ final class SystemProxyManager: @unchecked Sendable {
         let wasUsingHelper = usingHelper
         lock.unlock()
 
-        if let backup = loadDirectBackup() {
+        if let backup = loadDirectBackup(), directBackupBelongsToCurrentProcess(backup) {
             let backedUpServices = backup.services.map(\.service)
             if currentProxyMatchesRockxy(port: backup.rockxyPort, backedUpServices: backedUpServices),
                effectiveSystemProxyMatchesRockxy(port: backup.rockxyPort) {
@@ -736,28 +759,8 @@ final class SystemProxyManager: @unchecked Sendable {
             usingHelper = false
         }
         activeServices = []
+        sessionGeneration &+= 1
         lock.unlock()
-    }
-
-    private func rollbackUnconfirmedOverride() async {
-        lock.lock()
-        let helper = usingHelper
-        lock.unlock()
-
-        if helper {
-            do {
-                try await HelperConnection.shared.restoreSystemProxy()
-            } catch {
-                Self.logger.error(
-                    "Could not roll back an unconfirmed helper proxy override: \(error.localizedDescription)"
-                )
-            }
-            return
-        }
-
-        if let backup = loadDirectBackup() {
-            restoreDirectMode(using: backup)
-        }
     }
 
     /// Checks the routed service when it can be identified. If route-to-service mapping is
@@ -838,74 +841,62 @@ final class SystemProxyManager: @unchecked Sendable {
             && !hasGlobalBypass
     }
 
-    // MARK: - Launch-Time Recovery
-
-    /// Called at app launch to detect and restore stale direct-mode proxy overrides
-    /// left behind by a crash or force-quit.
-    func recoverStaleProxyIfNeeded() async {
-        if let backup = loadDirectBackup() {
-            let residualOwnedServices = recoverableDirectServices(in: backup)
-            // The session that wrote this backup is by definition gone: this app process is the
-            // only one that can own a direct-mode override, and it has just launched.
-            switch ProxyBackupRecoveryPolicy.action(
-                residualOwnedServicesExist: !residualOwnedServices.isEmpty,
-                ownerSessionIsLive: false
-            ) {
-            case .restore:
-                Self.logger
-                    .info(
-                        "Recovering \(residualOwnedServices.count) stale direct-mode service(s) from a previous session"
-                    )
-                if recoverOwnedDirectServices(backup: backup, ownedServices: residualOwnedServices) {
-                    stopBypassListObserver()
-                    clearInMemoryOverrideState()
-                    NotificationCenter.default.post(
-                        name: .systemProxyDidChange,
-                        object: nil,
-                        userInfo: ["enabled": false]
-                    )
-                } else {
-                    Self.logger.error("Stale direct proxy recovery incomplete — backup preserved for retry")
-                }
-            case .clear:
-                Self.logger.info("No backed-up service is still Rockxy-owned, clearing stale direct backup")
-                clearDirectBackup()
-            case .preserve:
-                break
-            }
-        }
-
-        if let helperStatus = try? await HelperConnection.shared.getProxyStatus(),
-           helperStatus.isOverridden
-        {
-            Self.logger.warning("Recovering stale helper-owned proxy override from previous session")
-            do {
-                try await HelperConnection.shared.restoreSystemProxy()
-            } catch {
-                Self.logger.error("Stale helper proxy recovery failed: \(error.localizedDescription)")
-            }
+    /// Best-effort cleanup used during late termination fallback and signal handling.
+    ///
+    /// It runs as one operation, and it waits for any enable or disable already in progress. That
+    /// wait is the point: restoring every service and clearing the backup while an enable loop
+    /// still has proxy commands left to write would put the settings back, delete the restore
+    /// point, and then let the loop re-apply the override with nothing on disk to undo it.
+    func performEmergencyTerminationCleanup(reason: String) {
+        Self.operationGate.withOperation {
+            performEmergencyTerminationCleanupLocked(reason: reason)
         }
     }
 
-    /// Best-effort cleanup used during late termination fallback and signal handling.
-    func performEmergencyTerminationCleanup(reason: String) {
+    /// The cleanup itself. Only ever reached with the operation gate held.
+    private func performEmergencyTerminationCleanupLocked(reason: String) {
         stopBypassListObserver()
+        // Anything queued for the session being torn down stops here. It is bumped inside the gate
+        // this cleanup holds, so a bypass write already waiting on that gate reads the new value
+        // and issues nothing.
+        lock.lock()
+        isEnabled = false
+        sessionGeneration &+= 1
+        lock.unlock()
 
-        if let backup = loadDirectBackup() {
-            let residualOwnedServices = recoverableDirectServices(in: backup)
-            if !residualOwnedServices.isEmpty {
-                Self.logger
-                    .warning(
-                        "\(reason): restoring \(residualOwnedServices.count) owned direct-mode service(s) during shutdown"
-                    )
-                if !recoverOwnedDirectServices(backup: backup, ownedServices: residualOwnedServices) {
-                    Self.logger.warning("\(reason): direct restore incomplete, leaving the narrowed backup for retry")
+        do {
+            let handledDirectSession = try DirectProxySessionLock.withExclusiveAccess(
+                backupURL: Self.directBackupURL
+            ) {
+                guard let backup = loadDirectBackup() else {
+                    return false
                 }
+                if directBackupOwnerIsLive(backup), !directBackupBelongsToCurrentProcess(backup) {
+                    Self.logger.info("\(reason): preserving the direct proxy session owned by another live app process")
+                    return true
+                }
+                let residualOwnedServices = recoverableDirectServices(in: backup)
+                if !residualOwnedServices.isEmpty {
+                    Self.logger
+                        .warning(
+                            "\(reason): restoring \(residualOwnedServices.count) owned direct-mode service(s) during shutdown"
+                        )
+                    if !recoverOwnedDirectServices(backup: backup, ownedServices: residualOwnedServices) {
+                        Self.logger.warning("\(reason): direct restore incomplete, leaving the narrowed backup for retry")
+                    }
+                    return true
+                }
+
+                Self.logger.info("\(reason): clearing stale direct backup because no service is still Rockxy-owned")
+                clearDirectBackup()
+                return true
+            }
+            if handledDirectSession {
                 return
             }
-
-            Self.logger.info("\(reason): clearing stale direct backup because no service is still Rockxy-owned")
-            clearDirectBackup()
+        } catch {
+            Self.logger.error("\(reason): could not acquire direct proxy session lock: \(error.localizedDescription)")
+            return
         }
 
         if helperEmergencyRestoreNeeded() {
@@ -914,12 +905,7 @@ final class SystemProxyManager: @unchecked Sendable {
                 return
             }
 
-            Self.logger.error("\(reason): helper emergency restore did not complete, continuing fallback cleanup")
-        }
-
-        if anyLoopbackProxyEnabled(on: nil) {
-            Self.logger.warning("\(reason): loopback proxy still enabled without backup, forcing proxy states off")
-            try? disableSystemProxyViaNetworkSetup()
+            Self.logger.error("\(reason): helper emergency restore did not complete")
         }
     }
 
@@ -931,7 +917,6 @@ final class SystemProxyManager: @unchecked Sendable {
     private let proxyConfigurationMonitor = SystemProxyConfigurationMonitor()
     private static let routePath = "/sbin/route"
     private static let helperBackupPath = "/Library/Application Support/\(RockxyIdentity.current.sharedSupportDirectoryName)/proxy-backup.plist"
-
     // MARK: - Direct Backup Persistence
 
     private static var directBackupURL: URL {
@@ -951,241 +936,359 @@ final class SystemProxyManager: @unchecked Sendable {
             .appendingPathComponent("RockxyHelperTool", isDirectory: false)
     }
 
+    /// Serializes enable, disable, and termination cleanup against each other. It is static
+    /// because the signal handler and the capture task both reach the same shared manager, and
+    /// the thing being protected is the one machine's proxy settings.
+    private static let operationGate = ProxyOperationGate()
+    /// Keeps helper-backed and startup lifecycle operations ordered across their suspension
+    /// points. The blocking gate above still guards synchronous direct-mode mutations and signal
+    /// cleanup, while this one prevents an older async continuation from ending a newer session.
+    private static let lifecycleGate = ProxyAsyncOperationGate()
+
     private let lock = NSLock()
     private var isEnabled = false
     private var usingHelper = false
     private var activeServices: [String] = []
     private var directRestorePending = false
+    /// Which override session the manager is on. Bumped by everything that ends one, and read
+    /// inside the operation gate, so work queued for a session that has since ended never runs.
+    private var sessionGeneration: UInt64 = 0
     private var originalBypassDomains: [String: [String]] = [:]
     private var originalProxyState: [String: ServiceProxySnapshot] = [:]
     private var bypassObserver: NSObjectProtocol?
+    /// The watchdog job currently guarding this session's override, if one was installed. Held so
+    /// the next arming knows which job it supersedes and the disable path removes the right one.
+    private var activeDirectWatchdogLabel: String?
 
-    private static func submitDirectProxyWatchdog(
-        label: String,
-        executableURL: URL,
-        parentPID: pid_t,
-        backupPath: String
-    )
-        throws
-    {
-        try removeDirectProxyWatchdog(label: label, tolerateMissing: true)
-        _ = try runLaunchctl(directWatchdogSubmitArguments(
-            label: label,
-            executablePath: executableURL.path,
-            parentPID: parentPID,
-            backupPath: backupPath
-        ))
-    }
-
-    private static func removeDirectProxyWatchdog(
-        label: String = directWatchdogLabel,
-        tolerateMissing: Bool
-    )
-        throws
-    {
-        _ = try runLaunchctl(["remove", label], toleratedExitCodes: tolerateMissing ? [3] : [])
-    }
-
-    @discardableResult
-    private static func runLaunchctl(
-        _ arguments: [String],
-        toleratedExitCodes: Set<Int32> = []
-    )
-        throws -> String
-    {
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/bin/launchctl")
-        process.arguments = arguments
-
-        let stdoutPipe = Pipe()
-        let stderrPipe = Pipe()
-        process.standardOutput = stdoutPipe
-        process.standardError = stderrPipe
-
-        do {
-            try process.run()
-        } catch {
-            throw SystemProxyError.unexpectedOutput("Failed to launch launchctl: \(error.localizedDescription)")
-        }
-
-        process.waitUntilExit()
-
-        let stdout = String(data: stdoutPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
-        let stderr = String(data: stderrPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
-
-        let terminationStatus = process.terminationStatus
-        if terminationStatus == 0 || toleratedExitCodes.contains(terminationStatus) {
-            return stdout
-        }
-
-        let combined = stderr.isEmpty ? stdout : stderr
-        throw SystemProxyError.unexpectedOutput(
-            "launchctl \(arguments.joined(separator: " ")) failed (exit \(terminationStatus)): \(combined)"
-        )
-    }
-
-    /// Shared direct-mode restore routine used by both same-session cleanup and ownership-based cleanup.
-    @discardableResult
-    private func restoreDirectMode(using sourceBackup: DirectProxyBackup) -> Bool {
-        let backup = sourceBackup.markedRecoveryPending()
-        do {
-            try writeDirectBackup(backup)
-        } catch {
-            Self.logger.error("Could not mark direct recovery pending — leaving settings untouched: \(error.localizedDescription)")
-            return false
-        }
-        let backedUpServices = backup.services.map(\.service)
-
-        var allSucceeded = true
-        var failedServices: Set<String> = []
-
-        for entry in backup.services {
-            let snapshot = ServiceProxySnapshot(
-                httpEnabled: entry.httpEnabled,
-                httpHost: entry.httpHost,
-                httpPort: entry.httpPort,
-                httpsEnabled: entry.httpsEnabled,
-                httpsHost: entry.httpsHost,
-                httpsPort: entry.httpsPort,
-                socksEnabled: entry.socksEnabled,
-                socksHost: entry.socksHost,
-                socksPort: entry.socksPort,
-                pacEnabled: entry.pacEnabled,
-                pacURL: entry.pacURL,
-                autoDiscoveryEnabled: entry.autoDiscoveryEnabled
-            )
-            do {
-                try restoreServiceProxyState(service: entry.service, snapshot: snapshot)
-            } catch {
-                allSucceeded = false
-                failedServices.insert(entry.service)
-                Self.logger.error("Failed to restore proxy state for '\(entry.service)': \(error.localizedDescription)")
-            }
-            do {
-                try restoreServiceBypassDomains(service: entry.service, domains: entry.bypassDomains)
-            } catch {
-                allSucceeded = false
-                failedServices.insert(entry.service)
-                Self.logger.error("Failed to restore bypass for '\(entry.service)': \(error.localizedDescription)")
-            }
-        }
-
-        // Any service still pointing at Rockxy keeps the backup alive, even when the others
-        // restored cleanly — that service has no other restore point.
-        let stillOwnedServices = allSucceeded
-            ? residualOwnedServicesAfterRestore(port: backup.rockxyPort, backedUpServices: backedUpServices)
-            : residualRockxyOwnedServices(port: backup.rockxyPort, backedUpServices: backedUpServices)
-
-        let proxyStillPointsAtRockxy: Bool = if allSucceeded {
-            backedUpServices.isEmpty ? anyLoopbackProxyEnabled(on: nil) : !stillOwnedServices.isEmpty
-        } else {
-            true
-        }
-
-        let restored = Self.shouldClearDirectBackupAfterRestoreAttempt(
-            commandsSucceeded: allSucceeded,
-            proxyStillPointsAtRockxy: proxyStillPointsAtRockxy
-        )
-        lock.lock()
-        if restored {
-            clearDirectBackup()
-            directRestorePending = false
-        } else {
-            if allSucceeded {
-                Self.logger.warning(
-                    "Direct restore commands completed but proxy still points at Rockxy — keeping backup on disk for watchdog retry"
-                )
-            } else {
-                Self.logger.warning("Partial restore failure — keeping backup on disk for retry")
-            }
-            retainUnresolvedDirectBackup(
-                backup: backup,
-                failedServices: failedServices,
-                stillOwnedServices: Set(stillOwnedServices)
-            )
-            // directRestorePending stays true for same-session retry
-        }
-        lock.unlock()
-        return restored
+    /// A label no `launchctl` job is using yet, so a watcher can be submitted before the one it
+    /// replaces is removed.
+    private static func uniqueDirectWatchdogLabel() -> String {
+        "\(directWatchdogLabel).\(UUID().uuidString)"
     }
 
     // MARK: - NetworkSetup — Enable on ALL Enabled Services
 
     private func enableSystemProxyViaNetworkSetup(port: Int) throws {
+        // The whole enable runs as one operation. A termination cleanup arriving on the signal
+        // thread has to wait for it: restoring and clearing the backup while this loop still has
+        // proxy commands to write would leave the user overridden with no restore point at all.
+        try Self.operationGate.withOperation {
+            try applyDirectOverride(port: port)
+        }
+    }
+
+    private func applyDirectOverride(port: Int) throws {
+        try DirectProxySessionLock.withExclusiveAccess(backupURL: Self.directBackupURL) {
+            try applyDirectOverrideLocked(port: port)
+        }
+    }
+
+    /// The complete ownership claim and mutation sequence, held under the cross-process lock.
+    private func applyDirectOverrideLocked(port: Int) throws {
+        // Never use another loopback proxy as the restoration baseline. This also closes the
+        // cross-mode race where a helper-backed session becomes visible while direct fallback is
+        // being considered but before a direct restore point is published.
+        if loadDirectBackup() == nil, anyLoopbackProxyEnabled(on: nil) {
+            throw SystemProxyError.proxySessionInUse
+        }
+
         let services = try detectAllEnabledServices()
         guard !services.isEmpty else {
             throw SystemProxyError.noActiveNetworkService
         }
 
+        // The watchdog is the only thing that puts these settings back when this process dies, so
+        // it is armed before a single service is mutated. An override applied first and watched
+        // afterwards is an override that can outlive the app with nothing watching it at all —
+        // and a death anywhere in the mutation loop would be exactly that.
+        let arming = try directWatchdogArming()
+        let existingBackup = loadDirectBackup()
+        let hadBackupBefore = existingBackup != nil
+        // The services that already had a restore point. Only their entries may outlive a failed
+        // attempt: an entry this attempt captures for a service it never touches describes
+        // settings nobody overrode, and keeping it is how a later enable comes to replay a stale
+        // snapshot over a newer user setting.
+        let preAttemptServices = Set(existingBackup?.services.map(\.service) ?? [])
+
         Self.logger.info("Setting proxy on all \(services.count) enabled services")
 
-        try prepareDirectBackup(port: port, services: services)
+        var touchedServices: [String] = []
+        var configuredServices: [String] = []
+        var skippedServices: [String] = []
 
-        var mutatedServices: [String] = []
-        do {
-            for service in services {
-                try runNetworkSetup(["-setwebproxy", service, "127.0.0.1", String(port)])
-                try runNetworkSetup(["-setwebproxystate", service, "on"])
-                try runNetworkSetup(["-setsecurewebproxy", service, "127.0.0.1", String(port)])
-                try runNetworkSetup(["-setsecurewebproxystate", service, "on"])
-                try runNetworkSetup(["-setsocksfirewallproxystate", service, "off"])
-                try runNetworkSetup(["-setautoproxystate", service, "off"])
-                try runNetworkSetup(["-setproxyautodiscovery", service, "off"])
-                mutatedServices.append(service)
-                Self.logger.info("System proxy set on '\(service)' -> 127.0.0.1:\(port)")
+        // The restore point is published first so the watchdog has something to observe from the
+        // moment it starts: it sees the backup, waits while this process's identity is live, and
+        // exits once a successful rollback or restore clears it. Only then does the first proxy
+        // command run.
+        let failure = DirectOverrideApplication.run(
+            persistBackup: {
+                try prepareDirectBackup(
+                    port: port,
+                    services: services,
+                    ownerPID: arming.parentPID,
+                    ownerStartSignature: arming.parentStartSignature
+                )
+            },
+            armWatchdog: { try armDirectProxyWatchdog(arming, hadBackupBefore: hadBackupBefore) },
+            mutateServices: {
+                for service in services {
+                    // The capture this backup holds was taken earlier — moments ago for a service
+                    // just added, a whole session ago for one being reclaimed. What the override
+                    // is about to start from is a fact about the machine now, so the settings are
+                    // re-read in full and compared against what this process can actually prove
+                    // about them. A service that answers neither leaves without a command.
+                    guard let baseline = directOverrideBaseline(for: service, port: port) else {
+                        skippedServices.append(service)
+                        continue
+                    }
+                    // The record comes before the first command, and it is what makes a crash in
+                    // the middle of the seven recoverable at all: a service stopped half-way is
+                    // neither Rockxy's nor the user's, so nothing but this record can tell a
+                    // later relaunch that these settings are Rockxy's own work to undo.
+                    try advanceDirectApplicationJournal(
+                        service: service,
+                        baseline: baseline,
+                        to: .applying,
+                        port: port
+                    )
+                    guard restorationState(for: service) == baseline else {
+                        throw SystemProxyError.proxyStateChangedDuringCommit(service: service)
+                    }
+                    touchedServices.append(service)
+                    try runNetworkSetup(["-setwebproxy", service, "127.0.0.1", String(port)])
+                    try runNetworkSetup(["-setwebproxystate", service, "on"])
+                    try runNetworkSetup(["-setsecurewebproxy", service, "127.0.0.1", String(port)])
+                    try runNetworkSetup(["-setsecurewebproxystate", service, "on"])
+                    try runNetworkSetup(["-setsocksfirewallproxystate", service, "off"])
+                    try runNetworkSetup(["-setautoproxystate", service, "off"])
+                    try runNetworkSetup(["-setproxyautodiscovery", service, "off"])
+                    configuredServices.append(service)
+                    Self.logger.info("System proxy set on '\(service)' -> 127.0.0.1:\(port)")
+                }
             }
-        } catch {
-            Self.logger.error("Proxy setup failed after \(mutatedServices.count) service(s), rolling back")
-            if let backup = loadDirectBackup() {
-                restoreDirectMode(using: backup)
+        )
+
+        if let failure {
+            switch failure.step {
+            case .persistBackup, .armWatchdog:
+                // Not one setting was touched, so there is nothing to undo.
+                throw failure.error
+            case .mutateServices:
+                Self.logger.error("Proxy setup failed after \(configuredServices.count) service(s), rolling back")
+                // The rollback's answer decides what this attempt may claim. A service it could
+                // not put back still carries proxy state Rockxy wrote, and reporting only the
+                // original failure would leave that state on the machine with nothing said
+                // about it.
+                let rollbackSucceeded = rollBackDirectOverride(
+                    touchedServices: touchedServices,
+                    preAttemptServices: preAttemptServices
+                )
+                clearInMemoryOverrideState()
+                lock.lock()
+                directRestorePending = !rollbackSucceeded
+                lock.unlock()
+
+                switch Self.directOverrideAttemptOutcome(
+                    applySucceeded: false,
+                    rollbackSucceeded: rollbackSucceeded
+                ) {
+                case .enabled, .rolledBack:
+                    throw failure.error
+                case .rollbackIncomplete:
+                    throw SystemProxyError.overrideRollbackIncomplete(
+                        reason: failure.error.localizedDescription
+                    )
+                }
             }
-            throw error
         }
 
-        guard !mutatedServices.isEmpty else {
-            clearDirectBackup()
+        guard !configuredServices.isEmpty else {
+            // Not one service could be configured, and none was touched. Whatever this attempt
+            // captured for itself must not outlive it, but an entry that predates it is still the
+            // only restore point its own service has — and clearing the file outright is how a
+            // service still carrying an earlier session's override loses it.
+            _ = rollBackDirectOverride(
+                touchedServices: touchedServices,
+                preAttemptServices: preAttemptServices
+            )
+            clearInMemoryOverrideState()
             throw SystemProxyError.noActiveNetworkService
         }
+
+        // An entry this attempt captured for a service it then skipped describes settings nobody
+        // overrode. Keeping it would hand the next enable a snapshot older than whatever the user
+        // has set in the meantime, and the enable after that would write it back over their change.
+        dropUntouchedCapturedEntries(skippedServices.filter { !preAttemptServices.contains($0) })
 
         lock.lock()
         isEnabled = true
         usingHelper = false
-        activeServices = mutatedServices
+        activeServices = configuredServices
         directRestorePending = true
         lock.unlock()
-
-        startDirectProxyWatchdog()
     }
 
-    // MARK: - NetworkSetup — Disable on ALL Configured Services
+    /// Removes the entries this attempt captured for services it never issued a command against.
+    ///
+    /// Only those: an entry that was already on disk belongs to a service some earlier session may
+    /// still be overriding, and this attempt never touched it either way. A failed write simply
+    /// leaves the backup as it is, which is the safe direction — a spare restore point costs a
+    /// deferred service, a missing one costs the settings.
+    private func dropUntouchedCapturedEntries(_ services: [String]) {
+        guard !services.isEmpty, let backup = loadDirectBackup() else {
+            return
+        }
+        let dropped = Set(services)
+        let retained = backup.services.map(\.service).filter { !dropped.contains($0) }
+        guard retained.count != backup.services.count else {
+            return
+        }
+        do {
+            try writeDirectBackup(backup.with(
+                services: ProxyBackupSubset.select(
+                    backup.services,
+                    services: Set(retained),
+                    serviceName: \.service
+                ),
+                journal: ProxyBackupSubset.select(
+                    backup.journal,
+                    services: Set(retained),
+                    serviceName: \.service
+                )
+            ))
+        } catch {
+            Self.logger
+                .error(
+                    "Could not drop the freshly captured entries for skipped services: \(error.localizedDescription)"
+                )
+        }
+    }
 
-    private func disableSystemProxyViaNetworkSetup() throws {
-        lock.lock()
-        let services = activeServices
-        lock.unlock()
-
-        let targetServices = services.isEmpty ? (try? detectAllEnabledServices()) ?? [] : services
-
-        for service in targetServices {
-            do {
-                try runNetworkSetup(["-setwebproxystate", service, "off"])
-                try runNetworkSetup(["-setsecurewebproxystate", service, "off"])
-                try runNetworkSetup(["-setsocksfirewallproxystate", service, "off"])
-                try runNetworkSetup(["-setautoproxystate", service, "off"])
-                try runNetworkSetup(["-setproxyautodiscovery", service, "off"])
-                Self.logger.info("System proxy disabled on '\(service)'")
-            } catch {
-                Self.logger.debug("Failed to disable proxy for '\(service)': \(error.localizedDescription)")
-            }
+    /// The state this service's override sequence may start from, or nil when it may not start at
+    /// all.
+    ///
+    /// A service that still reads exactly as captured is a fresh one and answers with the capture.
+    /// A service that has moved on answers only when the record of this machine's own earlier
+    /// override still explains what is live — which is what a reclaim is. Anything else is the
+    /// user's configuration or another tool's, and it is left with no command issued against it.
+    private func directOverrideBaseline(for service: String, port: Int) -> ProxyServiceRestorationState? {
+        guard let backup = loadDirectBackup(),
+              let entry = backup.services.first(where: { $0.service == service })
+        else {
+            Self.logger.warning("Skipping proxy for '\(service)' — it has no captured restore point")
+            return nil
         }
 
+        guard case let .apply(baseline) = ProxyOverrideApplicationPreflight.decision(
+            captured: entry.restorationTarget,
+            live: restorationState(for: service),
+            priorEntry: backup.journal.first { $0.service == service },
+            port: port
+        ) else {
+            Self.logger
+                .warning(
+                    "Skipping proxy for '\(service)' — its live settings are neither the ones captured for it nor any this process wrote"
+                )
+            return nil
+        }
+        return baseline
+    }
+
+    /// Moves one service's override record on, and refuses to go further if it cannot be stored.
+    ///
+    /// The write is the permission to issue the command. A command nothing on disk accounts for
+    /// is exactly the shape recovery has no way to reason about, so the sequence stops here
+    /// rather than mutating a service it could not record.
+    ///
+    /// Only this service's record changes. Every other one is left exactly where it is: the backup
+    /// can already be mid-recovery from an earlier session, or already carry an override this
+    /// attempt is reclaiming, and those records are the only thing that says which live states may
+    /// still be written.
+    private func advanceDirectApplicationJournal(
+        service: String,
+        baseline: ProxyServiceRestorationState,
+        to stage: ProxyRecoveryStage,
+        port: Int
+    ) throws {
+        guard let backup = loadDirectBackup(),
+              let entry = backup.services.first(where: { $0.service == service })
+        else {
+            throw SystemProxyError.proxyRestoreFailed
+        }
+        var journal = backup.journal.filter { $0.service != service }
+        journal.append(ProxyServiceRecoveryJournalEntry(
+            overrideApplicationFor: entry.restorationTarget,
+            baseline: baseline,
+            stage: stage,
+            port: port
+        ))
+        try writeDirectBackup(backup.with(journal: journal))
+    }
+
+    /// Submits the watchdog against the backup that was just published, before the first proxy
+    /// command runs.
+    ///
+    /// The new watcher goes in under a label nothing is using yet, and the one it supersedes is
+    /// only removed once the replacement is known installed. Removing first and submitting after
+    /// is what could leave an override — this attempt's, or one already on the machine — with no
+    /// watcher at all the moment the submit failed.
+    ///
+    /// A failure here costs nothing but the restore point this very attempt created: no setting
+    /// has been touched, so there is nothing to undo, and whatever was watching before still is.
+    /// An earlier session's backup is left exactly where it is — it belongs to an override this
+    /// attempt did not apply.
+    private func armDirectProxyWatchdog(
+        _ arming: DirectWatchdogArming,
+        hadBackupBefore: Bool
+    ) throws {
+        let newLabel = Self.uniqueDirectWatchdogLabel()
         lock.lock()
-        isEnabled = false
-        usingHelper = false
-        activeServices = []
+        let supersededLabel = activeDirectWatchdogLabel
         lock.unlock()
 
-        try? Self.removeDirectProxyWatchdog(tolerateMissing: true)
+        let outcome = DirectProxyWatchdogInstallation.install(
+            newLabel: newLabel,
+            supersededLabel: supersededLabel,
+            submit: { label in
+                try Self.submitDirectProxyWatchdog(
+                    label: label,
+                    executableURL: arming.executableURL,
+                    parentPID: arming.parentPID,
+                    parentStartSignature: arming.parentStartSignature,
+                    backupPath: Self.directBackupURL.path
+                )
+            },
+            remove: { label in
+                try Self.removeDirectProxyWatchdog(label: label, tolerateMissing: true)
+            }
+        )
+
+        switch outcome {
+        case let .installed(activeLabel, supersededLabel):
+            lock.lock()
+            activeDirectWatchdogLabel = activeLabel
+            lock.unlock()
+            Self.logger
+                .info(
+                    "Registered direct proxy watchdog '\(activeLabel)' for pid \(arming.parentPID) before the first proxy change, superseding '\(supersededLabel ?? "none")'"
+                )
+            // A build before the label became unique left one job behind under the fixed name. It
+            // is only asked to go once a replacement is already watching.
+            if supersededLabel == nil {
+                try? Self.removeDirectProxyWatchdog(label: Self.directWatchdogLabel, tolerateMissing: true)
+            }
+        case let .failed(activeLabel, error):
+            Self.logger
+                .error(
+                    "Failed to start direct proxy watchdog: \(error.localizedDescription) — '\(activeLabel ?? "no")' watcher left in place"
+                )
+            if !hadBackupBefore {
+                clearDirectBackup()
+            }
+            throw SystemProxyError.directProxyWatchdogUnavailable(
+                reason: "the watchdog could not be registered, so no proxy setting was changed"
+            )
+        }
     }
 
     /// Snapshots bypass domains and proxy state for all detected target services
@@ -1288,25 +1391,6 @@ final class SystemProxyManager: @unchecked Sendable {
             try runNetworkSetup(args)
         }
         Self.logger.info("Restored \(domains.count) bypass domain(s) for '\(service)'")
-    }
-
-    private func applyBypassDomainsViaNetworkSetup(_ domains: [String]) throws {
-        lock.lock()
-        let services = activeServices
-        lock.unlock()
-
-        let targetServices = services.isEmpty ? ((try? detectAllEnabledServices()) ?? []) : services
-
-        for service in targetServices {
-            if domains.isEmpty {
-                try runNetworkSetup(["-setproxybypassdomains", service, "Empty"])
-            } else {
-                let args = ["-setproxybypassdomains", service] + domains
-                try runNetworkSetup(args)
-            }
-        }
-
-        Self.logger.info("Applied \(domains.count) bypass domain(s) via networksetup")
     }
 
     // MARK: - Network Service Detection
@@ -1434,15 +1518,36 @@ final class SystemProxyManager: @unchecked Sendable {
 
     /// Extends the session backup before mutating newly enabled services. Existing entries
     /// remain authoritative until the whole session has restored successfully.
-    private func prepareDirectBackup(port: Int, services: [String]) throws {
+    private func prepareDirectBackup(
+        port: Int,
+        services: [String],
+        ownerPID: Int32,
+        ownerStartSignature: String
+    ) throws {
         let existingBackup = loadDirectBackup()
+        guard existingBackup != nil || !directBackupFileExists else {
+            throw SystemProxyError.proxyRestoreFailed
+        }
+        if let existingBackup,
+           !DirectProxyBackupOwnerPolicy.belongsToSession(
+               existingBackup,
+               processIdentifier: ownerPID,
+               processStartSignature: ownerStartSignature
+           )
+        {
+            throw SystemProxyError.proxySessionInUse
+        }
         let existingServices = Set(existingBackup?.services.map(\.service) ?? [])
         let missingServices = services.filter { !existingServices.contains($0) }
         let additions = try missingServices.map(captureDirectServiceBackup)
-        let backup = DirectProxyBackup(
-            services: (existingBackup?.services ?? []) + additions,
-            timestamp: existingBackup?.timestamp ?? Date(),
-            rockxyPort: port
+        // Whatever the previous attempt recorded travels with the extended backup.
+        let backup = DirectProxyBackup.extending(
+            existingBackup,
+            with: additions,
+            rockxyPort: port,
+            now: Date(),
+            ownerPID: ownerPID,
+            ownerStartSignature: ownerStartSignature
         )
 
         if additions.isEmpty, existingBackup?.rockxyPort == port {
@@ -1453,77 +1558,21 @@ final class SystemProxyManager: @unchecked Sendable {
         try writeDirectBackup(backup)
     }
 
-    private func captureDirectServiceBackup(service: String) throws -> DirectServiceBackup {
-        let http = parseProxyOutput(try runNetworkSetup(["-getwebproxy", service]))
-        let https = parseProxyOutput(try runNetworkSetup(["-getsecurewebproxy", service]))
-        let socks = parseProxyOutput(try runNetworkSetup(["-getsocksfirewallproxy", service]))
-        let pac = ProxyRestoreCommandBuilder.parsePACOutput(
-            try runNetworkSetup(["-getautoproxyurl", service])
-        )
-        let autoDiscovery = ProxyRestoreCommandBuilder.parseAutoDiscoveryOutput(
-            try runNetworkSetup(["-getproxyautodiscovery", service])
-        )
-        let bypassOutput = try runNetworkSetup(["-getproxybypassdomains", service])
-        let bypass = bypassOutput.components(separatedBy: "\n")
-            .map { $0.trimmingCharacters(in: .whitespaces) }
-            .filter { !$0.isEmpty && !$0.hasPrefix("There aren't any bypass domains") }
-
-        return DirectServiceBackup(
-            service: service,
-            httpEnabled: http.enabled,
-            httpHost: http.host,
-            httpPort: http.port,
-            httpsEnabled: https.enabled,
-            httpsHost: https.host,
-            httpsPort: https.port,
-            socksEnabled: socks.enabled,
-            socksHost: socks.host,
-            socksPort: socks.port,
-            pacEnabled: pac.enabled,
-            pacURL: pac.url,
-            autoDiscoveryEnabled: autoDiscovery,
-            bypassDomains: bypass
-        )
-    }
-
+    /// Publishes the direct backup, permissions and all, in a single act.
+    ///
+    /// Everything that can fail happens before the new contents become visible, so a throw from
+    /// here always means the file on disk is still the previous record — which is what the
+    /// callers that treat a successful write as their permission to issue a command depend on.
     private func writeDirectBackup(_ backup: DirectProxyBackup) throws {
         let url = Self.directBackupURL
         let parentDir = url.deletingLastPathComponent()
         try FileManager.default.createDirectory(at: parentDir, withIntermediateDirectories: true)
         try FileManager.default.setAttributes(
-            [.posixPermissions: 0o700],
+            [.posixPermissions: ProxyBackupFilePublication.ownerOnlyDirectoryPermissions],
             ofItemAtPath: parentDir.path
         )
-        let data = try PropertyListEncoder().encode(backup)
-        try data.write(to: url, options: .atomic)
-        try FileManager.default.setAttributes(
-            [.posixPermissions: 0o600],
-            ofItemAtPath: url.path
-        )
+        try ProxyBackupFilePublication.publish(PropertyListEncoder().encode(backup), to: url)
         Self.logger.info("Persisted direct backup for \(backup.services.count) service(s) at port \(backup.rockxyPort)")
-    }
-
-    private func startDirectProxyWatchdog() {
-        let executableURL = Self.directWatchdogExecutableURL
-        guard FileManager.default.isExecutableFile(atPath: executableURL.path) else {
-            Self.logger.warning("Could not resolve helper executable for direct proxy watchdog")
-            return
-        }
-
-        do {
-            try Self.submitDirectProxyWatchdog(
-                label: Self.directWatchdogLabel,
-                executableURL: executableURL,
-                parentPID: ProcessInfo.processInfo.processIdentifier,
-                backupPath: Self.directBackupURL.path
-            )
-            Self.logger
-                .info(
-                    "Registered direct proxy watchdog '\(Self.directWatchdogLabel)' for pid \(ProcessInfo.processInfo.processIdentifier)"
-                )
-        } catch {
-            Self.logger.warning("Failed to start direct proxy watchdog: \(error.localizedDescription)")
-        }
     }
 
     // MARK: - Process Execution
@@ -1604,12 +1653,595 @@ final class SystemProxyManager: @unchecked Sendable {
     }
 }
 
+// MARK: - Direct Backup Capture
+
+extension SystemProxyManager {
+    private func captureDirectServiceBackup(service: String) throws -> DirectServiceBackup {
+        let http = parseProxyOutput(try runNetworkSetup(["-getwebproxy", service]))
+        let https = parseProxyOutput(try runNetworkSetup(["-getsecurewebproxy", service]))
+        let socks = parseProxyOutput(try runNetworkSetup(["-getsocksfirewallproxy", service]))
+        let pac = ProxyRestoreCommandBuilder.parsePACOutput(
+            try runNetworkSetup(["-getautoproxyurl", service])
+        )
+        let autoDiscovery = ProxyRestoreCommandBuilder.parseAutoDiscoveryOutput(
+            try runNetworkSetup(["-getproxyautodiscovery", service])
+        )
+        let bypassOutput = try runNetworkSetup(["-getproxybypassdomains", service])
+        let bypass = bypassOutput.components(separatedBy: "\n")
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty && !$0.hasPrefix("There aren't any bypass domains") }
+
+        return DirectServiceBackup(
+            service: service,
+            httpEnabled: http.enabled,
+            httpHost: http.host,
+            httpPort: http.port,
+            httpsEnabled: https.enabled,
+            httpsHost: https.host,
+            httpsPort: https.port,
+            socksEnabled: socks.enabled,
+            socksHost: socks.host,
+            socksPort: socks.port,
+            pacEnabled: pac.enabled,
+            pacURL: pac.url,
+            autoDiscoveryEnabled: autoDiscovery,
+            bypassDomains: bypass
+        )
+    }
+}
+
+// MARK: - Direct Bypass Writes
+
+/// Rockxy's own bypass list, written onto the services a direct-mode session overrode.
+///
+/// It lives apart from the enable and restore flow because it is a different act with the same
+/// hazards: it is part of the effective routing, it runs long after the enable that authorized it,
+/// and it can be queued behind a disable that has already put everything back.
+extension SystemProxyManager {
+    private func rollbackUnconfirmedOverride() async {
+        lock.lock()
+        let helper = usingHelper
+        let mutatedServices = Set(activeServices)
+        lock.unlock()
+
+        if helper {
+            do {
+                try await HelperConnection.shared.restoreSystemProxy()
+            } catch {
+                Self.logger.error(
+                    "Could not roll back an unconfirmed helper proxy override: \(error.localizedDescription)"
+                )
+            }
+            return
+        }
+
+        // This session wrote those services itself, so undoing its own unconfirmed work does not
+        // depend on the live settings still proving ownership — which they may no longer do if
+        // the very change that broke confirmation is what is sitting on them.
+        // Serialized with everything else that writes these services and this file. The gate is
+        // reentrant, so an enable already holding it can still roll itself back without waiting on
+        // itself, while a rollback reached from the confirmation check — where the enable has long
+        // since let go — takes it for real.
+        _ = Self.operationGate.withOperation {
+            invalidateQueuedDirectProxyWork()
+            if let currentBackup = loadDirectBackup() {
+                restoreDirectMode(using: currentBackup, locallyMutatedServices: mutatedServices)
+            }
+        }
+    }
+
+    /// Ends the direct session from the perspective of work waiting on the operation gate.
+    ///
+    /// This must run while the gate is held and before restoration starts. A bypass write queued
+    /// behind that restore then observes both a new generation and an inactive override when it
+    /// acquires the gate, so it cannot write after the backup has been consumed.
+    private func invalidateQueuedDirectProxyWork() {
+        lock.lock()
+        isEnabled = false
+        sessionGeneration &+= 1
+        lock.unlock()
+    }
+
+    /// Writes Rockxy's bounded bypass list onto the services this session overrode.
+    ///
+    /// It runs as one operation for the same reason the enable loop does: the bypass list is part
+    /// of the effective routing, and a disable or a termination cleanup writing the captured
+    /// settings back at the same time would interleave with it. The gate alone is not enough
+    /// though — it only orders the two, and losing the race means this write lands *after* the
+    /// cleanup restored every service and deleted the restore point, leaving Rockxy's bypass list
+    /// on the user's machine with nothing left to undo it. So the session is re-checked inside the
+    /// gate, where nothing can end it between the check and the commands.
+    private func applyBypassDomainsViaNetworkSetup(_ domains: [String], queuedGeneration: UInt64) throws {
+        try Self.operationGate.withOperation {
+            lock.lock()
+            let services = activeServices
+            let generation = sessionGeneration
+            let overrideIsActive = isEnabled
+            lock.unlock()
+
+            guard ProxyOperationSessionPolicy.mayRun(
+                queuedGeneration: queuedGeneration,
+                currentGeneration: generation,
+                overrideIsActive: overrideIsActive
+            ) else {
+                Self.logger
+                    .info("Skipping a bypass write queued for a proxy session that has already ended")
+                return
+            }
+
+            guard !services.isEmpty, var backup = loadDirectBackup() else {
+                throw SystemProxyError.proxyRestoreFailed
+            }
+
+            for service in services {
+                guard let entry = backup.journal.first(where: { $0.service == service }) else {
+                    throw SystemProxyError.proxyRestoreFailed
+                }
+
+                let live = restorationState(for: service)
+                switch ProxyBypassUpdatePreflight.decision(
+                    entry: entry,
+                    live: live,
+                    ownedPort: backup.rockxyPort,
+                    requestedDomains: domains
+                ) {
+                case .abort:
+                    throw SystemProxyError.proxyStateChangedDuringCommit(service: service)
+                case .unchanged:
+                    if entry.previousAppliedBypassDomains != nil {
+                        let stable = entry.completingAppliedBypassUpdate(at: domains)
+                        backup = backup.with(journal: replacingDirectJournal(backup.journal, entry: stable))
+                        try writeDirectBackup(backup)
+                    }
+                case let .apply(baseline):
+                    let pending = entry.recordingAppliedBypassDomains(
+                        domains,
+                        from: baseline.bypassDomains
+                    )
+                    backup = backup.with(journal: replacingDirectJournal(backup.journal, entry: pending))
+                    try writeDirectBackup(backup)
+
+                    // The record publication can take long enough for another actor to change the
+                    // service. Re-read every field before the command and refuse that foreign state.
+                    guard restorationState(for: service) == baseline else {
+                        throw SystemProxyError.proxyStateChangedDuringCommit(service: service)
+                    }
+
+                    if domains.isEmpty {
+                        try runNetworkSetup(["-setproxybypassdomains", service, "Empty"])
+                    } else {
+                        try runNetworkSetup(["-setproxybypassdomains", service] + domains)
+                    }
+
+                    let stable = pending.completingAppliedBypassUpdate(at: domains)
+                    backup = backup.with(journal: replacingDirectJournal(backup.journal, entry: stable))
+                    try writeDirectBackup(backup)
+                }
+            }
+
+            Self.logger.info("Applied \(domains.count) bypass domain(s) via networksetup")
+        }
+    }
+
+    private func replacingDirectJournal(
+        _ journal: [ProxyServiceRecoveryJournalEntry],
+        entry: ProxyServiceRecoveryJournalEntry
+    )
+        -> [ProxyServiceRecoveryJournalEntry]
+    {
+        journal.filter { $0.service != entry.service } + [entry]
+    }
+}
+
+// MARK: - Direct Watchdog Job Control
+
+/// The `launchctl` plumbing behind the direct-mode watchdog. It sits apart from the enable and
+/// restore flows because it answers a different question: not what the override is, but which job
+/// is currently watching it.
+extension SystemProxyManager {
+    private static func submitDirectProxyWatchdog(
+        label: String,
+        executableURL: URL,
+        parentPID: pid_t,
+        parentStartSignature: String,
+        backupPath: String
+    )
+        throws
+    {
+        _ = try runLaunchctl(directWatchdogSubmitArguments(
+            label: label,
+            executablePath: executableURL.path,
+            parentPID: parentPID,
+            parentStartSignature: parentStartSignature,
+            backupPath: backupPath
+        ))
+    }
+
+    private static func removeDirectProxyWatchdog(
+        label: String,
+        tolerateMissing: Bool
+    )
+        throws
+    {
+        _ = try runLaunchctl(["remove", label], toleratedExitCodes: tolerateMissing ? [3] : [])
+    }
+
+    @discardableResult
+    private static func runLaunchctl(
+        _ arguments: [String],
+        toleratedExitCodes: Set<Int32> = []
+    )
+        throws -> String
+    {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/launchctl")
+        process.arguments = arguments
+
+        let stdoutPipe = Pipe()
+        let stderrPipe = Pipe()
+        process.standardOutput = stdoutPipe
+        process.standardError = stderrPipe
+
+        do {
+            try process.run()
+        } catch {
+            throw SystemProxyError.unexpectedOutput("Failed to launch launchctl: \(error.localizedDescription)")
+        }
+
+        process.waitUntilExit()
+
+        let stdout = String(data: stdoutPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        let stderr = String(data: stderrPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+
+        let terminationStatus = process.terminationStatus
+        if terminationStatus == 0 || toleratedExitCodes.contains(terminationStatus) {
+            return stdout
+        }
+
+        let combined = stderr.isEmpty ? stdout : stderr
+        throw SystemProxyError.unexpectedOutput(
+            "launchctl \(arguments.joined(separator: " ")) failed (exit \(terminationStatus)): \(combined)"
+        )
+    }
+}
+
 // MARK: - Direct-Mode Recovery
 
 /// Ownership and subset-restore behavior for direct-mode backups. Recovery asks a different
 /// question from readiness — which backed-up services still need their restore point — so it
 /// lives apart from the enable/disable flow it supports.
 extension SystemProxyManager {
+    /// Shared direct-mode restore routine used by both same-session cleanup and ownership-based
+    /// cleanup.
+    ///
+    /// Every service is planned against the recovery journal first. The narrowed backup and an
+    /// `inFlight` record for each service about to be written are persisted before the first
+    /// command, and each service's record advances to `restored` as soon as its commands return.
+    /// A process that dies anywhere in between leaves a record the next attempt can read: live
+    /// settings this restore could have produced are written again, and settings it could not are
+    /// left to whoever made them.
+    ///
+    /// `preAttemptServices` names the services the backup already held before the caller captured
+    /// anything. Only those preserved entries may outlive this attempt: an entry the same attempt
+    /// captured for a service it then never touched describes settings nobody overrode, and
+    /// keeping it would hand the next enable a snapshot to write back over a change made in the
+    /// meantime.
+    @discardableResult
+    private func restoreDirectMode(
+        using sourceBackup: DirectProxyBackup,
+        authorizedServices: Set<String>? = nil,
+        locallyMutatedServices: Set<String> = [],
+        preAttemptServices: Set<String>? = nil
+    )
+        -> Bool
+    {
+        // A caller may authorize part of the backup — the services one failed attempt touched,
+        // say. The rest is not merely left unwritten: its entries stay in the backup on disk for
+        // the whole run, because a crash or a failed write during this restore must never be the
+        // moment a service that was never touched loses the only restore point it has.
+        let authorized = authorizedServices ?? Set(sourceBackup.services.map(\.service))
+        let authorizedEntries = sourceBackup.services.filter { authorized.contains($0.service) }
+        let preservedServices = sourceBackup.services
+            .map(\.service)
+            .filter { !authorized.contains($0) }
+
+        // A service with no usable record enters recovery only when the live settings still prove
+        // Rockxy owns it on the persisted port — or when they are exactly one of the states this
+        // process's own override commands pass through. Anything else keeps its restore point
+        // rather than being adopted as the state a restore begins from.
+        let plan = ProxyRecoveryPlanner.plan(
+            targets: authorizedEntries.map(\.restorationTarget),
+            journal: sourceBackup.journal,
+            liveStates: currentRestorationStates(for: authorizedEntries.map(\.service)),
+            ownedPort: sourceBackup.rockxyPort,
+            locallyMutatedServices: locallyMutatedServices
+        )
+
+        if !plan.abandonedServices.isEmpty {
+            Self.logger
+                .warning(
+                    "Leaving \(plan.abandonedServices.count) service(s) out of direct recovery — their proxy settings were changed outside this restore"
+                )
+        }
+
+        // Every planned service is recorded at the stage it was planned at. A service nothing has
+        // been issued for stays `pending`, so a crash while an earlier service is being written
+        // cannot make it look half-restored and hand a later attempt a licence to write over a
+        // change made in the meantime.
+        let plannedJournal = plan.entriesToRestore + ProxyBackupSubset.select(
+            sourceBackup.journal,
+            services: Set(plan.deferredServices + preservedServices),
+            serviceName: \.service
+        )
+        let retention = ProxyBackupRetention(
+            authorized: plan.servicesKeepingBackup,
+            preserved: preservedServices,
+            preAttemptServices: preAttemptServices
+        )
+
+        guard !plan.entriesToRestore.isEmpty else {
+            // Nothing may be written this time. A service whose settings could not be read keeps
+            // its restore point; everything else has already left recovery. The backup keeps the
+            // flag it arrived with, because no write has begun.
+            let proxyStillPointsAtRockxy = authorizedEntries.isEmpty
+                ? anyLoopbackProxyEnabled(on: nil)
+                : !plan.deferredServices.isEmpty
+            return finishDirectRestore(
+                backup: sourceBackup.with(
+                    journal: plannedJournal,
+                    recoveryPending: sourceBackup.recoveryPending
+                ),
+                unresolvedServices: plan.deferredServices,
+                retention: retention,
+                preservedRecoveryPending: sourceBackup.recoveryPending,
+                journal: plannedJournal,
+                commandsSucceeded: true,
+                proxyStillPointsAtRockxy: proxyStillPointsAtRockxy
+            )
+        }
+
+        let narrowedBackup = sourceBackup.with(
+            services: ProxyBackupSubset.select(
+                sourceBackup.services,
+                services: Set(retention.services),
+                serviceName: \.service
+            ),
+            journal: plannedJournal,
+            recoveryPending: true
+        )
+        do {
+            try writeDirectBackup(narrowedBackup)
+        } catch {
+            Self.logger.error("Could not mark direct recovery pending — leaving settings untouched: \(error.localizedDescription)")
+            return false
+        }
+
+        // The loop below is the one the watchdog binary runs too. It is shared rather than
+        // reimplemented because the state it leaves behind is only ever observed after a crash,
+        // which is exactly where two copies would be found to have drifted.
+        let outcome = DirectProxyRecoveryRunner.run(
+            entriesToRestore: plan.entriesToRestore,
+            backup: narrowedBackup,
+            journal: plannedJournal,
+            retention: retention,
+            deferredServices: plan.deferredServices,
+            effects: directRecoveryEffects()
+        )
+
+        // Any service still pointing at Rockxy keeps the backup alive, even when the others
+        // restored cleanly — that service has no other restore point.
+        let stillOwnedServices = outcome.allSucceeded
+            ? residualOwnedServicesAfterRestore(
+                port: outcome.backup.rockxyPort,
+                backedUpServices: outcome.attemptedServices
+            )
+            : residualRockxyOwnedServices(
+                port: outcome.backup.rockxyPort,
+                backedUpServices: outcome.attemptedServices
+            )
+
+        let unresolvedServices = ProxyBackupSubset.unresolvedEntries(
+            outcome.attemptedServices,
+            failedServices: outcome.failedServices,
+            stillOwnedServices: Set(stillOwnedServices),
+            serviceName: { $0 }
+        ) + outcome.deferredServices
+
+        return finishDirectRestore(
+            backup: outcome.backup,
+            unresolvedServices: unresolvedServices,
+            retention: outcome.retention,
+            preservedRecoveryPending: sourceBackup.recoveryPending,
+            journal: outcome.journal,
+            commandsSucceeded: outcome.allSucceeded,
+            proxyStillPointsAtRockxy: outcome.allSucceeded ? !unresolvedServices.isEmpty : true
+        )
+    }
+
+    /// How the app reaches `networksetup` and the direct backup file during a recovery run.
+    private func directRecoveryEffects() -> DirectProxyRecoveryEffects {
+        DirectProxyRecoveryEffects(
+            readState: { [weak self] service in self?.restorationState(for: service) },
+            publishBackup: { [weak self] backup in
+                guard let self else {
+                    throw SystemProxyError.proxyRestoreFailed
+                }
+                try writeDirectBackup(backup)
+            },
+            restoreProxyState: { [weak self] entry in
+                guard let self else {
+                    throw SystemProxyError.proxyRestoreFailed
+                }
+                try restoreServiceProxyState(
+                    service: entry.service,
+                    snapshot: Self.restorationSnapshot(for: entry)
+                )
+            },
+            restoreBypassDomains: { [weak self] entry in
+                guard let self else {
+                    throw SystemProxyError.proxyRestoreFailed
+                }
+                try restoreServiceBypassDomains(service: entry.service, domains: entry.bypassDomains)
+            },
+            log: { event in
+                switch event {
+                case let .droppedChangedService(service):
+                    Self.logger
+                        .warning(
+                            "Dropping '\(service)' from this direct restore — its proxy settings are no longer the ones this recovery planned for"
+                        )
+                case let .deferredUnreadableService(service):
+                    Self.logger
+                        .warning("Deferring '\(service)' — its proxy settings could not be read before restoring")
+                case let .uncommittedService(service, error):
+                    Self.logger
+                        .error(
+                            "Could not record the restore of '\(service)' — issuing no command for it: \(error.localizedDescription)"
+                        )
+                case let .failedStep(service, step, error):
+                    Self.logger
+                        .error(
+                            "Stopped restoring '\(service)' at the \(step.rawValue) step: \(error?.localizedDescription ?? "unknown error")"
+                        )
+                case let .backupUpdateFailed(error):
+                    Self.logger.error("Could not update the retained direct backup: \(error.localizedDescription)")
+                }
+            }
+        )
+    }
+
+    /// The captured settings for one service in the shape the restore commands take.
+    private static func restorationSnapshot(for entry: DirectServiceBackup) -> ServiceProxySnapshot {
+        ServiceProxySnapshot(
+            httpEnabled: entry.httpEnabled,
+            httpHost: entry.httpHost,
+            httpPort: entry.httpPort,
+            httpsEnabled: entry.httpsEnabled,
+            httpsHost: entry.httpsHost,
+            httpsPort: entry.httpsPort,
+            socksEnabled: entry.socksEnabled,
+            socksHost: entry.socksHost,
+            socksPort: entry.socksPort,
+            pacEnabled: entry.pacEnabled,
+            pacURL: entry.pacURL,
+            autoDiscoveryEnabled: entry.autoDiscoveryEnabled
+        )
+    }
+
+    /// Clears the direct backup when nothing is left to recover, or narrows it to exactly the
+    /// services that still need a restore point.
+    ///
+    /// What survives the attempt is not the same set that survived inside it. Every preserved
+    /// entry was kept for the whole run so no untouched service could lose its restore point
+    /// mid-flight, but only the entries that were already on disk beforehand may outlive it: one
+    /// this attempt captured itself belongs to a service nobody overrode, and leaving it behind
+    /// is how a later enable comes to write a stale snapshot over a newer user setting.
+    private func finishDirectRestore(
+        backup: DirectProxyBackup,
+        unresolvedServices: [String],
+        retention: ProxyBackupRetention,
+        preservedRecoveryPending: Bool,
+        journal: [ProxyServiceRecoveryJournalEntry],
+        commandsSucceeded: Bool,
+        proxyStillPointsAtRockxy: Bool
+    )
+        -> Bool
+    {
+        let restored = Self.shouldClearDirectBackupAfterRestoreAttempt(
+            commandsSucceeded: commandsSucceeded,
+            proxyStillPointsAtRockxy: proxyStillPointsAtRockxy
+        )
+        let survivingPreservedServices = retention.preservedServicesPredatingAttempt
+        lock.lock()
+        if restored {
+            // The authorized services are back where they started. Entries that predate this
+            // attempt are still the only restore point their own services have, so the file is
+            // narrowed to them rather than deleted.
+            if survivingPreservedServices.isEmpty {
+                clearDirectBackup()
+            } else {
+                // They keep the flag they arrived with. This attempt did not start a recovery for
+                // them, and claiming it had would keep them in play at every later launch.
+                retainUnresolvedDirectBackup(
+                    backup: backup,
+                    unresolvedServices: survivingPreservedServices,
+                    journal: journal,
+                    recoveryPending: preservedRecoveryPending
+                )
+            }
+            directRestorePending = false
+        } else {
+            if commandsSucceeded {
+                Self.logger.warning(
+                    "Direct restore commands completed but proxy still points at Rockxy — keeping backup on disk for watchdog retry"
+                )
+            } else {
+                Self.logger.warning("Partial restore failure — keeping backup on disk for retry")
+            }
+            // Nothing is removed when there is nothing to keep: an attempt that could not show
+            // the settings are back is not one whose word to delete a restore point is worth
+            // taking.
+            retainUnresolvedDirectBackup(
+                backup: backup,
+                unresolvedServices: retention.retainedAfterAttempt(unresolvedServices: unresolvedServices),
+                journal: journal
+            )
+            // directRestorePending stays true for same-session retry
+        }
+        lock.unlock()
+        return restored
+    }
+
+    // MARK: - Direct Override Rollback
+
+    /// Puts back every service an enable attempt mutated, and reports whether it managed to.
+    ///
+    /// Only the mutated services are authorized, and only they are written. The entries for
+    /// services the attempt never reached stay in the backup on disk for the whole rollback
+    /// rather than being removed and added back at the end: a crash or a failed write in between
+    /// would otherwise be the moment an untouched service lost the restore point it still needs.
+    ///
+    /// Being touched is not on its own a licence to write. A service is recorded as touched
+    /// before its first command runs, so each one has to show that its live settings really are
+    /// one of the states the override sequence passes through — which leaves a command that never
+    /// mutated anything, and a change somebody else made in the meantime, exactly as they are.
+    @discardableResult
+    private func rollBackDirectOverride(
+        touchedServices: [String],
+        preAttemptServices: Set<String>
+    ) -> Bool {
+        guard let backup = loadDirectBackup() else {
+            return !directBackupFileExists
+        }
+        guard !touchedServices.isEmpty else {
+            // Nothing was written, so nothing needs undoing — but this attempt may have captured
+            // entries for services it never reached, and those describe settings nobody
+            // overrode. Narrowing to what predates the attempt is what keeps a later enable from
+            // replaying them over a newer user setting.
+            return finishDirectRestore(
+                backup: backup,
+                unresolvedServices: [],
+                retention: ProxyBackupRetention(
+                    authorized: [],
+                    preserved: backup.services.map(\.service),
+                    preAttemptServices: preAttemptServices
+                ),
+                preservedRecoveryPending: backup.recoveryPending,
+                journal: backup.journal,
+                commandsSucceeded: true,
+                proxyStillPointsAtRockxy: false
+            )
+        }
+
+        let touched = Set(touchedServices)
+        return restoreDirectMode(
+            using: backup,
+            authorizedServices: touched,
+            locallyMutatedServices: touched,
+            preAttemptServices: preAttemptServices
+        )
+    }
+
     /// Recovery's per-service ownership view of a backup. `currentProxyMatchesRockxy` answers a
     /// readiness question — is capture actually routed through Rockxy — and deliberately requires
     /// the routed service, or every backed-up service, to match. Recovery asks something else:
@@ -1622,37 +2254,83 @@ extension SystemProxyManager {
         )
     }
 
-    /// Once a restore has started, every retained entry is known unresolved even if a partial
-    /// command already changed the live shape enough that strict ownership no longer matches.
+    /// Once a restore has started, every retained entry stays in play even if a partial command
+    /// already changed the live shape enough that strict ownership no longer matches. Which of
+    /// them may still be written is decided per service against the recovery journal, so a
+    /// service the user changed between attempts is dropped rather than overwritten.
     private func recoverableDirectServices(in backup: DirectProxyBackup) -> [String] {
-        if backup.recoveryPending {
+        if backup.recoveryPending || !backup.journal.isEmpty {
             return backup.services.map(\.service)
         }
-        return residualRockxyOwnedServices(
-            port: backup.rockxyPort,
-            backedUpServices: backup.services.map(\.service)
+
+        let backedUpServices = backup.services.map(\.service)
+        let liveStates = currentRestorationStates(for: backedUpServices)
+        guard liveStates.count == backedUpServices.count else {
+            // A transient read failure is not evidence that the override disappeared. Keep every
+            // entry recoverable so the planner can defer unreadable services without discarding
+            // the only restore point.
+            return backedUpServices
+        }
+        return ProxyOverrideOwnership.residualOwnedServices(
+            in: backedUpServices.compactMap { liveStates[$0]?.overrideState },
+            port: backup.rockxyPort
         )
     }
 
-    /// Reads only the fields ownership depends on for one service.
+    /// Reads only the fields ownership depends on for one service. A service whose settings
+    /// cannot be read reports as not overridden, which keeps recovery from claiming ownership it
+    /// cannot prove.
     private func currentOverrideState(for service: String) -> ProxyServiceOverrideState {
-        let snapshot = captureProxySnapshot(for: service)
-        let bypassOutput = (try? runNetworkSetup(["-getproxybypassdomains", service])) ?? ""
-        let hasGlobalBypass = bypassOutput.components(separatedBy: "\n").contains {
-            $0.trimmingCharacters(in: .whitespacesAndNewlines) == "*"
+        restorationState(for: service)?.overrideState
+            ?? ProxyServiceOverrideState.unreadable(service: service)
+    }
+
+    /// The full restoration-relevant shape of each service, keyed by service name.
+    ///
+    /// A service whose settings cannot be read is left out rather than reported as empty: an
+    /// unreadable service is not a changed one, and an empty state would look exactly like a user
+    /// who had just turned every proxy off — which is the difference between deferring a service
+    /// and writing over it.
+    fileprivate func currentRestorationStates(
+        for services: [String]
+    )
+        -> [String: ProxyServiceRestorationState]
+    {
+        var states: [String: ProxyServiceRestorationState] = [:]
+        for service in services {
+            states[service] = restorationState(for: service)
         }
-        return ProxyServiceOverrideState(
+        return states
+    }
+
+    /// Reads every proxy field of one service, or nothing at all. A single failed `networksetup`
+    /// read makes the whole state nil: a partially read service cannot be compared against a
+    /// journal without inventing values for the fields that were not read.
+    fileprivate func restorationState(for service: String) -> ProxyServiceRestorationState? {
+        guard let httpOutput = try? runNetworkSetup(["-getwebproxy", service]),
+              let httpsOutput = try? runNetworkSetup(["-getsecurewebproxy", service]),
+              let socksOutput = try? runNetworkSetup(["-getsocksfirewallproxy", service]),
+              let pacOutput = try? runNetworkSetup(["-getautoproxyurl", service]),
+              let autoDiscoveryOutput = try? runNetworkSetup(["-getproxyautodiscovery", service]),
+              let bypassOutput = try? runNetworkSetup(["-getproxybypassdomains", service])
+        else {
+            return nil
+        }
+
+        let http = parseProxyOutput(httpOutput)
+        let https = parseProxyOutput(httpsOutput)
+        let socks = parseProxyOutput(socksOutput)
+        let pac = ProxyRestoreCommandBuilder.parsePACOutput(pacOutput)
+
+        return ProxyServiceRestorationState(
             service: service,
-            httpEnabled: snapshot.httpEnabled,
-            httpHost: snapshot.httpHost,
-            httpPort: snapshot.httpPort,
-            httpsEnabled: snapshot.httpsEnabled,
-            httpsHost: snapshot.httpsHost,
-            httpsPort: snapshot.httpsPort,
-            socksEnabled: snapshot.socksEnabled,
-            pacEnabled: snapshot.pacEnabled,
-            autoDiscoveryEnabled: snapshot.autoDiscoveryEnabled,
-            hasGlobalBypass: hasGlobalBypass
+            http: ProxyEndpointState(enabled: http.enabled, host: http.host, port: http.port),
+            https: ProxyEndpointState(enabled: https.enabled, host: https.host, port: https.port),
+            socks: ProxyEndpointState(enabled: socks.enabled, host: socks.host, port: socks.port),
+            pacEnabled: pac.enabled,
+            pacURL: pac.url,
+            autoDiscoveryEnabled: ProxyRestoreCommandBuilder.parseAutoDiscoveryOutput(autoDiscoveryOutput),
+            bypassDomains: ProxyBypassDomainOutput.parse(bypassOutput)
         )
     }
 
@@ -1662,15 +2340,18 @@ extension SystemProxyManager {
     /// the original backup stays put and no setting is touched.
     @discardableResult
     private func recoverOwnedDirectServices(backup: DirectProxyBackup, ownedServices: [String]) -> Bool {
-        let ownedBackup = DirectProxyBackup(
+        let retainedServices = Set(ownedServices)
+        let ownedBackup = backup.with(
             services: ProxyBackupSubset.select(
                 backup.services,
-                services: Set(ownedServices),
+                services: retainedServices,
                 serviceName: \.service
             ),
-            timestamp: backup.timestamp,
-            rockxyPort: backup.rockxyPort,
-            recoveryPending: true
+            journal: ProxyBackupSubset.select(
+                backup.journal,
+                services: retainedServices,
+                serviceName: \.service
+            )
         )
         guard !ownedBackup.services.isEmpty else {
             clearDirectBackup()
@@ -1690,29 +2371,33 @@ extension SystemProxyManager {
         return restoreDirectMode(using: ownedBackup)
     }
 
-    /// Keeps only the services a restore attempt left unresolved, so the retry cannot write the
-    /// captured settings back onto a service that already restored.
+    /// Keeps only the services a restore attempt left unresolved, along with their journal
+    /// records, so the retry cannot write the captured settings back onto a service that already
+    /// restored — or onto one the user has since changed.
     private func retainUnresolvedDirectBackup(
         backup: DirectProxyBackup,
-        failedServices: Set<String>,
-        stillOwnedServices: Set<String>
+        unresolvedServices: [String],
+        journal: [ProxyServiceRecoveryJournalEntry],
+        recoveryPending: Bool? = nil
     ) {
-        let unresolvedEntries = ProxyBackupSubset.unresolvedEntries(
-            backup.services,
-            failedServices: failedServices,
-            stillOwnedServices: stillOwnedServices,
-            serviceName: \.service
-        )
-        guard !unresolvedEntries.isEmpty, unresolvedEntries.count < backup.services.count else {
+        guard !unresolvedServices.isEmpty else {
             return
         }
 
+        let retainedServices = Set(unresolvedServices)
         do {
-            try writeDirectBackup(DirectProxyBackup(
-                services: unresolvedEntries,
-                timestamp: backup.timestamp,
-                rockxyPort: backup.rockxyPort,
-                recoveryPending: true
+            try writeDirectBackup(backup.with(
+                services: ProxyBackupSubset.select(
+                    backup.services,
+                    services: retainedServices,
+                    serviceName: \.service
+                ),
+                journal: ProxyBackupSubset.select(
+                    journal,
+                    services: retainedServices,
+                    serviceName: \.service
+                ),
+                recoveryPending: recoveryPending
             ))
         } catch {
             Self.logger
@@ -1748,6 +2433,139 @@ extension SystemProxyManager {
         }
 
         return stillOwnedServices
+    }
+}
+
+// MARK: - Launch-Time Recovery
+
+extension SystemProxyManager {
+    /// The identity and executable a direct-mode watchdog is submitted with, resolved before any
+    /// service is mutated.
+    private struct DirectWatchdogArming {
+        let executableURL: URL
+        let parentPID: pid_t
+        let parentStartSignature: String
+    }
+
+    /// Resolves that arming, or refuses the override outright. Both halves have to be in hand
+    /// before anything is written: an override applied first and watched afterwards can outlive
+    /// the app with nothing watching it at all.
+    private func directWatchdogArming() throws -> DirectWatchdogArming {
+        let executableURL = Self.directWatchdogExecutableURL
+        let parentPID = ProcessInfo.processInfo.processIdentifier
+        let parentStartSignature = ProcessStartIdentity.startSignature(for: parentPID)
+
+        guard Self.directWatchdogPreflightIsSatisfied(
+            executableIsAvailable: FileManager.default.isExecutableFile(atPath: executableURL.path),
+            parentStartSignature: parentStartSignature
+        ), let parentStartSignature else {
+            throw SystemProxyError.directProxyWatchdogUnavailable(
+                reason: "this process could not be identified to the watchdog, or the watchdog executable is missing"
+            )
+        }
+
+        return DirectWatchdogArming(
+            executableURL: executableURL,
+            parentPID: parentPID,
+            parentStartSignature: parentStartSignature
+        )
+    }
+
+    private var directBackupFileExists: Bool {
+        FileManager.default.fileExists(atPath: Self.directBackupURL.path)
+    }
+
+    private func directBackupBelongsToCurrentProcess(_ backup: DirectProxyBackup) -> Bool {
+        let processIdentifier = ProcessInfo.processInfo.processIdentifier
+        return DirectProxyBackupOwnerPolicy.belongsToSession(
+            backup,
+            processIdentifier: processIdentifier,
+            processStartSignature: ProcessStartIdentity.startSignature(for: processIdentifier)
+        )
+    }
+
+    private func directBackupOwnerIsLive(_ backup: DirectProxyBackup) -> Bool {
+        DirectProxyBackupOwnerPolicy.ownerIsLive(
+            backup,
+            processIsAlive: ProcessStartIdentity.isAlive,
+            liveStartSignature: ProcessStartIdentity.startSignature
+        )
+    }
+
+    /// Called at app launch to detect and restore stale direct-mode proxy overrides left behind
+    /// by a crash or force-quit.
+    func recoverStaleProxyIfNeeded() async {
+        await Self.lifecycleGate.withOperation { [self] in
+            await recoverStaleProxyIfNeededLocked()
+        }
+    }
+
+    private func recoverStaleProxyIfNeededLocked() async {
+        switch recoverStaleDirectProxyIfNeeded() {
+        case .restored:
+            stopBypassListObserver()
+            clearInMemoryOverrideState()
+            NotificationCenter.default.post(
+                name: .systemProxyDidChange,
+                object: nil,
+                userInfo: ["enabled": false]
+            )
+        case .restoreIncomplete:
+            lock.withLock { directRestorePending = true }
+        case .preserved:
+            Self.logger.info("A live app process owns the direct proxy backup — preserving its session")
+        case .noBackup, .cleared:
+            break
+        }
+
+        // Helper startup recovery and its owner watchdog make this decision from the persisted
+        // PID and start signature. An app-side status probe cannot distinguish a stale override
+        // from another live Rockxy instance, so it must never restore one unconditionally.
+    }
+
+    private func recoverStaleDirectProxyIfNeeded() -> DirectStaleRecoveryOutcome {
+        Self.operationGate.withOperation { [self] in
+            do {
+                return try DirectProxySessionLock.withExclusiveAccess(backupURL: Self.directBackupURL) {
+                    guard directBackupFileExists else {
+                        return .noBackup
+                    }
+                    guard let backup = loadDirectBackup() else {
+                        Self.logger.error("Stale direct backup could not be read — preserving it for retry")
+                        return .restoreIncomplete
+                    }
+                    guard !directBackupOwnerIsLive(backup) else {
+                        return .preserved
+                    }
+
+                    let residualOwnedServices = recoverableDirectServices(in: backup)
+                    switch ProxyBackupRecoveryPolicy.action(
+                        residualOwnedServicesExist: !residualOwnedServices.isEmpty,
+                        ownerSessionIsLive: false
+                    ) {
+                    case .restore:
+                        Self.logger
+                            .info(
+                                "Recovering \(residualOwnedServices.count) stale direct-mode service(s) from a previous session"
+                            )
+                        guard recoverOwnedDirectServices(backup: backup, ownedServices: residualOwnedServices) else {
+                            Self.logger.error("Stale direct proxy recovery incomplete — backup preserved for retry")
+                            return .restoreIncomplete
+                        }
+                        return .restored
+                    case .clear:
+                        Self.logger.info("No backed-up service is still Rockxy-owned, clearing stale direct backup")
+                        clearDirectBackup()
+                        return .cleared
+                    case .preserve:
+                        return .preserved
+                    }
+                }
+            } catch {
+                Self.logger.error("Could not acquire direct proxy recovery lock: \(error.localizedDescription)")
+                return .restoreIncomplete
+            }
+        }
     }
 }
 

--- a/RockxyHelperTool/CrashRecovery.swift
+++ b/RockxyHelperTool/CrashRecovery.swift
@@ -1,6 +1,22 @@
 import Foundation
 import os
 
+// MARK: - CrashRecoveryError
+
+enum CrashRecoveryError: LocalizedError {
+    case backupOwnedByAnotherSession
+    case backupUnreadable
+
+    var errorDescription: String? {
+        switch self {
+        case .backupOwnedByAnotherSession:
+            "Another app process owns the existing proxy recovery backup"
+        case .backupUnreadable:
+            "The proxy recovery backup exists but could not be read safely"
+        }
+    }
+}
+
 /// Manages proxy settings backup and crash recovery.
 /// Stores original proxy configuration to a plist file before Rockxy overrides it.
 /// On daemon launch, checks for stale backups indicating a previous crash and restores settings.
@@ -108,18 +124,28 @@ enum CrashRecovery {
             rockxyPort: Int?,
             ownerPID: Int32?,
             ownerStartSignature: String?,
-            recoveryPending: Bool = false
+            ownerUID: uid_t? = nil,
+            recoveryPending: Bool = false,
+            journal: [ProxyServiceRecoveryJournalEntry] = [],
+            copyRole: ProxyBackupCopyRole? = nil
         ) {
             self.services = services
             self.timestamp = timestamp
             self.rockxyPort = rockxyPort
             self.ownerPID = ownerPID
             self.ownerStartSignature = ownerStartSignature
+            self.ownerUID = ownerUID
             self.recoveryPending = recoveryPending
+            self.journal = journal
+            self.copyRole = copyRole
         }
 
         /// Backups written before owner identity existed decode with no owner, which recovery
-        /// reads as "the session that took this override is gone".
+        /// reads as "the session that took this override is gone". A backup written before the
+        /// recovery journal existed decodes with an empty journal, which recovery reads as "no
+        /// step has been recorded for these services yet". One written before the copy marker
+        /// existed decodes with no role, which is what keeps its compatibility location readable
+        /// by this build.
         init(from decoder: any Decoder) throws {
             let container = try decoder.container(keyedBy: CodingKeys.self)
             services = try container.decode([ServiceProxyBackup].self, forKey: .services)
@@ -127,7 +153,14 @@ enum CrashRecovery {
             rockxyPort = try container.decodeIfPresent(Int.self, forKey: .rockxyPort)
             ownerPID = try container.decodeIfPresent(Int32.self, forKey: .ownerPID)
             ownerStartSignature = try container.decodeIfPresent(String.self, forKey: .ownerStartSignature)
+            ownerUID = try container.decodeIfPresent(uid_t.self, forKey: .ownerUID)
             recoveryPending = try container.decodeIfPresent(Bool.self, forKey: .recoveryPending) ?? false
+            // A journal record this build cannot read must not cost the backup its restore point,
+            // and must not cost the records beside it either: each one is read on its own, and a
+            // service left without a usable record is deferred rather than rebaselined from
+            // settings that may now belong to the user.
+            journal = ProxyRecoveryJournalCoding.decodeEntries(from: container, forKey: .journal)
+            copyRole = try? container.decodeIfPresent(ProxyBackupCopyRole.self, forKey: .copyRole)
         }
 
         // MARK: Internal
@@ -139,10 +172,33 @@ enum CrashRecovery {
         /// tells it apart from a later process which inherited the same PID.
         let ownerPID: Int32?
         let ownerStartSignature: String?
+        let ownerUID: uid_t?
         /// True after recovery has narrowed the backup and before every retained entry has been
-        /// fully restored. Retained entries remain authoritative even after partial commands
-        /// change their live shape enough that strict ownership no longer matches.
+        /// fully restored. Kept so a build that predates the journal still reads this backup the
+        /// way it always has.
         let recoveryPending: Bool
+        /// Per-service recovery intent. Each entry records the state its step expected to find
+        /// and the state that step leaves behind, which is what lets a retry tell an interrupted
+        /// restore apart from a service the user has since changed.
+        let journal: [ProxyServiceRecoveryJournalEntry]
+        /// Which on-disk copy this is. Absent only on a backup written before the marker existed.
+        let copyRole: ProxyBackupCopyRole?
+
+        /// The same backup labelled as one of its copies, which is what distinguishes the record
+        /// a commit publishes from the one kept only so an older build can still find something.
+        func markedAs(_ role: ProxyBackupCopyRole) -> ProxyBackup {
+            ProxyBackup(
+                services: services,
+                timestamp: timestamp,
+                rockxyPort: rockxyPort,
+                ownerPID: ownerPID,
+                ownerStartSignature: ownerStartSignature,
+                ownerUID: ownerUID,
+                recoveryPending: recoveryPending,
+                journal: journal,
+                copyRole: role
+            )
+        }
 
         // MARK: Private
 
@@ -152,8 +208,31 @@ enum CrashRecovery {
             case rockxyPort
             case ownerPID
             case ownerStartSignature
+            case ownerUID
             case recoveryPending
+            case journal
+            case copyRole
         }
+    }
+
+    /// The still-live owner a preserved backup belongs to. The start signature travels with the
+    /// identifier so the re-armed watchdog watches the same process, not whatever later inherits
+    /// its PID. It is not optional: a preserved owner has just been authenticated against that
+    /// exact signature, so there is always one to hand on.
+    struct PreservedOwner: Equatable {
+        // MARK: Lifecycle
+
+        init(processIdentifier: Int32, startSignature: String, userID: uid_t?) {
+            self.processIdentifier = processIdentifier
+            self.startSignature = startSignature
+            self.userID = userID
+        }
+
+        // MARK: Internal
+
+        let processIdentifier: Int32
+        let startSignature: String
+        let userID: uid_t?
     }
 
     /// What launch-time recovery did with the backup it found.
@@ -163,17 +242,36 @@ enum CrashRecovery {
         case restored
         case restoreIncomplete
         /// The recorded owner is still alive and still passes caller validation, so its override
-        /// stays in place. The PID is handed back so the helper can re-arm its owner watchdog.
-        case preserved(ownerPID: Int32?)
+        /// stays in place. The owner identity is handed back so the helper can re-arm its
+        /// watchdog against the same process.
+        case preserved(owner: PreservedOwner?)
     }
 
     // MARK: - Public API
 
     /// Save current proxy settings for all specified services before overriding them.
     /// The owning app process is recorded with the backup so a later helper launch can tell a
-    /// still-running session from a stranded override.
-    static func saveOriginalSettings(services: [String], rockxyPort: Int, ownerPID: Int32) throws {
-        let existingBackup = loadBackup()
+    /// still-running session from a stranded override. The caller supplies the start signature it
+    /// already acquired, so the identity written here is the same one the watchdog watches.
+    @discardableResult
+    static func saveOriginalSettings(
+        services: [String],
+        rockxyPort: Int,
+        ownerPID: Int32,
+        ownerStartSignature: String,
+        ownerUID: uid_t
+    ) throws -> ProxyBackup {
+        let existingBackup = try loadBackup()
+        if let existingBackup,
+           !HelperBoundProcessIdentityPolicy.recordedSessionBelongsToCaller(
+               recordedOwnerPID: existingBackup.ownerPID,
+               recordedOwnerStartSignature: existingBackup.ownerStartSignature,
+               callerPID: ownerPID,
+               callerStartSignature: ownerStartSignature
+           )
+        {
+            throw CrashRecoveryError.backupOwnedByAnotherSession
+        }
         let existingServices = Set(existingBackup?.services.map(\.service) ?? [])
         let servicesToCapture = services.filter { !existingServices.contains($0) }
 
@@ -225,13 +323,22 @@ enum CrashRecovery {
             }
         }
 
+        // Whatever the previous attempt recorded travels with the extended backup. See
+        // `ProxyBackupExtension` for why adding a service or changing the port must never be the
+        // moment a record is dropped.
+        let carried = ProxyBackupExtension.carriedForward(
+            journal: existingBackup?.journal,
+            recoveryPending: existingBackup?.recoveryPending
+        )
         let backup = ProxyBackup(
             services: (existingBackup?.services ?? []) + serviceBackups,
             timestamp: existingBackup?.timestamp ?? Date(),
             rockxyPort: rockxyPort,
             ownerPID: ownerPID,
-            ownerStartSignature: ProcessStartIdentity.startSignature(for: ownerPID),
-            recoveryPending: false
+            ownerStartSignature: ownerStartSignature,
+            ownerUID: ownerUID,
+            recoveryPending: carried.recoveryPending,
+            journal: carried.journal
         )
 
         do {
@@ -244,47 +351,157 @@ enum CrashRecovery {
             logger.error("Failed to save proxy backup: \(error.localizedDescription)")
             throw error
         }
+
+        return backup
     }
 
     /// Writes a backup to every backup location with owner-only permissions.
     /// Used both for the initial capture and for the reduced backup a subset restore persists
     /// before it touches any setting.
+    ///
+    /// One location is authoritative and its publication is the commit: it either happened or it
+    /// did not, with nothing left to fail afterwards. The second location exists so a build that
+    /// predates the current support directory can still find a backup.
+    ///
+    /// The compatibility copies are dealt with *before* the commit, and a copy that can be neither
+    /// marked nor removed stops this call before the commit is attempted. That order is the whole
+    /// guarantee. A build older than the marker wrote unmarked bytes to both locations, and this
+    /// build reads an unmarked compatibility copy as truth — correctly, because for that build it
+    /// was the only backup there was. Committing first and mirroring afterwards would leave those
+    /// stale unmarked bytes sitting beside a record that had already moved on, and the moment the
+    /// authoritative file was lost they would be read back and written onto the user's services.
+    /// Marking the copy first means an unmarked one can only survive where no commit in the
+    /// current format ever succeeded, which is exactly when it is the honest answer.
+    ///
+    /// A throw therefore means nothing was committed, which is what the callers that treat a
+    /// successful write as their permission to issue a command depend on.
     static func persist(_ backup: ProxyBackup) throws {
-        try ensureBackupDirectoryExists()
-        let data = try PropertyListEncoder().encode(backup)
-        for url in backupURLs {
-            try data.write(to: url, options: .atomic)
-            try FileManager.default.setAttributes(
-                [.posixPermissions: 0o600],
-                ofItemAtPath: url.path
-            )
+        guard let authoritativeURL = backupURLs.first else {
+            return
         }
+        try ensureBackupDirectoryExists(for: authoritativeURL)
+
+        let encoder = PropertyListEncoder()
+        let authoritativeData = try encoder.encode(backup.markedAs(.authoritative))
+        let mirrorData = try encoder.encode(backup.markedAs(.mirror))
+
+        try ProxyBackupCommit.run(
+            prepareCompatibilityCopies: {
+                for url in backupURLs.dropFirst() {
+                    try prepareCompatibilityCopy(mirrorData, at: url)
+                }
+            },
+            publishAuthoritative: {
+                try ProxyBackupFilePublication.publish(authoritativeData, to: authoritativeURL)
+            }
+        )
     }
 
-    /// Narrows the backup on disk to `services` before a subset restore mutates anything.
+    /// Narrows the backup on disk to `services` before a subset restore mutates anything, and
+    /// records the recovery intent for exactly those services.
+    ///
     /// Dropping the entries recovery no longer owns is what stops a later retry from writing
-    /// stale settings over a service the user has since changed.
+    /// stale settings over a service the user has since changed; writing the journal in the same
+    /// step is what lets that retry tell an interrupted restore apart from such a change.
+    ///
+    /// `recoveryPending` says whether this narrowing is about to be followed by a write. An
+    /// attempt that decided to write nothing leaves the flag alone, because marking recovery as
+    /// started would cost every service in the backup the one chance it has to record the state
+    /// its restore begins from.
+    @discardableResult
     static func reduceBackup(
         _ backup: ProxyBackup,
         to services: [String],
-        rockxyPort: Int? = nil
+        rockxyPort: Int? = nil,
+        journal: [ProxyServiceRecoveryJournalEntry]? = nil,
+        recoveryPending: Bool = true
     )
         throws -> ProxyBackup
     {
+        let retainedServices = Set(services)
+        let retainedJournal = ProxyBackupSubset.select(
+            journal ?? backup.journal,
+            services: retainedServices,
+            serviceName: \.service
+        )
         let reduced = ProxyBackup(
             services: ProxyBackupSubset.select(
                 backup.services,
-                services: Set(services),
+                services: retainedServices,
                 serviceName: \.service
             ),
             timestamp: backup.timestamp,
             rockxyPort: backup.rockxyPort ?? rockxyPort,
-            ownerPID: nil,
-            ownerStartSignature: nil,
-            recoveryPending: true
+            ownerPID: backup.ownerPID,
+            ownerStartSignature: backup.ownerStartSignature,
+            ownerUID: backup.ownerUID,
+            recoveryPending: recoveryPending,
+            journal: retainedJournal
         )
         try persist(reduced)
         return reduced
+    }
+
+    /// Records what an override is about to do, without narrowing the backup or disturbing the
+    /// session that owns it.
+    ///
+    /// This is not `reduceBackup`. That one is recovery's own bookkeeping: it drops the services
+    /// recovery no longer owns and says a recovery has started. None of that is true here — the
+    /// override has not begun, every captured service
+    /// still needs its entry, and the owner is precisely the session being recorded. Only the
+    /// journal changes.
+    @discardableResult
+    static func recordOverrideApplication(
+        _ backup: ProxyBackup,
+        journal: [ProxyServiceRecoveryJournalEntry]
+    )
+        throws -> ProxyBackup
+    {
+        let recorded = ProxyBackup(
+            services: backup.services,
+            timestamp: backup.timestamp,
+            rockxyPort: backup.rockxyPort,
+            ownerPID: backup.ownerPID,
+            ownerStartSignature: backup.ownerStartSignature,
+            ownerUID: backup.ownerUID,
+            recoveryPending: backup.recoveryPending,
+            journal: journal
+        )
+        try persist(recorded)
+        return recorded
+    }
+
+    /// Drops the entries an override attempt captured for services it then never touched, leaving
+    /// the owner identity and everything else exactly as it is.
+    ///
+    /// This is not `reduceBackup`. That one is recovery's own bookkeeping: it drops the services
+    /// recovery no longer owns and says a recovery has started. None of that is true here — the
+    /// session is running and still owns everything that
+    /// is left. What goes is only what describes settings nobody overrode, because keeping it
+    /// would hand the next override a snapshot older than whatever the user has set since.
+    @discardableResult
+    static func dropUntouchedCapturedServices(
+        _ backup: ProxyBackup,
+        services: [String]
+    )
+        throws -> ProxyBackup
+    {
+        let dropped = Set(services)
+        guard backup.services.contains(where: { dropped.contains($0.service) }) else {
+            return backup
+        }
+        let narrowed = ProxyBackup(
+            services: backup.services.filter { !dropped.contains($0.service) },
+            timestamp: backup.timestamp,
+            rockxyPort: backup.rockxyPort,
+            ownerPID: backup.ownerPID,
+            ownerStartSignature: backup.ownerStartSignature,
+            ownerUID: backup.ownerUID,
+            recoveryPending: backup.recoveryPending,
+            journal: backup.journal.filter { !dropped.contains($0.service) }
+        )
+        try persist(narrowed)
+        return narrowed
     }
 
     /// Check for stale backup on daemon launch and restore if found.
@@ -297,16 +514,35 @@ enum CrashRecovery {
             return .noBackup
         }
 
-        guard let backup = loadBackup() else {
-            logger.warning("Backup file exists but could not be read — clearing")
-            clearBackup()
-            return .cleared
+        let backup: ProxyBackup
+        do {
+            guard let loadedBackup = try loadBackup() else {
+                logger.info("No readable proxy backup remains — clean startup")
+                return .noBackup
+            }
+            backup = loadedBackup
+        } catch {
+            logger.error("Backup file exists but could not be read — preserving it for retry")
+            return .restoreIncomplete
         }
 
         // Legacy backups predate the persisted port, so fall back to the port the backed-up
         // services are still overriding, then to the port the live status reports. With none of
         // those, nothing can be identified as Rockxy-owned.
-        let overrideStates = ProxyConfigurator.currentOverrideStates(for: backup.services.map(\.service))
+        let backedUpServices = backup.services.map(\.service)
+        // One read serves every question below: which services still carry the override, which
+        // port they carry it on, and whether the recorded session ever finished applying it.
+        let liveStates = ProxyConfigurator.currentRestorationStates(for: backedUpServices)
+        let overrideStates = backedUpServices.map {
+            liveStates[$0]?.overrideState ?? ProxyServiceOverrideState.unreadable(service: $0)
+        }
+        if liveStates.count != backedUpServices.count {
+            // A failed read is not evidence that an override disappeared. This is especially
+            // important for backups created before journaling, where strict ownership would
+            // otherwise see no residual service and discard the only restore point.
+            logger.error("At least one backed-up service is unreadable — preserving backup for retry")
+            return .restoreIncomplete
+        }
         let fallbackPort: () -> Int? = {
             if let inferredPort = ProxyOverrideOwnership.inferredOwnedPort(in: overrideStates) {
                 return inferredPort
@@ -321,16 +557,40 @@ enum CrashRecovery {
             return .cleared
         }
 
-        let residualOwnedServices = if backup.recoveryPending {
-            backup.services.map(\.service)
+        // A recovery already under way keeps every retained service in play: a partial command
+        // can leave a shape strict ownership no longer recognises. Which of those services may
+        // still be written is then decided per service against the recovery journal, so a
+        // service the user changed between attempts is dropped rather than overwritten.
+        let residualOwnedServices = if backup.recoveryPending || !backup.journal.isEmpty {
+            backedUpServices
         } else {
             ProxyOverrideOwnership.residualOwnedServices(in: overrideStates, port: ownedPort ?? 0)
         }
-        let liveOwnerPID = backup.recoveryPending ? nil : liveOwnerPID(for: backup)
+
+        // A live owner only keeps its session when that session is provably finished: every
+        // backed-up service carrying the exact state its own record says the override ends at. An
+        // application that stopped part-way left a service that is neither Rockxy's nor the user's,
+        // and the sequence that would have completed it has already failed — so the owner still
+        // being alive is not a reason to leave that shape on the machine. It is recovered now,
+        // while the record that explains it is still readable.
+        let sessionIsComplete = !backup.recoveryPending
+            && ProxyOverrideSessionCompletionPolicy.sessionIsFullyApplied(
+                services: backedUpServices,
+                journal: backup.journal,
+                liveStates: liveStates,
+                ownedPort: ownedPort
+            )
+        let liveOwner = sessionIsComplete ? liveOwner(for: backup) : nil
+        if !sessionIsComplete, !backup.recoveryPending, !backup.journal.isEmpty {
+            logger
+                .warning(
+                    "The recorded proxy session did not finish applying its override — recovering it rather than preserving it"
+                )
+        }
 
         switch ProxyBackupRecoveryPolicy.action(
             residualOwnedServicesExist: !residualOwnedServices.isEmpty,
-            ownerSessionIsLive: liveOwnerPID != nil
+            ownerSessionIsLive: liveOwner != nil
         ) {
         case .restore:
             logger
@@ -349,7 +609,7 @@ enum CrashRecovery {
             }
         case .preserve:
             logger.info("Owned proxy backup belongs to a live authenticated owner — preserving the active session")
-            return .preserved(ownerPID: liveOwnerPID)
+            return .preserved(owner: liveOwner)
         case .clear:
             logger.info("No backed-up service still points at the Rockxy session — clearing stale backup")
             clearBackup()
@@ -361,7 +621,11 @@ enum CrashRecovery {
     /// caller validation as the Rockxy app. A recycled PID, a legacy backup with no recorded
     /// identity, or a process that no longer validates all resolve to nil, which makes recovery
     /// treat the override as stranded.
-    static func liveOwnerPID(for backup: ProxyBackup) -> Int32? {
+    ///
+    /// The recorded start signature is returned with the identifier: this call has just proved it
+    /// names the live process, so the watchdog that gets re-armed can keep checking against it
+    /// instead of trusting the PID on its own.
+    static func liveOwner(for backup: ProxyBackup) -> PreservedOwner? {
         guard let ownerPID = backup.ownerPID, ownerPID > 0 else {
             return nil
         }
@@ -383,26 +647,55 @@ enum CrashRecovery {
             return nil
         }
 
-        return ownerPID
+        guard let ownerStartSignature = backup.ownerStartSignature, !ownerStartSignature.isEmpty else {
+            // Unreachable in practice: the identity check above only passes when a signature was
+            // recorded. Refusing here keeps that guarantee local rather than assumed.
+            return nil
+        }
+
+        return PreservedOwner(
+            processIdentifier: ownerPID,
+            startSignature: ownerStartSignature,
+            userID: backup.ownerUID
+        )
     }
 
     /// Load the backup data from disk.
-    /// Returns nil if file doesn't exist, is corrupt, or uses an old format.
-    /// Invalid backup files are cleared automatically.
-    static func loadBackup() -> ProxyBackup? {
-        for url in backupURLs {
+    /// Returns nil only when no copy exists. An unreadable or unrecognized copy is preserved and
+    /// reported as an error so a transient filesystem failure can never be mistaken for a clean
+    /// restore and delete the only recovery point.
+    ///
+    /// A compatibility copy can be a legacy unmarked backup or a current marked mirror. Current
+    /// writers prepare mirrors before the authoritative publication, so a surviving marked copy is
+    /// either the committed record or a safe record whose later commit failed and authorized no
+    /// command. Either preserves the exact restore point when the authoritative file is unavailable.
+    static func loadBackup() throws -> ProxyBackup? {
+        var foundUnusableCopy = false
+        for (index, url) in backupURLs.enumerated() {
             guard FileManager.default.fileExists(atPath: url.path) else {
                 continue
             }
 
             do {
                 let data = try Data(contentsOf: url)
-                return try PropertyListDecoder().decode(ProxyBackup.self, from: data)
+                let backup = try PropertyListDecoder().decode(ProxyBackup.self, from: data)
+                guard ProxyBackupCopyPolicy.isRecoveryTruth(
+                    role: backup.copyRole,
+                    isAuthoritativeLocation: index == 0
+                ) else {
+                    logger.warning("Ignoring a proxy backup whose copy role does not match its location at \(url.path)")
+                    foundUnusableCopy = true
+                    continue
+                }
+                return backup
             } catch {
                 logger.error("Failed to decode proxy backup at \(url.path): \(error.localizedDescription)")
+                foundUnusableCopy = true
             }
         }
-        clearBackup()
+        if foundUnusableCopy {
+            throw CrashRecoveryError.backupUnreadable
+        }
         return nil
     }
 
@@ -446,24 +739,50 @@ enum CrashRecovery {
 
     // MARK: - Private Helpers
 
-    private static func ensureBackupDirectoryExists() throws {
-        for url in backupURLs {
-            let dir = url.deletingLastPathComponent()
-            if !FileManager.default.fileExists(atPath: dir.path) {
-                try FileManager.default.createDirectory(
-                    at: dir,
-                    withIntermediateDirectories: true,
-                    attributes: [.posixPermissions: 0o700]
+    /// Creates the directory one backup location lives in, with owner-only permissions.
+    ///
+    /// The authoritative location and every compatibility location must be ready before the
+    /// authoritative record is committed. A compatibility path that can be neither prepared nor
+    /// cleared blocks the commit so stale unmarked bytes cannot survive beside newer truth.
+    private static func ensureBackupDirectoryExists(for url: URL) throws {
+        let dir = url.deletingLastPathComponent()
+        guard !FileManager.default.fileExists(atPath: dir.path) else {
+            return
+        }
+        try FileManager.default.createDirectory(
+            at: dir,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: ProxyBackupFilePublication.ownerOnlyDirectoryPermissions]
+        )
+    }
+
+    /// Brings one compatibility copy up to date before the authoritative commit is attempted, or
+    /// leaves nothing there a later loader could mistake for truth.
+    ///
+    /// Writing the marked copy is the ordinary path. When that cannot be done, removing whatever
+    /// is at the location is just as good an answer: an absent compatibility copy is never read,
+    /// so nothing stale can survive the commit that follows. Only a file that can be neither
+    /// rewritten nor removed is a genuine blocker, and that throws — before anything is committed
+    /// and therefore before any command is authorized.
+    private static func prepareCompatibilityCopy(_ data: Data, at url: URL) throws {
+        let outcome = try ProxyBackupCompatibilityCopy.prepare(
+            publish: {
+                try ensureBackupDirectoryExists(for: url)
+                try ProxyBackupFilePublication.publish(data, to: url)
+            },
+            remove: { try? FileManager.default.removeItem(at: url) },
+            copyExists: { FileManager.default.fileExists(atPath: url.path) }
+        )
+        if outcome == .invalidated {
+            logger
+                .warning(
+                    "Could not write the compatibility proxy backup at \(url.path) — removed the stale copy instead"
                 )
-            }
         }
     }
 
     private static func readBypassDomains(service: String) throws -> [String] {
-        let output = try readProxySettings(type: "proxybypassdomains", service: service)
-        return output.components(separatedBy: "\n")
-            .map { $0.trimmingCharacters(in: .whitespaces) }
-            .filter { !$0.isEmpty && !$0.hasPrefix("There aren't any bypass domains") }
+        ProxyBypassDomainOutput.parse(try readProxySettings(type: "proxybypassdomains", service: service))
     }
 
     private static func readProxySettings(type: String, service: String) throws -> String {

--- a/RockxyHelperTool/HelperDelegate.swift
+++ b/RockxyHelperTool/HelperDelegate.swift
@@ -16,16 +16,31 @@ final class HelperDelegate: NSObject, NSXPCListenerDelegate {
             return false
         }
 
-        Self.logger.info("Accepted XPC connection from pid \(connection.processIdentifier)")
+        let processID = connection.processIdentifier
+        guard let startSignature = ProcessStartIdentity.startSignature(for: processID),
+              !startSignature.isEmpty
+        else {
+            Self.logger.warning("Rejected XPC connection whose process identity could not be captured (pid: \(processID))")
+            return false
+        }
+
+        Self.logger.info("Accepted XPC connection from pid \(processID)")
         IdleExitMonitor.resetIdleTimer()
 
         connection.exportedInterface = NSXPCInterface(with: RockxyHelperProtocol.self)
-        connection.exportedObject = HelperService.shared
+        // One service object per connection, bound to the peer this listener just authenticated.
+        // Exporting a process-wide object would leave every ownership-bearing method deciding
+        // from an identifier the message carried, which the sender chooses.
+        connection.exportedObject = HelperService(
+            boundConnectionPID: processID,
+            boundConnectionStartSignature: startSignature,
+            boundUserID: connection.effectiveUserIdentifier
+        )
 
         connection.invalidationHandler = {
             let processID = connection.processIdentifier
             Self.logger.warning("XPC connection invalidated for pid \(processID)")
-            HelperService.shared.handleConnectionInvalidated(processID: processID)
+            HelperService.handleConnectionInvalidated(processID: processID)
         }
 
         connection.interruptionHandler = {

--- a/RockxyHelperTool/HelperService.swift
+++ b/RockxyHelperTool/HelperService.swift
@@ -1,4 +1,3 @@
-import Darwin
 import Foundation
 import os
 import Security
@@ -13,13 +12,62 @@ import Security
 final class HelperService: NSObject, RockxyHelperProtocol {
     // MARK: Lifecycle
 
-    override private init() {
+    /// One service object per accepted connection, bound to that connection's authenticated peer.
+    ///
+    /// The exported object used to be a process-wide singleton, which left every ownership-bearing
+    /// method deciding from an identifier the message carried. That identifier is a claim: a
+    /// caller could name any process at all and have the helper arm a watchdog on it, or record
+    /// it as the session that owns the user's proxy settings. Binding the object to the
+    /// connection replaces the claim with something the sender cannot choose.
+    init(boundConnectionPID: Int32, boundConnectionStartSignature: String, boundUserID: uid_t) {
+        self.boundConnectionPID = boundConnectionPID
+        self.boundConnectionStartSignature = boundConnectionStartSignature
+        self.boundUserID = boundUserID
         super.init()
     }
 
     // MARK: Internal
 
-    static let shared = HelperService()
+    /// Retries a retained launch-time restore point under the same gate as XPC mutations.
+    /// Calls coalesce, and a later idle check starts a fresh bounded chain after exhaustion.
+    static func scheduleBackupRecovery(reason: String) {
+        automaticRestoreRetrier.run(
+            key: startupRecoveryRetryKey,
+            operation: {
+                switch performStartupRecovery() {
+                case let .preserved(owner):
+                    if let owner {
+                        resumeOwnerWatchdog(
+                            for: owner.processIdentifier,
+                            startSignature: owner.startSignature,
+                            userID: owner.userID
+                        )
+                    }
+                    return true
+                case .noBackup, .cleared, .restored:
+                    return true
+                case .restoreIncomplete:
+                    logger.warning("Proxy backup recovery after \(reason) remains incomplete and will retry")
+                    return false
+                }
+            },
+            onExhausted: {
+                logger.error("Proxy backup recovery after \(reason) exhausted bounded retries; preserving backup")
+            }
+        )
+    }
+
+    /// Runs helper launch recovery under the same system-wide lock used by direct mode.
+    static func performStartupRecovery() -> CrashRecovery.StartupRecoveryOutcome {
+        do {
+            return try DirectProxySessionLock.withExclusiveAccess(userID: 0) {
+                CrashRecovery.restoreIfNeeded()
+            }
+        } catch {
+            logger.error("Could not serialize helper startup recovery: \(error.localizedDescription)")
+            return .restoreIncomplete
+        }
+    }
 
     func overrideSystemProxy(port: Int, ownerPID: Int32, withReply reply: @escaping (Bool, String?) -> Void) {
         IdleExitMonitor.resetIdleTimer()
@@ -31,34 +79,92 @@ final class HelperService: NSObject, RockxyHelperProtocol {
             return
         }
 
-        guard ownerPID > 0 else {
-            Self.logger.error("SECURITY: Rejected invalid owner PID \(ownerPID)")
-            reply(false, "Invalid owner PID")
+        // The override is recorded and watched for whoever this connection actually is, never for
+        // whoever the message says. The parameter is kept and required to agree so the wire
+        // protocol is unchanged and a disagreement is refused rather than quietly reinterpreted.
+        guard let authorizedOwnerPID = HelperOwnerBindingPolicy.authorizedOwnerPID(
+            boundConnectionPID: boundConnectionPID,
+            requestedOwnerPID: ownerPID
+        ) else {
+            Self.logger
+                .error(
+                    "SECURITY: Rejected owner PID \(ownerPID) — it is not the authenticated connection \(self.boundConnectionPID)"
+                )
+            reply(false, "Owner PID does not match the calling process")
             return
         }
 
-        if let lastChange = lastProxyChangeTime,
-           Date().timeIntervalSince(lastChange) < Self.rateLimitInterval
-        {
-            Self.logger.warning("SECURITY: Rate-limited proxy change request")
-            reply(false, "Too many requests — wait before retrying")
-            return
-        }
-
-        guard let result = Self.mutationGate.withExclusiveAccess({
-            Result {
-                try ProxyConfigurator.overrideProxy(port: port, ownerPID: ownerPID)
-                lastProxyChangeTime = Date()
-                startOwnerWatchdog(for: ownerPID)
+        // The rate-limit check reads and writes the same timestamp, so both halves happen inside
+        // the gate. Deciding outside it let two concurrently delivered requests observe the same
+        // stale value and then race on replacing it.
+        guard let outcome = Self.mutationGate.withExclusiveAccess({ () -> ProxyOverrideOutcome in
+            guard !HelperProxyRateLimitPolicy.isRateLimited(
+                lastChange: Self.lastProxyChangeTime,
+                now: Date(),
+                interval: Self.rateLimitInterval
+            ) else {
+                return .rateLimited
             }
+
+            // The owner's start identity is acquired before a single setting is touched. It is
+            // what the watchdog compares against for the whole session, and a process identifier
+            // on its own is recyclable — so an override that cannot be tied to an exact process
+            // is refused rather than left with a watchdog that cannot tell one from another.
+            let liveStartSignature = ProcessStartIdentity.startSignature(for: authorizedOwnerPID)
+            guard HelperBoundProcessIdentityPolicy.isCurrent(
+                boundPID: authorizedOwnerPID,
+                boundStartSignature: boundConnectionStartSignature,
+                liveStartSignature: liveStartSignature
+            ) else {
+                return .ownerIdentityUnavailable
+            }
+            let startSignature = boundConnectionStartSignature
+
+            return .attempted(Result {
+                try DirectProxySessionLock.withExclusiveAccess(userID: boundUserID) {
+                    guard !DirectProxySessionLock.anyDirectBackupExists() else {
+                        throw ProxyConfiguratorError.directSessionInUse
+                    }
+                    do {
+                        try ProxyConfigurator.overrideProxy(
+                            port: port,
+                            ownerPID: authorizedOwnerPID,
+                            ownerStartSignature: startSignature,
+                            ownerUID: boundUserID
+                        )
+                    } catch ProxyConfiguratorError.overrideRollbackIncomplete(let services) {
+                        // A partial rollback gets the same live watchdog as a successful override.
+                        Self.lastProxyChangeTime = Date()
+                        Self.startOwnerWatchdog(
+                            for: authorizedOwnerPID,
+                            startSignature: startSignature,
+                            userID: boundUserID
+                        )
+                        throw ProxyConfiguratorError.overrideRollbackIncomplete(services: services)
+                    }
+                    Self.lastProxyChangeTime = Date()
+                    Self.startOwnerWatchdog(
+                        for: authorizedOwnerPID,
+                        startSignature: startSignature,
+                        userID: boundUserID
+                    )
+                }
+            })
         }) else {
             reply(false, HelperPrivilegedMutationGate.busyMessage)
             return
         }
-        switch result {
-        case .success:
+
+        switch outcome {
+        case .rateLimited:
+            Self.logger.warning("SECURITY: Rate-limited proxy change request")
+            reply(false, "Too many requests — wait before retrying")
+        case .ownerIdentityUnavailable:
+            Self.logger.error("SECURITY: Refused proxy override — the requesting process could not be identified")
+            reply(false, "Could not identify the requesting app — no proxy settings were changed")
+        case .attempted(.success):
             reply(true, nil)
-        case let .failure(error):
+        case let .attempted(.failure(error)):
             Self.logger.error("Failed to override proxy: \(error.localizedDescription)")
             reply(false, error.localizedDescription)
         }
@@ -70,8 +176,32 @@ final class HelperService: NSObject, RockxyHelperProtocol {
 
         guard let result = Self.mutationGate.withExclusiveAccess({
             Result {
-                try ProxyConfigurator.restoreProxyOrThrow()
-                stopOwnerWatchdog()
+                try DirectProxySessionLock.withExclusiveAccess(userID: boundUserID) {
+                    if let backup = try CrashRecovery.loadBackup() {
+                        let ownerSessionIsLive: Bool = if let ownerPID = backup.ownerPID {
+                            ProxyBackupOwnerIdentityPolicy.ownerSessionIsLive(
+                                recordedOwnerPID: ownerPID,
+                                recordedStartSignature: backup.ownerStartSignature,
+                                ownerProcessIsAlive: ProcessStartIdentity.isAlive(ownerPID),
+                                liveStartSignature: ProcessStartIdentity.startSignature(for: ownerPID),
+                                ownerPassesCallerValidation: true
+                            )
+                        } else {
+                            false
+                        }
+                        guard HelperBoundProcessIdentityPolicy.mayRestoreSession(
+                            ownerSessionIsLive: ownerSessionIsLive,
+                            recordedOwnerPID: backup.ownerPID,
+                            recordedOwnerStartSignature: backup.ownerStartSignature,
+                            callerPID: boundConnectionPID,
+                            callerStartSignature: boundConnectionStartSignature
+                        ) else {
+                            throw ProxyConfiguratorError.noOwnedProxySession
+                        }
+                    }
+                    try ProxyConfigurator.restoreProxyOrThrow()
+                    Self.stopOwnerWatchdog()
+                }
             }
         }) else {
             reply(false, HelperPrivilegedMutationGate.busyMessage)
@@ -104,16 +234,28 @@ final class HelperService: NSObject, RockxyHelperProtocol {
         IdleExitMonitor.resetIdleTimer()
         Self.logger.info("prepareForUninstall called")
 
-        let preparation: Void? = Self.mutationGate.withExclusiveAccess {
-            stopOwnerWatchdog()
-            ProxyConfigurator.restoreProxy()
-            CrashRecovery.clearBackup()
-        }
-        guard preparation != nil else {
+        // Nothing is torn down until the settings are provably back. Stopping the watchdog and
+        // clearing the backup together remove the last two things that could restore them, so a
+        // restore that failed must leave both exactly where they are — otherwise a failed
+        // uninstall becomes a permanent override with no way back.
+        guard let prepared = Self.mutationGate.withExclusiveAccess({
+            HelperUninstallPreparation.run(
+                restore: { try ProxyConfigurator.restoreProxyOrThrow() },
+                stopWatchdog: { Self.stopOwnerWatchdog() },
+                clearBackup: { CrashRecovery.clearBackup() }
+            )
+        }) else {
+            Self.logger.error("prepareForUninstall refused — another privileged mutation is running")
             reply(false)
             return
         }
-        reply(true)
+        if !prepared {
+            Self.logger
+                .error(
+                    "prepareForUninstall could not restore the proxy — keeping the backup and the watchdog in place"
+                )
+        }
+        reply(prepared)
     }
 
     func prepareForExecutableRefresh(withReply reply: @escaping (Bool) -> Void) {
@@ -148,7 +290,7 @@ final class HelperService: NSObject, RockxyHelperProtocol {
             return
         }
 
-        stopOwnerWatchdog()
+        Self.stopOwnerWatchdog()
         reply(true)
 
         // Give XPC enough time to deliver the acknowledgement. A zero exit is intentional:
@@ -162,22 +304,32 @@ final class HelperService: NSObject, RockxyHelperProtocol {
     /// Re-arms the owner watchdog for a session that survived a helper relaunch.
     /// Without this, an override preserved at startup would have no observer left, so the owner
     /// dying later would strand the user's proxy settings with nothing to restore them.
-    func resumeOwnerWatchdog(for pid: Int32) {
-        guard pid > 0 else {
+    ///
+    /// The start signature comes from the backup recovery already authenticated, so the re-armed
+    /// watchdog watches the same process identity rather than whatever later inherits the PID.
+    static func resumeOwnerWatchdog(for pid: Int32, startSignature: String, userID: uid_t?) {
+        guard pid > 0, !startSignature.isEmpty else {
             return
         }
-        Self.logger.info("Re-arming owner watchdog for preserved session pid \(pid)")
-        startOwnerWatchdog(for: pid)
+        // Backups written before the user identity field existed still carry an exact PID and
+        // start signature. Keep their recovery observer alive as well; the session lock is global,
+        // so its compatibility parameter does not weaken which backup the watchdog may restore.
+        let lockIdentity = userID ?? 0
+        if userID == nil {
+            logger.warning("Re-arming owner watchdog for a legacy proxy backup without a recorded user identity")
+        }
+        logger.info("Re-arming owner watchdog for preserved session pid \(pid)")
+        startOwnerWatchdog(for: pid, startSignature: startSignature, userID: lockIdentity)
     }
 
-    func handleConnectionInvalidated(processID: Int32) {
+    static func handleConnectionInvalidated(processID: Int32) {
         let action: InvalidationAction
         let owner = currentOwnerSnapshot()
 
         if let owner {
             let ownerPID = owner.processIdentifier
-            let ownerAlive = isProcessAlive(ownerPID)
-            action = Self.invalidationAction(
+            let ownerAlive = ownerSessionIsLive(owner)
+            action = invalidationAction(
                 ownerPID: ownerPID,
                 invalidatedPID: processID,
                 ownerAlive: ownerAlive
@@ -188,16 +340,16 @@ final class HelperService: NSObject, RockxyHelperProtocol {
 
         switch action {
         case .ignore:
-            Self.logger.debug("Ignoring XPC invalidation for pid \(processID)")
+            logger.debug("Ignoring XPC invalidation for pid \(processID)")
         case let .restore(ownerPID):
-            Self.logger.warning("XPC owner connection \(ownerPID) vanished — restoring proxy override automatically")
+            logger.warning("XPC owner connection \(ownerPID) vanished — restoring proxy override automatically")
             requestAutomaticProxyRestore(
                 for: ownerPID,
                 ownershipToken: owner?.token,
                 reason: "owner connection invalidation"
             )
         case let .watchdog(ownerPID):
-            Self.logger.info("Owner pid \(ownerPID) still alive after XPC invalidation — deferring to watchdog")
+            logger.info("Owner pid \(ownerPID) still alive after XPC invalidation — deferring to watchdog")
             scheduleOwnerDisconnectRecheck(for: ownerPID, ownershipToken: owner?.token)
         }
     }
@@ -215,7 +367,24 @@ final class HelperService: NSObject, RockxyHelperProtocol {
         }
 
         guard let result = Self.mutationGate.withExclusiveAccess({
-            Result { try ProxyConfigurator.setBypassDomains(domains) }
+            Result {
+                guard let backup = try CrashRecovery.loadBackup(),
+                      HelperBoundProcessIdentityPolicy.ownsProxySession(
+                          boundPID: boundConnectionPID,
+                          boundStartSignature: boundConnectionStartSignature,
+                          liveStartSignature: ProcessStartIdentity.startSignature(for: boundConnectionPID),
+                          recordedOwnerPID: backup.ownerPID,
+                          recordedOwnerStartSignature: backup.ownerStartSignature,
+                          hasBackedUpServices: !backup.services.isEmpty
+                      )
+                else {
+                    throw ProxyConfiguratorError.noOwnedProxySession
+                }
+                try ProxyConfigurator.setBypassDomains(
+                    domains,
+                    services: backup.services.map(\.service)
+                )
+            }
         }) else {
             reply(false, HelperPrivilegedMutationGate.busyMessage)
             return
@@ -416,6 +585,25 @@ final class HelperService: NSObject, RockxyHelperProtocol {
         case watchdog(ownerPID: Int32)
     }
 
+    /// Whether an override request was refused before it could run, or actually attempted. Every
+    /// answer is produced inside the mutation gate so the rate limit sees a consistent timestamp
+    /// and no refusal path can touch a setting, and each keeps the reply shape the caller expects.
+    private enum ProxyOverrideOutcome {
+        case rateLimited
+        case ownerIdentityUnavailable
+        case attempted(Result<Void, any Error>)
+    }
+
+    /// The app process a watchdog is watching. The start signature is carried alongside the
+    /// identifier — and is never absent — because a recycled identifier would otherwise read as
+    /// the same live owner.
+    private struct OwnerSession {
+        let processIdentifier: Int32
+        let startSignature: String
+        let userID: uid_t
+        let token: UUID
+    }
+
     private static let logger = Logger(
         subsystem: RockxyIdentity.current.logSubsystem,
         category: "HelperService"
@@ -425,6 +613,7 @@ final class HelperService: NSObject, RockxyHelperProtocol {
     private static let rateLimitInterval: TimeInterval = 2.0
     private static let ownerWatchdogInterval: TimeInterval = 2.0
     private static let connectionInvalidationGraceInterval: TimeInterval = 0.5
+    private static let startupRecoveryRetryKey = "retained-proxy-backup"
 
     // MARK: - Private Certificate Helpers
 
@@ -447,11 +636,22 @@ final class HelperService: NSObject, RockxyHelperProtocol {
     private static let mutationGate = HelperPrivilegedMutationGate.shared
     private static let automaticRestoreRetrier = HelperPrivilegedMutationRetrier(gate: mutationGate)
 
-    private var lastProxyChangeTime: Date?
-    private let ownerStateLock = NSLock()
-    private var ownerWatchdog: DispatchSourceTimer?
-    private var ownerPID: Int32?
-    private var ownerWatchdogToken: UUID?
+    /// The owner session is process-global while the exported object is per-connection: one
+    /// machine has one set of proxy settings and one watchdog over them, however many clients are
+    /// talking to the helper.
+    ///
+    /// `lastProxyChangeTime` is only ever read or written while the privileged mutation gate is
+    /// held.
+    private static var lastProxyChangeTime: Date?
+    private static let ownerStateLock = NSLock()
+    private static var ownerWatchdog: DispatchSourceTimer?
+    private static var ownerSession: OwnerSession?
+
+    /// The authenticated peer of the connection this object was exported on. Every
+    /// ownership-bearing method is answered for this identity and no other.
+    private let boundConnectionPID: Int32
+    private let boundConnectionStartSignature: String
+    private let boundUserID: uid_t
 
     private static func invalidationAction(
         ownerPID: Int32?,
@@ -469,80 +669,85 @@ final class HelperService: NSObject, RockxyHelperProtocol {
 
     // MARK: - Owner Watchdog
 
-    private func startOwnerWatchdog(for pid: Int32) {
+    private static func startOwnerWatchdog(for pid: Int32, startSignature: String, userID: uid_t) {
         stopOwnerWatchdog()
 
         let ownershipToken = UUID()
         let timer = DispatchSource.makeTimerSource(queue: DispatchQueue.global(qos: .utility))
-        timer.schedule(deadline: .now() + Self.ownerWatchdogInterval, repeating: Self.ownerWatchdogInterval)
+        timer.schedule(deadline: .now() + ownerWatchdogInterval, repeating: ownerWatchdogInterval)
 
         ownerStateLock.lock()
-        ownerPID = pid
-        ownerWatchdogToken = ownershipToken
+        ownerSession = OwnerSession(
+            processIdentifier: pid,
+            startSignature: startSignature,
+            userID: userID,
+            token: ownershipToken
+        )
         ownerWatchdog = timer
         ownerStateLock.unlock()
-        timer.setEventHandler { [weak self] in
-            guard let self else {
-                return
-            }
-            guard let owner = self.currentOwnerSnapshot(),
+        timer.setEventHandler {
+            guard let owner = currentOwnerSnapshot(),
                   owner.token == ownershipToken
             else {
                 return
             }
             let ownerPID = owner.processIdentifier
 
-            if self.isProcessAlive(ownerPID) {
+            if ownerSessionIsLive(owner) {
                 return
             }
 
-            Self.logger.warning("Owner app process \(ownerPID) is gone — restoring proxy override automatically")
-            self.requestAutomaticProxyRestore(
+            logger.warning("Owner app process \(ownerPID) is gone — restoring proxy override automatically")
+            requestAutomaticProxyRestore(
                 for: ownerPID,
                 ownershipToken: ownershipToken,
                 reason: "owner watchdog"
             )
         }
         timer.resume()
-        Self.logger.info("Started owner watchdog for app PID \(pid)")
+        logger.info("Started owner watchdog for app PID \(pid)")
     }
 
-    private func stopOwnerWatchdog() {
+    private static func stopOwnerWatchdog() {
         ownerStateLock.lock()
         let watchdog = ownerWatchdog
         ownerWatchdog = nil
-        ownerPID = nil
-        ownerWatchdogToken = nil
+        ownerSession = nil
         ownerStateLock.unlock()
         watchdog?.cancel()
     }
 
-    private func isProcessAlive(_ pid: Int32) -> Bool {
-        if kill(pid, 0) == 0 {
-            return true
-        }
-        return errno == EPERM
+    /// Whether the watched owner is still the exact process the watchdog was armed for. Every
+    /// liveness and recheck path goes through here so a recycled identifier can never keep a
+    /// stranded override alive.
+    private static func ownerSessionIsLive(_ owner: OwnerSession) -> Bool {
+        let processIsAlive = ProcessStartIdentity.isAlive(owner.processIdentifier)
+        return ProxyOwnerWatchdogPolicy.watchedOwnerIsLive(
+            recordedPID: owner.processIdentifier,
+            recordedStartSignature: owner.startSignature,
+            processIsAlive: processIsAlive,
+            liveStartSignature: processIsAlive
+                ? ProcessStartIdentity.startSignature(for: owner.processIdentifier)
+                : nil
+        )
     }
 
-    private func scheduleOwnerDisconnectRecheck(for pid: Int32, ownershipToken: UUID?) {
-        let delay = Self.connectionInvalidationGraceInterval
+    private static func scheduleOwnerDisconnectRecheck(for pid: Int32, ownershipToken: UUID?) {
+        let delay = connectionInvalidationGraceInterval
         guard let ownershipToken else {
             return
         }
-        DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + delay) { [weak self] in
-            guard let self else {
-                return
-            }
-            guard self.ownerMatches(processIdentifier: pid, token: ownershipToken)
+        DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + delay) {
+            guard let owner = matchedOwnerSession(processIdentifier: pid, token: ownershipToken)
             else {
                 return
             }
-            guard !self.isProcessAlive(pid) else {
+            guard !ownerSessionIsLive(owner) else {
                 return
             }
 
-            Self.logger.warning("Owner pid \(pid) disappeared after XPC invalidation grace period — restoring proxy")
-            self.requestAutomaticProxyRestore(
+            logger.warning("Owner pid \(pid) disappeared after XPC invalidation grace period — restoring proxy")
+            requestAutomaticProxyRestore(
                 for: pid,
                 ownershipToken: ownershipToken,
                 reason: "owner disconnect recheck"
@@ -550,7 +755,7 @@ final class HelperService: NSObject, RockxyHelperProtocol {
         }
     }
 
-    private func requestAutomaticProxyRestore(
+    private static func requestAutomaticProxyRestore(
         for expectedOwnerPID: Int32,
         ownershipToken: UUID?,
         reason: String
@@ -559,47 +764,54 @@ final class HelperService: NSObject, RockxyHelperProtocol {
             return
         }
         let retryKey = ownershipToken.uuidString
-        Self.automaticRestoreRetrier.run(
+        automaticRestoreRetrier.run(
             key: retryKey,
-            operation: { [weak self] in
-                guard let self,
-                      self.ownerMatches(processIdentifier: expectedOwnerPID, token: ownershipToken)
+            operation: {
+                guard let owner = matchedOwnerSession(
+                    processIdentifier: expectedOwnerPID,
+                    token: ownershipToken
+                )
                 else {
                     return true
                 }
 
                 do {
-                    try ProxyConfigurator.restoreProxyOrThrow()
-                    self.stopOwnerWatchdog()
-                    Self.logger.info("Automatic proxy restoration completed after \(reason)")
+                    try DirectProxySessionLock.withExclusiveAccess(userID: owner.userID) {
+                        try ProxyConfigurator.restoreProxyOrThrow()
+                    }
+                    stopOwnerWatchdog()
+                    logger.info("Automatic proxy restoration completed after \(reason)")
                     return true
                 } catch {
-                    Self.logger.error(
+                    logger.error(
                         "Automatic proxy restoration after \(reason) failed and will retry: \(error.localizedDescription)"
                     )
                     return false
                 }
             },
             onExhausted: {
-                Self.logger.error(
+                logger.error(
                     "Automatic proxy restoration after \(reason) exhausted bounded retries; preserving backup for recovery"
                 )
             }
         )
     }
 
-    private func currentOwnerSnapshot() -> (processIdentifier: Int32, token: UUID)? {
+    private static func currentOwnerSnapshot() -> OwnerSession? {
         ownerStateLock.lock()
         defer { ownerStateLock.unlock() }
-        guard let ownerPID, let ownerWatchdogToken else {
-            return nil
-        }
-        return (ownerPID, ownerWatchdogToken)
+        return ownerSession
     }
 
-    private func ownerMatches(processIdentifier: Int32, token: UUID) -> Bool {
+    private static func matchedOwnerSession(processIdentifier: Int32, token: UUID) -> OwnerSession? {
         ownerStateLock.lock()
         defer { ownerStateLock.unlock() }
-        return ownerPID == processIdentifier && ownerWatchdogToken == token
+        guard let ownerSession,
+              ownerSession.processIdentifier == processIdentifier,
+              ownerSession.token == token
+        else {
+            return nil
+        }
+        return ownerSession
     }
 }

--- a/RockxyHelperTool/IdleExitMonitor.swift
+++ b/RockxyHelperTool/IdleExitMonitor.swift
@@ -32,6 +32,8 @@ enum IdleExitMonitor {
     )
 
     private static let idleTimeout: TimeInterval = 5 * 60
+    /// The same gate every privileged mutation takes, so exiting is serialized against them.
+    private static let mutationGate = HelperPrivilegedMutationGate.shared
     private static let queue = DispatchQueue(label: "com.amunx.rockxy.helper.idle-exit")
 
     private static var idleTimer: DispatchSourceTimer?
@@ -55,15 +57,41 @@ enum IdleExitMonitor {
         timer.resume()
     }
 
+    /// Must be called on `queue`.
+    ///
+    /// A timer event that has already been dequeued cannot be cancelled, so reading the proxy
+    /// status and exiting on the answer used to be enough to exit in the middle of somebody
+    /// else's privileged mutation — with the reply never arriving and the settings left part-way.
+    /// The decision now runs through the same exclusive gate every proxy and certificate mutation
+    /// takes: a busy gate means the helper is still needed, and a free one cannot be filled
+    /// between the recheck and the exit because this holds it.
     private static func checkAndExit() {
-        let status = ProxyConfigurator.getCurrentStatus()
-        if status.isOverridden {
-            logger.info("Idle timeout reached but proxy is still overridden on port \(status.port) — deferring exit")
+        switch HelperIdleExitSequence.run(
+            proxyIsOverridden: {
+                // The status answers for the routed service alone, so an override that stopped on
+                // a secondary one reads as idle. A restore point still on disk names exactly the
+                // services in that position, and exiting would take away the only process left
+                // that could put them back.
+                HelperOverrideResidencyPolicy.overrideNeedsHelper(
+                    routedServiceIsOverridden: ProxyConfigurator.getCurrentStatus().isOverridden,
+                    unresolvedBackupExists: CrashRecovery.hasBackup()
+                )
+            },
+            acquireExitBarrier: { mutationGate.beginProcessExitBarrier() },
+            release: { mutationGate.release($0) }
+        ) {
+        case .deferOverridden:
+            logger.info("Idle timeout reached but a proxy override or its restore point is still in place — deferring exit")
+            if CrashRecovery.hasBackup() {
+                HelperService.scheduleBackupRecovery(reason: "idle residency check")
+            }
             scheduleTimerOnQueue()
-            return
+        case .deferBusy:
+            logger.info("Idle timeout reached while a privileged operation is running — deferring exit")
+            scheduleTimerOnQueue()
+        case .exit:
+            logger.info("Idle timeout reached with no active proxy override — exiting")
+            exit(0)
         }
-
-        logger.info("Idle timeout reached with no active proxy override — exiting")
-        exit(0)
     }
 }

--- a/RockxyHelperTool/Info.plist
+++ b/RockxyHelperTool/Info.plist
@@ -30,6 +30,8 @@
 	<string>$(ROCKXY_ALLOWED_CALLER_IDENTIFIERS)</string>
 	<key>RockxyLogSubsystem</key>
 	<string>$(ROCKXY_HELPER_BUNDLE_ID)</string>
+	<key>RockxyAppSupportDirectoryName</key>
+	<string>$(ROCKXY_APP_SUPPORT_DIRECTORY_NAME)</string>
 	<key>RockxySharedSupportDirectoryName</key>
 	<string>$(ROCKXY_SHARED_SUPPORT_DIRECTORY_NAME)</string>
 	<key>RockxySharedCertificateLabelPrefix</key>

--- a/RockxyHelperTool/ProxyConfigurator.swift
+++ b/RockxyHelperTool/ProxyConfigurator.swift
@@ -27,7 +27,17 @@ enum ProxyConfigurator {
 
     /// Override system HTTP and HTTPS proxy to 127.0.0.1 on the given port.
     /// Saves current settings via CrashRecovery before making changes.
-    static func overrideProxy(port: Int, ownerPID: Int32) throws {
+    ///
+    /// `ownerStartSignature` is the kernel start identity of the app process taking the override,
+    /// acquired by the caller before this point. It is required rather than looked up here: an
+    /// override that cannot name the exact process it belongs to would leave a watchdog with
+    /// nothing but a recyclable identifier to decide by.
+    static func overrideProxy(
+        port: Int,
+        ownerPID: Int32,
+        ownerStartSignature: String,
+        ownerUID: uid_t
+    ) throws {
         let services = try detectAllEnabledServices()
         guard !services.isEmpty else {
             throw ProxyConfiguratorError.noActiveService
@@ -35,35 +45,129 @@ enum ProxyConfigurator {
 
         // Existing service snapshots are preserved, while newly enabled services are added
         // before they are mutated so every touched route has an exact restore point.
-        try CrashRecovery.saveOriginalSettings(services: services, rockxyPort: port, ownerPID: ownerPID)
+        let hadBackupBefore = CrashRecovery.hasBackup()
+        // The services that already had a restore point. Only their entries may outlive a failed
+        // attempt: an entry this attempt captures for a service it never touches describes
+        // settings nobody overrode, and keeping it is how a later override comes to replay a
+        // stale snapshot over a newer user setting.
+        let preAttemptServices = Set(try CrashRecovery.loadBackup()?.services.map(\.service) ?? [])
+        var backup = try CrashRecovery.saveOriginalSettings(
+            services: services,
+            rockxyPort: port,
+            ownerPID: ownerPID,
+            ownerStartSignature: ownerStartSignature,
+            ownerUID: ownerUID
+        )
 
         logger.info("Setting system proxy to 127.0.0.1:\(port) for \(services.count) service(s)")
 
-        var configuredCount = 0
+        var configuredServices: [String] = []
+        var partiallyAppliedServices: [String] = []
+        var skippedServices: [String] = []
+
         for service in services {
+            guard let serviceBackup = backup.services.first(where: { $0.service == service }) else {
+                // No restore point exists for this service, so nothing may be written to it.
+                logger.warning("Skipping proxy for '\(service)' — it has no captured restore point")
+                continue
+            }
+
+            let captured = restorationTarget(for: serviceBackup)
+            // The capture this backup holds was taken earlier — moments ago for a service just
+            // added, a whole session ago for one being reclaimed. What the override is about to
+            // start from is a fact about the machine now, so the settings are re-read here, in
+            // full, and compared against what this machine can actually prove about them.
+            guard case let .apply(baseline) = ProxyOverrideApplicationPreflight.decision(
+                captured: captured,
+                live: readRestorationState(for: service),
+                priorEntry: backup.journal.first { $0.service == service },
+                port: port
+            ) else {
+                logger
+                    .warning(
+                        "Skipping proxy for '\(service)' — its live settings are neither the ones captured for it nor any this machine wrote"
+                    )
+                skippedServices.append(service)
+                continue
+            }
+
             do {
-                try runNetworkSetup(["-setwebproxy", service, "127.0.0.1", String(port)])
-                try runNetworkSetup(["-setwebproxystate", service, "on"])
-                try runNetworkSetup(["-setsecurewebproxy", service, "127.0.0.1", String(port)])
-                try runNetworkSetup(["-setsecurewebproxystate", service, "on"])
-                try runNetworkSetup(["-setsocksfirewallproxystate", service, "off"])
-                try runNetworkSetup(["-setautoproxystate", service, "off"])
-                try runNetworkSetup(["-setproxyautodiscovery", service, "off"])
-                configuredCount += 1
+                // Only this service's record changes, and it changes immediately before this
+                // service's first command. Every other record is left exactly where it is: the
+                // backup can already be mid-recovery, or already carry an override this attempt is
+                // reclaiming, and those records are the only thing that says which live states may
+                // still be written. A record that cannot be stored stops the sequence, because a
+                // command nothing on disk accounts for is what a later relaunch cannot reason
+                // about.
+                backup = try CrashRecovery.recordOverrideApplication(
+                    backup,
+                    journal: advancedApplication(
+                        backup.journal,
+                        service: service,
+                        captured: captured,
+                        baseline: baseline,
+                        to: .applying,
+                        port: port
+                    )
+                )
+                guard readRestorationState(for: service) == baseline else {
+                    throw ProxyConfiguratorError.executionFailed(
+                        command: "proxy preflight",
+                        reason: "The live settings changed while the recovery record was being committed"
+                    )
+                }
+                try applyOverride(service: service, port: port)
+                configuredServices.append(service)
                 logger.info("Proxy set on '\(service)' → 127.0.0.1:\(port)")
             } catch {
+                // A sequence that stopped part-way leaves a shape that is neither Rockxy's nor
+                // the user's, so the attempt stops here and puts back what it touched. A service
+                // that still reads exactly as captured was never written and simply drops out.
+                guard ProxyOverrideApplicationPolicy.serviceIsUntouched(
+                    live: readRestorationState(for: service),
+                    captured: baseline
+                ) else {
+                    partiallyAppliedServices.append(service)
+                    logger
+                        .error(
+                            "Proxy override on '\(service)' stopped part-way: \(error.localizedDescription)"
+                        )
+                    break
+                }
                 logger.debug("Skipping proxy for '\(service)': \(error.localizedDescription)")
             }
         }
 
-        guard configuredCount > 0 else {
-            throw ProxyConfiguratorError.executionFailed(
-                command: "setwebproxy (all services)",
-                reason: "Failed to configure proxy on any network service"
+        let touchedServices = configuredServices + partiallyAppliedServices
+        guard partiallyAppliedServices.isEmpty, !configuredServices.isEmpty else {
+            try failOverride(
+                backup: backup,
+                touchedServices: touchedServices,
+                partiallyAppliedServices: partiallyAppliedServices,
+                configuredServices: configuredServices,
+                port: port,
+                preAttemptServices: preAttemptServices,
+                clearsBackup: !hadBackupBefore
             )
+            return
         }
 
-        logger.info("System proxy override complete on \(configuredCount) service(s)")
+        // An entry this attempt captured for a service it then skipped describes settings nobody
+        // overrode. Keeping it would hand the next override a snapshot older than whatever the user
+        // has set in the meantime. Entries that predate this attempt are left alone: they belong to
+        // services an earlier session may still be overriding.
+        let untouchedCapturedServices = skippedServices.filter { !preAttemptServices.contains($0) }
+        do {
+            try CrashRecovery.dropUntouchedCapturedServices(backup, services: untouchedCapturedServices)
+        } catch {
+            // A spare restore point costs a deferred service; a missing one costs the settings.
+            logger
+                .error(
+                    "Could not drop the freshly captured entries for skipped services: \(error.localizedDescription)"
+                )
+        }
+
+        logger.info("System proxy override complete on \(configuredServices.count) service(s)")
     }
 
     /// Restore proxy settings from backup. Logs errors but does not throw.
@@ -77,7 +181,7 @@ enum ProxyConfigurator {
 
     /// Restore proxy settings from CrashRecovery backup. Throws on failure.
     static func restoreProxyOrThrow() throws {
-        guard let sourceBackup = CrashRecovery.loadBackup() else {
+        guard let sourceBackup = try CrashRecovery.loadBackup() else {
             logger.info("No proxy backup exists, so there is no owned proxy state to restore")
             return
         }
@@ -85,66 +189,15 @@ enum ProxyConfigurator {
         let inferredPort = ProxyOverrideOwnership.inferredOwnedPort(
             in: currentOverrideStates(for: backedUpServices)
         )
-        let backup = try CrashRecovery.reduceBackup(
-            sourceBackup,
-            to: backedUpServices,
-            rockxyPort: inferredPort
+
+        try failIfUnresolved(
+            runJournaledRestore(
+                backup: sourceBackup,
+                candidateServices: backedUpServices,
+                port: sourceBackup.rockxyPort ?? inferredPort
+            ),
+            command: "restore proxy"
         )
-
-        var failedServices: Set<String> = []
-        for service in backup.services.map(\.service) {
-            do {
-                try disableProxyStates(for: service)
-                logger.debug("Disabled proxy on '\(service)'")
-            } catch {
-                failedServices.insert(service)
-                logger.debug("Failed to disable proxy for '\(service)': \(error.localizedDescription)")
-            }
-        }
-
-        logger.info("Restoring original proxy settings for \(backup.services.count) service(s)")
-
-        for serviceBackup in backup.services {
-            logger.info("Restoring proxy settings for '\(serviceBackup.service)'")
-
-            do {
-                try applyServiceBackup(serviceBackup)
-            } catch {
-                failedServices.insert(serviceBackup.service)
-                logger
-                    .error(
-                        "Failed to restore proxy for '\(serviceBackup.service)': \(error.localizedDescription)"
-                    )
-            }
-        }
-
-        let stillOwnedServices = Set(backup.rockxyPort.map { port in
-            ProxyOverrideOwnership.residualOwnedServices(
-                in: currentOverrideStates(for: backup.services.map(\.service)),
-                port: port
-            )
-        } ?? [])
-        let unresolvedEntries = ProxyBackupSubset.unresolvedEntries(
-            backup.services,
-            failedServices: failedServices,
-            stillOwnedServices: stillOwnedServices,
-            serviceName: \.service
-        )
-
-        guard unresolvedEntries.isEmpty else {
-            do {
-                _ = try CrashRecovery.reduceBackup(backup, to: unresolvedEntries.map(\.service))
-            } catch {
-                logger.error("Could not narrow the retained proxy backup: \(error.localizedDescription)")
-            }
-            throw ProxyConfiguratorError.executionFailed(
-                command: "restore proxy",
-                reason: "\(unresolvedEntries.count) network service(s) could not be restored; the recovery backup was preserved"
-            )
-        }
-
-        CrashRecovery.clearBackup()
-        logger.info("Proxy settings restored successfully")
     }
 
     /// Restores only the backed-up services that still carry Rockxy's override, leaving any
@@ -156,122 +209,46 @@ enum ProxyConfigurator {
     /// on disk and nothing is mutated — losing the restore point is worse than a stranded
     /// override that can still be recovered later.
     static func restoreOwnedServicesOrThrow(ownedServices: [String], port: Int?) throws {
-        guard let backup = CrashRecovery.loadBackup() else {
+        guard let backup = try CrashRecovery.loadBackup() else {
             logger.info("No proxy backup exists, so there is no owned proxy state to restore")
             return
         }
 
-        let ownedEntries = ProxyBackupSubset.select(
-            backup.services,
-            services: Set(ownedServices),
-            serviceName: \.service
+        try failIfUnresolved(
+            runJournaledRestore(
+                backup: backup,
+                candidateServices: ownedServices,
+                port: backup.rockxyPort ?? port
+            ),
+            command: "restore owned proxy services"
         )
-        guard !ownedEntries.isEmpty else {
-            logger.info("No backed-up service is still Rockxy-owned — clearing the stale backup")
-            CrashRecovery.clearBackup()
-            return
-        }
-
-        let reducedBackup: CrashRecovery.ProxyBackup
-        do {
-            reducedBackup = try CrashRecovery.reduceBackup(
-                backup,
-                to: ownedEntries.map(\.service),
-                rockxyPort: port
-            )
-        } catch {
-            logger
-                .error(
-                    "Could not persist the reduced proxy backup — leaving settings untouched: \(error.localizedDescription)"
-                )
-            throw error
-        }
-
-        logger.info("Restoring original proxy settings for \(reducedBackup.services.count) owned service(s)")
-
-        var failedServices: Set<String> = []
-        for serviceBackup in reducedBackup.services {
-            do {
-                try disableProxyStates(for: serviceBackup.service)
-                try applyServiceBackup(serviceBackup)
-            } catch {
-                failedServices.insert(serviceBackup.service)
-                logger
-                    .error(
-                        "Failed to restore proxy for '\(serviceBackup.service)': \(error.localizedDescription)"
-                    )
-            }
-        }
-
-        let stillOwnedServices = Set(port.map { ownedPort in
-            ProxyOverrideOwnership.residualOwnedServices(
-                in: currentOverrideStates(for: reducedBackup.services.map(\.service)),
-                port: ownedPort
-            )
-        } ?? [])
-        let unresolvedEntries = ProxyBackupSubset.unresolvedEntries(
-            reducedBackup.services,
-            failedServices: failedServices,
-            stillOwnedServices: stillOwnedServices,
-            serviceName: \.service
-        )
-
-        guard unresolvedEntries.isEmpty else {
-            // Keep exactly the services that still need recovery so a retry has a restore point
-            // for them and only them.
-            do {
-                _ = try CrashRecovery.reduceBackup(reducedBackup, to: unresolvedEntries.map(\.service))
-            } catch {
-                logger
-                    .error(
-                        "Could not narrow the retained proxy backup: \(error.localizedDescription)"
-                    )
-            }
-            throw ProxyConfiguratorError.executionFailed(
-                command: "restore owned proxy services",
-                reason: "\(unresolvedEntries.count) network service(s) could not be restored; the recovery backup was preserved"
-            )
-        }
-
-        CrashRecovery.clearBackup()
-        logger.info("Owned proxy settings restored successfully")
     }
 
     /// Reads the ownership-relevant proxy fields for each service. Services that cannot be read
     /// report as not overridden, which keeps recovery from claiming ownership it cannot prove.
     static func currentOverrideStates(for services: [String]) -> [ProxyServiceOverrideState] {
         services.map { service in
-            let http = parseProxyOutput((try? runNetworkSetup(["-getwebproxy", service])) ?? "")
-            let https = parseProxyOutput((try? runNetworkSetup(["-getsecurewebproxy", service])) ?? "")
-            let socks = parseProxyOutput((try? runNetworkSetup(["-getsocksfirewallproxy", service])) ?? "")
-            let pac = parsePACOutput((try? runNetworkSetup(["-getautoproxyurl", service])) ?? "")
-            let autoDiscovery = parseAutoDiscoveryOutput(
-                (try? runNetworkSetup(["-getproxyautodiscovery", service])) ?? ""
-            )
-            let bypassOutput = (try? runNetworkSetup(["-getproxybypassdomains", service])) ?? ""
-            let hasGlobalBypass = bypassOutput.components(separatedBy: "\n").contains {
-                $0.trimmingCharacters(in: .whitespacesAndNewlines) == "*"
-            }
-            return ProxyServiceOverrideState(
-                service: service,
-                httpEnabled: http.enabled,
-                httpHost: http.host,
-                httpPort: http.port,
-                httpsEnabled: https.enabled,
-                httpsHost: https.host,
-                httpsPort: https.port,
-                socksEnabled: socks.enabled,
-                pacEnabled: pac.enabled,
-                autoDiscoveryEnabled: autoDiscovery,
-                hasGlobalBypass: hasGlobalBypass
-            )
+            readRestorationState(for: service)?.overrideState
+                ?? ProxyServiceOverrideState.unreadable(service: service)
         }
+    }
+
+    /// Reads the full restoration-relevant shape of each service, keyed by service name.
+    ///
+    /// A service whose settings cannot be read is left out rather than reported as empty: an
+    /// unreadable service is not a changed one, and guessing either way would decide whether
+    /// recovery writes over it.
+    static func currentRestorationStates(for services: [String]) -> [String: ProxyServiceRestorationState] {
+        var states: [String: ProxyServiceRestorationState] = [:]
+        for service in services {
+            states[service] = readRestorationState(for: service)
+        }
+        return states
     }
 
     /// Set bypass domains on all enabled network services.
     /// Pass an empty array to clear the bypass list (uses "Empty" per macOS convention).
-    static func setBypassDomains(_ domains: [String]) throws {
-        let services = try detectAllEnabledServices()
+    static func setBypassDomains(_ domains: [String], services: [String]) throws {
         guard !services.isEmpty else {
             throw ProxyConfiguratorError.noActiveService
         }
@@ -287,19 +264,77 @@ enum ProxyConfigurator {
             )
         }
 
+        guard var backup = try CrashRecovery.loadBackup() else {
+            throw ProxyConfiguratorError.noOwnedProxySession
+        }
         var failedServices: [String] = []
         for service in services {
-            do {
-                if domains.isEmpty {
-                    try runNetworkSetup(["-setproxybypassdomains", service, "Empty"])
-                } else {
-                    let args = ["-setproxybypassdomains", service] + domains
-                    try runNetworkSetup(args)
-                }
-                logger.debug("Set bypass domains on '\(service)': \(domains)")
-            } catch {
+            guard let entry = backup.journal.first(where: { $0.service == service }) else {
                 failedServices.append(service)
-                logger.debug("Failed to set bypass domains for '\(service)': \(error.localizedDescription)")
+                continue
+            }
+
+            let live = readRestorationState(for: service)
+            switch ProxyBypassUpdatePreflight.decision(
+                entry: entry,
+                live: live,
+                ownedPort: backup.rockxyPort,
+                requestedDomains: domains
+            ) {
+            case .abort:
+                failedServices.append(service)
+                continue
+            case .unchanged:
+                if entry.previousAppliedBypassDomains != nil {
+                    do {
+                        backup = try CrashRecovery.recordOverrideApplication(
+                            backup,
+                            journal: replacing(
+                                backup.journal,
+                                entry: entry.completingAppliedBypassUpdate(at: domains)
+                            )
+                        )
+                    } catch {
+                        failedServices.append(service)
+                    }
+                }
+                continue
+            case let .apply(baseline):
+                do {
+                    let pendingEntry = entry.recordingAppliedBypassDomains(
+                        domains,
+                        from: baseline.bypassDomains
+                    )
+                    backup = try CrashRecovery.recordOverrideApplication(
+                        backup,
+                        journal: replacing(backup.journal, entry: pendingEntry)
+                    )
+
+                    // The durable transition was published after the first read. Re-check the
+                    // complete state now so a change during publication is never overwritten.
+                    guard readRestorationState(for: service) == baseline else {
+                        failedServices.append(service)
+                        continue
+                    }
+
+                    if domains.isEmpty {
+                        try runNetworkSetup(["-setproxybypassdomains", service, "Empty"])
+                    } else {
+                        try runNetworkSetup(["-setproxybypassdomains", service] + domains)
+                    }
+
+                    backup = try CrashRecovery.recordOverrideApplication(
+                        backup,
+                        journal: replacing(
+                            backup.journal,
+                            entry: pendingEntry.completingAppliedBypassUpdate(at: domains)
+                        )
+                    )
+                    logger.debug("Set bypass domains on '\(service)': \(domains)")
+                } catch {
+                    failedServices.append(service)
+                    logger.debug("Failed to set bypass domains for '\(service)': \(error.localizedDescription)")
+                }
             }
         }
 
@@ -329,7 +364,7 @@ enum ProxyConfigurator {
         guard let services = try? detectAllEnabledServices(), !services.isEmpty else {
             return (false, 0)
         }
-        guard let backup = CrashRecovery.loadBackup() else {
+        guard let backup = try? CrashRecovery.loadBackup() else {
             return (false, 0)
         }
 
@@ -430,9 +465,600 @@ enum ProxyConfigurator {
 
     // MARK: Private
 
+    /// What a running restore has decided so far: the journal as it stands, the services the
+    /// backup on disk still holds a restore point for, and how each attempted service turned out.
+    private struct JournaledRestoreState {
+        var journal: [ProxyServiceRecoveryJournalEntry]
+        var retention: ProxyBackupRetention
+        var deferredServices: [String]
+        var attemptedServices: [String] = []
+        var failedServices: Set<String> = []
+    }
+
     private static let logger = Logger(subsystem: RockxyIdentity.current.logSubsystem, category: "ProxyConfigurator")
     private static let networkSetupPath = "/usr/sbin/networksetup"
     private static let routePath = "/sbin/route"
+
+    /// Restores the backed-up services a recovery journal still authorizes, one service at a
+    /// time, recording the intent before each step and its completion after.
+    ///
+    /// The journal is what makes a retry safe. Before anything is written, the reduced backup and
+    /// an `inFlight` record for every service about to be touched are persisted, so a process
+    /// that dies part-way through leaves behind both the settings to write and the shape the
+    /// write was expected to produce. A later attempt then compares the live settings against
+    /// that record: settings this restore could have produced are written again, and settings it
+    /// could not are treated as someone else's and dropped from recovery untouched.
+    ///
+    /// `preservedServices` names backup entries this attempt is not authorized to write but must
+    /// keep on disk for its whole run. A rollback that only covers the services one failed
+    /// override touched must never be the moment an untouched service loses the only restore
+    /// point it has, so those entries are never removed and re-added — they are simply never
+    /// dropped.
+    private static func runJournaledRestore(
+        backup: CrashRecovery.ProxyBackup,
+        candidateServices: [String],
+        port: Int?,
+        locallyMutatedServices: Set<String> = [],
+        preservedServices: [String] = [],
+        preAttemptServices: Set<String>? = nil
+    )
+        -> [String]
+    {
+        let retentionOfPreservedOnly = ProxyBackupRetention(
+            authorized: [],
+            preserved: preservedServices,
+            preAttemptServices: preAttemptServices
+        )
+        let candidateEntries = ProxyBackupSubset.select(
+            backup.services,
+            services: Set(candidateServices),
+            serviceName: \.service
+        )
+
+        guard !candidateEntries.isEmpty else {
+            logger.info("No backed-up service is still Rockxy-owned — dropping it from the backup")
+            return finishRestore(
+                backup: backup,
+                unresolvedServices: [],
+                retention: retentionOfPreservedOnly,
+                journal: ProxyBackupSubset.select(
+                    backup.journal,
+                    services: Set(preservedServices),
+                    serviceName: \.service
+                ),
+                port: port,
+                recoveryPending: backup.recoveryPending
+            )
+        }
+
+        // A service with no usable record may only enter recovery when the live settings still
+        // prove Rockxy owns it on the persisted port, or when they are exactly one of the states
+        // this process's own override commands pass through. Anything weaker — a readable but
+        // foreign configuration, or one that could not be read at all — keeps its restore point
+        // for a later attempt instead of being adopted as a starting point.
+        let plan = ProxyRecoveryPlanner.plan(
+            targets: candidateEntries.map(restorationTarget(for:)),
+            journal: backup.journal,
+            liveStates: currentRestorationStates(for: candidateEntries.map(\.service)),
+            ownedPort: port,
+            locallyMutatedServices: locallyMutatedServices
+        )
+
+        if !plan.abandonedServices.isEmpty {
+            logger
+                .warning(
+                    "Leaving \(plan.abandonedServices.count) network service(s) out of automatic recovery — their proxy settings were changed outside this restore"
+                )
+        }
+        if !plan.completedServices.isEmpty {
+            logger.info("\(plan.completedServices.count) network service(s) were already restored")
+        }
+
+        // Entries for services that stay in the backup without being written this time round.
+        let deferredJournal = ProxyBackupSubset.select(
+            backup.journal,
+            services: Set(plan.deferredServices + preservedServices),
+            serviceName: \.service
+        )
+
+        guard !plan.entriesToRestore.isEmpty else {
+            // Nothing is written, so the backup keeps the flag it arrived with: an attempt that
+            // could read nothing must not count as the recovery that already started.
+            return finishRestore(
+                backup: backup,
+                unresolvedServices: plan.deferredServices,
+                retention: retentionOfPreservedOnly,
+                journal: deferredJournal,
+                port: port,
+                recoveryPending: backup.recoveryPending
+            )
+        }
+
+        logger.info("Restoring original proxy settings for \(plan.entriesToRestore.count) service(s)")
+
+        // Persist the intent before the first command runs. Every planned service is recorded at
+        // the stage it was planned at — a service nothing has been issued for stays `pending`, so
+        // a crash while an earlier service is being written cannot make it look half-restored and
+        // hand a later attempt a licence to overwrite a change made in the meantime.
+        var state = JournaledRestoreState(
+            journal: plan.entriesToRestore + deferredJournal,
+            retention: ProxyBackupRetention(
+                authorized: plan.servicesKeepingBackup,
+                preserved: preservedServices,
+                preAttemptServices: preAttemptServices
+            ),
+            deferredServices: plan.deferredServices
+        )
+        var workingBackup: CrashRecovery.ProxyBackup
+        do {
+            workingBackup = try CrashRecovery.reduceBackup(
+                backup,
+                to: state.retention.services,
+                rockxyPort: port,
+                journal: state.journal
+            )
+        } catch {
+            // Nothing has been written, and nothing may be: the record that would let a later
+            // attempt reason about a command is exactly what could not be stored.
+            logger
+                .error(
+                    "Could not persist the reduced proxy backup — leaving settings untouched: \(error.localizedDescription)"
+                )
+            return plan.entriesToRestore.map(\.service) + plan.deferredServices
+        }
+
+        for entry in plan.entriesToRestore {
+            guard let serviceBackup = candidateEntries.first(where: { $0.service == entry.service }) else {
+                continue
+            }
+
+            // The plan was made for every service at once, but the services are written one after
+            // another. Re-read this one immediately before its first command so a change made
+            // while an earlier service was being restored is seen before anything is overwritten.
+            guard preflightAllowsRestore(entry: entry, state: &state, backup: &workingBackup, port: port) else {
+                continue
+            }
+
+            // Only now, and only for this one service, does the record advance to `inFlight`.
+            // The commit is the permission to issue a command: if it cannot be written, not a
+            // single command is sent for this service, because an unrecorded write is exactly the
+            // case a later attempt has no way to reason about.
+            let inFlightEntry = entry.advanced(to: .inFlight)
+            let inFlightJournal = replacing(state.journal, entry: inFlightEntry)
+            var committedBackup: CrashRecovery.ProxyBackup?
+            let attempt = ProxyJournaledServiceRestore.run(
+                commitInFlight: {
+                    committedBackup = try CrashRecovery.reduceBackup(
+                        workingBackup,
+                        to: state.retention.services,
+                        rockxyPort: port,
+                        journal: inFlightJournal
+                    )
+                    logger.info("Restoring proxy settings for '\(entry.service)'")
+                },
+                restore: {
+                    switch ProxyServiceRecoveryPolicy.continuation(
+                        for: inFlightEntry,
+                        live: readRestorationState(for: entry.service)
+                    ) {
+                    case .restore:
+                        break
+                    case .complete:
+                        return .restored
+                    case .abandon, .retryLater:
+                        return .failed(
+                            step: .proxyState,
+                            error: ProxyRecoveryRevalidationError.stateChangedAfterCommit(
+                                service: entry.service
+                            )
+                        )
+                    }
+                    // The bypass list is the last thing written, and it is not written at all when
+                    // a proxy-state command failed: a restored bypass list beside a half-written
+                    // proxy state is a shape no prefix of the sequence produces.
+                    return ProxyServiceRestoreExecution.run(
+                        proxyState: {
+                            try disableProxyStates(for: entry.service)
+                            try applyServiceProxyState(serviceBackup)
+                        },
+                        bypassDomains: {
+                            try restoreBypassDomains(
+                                service: entry.service,
+                                domains: serviceBackup.bypassDomains
+                            )
+                        }
+                    )
+                }
+            )
+
+            guard case let .issued(outcome) = attempt else {
+                if case let .notIssued(commitError) = attempt {
+                    logger
+                        .error(
+                            "Could not record the restore of '\(entry.service)' — issuing no command for it: \(commitError.localizedDescription)"
+                        )
+                }
+                state.deferredServices.append(entry.service)
+                continue
+            }
+
+            state.journal = inFlightJournal
+            workingBackup = committedBackup ?? workingBackup
+            state.attemptedServices.append(entry.service)
+
+            if let failedStep = outcome.failedStep {
+                state.failedServices.insert(entry.service)
+                logger
+                    .error(
+                        "Stopped restoring '\(entry.service)' at the \(failedStep.rawValue) step: \(outcome.error?.localizedDescription ?? "unknown error")"
+                    )
+                continue
+            }
+
+            // Every command for this service returned. Recording that now is what keeps a death
+            // from this point on from looking like a command that never ran.
+            state.journal = advanced(state.journal, service: entry.service, to: .restored)
+            do {
+                workingBackup = try CrashRecovery.reduceBackup(
+                    workingBackup,
+                    to: state.retention.services,
+                    rockxyPort: port,
+                    journal: state.journal
+                )
+            } catch {
+                // The commands already landed, so a lost journal update costs nothing: the next
+                // attempt reads the live settings as the finished shape and stops there.
+                logger
+                    .error(
+                        "Could not record the completed restore for '\(entry.service)': \(error.localizedDescription)"
+                    )
+            }
+        }
+
+        let stillOwnedServices = Set(port.map { ownedPort in
+            ProxyOverrideOwnership.residualOwnedServices(
+                in: currentOverrideStates(for: state.attemptedServices),
+                port: ownedPort
+            )
+        } ?? [])
+        let unresolvedServices = ProxyBackupSubset.unresolvedEntries(
+            state.attemptedServices,
+            failedServices: state.failedServices,
+            stillOwnedServices: stillOwnedServices,
+            serviceName: { $0 }
+        ) + state.deferredServices
+
+        // Only a service this attempt could not resolve leaves the file mid-recovery. Entries it
+        // was never authorized to write keep the flag they arrived with: claiming a recovery had
+        // started for them would keep them in play at every later launch.
+        return finishRestore(
+            backup: workingBackup,
+            unresolvedServices: unresolvedServices,
+            retention: state.retention,
+            journal: state.journal,
+            port: port,
+            recoveryPending: !unresolvedServices.isEmpty || backup.recoveryPending
+        )
+    }
+
+    /// Re-checks one service against its record immediately before its first command, and acts on
+    /// the answer without writing a single setting.
+    ///
+    /// A service that changed since the plan was made leaves recovery here, and it leaves
+    /// durably: its entry is removed from the backup on disk before the loop moves on, so a
+    /// process that dies straight afterwards cannot come back and write over the change. A
+    /// service that has simply become unreadable keeps its restore point and its recorded stage.
+    private static func preflightAllowsRestore(
+        entry: ProxyServiceRecoveryJournalEntry,
+        state: inout JournaledRestoreState,
+        backup: inout CrashRecovery.ProxyBackup,
+        port: Int?
+    )
+        -> Bool
+    {
+        switch ProxyServiceRecoveryPolicy.continuation(
+            for: entry,
+            live: readRestorationState(for: entry.service)
+        ) {
+        case .restore:
+            return true
+        case .complete, .abandon:
+            logger
+                .warning(
+                    "Dropping '\(entry.service)' from this restore — its proxy settings are no longer the ones this recovery planned for"
+                )
+            state.retention.drop(entry.service)
+            state.journal.removeAll { $0.service == entry.service }
+        case .retryLater:
+            logger
+                .warning("Deferring '\(entry.service)' — its proxy settings could not be read before restoring")
+            state.deferredServices.append(entry.service)
+            state.journal = advanced(state.journal, service: entry.service, to: entry.stage)
+        }
+
+        do {
+            backup = try CrashRecovery.reduceBackup(
+                backup,
+                to: state.retention.services,
+                rockxyPort: port,
+                journal: state.journal
+            )
+        } catch {
+            logger.error("Could not update the retained proxy backup: \(error.localizedDescription)")
+        }
+        return false
+    }
+
+    /// Clears the backup when no service still needs one, or narrows it to exactly the services
+    /// that do — the ones this attempt could not resolve, plus the ones it was never authorized
+    /// to touch and that already had a restore point before it began. Reports back which of the
+    /// authorized services are still unresolved.
+    ///
+    /// What survives the attempt is not the same set that survived inside it. Every preserved
+    /// entry was kept for the whole run so no untouched service could lose its restore point
+    /// mid-flight, but an entry this very attempt captured for a service it then never touched
+    /// describes settings nobody overrode — and leaving it behind is how a later override comes
+    /// to write a stale snapshot over a newer user setting.
+    @discardableResult
+    private static func finishRestore(
+        backup: CrashRecovery.ProxyBackup,
+        unresolvedServices: [String],
+        retention: ProxyBackupRetention,
+        journal: [ProxyServiceRecoveryJournalEntry],
+        port: Int?,
+        recoveryPending: Bool
+    )
+        -> [String]
+    {
+        let retainedServices = retention.retainedAfterAttempt(unresolvedServices: unresolvedServices)
+        guard !retainedServices.isEmpty else {
+            CrashRecovery.clearBackup()
+            logger.info("Proxy settings restored successfully")
+            return unresolvedServices
+        }
+
+        // Keep exactly the services that still need recovery so a retry has a restore point
+        // for them and only them.
+        do {
+            try CrashRecovery.reduceBackup(
+                backup,
+                to: retainedServices,
+                rockxyPort: port,
+                journal: journal,
+                recoveryPending: recoveryPending
+            )
+        } catch {
+            logger.error("Could not narrow the retained proxy backup: \(error.localizedDescription)")
+        }
+        return unresolvedServices
+    }
+
+    /// Turns an unresolved-service list into the failure the restore APIs report.
+    private static func failIfUnresolved(_ services: [String], command: String) throws {
+        guard !services.isEmpty else {
+            return
+        }
+        throw ProxyConfiguratorError.executionFailed(
+            command: command,
+            reason: "\(services.count) network service(s) could not be restored; the recovery backup was preserved"
+        )
+    }
+
+    private static func advanced(
+        _ journal: [ProxyServiceRecoveryJournalEntry],
+        service: String,
+        to stage: ProxyRecoveryStage
+    )
+        -> [ProxyServiceRecoveryJournalEntry]
+    {
+        journal.map { $0.service == service ? $0.advanced(to: stage) : $0 }
+    }
+
+    /// The captured pre-Rockxy settings for one service, in the shape recovery compares against.
+    private static func restorationTarget(
+        for serviceBackup: CrashRecovery.ServiceProxyBackup
+    )
+        -> ProxyServiceRestorationState
+    {
+        ProxyServiceRestorationState(
+            service: serviceBackup.service,
+            http: ProxyEndpointState(
+                enabled: serviceBackup.httpEnabled,
+                host: serviceBackup.httpHost,
+                port: serviceBackup.httpPort
+            ),
+            https: ProxyEndpointState(
+                enabled: serviceBackup.httpsEnabled,
+                host: serviceBackup.httpsHost,
+                port: serviceBackup.httpsPort
+            ),
+            socks: ProxyEndpointState(
+                enabled: serviceBackup.socksEnabled,
+                host: serviceBackup.socksHost,
+                port: serviceBackup.socksPort
+            ),
+            pacEnabled: serviceBackup.pacEnabled,
+            pacURL: serviceBackup.pacURL,
+            autoDiscoveryEnabled: serviceBackup.autoDiscoveryEnabled,
+            bypassDomains: serviceBackup.bypassDomains
+        )
+    }
+
+    /// Reads every proxy field of one service. Any read that fails makes the whole state nil:
+    /// a partially read service cannot be compared against a journal without inventing values
+    /// for the fields that were not read.
+    private static func readRestorationState(for service: String) -> ProxyServiceRestorationState? {
+        guard let httpOutput = try? runNetworkSetup(["-getwebproxy", service]),
+              let httpsOutput = try? runNetworkSetup(["-getsecurewebproxy", service]),
+              let socksOutput = try? runNetworkSetup(["-getsocksfirewallproxy", service]),
+              let pacOutput = try? runNetworkSetup(["-getautoproxyurl", service]),
+              let autoDiscoveryOutput = try? runNetworkSetup(["-getproxyautodiscovery", service]),
+              let bypassOutput = try? runNetworkSetup(["-getproxybypassdomains", service])
+        else {
+            return nil
+        }
+
+        let http = parseProxyOutput(httpOutput)
+        let https = parseProxyOutput(httpsOutput)
+        let socks = parseProxyOutput(socksOutput)
+        let pac = parsePACOutput(pacOutput)
+
+        return ProxyServiceRestorationState(
+            service: service,
+            http: ProxyEndpointState(enabled: http.enabled, host: http.host, port: http.port),
+            https: ProxyEndpointState(enabled: https.enabled, host: https.host, port: https.port),
+            socks: ProxyEndpointState(enabled: socks.enabled, host: socks.host, port: socks.port),
+            pacEnabled: pac.enabled,
+            pacURL: pac.url,
+            autoDiscoveryEnabled: parseAutoDiscoveryOutput(autoDiscoveryOutput),
+            bypassDomains: ProxyBypassDomainOutput.parse(bypassOutput)
+        )
+    }
+
+    /// Writes Rockxy's loopback override onto one service, in a fixed order.
+    private static func applyOverride(service: String, port: Int) throws {
+        try runNetworkSetup(["-setwebproxy", service, "127.0.0.1", String(port)])
+        try runNetworkSetup(["-setwebproxystate", service, "on"])
+        try runNetworkSetup(["-setsecurewebproxy", service, "127.0.0.1", String(port)])
+        try runNetworkSetup(["-setsecurewebproxystate", service, "on"])
+        try runNetworkSetup(["-setsocksfirewallproxystate", service, "off"])
+        try runNetworkSetup(["-setautoproxystate", service, "off"])
+        try runNetworkSetup(["-setproxyautodiscovery", service, "off"])
+    }
+
+    /// Puts back every service a failed override attempt touched, then reports the failure.
+    ///
+    /// The backup stays on disk for the whole rollback, so a helper that dies half-way through it
+    /// still leaves the restore points behind. It is cleared only when this attempt created it
+    /// and every touched service is provably back: an earlier session's backup is never removed
+    /// by a later session's failure.
+    private static func failOverride(
+        backup: CrashRecovery.ProxyBackup,
+        touchedServices: [String],
+        partiallyAppliedServices: [String],
+        configuredServices: [String],
+        port: Int,
+        preAttemptServices: Set<String>,
+        clearsBackup: Bool
+    )
+        throws
+    {
+        let unresolvedServices = rollBackOverride(
+            touchedServices,
+            backup: backup,
+            port: port,
+            preAttemptServices: preAttemptServices
+        )
+
+        switch ProxyOverrideApplicationPolicy.outcome(
+            configuredServices: configuredServices,
+            partiallyAppliedServices: partiallyAppliedServices,
+            unresolvedServices: unresolvedServices
+        ) {
+        case .applied:
+            return
+        case .rolledBack:
+            if clearsBackup {
+                CrashRecovery.clearBackup()
+            }
+            throw ProxyConfiguratorError.executionFailed(
+                command: "setwebproxy (all services)",
+                reason: touchedServices.isEmpty
+                    ? "Failed to configure proxy on any network service"
+                    : "The proxy override was rolled back after it could not be applied to every network service"
+            )
+        case .rollbackIncomplete:
+            logger
+                .error(
+                    "Proxy override rollback incomplete on \(unresolvedServices.count) service(s) — preserving the recovery backup"
+                )
+            throw ProxyConfiguratorError.overrideRollbackIncomplete(services: unresolvedServices)
+        }
+    }
+
+    /// Writes the captured settings back onto the services an override attempt touched, and
+    /// reports the ones that are still not back where they started.
+    ///
+    /// This runs through the same journaled machinery a crash recovery uses, for the same reason:
+    /// each service records its intent before its first rollback command and its completion after
+    /// the last, so a helper that dies part-way through leaves a record the next attempt can
+    /// read. Running the commands raw would leave a half-restored service behind with nothing on
+    /// disk saying a write had started, which is precisely the state startup recovery cannot
+    /// reason about.
+    ///
+    /// Being touched is not on its own a licence to write. A service is recorded as touched
+    /// before its first command runs, so each one has to show that its live settings really are a
+    /// state the override sequence passes through; a command that mutated nothing, and a change
+    /// somebody else made in the meantime, are both left exactly as they are. Backup entries for
+    /// services this attempt never touched stay on disk throughout.
+    private static func rollBackOverride(
+        _ services: [String],
+        backup: CrashRecovery.ProxyBackup,
+        port: Int,
+        preAttemptServices: Set<String>
+    )
+        -> [String]
+    {
+        let untouchedServices = backup.services.map(\.service).filter { !services.contains($0) }
+        guard !services.isEmpty else {
+            // Nothing was written, so nothing needs undoing — but this attempt may have captured
+            // entries for services it never reached, and those describe settings nobody
+            // overrode. Narrowing to what predates the attempt is what keeps a later override
+            // from replaying them over a newer user setting.
+            return finishRestore(
+                backup: backup,
+                unresolvedServices: [],
+                retention: ProxyBackupRetention(
+                    authorized: [],
+                    preserved: untouchedServices,
+                    preAttemptServices: preAttemptServices
+                ),
+                journal: backup.journal,
+                port: port,
+                recoveryPending: backup.recoveryPending
+            )
+        }
+
+        logger.warning("Rolling back the proxy override on \(services.count) touched service(s)")
+        return runJournaledRestore(
+            backup: backup,
+            candidateServices: services,
+            port: port,
+            locallyMutatedServices: Set(services),
+            preservedServices: untouchedServices,
+            preAttemptServices: preAttemptServices
+        )
+    }
+
+    /// Replaces one service's override record, leaving every other service's record alone.
+    private static func advancedApplication(
+        _ journal: [ProxyServiceRecoveryJournalEntry],
+        service: String,
+        captured: ProxyServiceRestorationState,
+        baseline: ProxyServiceRestorationState,
+        to stage: ProxyRecoveryStage,
+        port: Int
+    )
+        -> [ProxyServiceRecoveryJournalEntry]
+    {
+        journal.filter { $0.service != service } + [
+            ProxyServiceRecoveryJournalEntry(
+                overrideApplicationFor: captured,
+                baseline: baseline,
+                stage: stage,
+                port: port
+            ),
+        ]
+    }
+
+    private static func replacing(
+        _ journal: [ProxyServiceRecoveryJournalEntry],
+        entry: ProxyServiceRecoveryJournalEntry
+    )
+        -> [ProxyServiceRecoveryJournalEntry]
+    {
+        journal.filter { $0.service != entry.service } + [entry]
+    }
 
     /// Turns every proxy mode off for one service before its snapshot is written back, so a
     /// mode the snapshot does not mention cannot survive the restore.
@@ -444,8 +1070,10 @@ enum ProxyConfigurator {
         try runNetworkSetup(["-setproxyautodiscovery", service, "off"])
     }
 
-    /// Writes one service's captured pre-Rockxy proxy configuration back verbatim.
-    private static func applyServiceBackup(_ serviceBackup: CrashRecovery.ServiceProxyBackup) throws {
+    /// Writes one service's captured pre-Rockxy proxy configuration back verbatim, apart from the
+    /// bypass list — that is written separately, and only once every proxy-state command has
+    /// returned.
+    private static func applyServiceProxyState(_ serviceBackup: CrashRecovery.ServiceProxyBackup) throws {
         let service = serviceBackup.service
 
         if !serviceBackup.httpHost.isEmpty, serviceBackup.httpPort > 0 {
@@ -488,8 +1116,6 @@ enum ProxyConfigurator {
         if serviceBackup.autoDiscoveryEnabled {
             try runNetworkSetup(["-setproxyautodiscovery", service, "on"])
         }
-
-        try restoreBypassDomains(service: service, domains: serviceBackup.bypassDomains)
     }
 
     private static func validateBinary(_ path: String) throws {
@@ -686,17 +1312,28 @@ enum ProxyConfigurator {
 // MARK: - ProxyConfiguratorError
 
 enum ProxyConfiguratorError: LocalizedError {
+    case directSessionInUse
     case executionFailed(command: String, reason: String)
     case noActiveService
+    case noOwnedProxySession
+    /// An override attempt failed and at least one service it touched could not be put back, so
+    /// the recovery backup was preserved and those services still need a live restore path.
+    case overrideRollbackIncomplete(services: [String])
 
     // MARK: Internal
 
     var errorDescription: String? {
         switch self {
+        case .directSessionInUse:
+            "A direct-mode proxy session is already active for this user"
         case let .executionFailed(command, reason):
             "networksetup \(command) failed: \(reason)"
         case .noActiveService:
             "No active network service detected"
+        case .noOwnedProxySession:
+            "No proxy session owned by this connection is active"
+        case let .overrideRollbackIncomplete(services):
+            "The proxy override failed and \(services.count) network service(s) could not be restored; the recovery backup was preserved"
         }
     }
 }

--- a/RockxyHelperTool/main.swift
+++ b/RockxyHelperTool/main.swift
@@ -1,4 +1,3 @@
-import Darwin
 import Foundation
 import os
 
@@ -6,96 +5,6 @@ import os
 
 private let identity = RockxyIdentity.current
 private let logger = Logger(subsystem: identity.logSubsystem, category: "Main")
-
-// MARK: - DirectProxyBackup
-
-private struct DirectProxyBackup: Codable {
-    init(
-        services: [DirectServiceBackup],
-        timestamp: Date,
-        rockxyPort: Int,
-        recoveryPending: Bool = false
-    ) {
-        self.services = services
-        self.timestamp = timestamp
-        self.rockxyPort = rockxyPort
-        self.recoveryPending = recoveryPending
-    }
-
-    init(from decoder: any Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        services = try container.decode([DirectServiceBackup].self, forKey: .services)
-        timestamp = try container.decode(Date.self, forKey: .timestamp)
-        rockxyPort = try container.decode(Int.self, forKey: .rockxyPort)
-        recoveryPending = try container.decodeIfPresent(Bool.self, forKey: .recoveryPending) ?? false
-    }
-
-    let services: [DirectServiceBackup]
-    let timestamp: Date
-    let rockxyPort: Int
-    let recoveryPending: Bool
-
-    private enum CodingKeys: String, CodingKey {
-        case services
-        case timestamp
-        case rockxyPort
-        case recoveryPending
-    }
-}
-
-// MARK: - DirectServiceBackup
-
-private struct DirectServiceBackup: Codable {
-    init(from decoder: any Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        service = try container.decode(String.self, forKey: .service)
-        httpEnabled = try container.decode(Bool.self, forKey: .httpEnabled)
-        httpHost = try container.decode(String.self, forKey: .httpHost)
-        httpPort = try container.decode(Int.self, forKey: .httpPort)
-        httpsEnabled = try container.decode(Bool.self, forKey: .httpsEnabled)
-        httpsHost = try container.decode(String.self, forKey: .httpsHost)
-        httpsPort = try container.decode(Int.self, forKey: .httpsPort)
-        socksEnabled = try container.decodeIfPresent(Bool.self, forKey: .socksEnabled) ?? false
-        socksHost = try container.decodeIfPresent(String.self, forKey: .socksHost) ?? ""
-        socksPort = try container.decodeIfPresent(Int.self, forKey: .socksPort) ?? 0
-        pacEnabled = try container.decodeIfPresent(Bool.self, forKey: .pacEnabled) ?? false
-        pacURL = try container.decodeIfPresent(String.self, forKey: .pacURL) ?? ""
-        autoDiscoveryEnabled = try container.decodeIfPresent(Bool.self, forKey: .autoDiscoveryEnabled) ?? false
-        bypassDomains = try container.decode([String].self, forKey: .bypassDomains)
-    }
-
-    let service: String
-    let httpEnabled: Bool
-    let httpHost: String
-    let httpPort: Int
-    let httpsEnabled: Bool
-    let httpsHost: String
-    let httpsPort: Int
-    let socksEnabled: Bool
-    let socksHost: String
-    let socksPort: Int
-    let pacEnabled: Bool
-    let pacURL: String
-    let autoDiscoveryEnabled: Bool
-    let bypassDomains: [String]
-
-    private enum CodingKeys: String, CodingKey {
-        case service
-        case httpEnabled
-        case httpHost
-        case httpPort
-        case httpsEnabled
-        case httpsHost
-        case httpsPort
-        case socksEnabled
-        case socksHost
-        case socksPort
-        case pacEnabled
-        case pacURL
-        case autoDiscoveryEnabled
-        case bypassDomains
-    }
-}
 
 // MARK: - DirectProxySnapshot
 
@@ -119,32 +28,49 @@ private struct DirectProxySnapshot {
 private enum DirectProxyWatchdog {
     // MARK: Internal
 
+    /// Watches the app process that took a direct-mode override and restores its settings once
+    /// that exact process is gone.
+    ///
+    /// The parent's kernel start signature is passed on the command line beside its identifier,
+    /// and both are compared on every poll. Watching the identifier alone would keep a watchdog
+    /// waiting on whatever process later inherits it, so the override it was armed for would
+    /// never be restored. An invocation that carries no signature is therefore not watched at
+    /// all: it exits without touching a setting, leaving the backup on disk for the app's own
+    /// launch-time recovery.
     static func run(arguments: [String]) -> Bool {
-        guard arguments.count >= 4,
-              arguments[1] == "--rockxy-direct-proxy-watchdog",
-              let parentPID = Int32(arguments[2]) else
-        {
+        switch DirectProxyWatchdogInvocation.parse(arguments: arguments) {
+        case .notAWatchdog:
             return false
-        }
+        case .unidentifiableParent:
+            logger
+                .error(
+                    "Direct proxy watchdog was not given an identifiable parent process — exiting without watching"
+                )
+            return true
+        case let .watch(parentPID, backupPath, parentStartSignature):
+            let backupURL = URL(fileURLWithPath: backupPath)
+            logger.info("RockxyHelperTool running direct proxy watchdog for parent pid \(parentPID)")
 
-        let backupPath = arguments[3]
-        let backupURL = URL(fileURLWithPath: backupPath)
-        logger.info("RockxyHelperTool running direct proxy watchdog for parent pid \(parentPID)")
-
-        while true {
-            let parentAlive = isProcessAlive(parentPID)
-            let backupExists = FileManager.default.fileExists(atPath: backupPath)
-
-            if !backupExists {
-                return true
-            }
-
-            if parentAlive {
-                Thread.sleep(forTimeInterval: 0.5)
-                continue
-            }
-
-            restoreIfNeeded(from: backupURL)
+            DirectProxyWatchdogRuntime.watch(
+                parentIsLive: {
+                    parentSessionIsLive(pid: parentPID, startSignature: parentStartSignature)
+                },
+                backupExists: {
+                    backupStillBelongsToWatchdog(
+                        at: backupURL,
+                        parentPID: parentPID,
+                        parentStartSignature: parentStartSignature
+                    )
+                },
+                restore: {
+                    restoreIfNeeded(
+                        from: backupURL,
+                        parentPID: parentPID,
+                        parentStartSignature: parentStartSignature
+                    )
+                },
+                waitBeforeNextPoll: { Thread.sleep(forTimeInterval: pollInterval) }
+            )
             return true
         }
     }
@@ -152,16 +78,64 @@ private enum DirectProxyWatchdog {
     // MARK: Private
 
     private static let networkSetupPath = "/usr/sbin/networksetup"
+    private static let pollInterval: TimeInterval = 0.5
 
-    /// Restores only the backed-up services that still carry Rockxy's override. A service the
+    /// Restores only the backed-up services the recovery journal still authorizes. A service the
     /// user re-pointed after the crash is left alone, and its absence never justifies deleting
     /// the restore point the remaining owned services still depend on.
-    private static func restoreIfNeeded(from backupURL: URL) {
+    ///
+    /// The journal is written before the first command and again after each service's commands
+    /// return, so a watchdog that dies mid-restore leaves a record a later attempt can read:
+    /// settings this restore could have produced are written again, and settings it could not are
+    /// treated as the user's and dropped from recovery untouched.
+    ///
+    /// The per-service loop is `DirectProxyRecoveryRunner`, the same one the app runs. Sharing it
+    /// rather than keeping a second copy here is deliberate: the states these two produce are only
+    /// ever observed after a crash, which is exactly where a divergence between them would first
+    /// be found — and it would be found as a user's settings overwritten.
+    private static func restoreIfNeeded(
+        from backupURL: URL,
+        parentPID: Int32,
+        parentStartSignature: String
+    ) {
+        do {
+            try DirectProxySessionLock.withExclusiveAccess(backupURL: backupURL) {
+                restoreIfNeededLocked(
+                    from: backupURL,
+                    parentPID: parentPID,
+                    parentStartSignature: parentStartSignature
+                )
+            }
+        } catch {
+            logger.error("Direct proxy watchdog could not acquire the session lock: \(error.localizedDescription)")
+        }
+    }
+
+    /// Reloads and validates ownership only after the cross-process lock is held.
+    private static func restoreIfNeededLocked(
+        from backupURL: URL,
+        parentPID: Int32,
+        parentStartSignature: String
+    ) {
         guard let backup = loadBackup(from: backupURL) else {
             return
         }
+        guard DirectProxyBackupOwnerPolicy.belongsToSession(
+            backup,
+            processIdentifier: parentPID,
+            processStartSignature: parentStartSignature
+        ) else {
+            logger.info("Direct proxy watchdog leaving a backup owned by another app session untouched")
+            return
+        }
 
-        let ownedServices = backup.recoveryPending
+        // A recovery already under way keeps every retained service in play, because a partial
+        // command can leave a shape strict ownership no longer recognises. An override this
+        // machine recorded itself as applying does the same, because a sequence that stopped
+        // half-way leaves a service strict ownership does not recognise either. Which of them may
+        // still be written is then decided per service against the journal.
+        let recoveryHasStarted = backup.recoveryPending || !backup.journal.isEmpty
+        let ownedServices = recoveryHasStarted
             ? backup.services.map(\.service)
             : residualOwnedServices(in: backup)
         guard !ownedServices.isEmpty else {
@@ -170,20 +144,66 @@ private enum DirectProxyWatchdog {
             return
         }
 
-        // Narrow the backup before mutating anything: if this write fails, the original backup
-        // and the current settings both stay exactly as they are.
-        let ownedBackup = DirectProxyBackup(
+        let candidateEntries = ProxyBackupSubset.select(
+            backup.services,
+            services: Set(ownedServices),
+            serviceName: \.service
+        )
+        // A service with no usable record enters recovery only when the live settings still prove
+        // Rockxy owns it on the persisted port. Anything weaker keeps its restore point rather
+        // than being adopted as the state a restore begins from.
+        let plan = ProxyRecoveryPlanner.plan(
+            targets: candidateEntries.map(\.restorationTarget),
+            journal: backup.journal,
+            liveStates: currentRestorationStates(for: candidateEntries.map(\.service)),
+            ownedPort: backup.rockxyPort
+        )
+
+        if !plan.abandonedServices.isEmpty {
+            logger
+                .warning(
+                    "Direct proxy watchdog leaving \(plan.abandonedServices.count) service(s) out of recovery — their proxy settings were changed outside this restore"
+                )
+        }
+
+        let plannedJournal = plan.entriesToRestore + ProxyBackupSubset.select(
+            backup.journal,
+            services: Set(plan.deferredServices),
+            serviceName: \.service
+        )
+
+        guard !plan.entriesToRestore.isEmpty else {
+            // Nothing is written, so the backup keeps the flag it arrived with.
+            retainOrClear(
+                backup: backup,
+                services: plan.deferredServices,
+                journal: plannedJournal,
+                recoveryPending: backup.recoveryPending,
+                at: backupURL
+            )
+            return
+        }
+
+        // Narrow the backup and record the intent before mutating anything: if this write fails,
+        // the original backup and the current settings both stay exactly as they are. Every
+        // planned service is recorded at the stage it was planned at, so a service nothing has
+        // been issued for stays `pending` even if this watchdog dies while writing another one.
+        let retention = ProxyBackupRetention(authorized: plan.servicesKeepingBackup, preserved: [])
+        let narrowedBackup = DirectProxyBackup(
             services: ProxyBackupSubset.select(
                 backup.services,
-                services: Set(ownedServices),
+                services: Set(retention.services),
                 serviceName: \.service
             ),
             timestamp: backup.timestamp,
             rockxyPort: backup.rockxyPort,
-            recoveryPending: true
+            ownerPID: backup.ownerPID,
+            ownerStartSignature: backup.ownerStartSignature,
+            recoveryPending: true,
+            journal: plannedJournal
         )
         do {
-            try write(ownedBackup, to: backupURL)
+            try write(narrowedBackup, to: backupURL)
         } catch {
             logger
                 .error(
@@ -194,64 +214,122 @@ private enum DirectProxyWatchdog {
 
         logger
             .warning(
-                "Direct proxy watchdog restoring \(ownedBackup.services.count) owned service(s) after parent exit"
-            )
-        var failedServices: Set<String> = []
-
-        for entry in ownedBackup.services {
-            let snapshot = DirectProxySnapshot(
-                httpEnabled: entry.httpEnabled,
-                httpHost: entry.httpHost,
-                httpPort: entry.httpPort,
-                httpsEnabled: entry.httpsEnabled,
-                httpsHost: entry.httpsHost,
-                httpsPort: entry.httpsPort,
-                socksEnabled: entry.socksEnabled,
-                socksHost: entry.socksHost,
-                socksPort: entry.socksPort,
-                pacEnabled: entry.pacEnabled,
-                pacURL: entry.pacURL,
-                autoDiscoveryEnabled: entry.autoDiscoveryEnabled
+                "Direct proxy watchdog restoring \(plan.entriesToRestore.count) owned service(s) after parent exit"
             )
 
-            do {
-                try restoreProxyState(for: entry.service, snapshot: snapshot)
-            } catch {
-                failedServices.insert(entry.service)
-                logger
-                    .error(
-                        "Direct proxy watchdog failed to restore proxy state for '\(entry.service)': \(error.localizedDescription)"
-                    )
-            }
-
-            do {
-                try restoreBypassDomains(for: entry.service, domains: entry.bypassDomains)
-            } catch {
-                failedServices.insert(entry.service)
-                logger
-                    .error(
-                        "Direct proxy watchdog failed to restore bypass domains for '\(entry.service)': \(error.localizedDescription)"
-                    )
-            }
-        }
-
-        let unresolvedEntries = ProxyBackupSubset.unresolvedEntries(
-            ownedBackup.services,
-            failedServices: failedServices,
-            stillOwnedServices: Set(residualOwnedServices(in: ownedBackup)),
-            serviceName: \.service
+        let outcome = DirectProxyRecoveryRunner.run(
+            entriesToRestore: plan.entriesToRestore,
+            backup: narrowedBackup,
+            journal: plannedJournal,
+            retention: retention,
+            deferredServices: plan.deferredServices,
+            effects: recoveryEffects(at: backupURL)
         )
 
-        guard !unresolvedEntries.isEmpty else {
+        let unresolvedServices = ProxyBackupSubset.unresolvedEntries(
+            outcome.attemptedServices,
+            failedServices: outcome.failedServices,
+            stillOwnedServices: Set(residualOwnedServices(in: outcome.backup)),
+            serviceName: { $0 }
+        ) + outcome.deferredServices
+
+        retainOrClear(
+            backup: outcome.backup,
+            services: outcome.retention.retainedAfterAttempt(unresolvedServices: unresolvedServices),
+            journal: outcome.journal,
+            recoveryPending: true,
+            at: backupURL
+        )
+    }
+
+    /// How the watchdog reaches `networksetup` and the backup file during a recovery run.
+    private static func recoveryEffects(at backupURL: URL) -> DirectProxyRecoveryEffects {
+        DirectProxyRecoveryEffects(
+            readState: { readRestorationState(for: $0) },
+            publishBackup: { try write($0, to: backupURL) },
+            restoreProxyState: { entry in
+                try restoreProxyState(for: entry.service, snapshot: snapshot(of: entry))
+            },
+            restoreBypassDomains: { entry in
+                try restoreBypassDomains(for: entry.service, domains: entry.bypassDomains)
+            },
+            log: { event in
+                switch event {
+                case let .droppedChangedService(service):
+                    logger
+                        .warning(
+                            "Direct proxy watchdog dropping '\(service)' — its proxy settings are no longer the ones this recovery planned for"
+                        )
+                case let .deferredUnreadableService(service):
+                    logger
+                        .warning(
+                            "Direct proxy watchdog deferring '\(service)' — its proxy settings could not be read before restoring"
+                        )
+                case let .uncommittedService(service, error):
+                    logger
+                        .error(
+                            "Direct proxy watchdog could not record the restore of '\(service)' — issuing no command for it: \(error.localizedDescription)"
+                        )
+                case let .failedStep(service, step, error):
+                    logger
+                        .error(
+                            "Direct proxy watchdog stopped restoring '\(service)' at the \(step.rawValue) step: \(error?.localizedDescription ?? "unknown error")"
+                        )
+                case let .backupUpdateFailed(error):
+                    logger
+                        .error(
+                            "Direct proxy watchdog could not update the retained backup: \(error.localizedDescription)"
+                        )
+                }
+            }
+        )
+    }
+
+    /// One service's captured settings in the shape the restore commands take.
+    private static func snapshot(of entry: DirectServiceBackup) -> DirectProxySnapshot {
+        DirectProxySnapshot(
+            httpEnabled: entry.httpEnabled,
+            httpHost: entry.httpHost,
+            httpPort: entry.httpPort,
+            httpsEnabled: entry.httpsEnabled,
+            httpsHost: entry.httpsHost,
+            httpsPort: entry.httpsPort,
+            socksEnabled: entry.socksEnabled,
+            socksHost: entry.socksHost,
+            socksPort: entry.socksPort,
+            pacEnabled: entry.pacEnabled,
+            pacURL: entry.pacURL,
+            autoDiscoveryEnabled: entry.autoDiscoveryEnabled
+        )
+    }
+
+    /// Keeps exactly the services that still need a restore point, or removes the backup when
+    /// none do.
+    private static func retainOrClear(
+        backup: DirectProxyBackup,
+        services: [String],
+        journal: [ProxyServiceRecoveryJournalEntry],
+        recoveryPending: Bool,
+        at backupURL: URL
+    ) {
+        guard !services.isEmpty else {
             try? FileManager.default.removeItem(at: backupURL)
             return
         }
 
+        let retainedServices = Set(services)
         let retainedBackup = DirectProxyBackup(
-            services: unresolvedEntries,
-            timestamp: ownedBackup.timestamp,
-            rockxyPort: ownedBackup.rockxyPort,
-            recoveryPending: true
+            services: ProxyBackupSubset.select(
+                backup.services,
+                services: retainedServices,
+                serviceName: \.service
+            ),
+            timestamp: backup.timestamp,
+            rockxyPort: backup.rockxyPort,
+            ownerPID: backup.ownerPID,
+            ownerStartSignature: backup.ownerStartSignature,
+            recoveryPending: recoveryPending,
+            journal: ProxyBackupSubset.select(journal, services: retainedServices, serviceName: \.service)
         )
         do {
             try write(retainedBackup, to: backupURL)
@@ -260,17 +338,57 @@ private enum DirectProxyWatchdog {
         }
         logger
             .warning(
-                "Direct proxy watchdog left \(unresolvedEntries.count) service(s) in the backup for later recovery"
+                "Direct proxy watchdog left \(services.count) service(s) in the backup for later recovery"
             )
     }
 
-    private static func write(_ backup: DirectProxyBackup, to backupURL: URL) throws {
-        let data = try PropertyListEncoder().encode(backup)
-        try data.write(to: backupURL, options: .atomic)
-        try FileManager.default.setAttributes(
-            [.posixPermissions: 0o600],
-            ofItemAtPath: backupURL.path
+    /// Reads the full restoration-relevant shape of each service. A service whose settings cannot
+    /// be read is left out rather than reported as empty, so recovery defers it instead of
+    /// treating an unreadable service as a changed one.
+    private static func currentRestorationStates(
+        for services: [String]
+    )
+        -> [String: ProxyServiceRestorationState]
+    {
+        var states: [String: ProxyServiceRestorationState] = [:]
+        for service in services {
+            states[service] = readRestorationState(for: service)
+        }
+        return states
+    }
+
+    private static func readRestorationState(for service: String) -> ProxyServiceRestorationState? {
+        guard let httpOutput = try? runNetworkSetup(["-getwebproxy", service]),
+              let httpsOutput = try? runNetworkSetup(["-getsecurewebproxy", service]),
+              let socksOutput = try? runNetworkSetup(["-getsocksfirewallproxy", service]),
+              let pacOutput = try? runNetworkSetup(["-getautoproxyurl", service]),
+              let autoDiscoveryOutput = try? runNetworkSetup(["-getproxyautodiscovery", service]),
+              let bypassOutput = try? runNetworkSetup(["-getproxybypassdomains", service])
+        else {
+            return nil
+        }
+
+        let http = parseProxyOutput(httpOutput)
+        let https = parseProxyOutput(httpsOutput)
+        let socks = parseProxyOutput(socksOutput)
+        let pac = parsePACOutput(pacOutput)
+
+        return ProxyServiceRestorationState(
+            service: service,
+            http: ProxyEndpointState(enabled: http.enabled, host: http.host, port: http.port),
+            https: ProxyEndpointState(enabled: https.enabled, host: https.host, port: https.port),
+            socks: ProxyEndpointState(enabled: socks.enabled, host: socks.host, port: socks.port),
+            pacEnabled: pac.enabled,
+            pacURL: pac.url,
+            autoDiscoveryEnabled: parseAutoDiscoveryOutput(autoDiscoveryOutput),
+            bypassDomains: ProxyBypassDomainOutput.parse(bypassOutput)
         )
+    }
+
+    /// Publishes the backup with its permissions already in place, so a reported failure always
+    /// means the previous record is still the one on disk.
+    private static func write(_ backup: DirectProxyBackup, to backupURL: URL) throws {
+        try ProxyBackupFilePublication.publish(PropertyListEncoder().encode(backup), to: backupURL)
     }
 
     private static func loadBackup(from backupURL: URL) -> DirectProxyBackup? {
@@ -279,45 +397,60 @@ private enum DirectProxyWatchdog {
             return try PropertyListDecoder().decode(DirectProxyBackup.self, from: data)
         } catch {
             logger.error("Direct proxy watchdog could not load backup: \(error.localizedDescription)")
-            try? FileManager.default.removeItem(at: backupURL)
             return nil
         }
     }
 
+    /// An unreadable record is retained and retried. A readable record owned by a newer session
+    /// ends this watcher, while a missing record means another recovery already completed.
+    private static func backupStillBelongsToWatchdog(
+        at backupURL: URL,
+        parentPID: Int32,
+        parentStartSignature: String
+    )
+        -> Bool
+    {
+        guard FileManager.default.fileExists(atPath: backupURL.path) else {
+            return false
+        }
+        guard let backup = loadBackup(from: backupURL) else {
+            return true
+        }
+        return DirectProxyBackupOwnerPolicy.belongsToSession(
+            backup,
+            processIdentifier: parentPID,
+            processStartSignature: parentStartSignature
+        )
+    }
+
     /// The backed-up services that still carry Rockxy's override on the persisted port.
     private static func residualOwnedServices(in backup: DirectProxyBackup) -> [String] {
-        ProxyOverrideOwnership.residualOwnedServices(
-            in: backup.services.map { currentOverrideState(for: $0.service) },
+        let services = backup.services.map(\.service)
+        let liveStates = currentRestorationStates(for: services)
+        guard liveStates.count == services.count else {
+            // A transient read failure cannot prove an override disappeared. Keep all candidates
+            // so the recovery planner defers unreadable services without dropping their backup.
+            return services
+        }
+        return ProxyOverrideOwnership.residualOwnedServices(
+            in: services.compactMap { liveStates[$0]?.overrideState },
             port: backup.rockxyPort
         )
     }
 
+    /// A service whose settings cannot be read reports as not overridden, which keeps recovery
+    /// from claiming ownership it cannot prove.
     private static func currentOverrideState(for service: String) -> ProxyServiceOverrideState {
-        let http = parseProxyOutput((try? runNetworkSetup(["-getwebproxy", service])) ?? "")
-        let https = parseProxyOutput((try? runNetworkSetup(["-getsecurewebproxy", service])) ?? "")
-        let socks = parseProxyOutput((try? runNetworkSetup(["-getsocksfirewallproxy", service])) ?? "")
-        let pac = parsePACOutput((try? runNetworkSetup(["-getautoproxyurl", service])) ?? "")
-        let autoDiscovery = parseAutoDiscoveryOutput(
-            (try? runNetworkSetup(["-getproxyautodiscovery", service])) ?? ""
-        )
-        let bypassOutput = (try? runNetworkSetup(["-getproxybypassdomains", service])) ?? ""
-        let hasGlobalBypass = bypassOutput.components(separatedBy: "\n").contains {
-            $0.trimmingCharacters(in: .whitespacesAndNewlines) == "*"
-        }
-
-        return ProxyServiceOverrideState(
-            service: service,
-            httpEnabled: http.enabled,
-            httpHost: http.host,
-            httpPort: http.port,
-            httpsEnabled: https.enabled,
-            httpsHost: https.host,
-            httpsPort: https.port,
-            socksEnabled: socks.enabled,
-            pacEnabled: pac.enabled,
-            autoDiscoveryEnabled: autoDiscovery,
-            hasGlobalBypass: hasGlobalBypass
-        )
+        readRestorationState(for: service)?.overrideState
+            ?? ProxyServiceOverrideState(
+                service: service,
+                httpEnabled: false,
+                httpHost: "",
+                httpPort: 0,
+                httpsEnabled: false,
+                httpsHost: "",
+                httpsPort: 0
+            )
     }
 
     private static func restoreProxyState(for service: String, snapshot: DirectProxySnapshot) throws {
@@ -448,11 +581,17 @@ private enum DirectProxyWatchdog {
         return stdout
     }
 
-    private static func isProcessAlive(_ pid: Int32) -> Bool {
-        if kill(pid, 0) == 0 {
-            return true
-        }
-        return errno == EPERM
+    /// Whether the watched parent is still the exact process this watchdog was armed for. A
+    /// reused identifier answers false, which is what makes the stranded override get restored
+    /// instead of waited on forever.
+    private static func parentSessionIsLive(pid: Int32, startSignature: String) -> Bool {
+        let processIsAlive = ProcessStartIdentity.isAlive(pid)
+        return ProxyOwnerWatchdogPolicy.watchedOwnerIsLive(
+            recordedPID: pid,
+            recordedStartSignature: startSignature,
+            processIsAlive: processIsAlive,
+            liveStartSignature: processIsAlive ? ProcessStartIdentity.startSignature(for: pid) : nil
+        )
     }
 }
 
@@ -465,8 +604,19 @@ logger.info("RockxyHelperTool starting up")
 // Check for stale proxy settings from a previous crash. A session whose owner is still alive
 // and still validates keeps its override, and its watchdog is re-armed before this helper takes
 // any new work, so a later owner death still restores the user's settings.
-if case let .preserved(ownerPID) = CrashRecovery.restoreIfNeeded(), let ownerPID {
-    HelperService.shared.resumeOwnerWatchdog(for: ownerPID)
+switch HelperService.performStartupRecovery() {
+case let .preserved(owner):
+    if let owner {
+        HelperService.resumeOwnerWatchdog(
+            for: owner.processIdentifier,
+            startSignature: owner.startSignature,
+            userID: owner.userID
+        )
+    }
+case .restoreIncomplete:
+    HelperService.scheduleBackupRecovery(reason: "helper startup")
+case .noBackup, .cleared, .restored:
+    break
 }
 
 let delegate = HelperDelegate()

--- a/RockxyTests/Core/ProxyEngine/HelperProxyBackupOwnerIdentityTests.swift
+++ b/RockxyTests/Core/ProxyEngine/HelperProxyBackupOwnerIdentityTests.swift
@@ -28,6 +28,7 @@ struct HelperProxyBackupOwnerIdentityTests {
         #expect(decoded.ownerPID == nil)
         #expect(decoded.ownerStartSignature == nil)
         #expect(decoded.recoveryPending == false)
+        #expect(decoded.journal.isEmpty)
     }
 
     @Test("Helper backups predating the persisted port still decode")
@@ -89,6 +90,122 @@ struct HelperProxyBackupOwnerIdentityTests {
         #expect(decoded.recoveryPending)
     }
 
+    @Test("A helper backup carries its recovery journal through a plist roundtrip")
+    func recoveryJournalRoundtrips() throws {
+        let live = ProxyServiceRestorationState(
+            service: "Wi-Fi",
+            http: ProxyEndpointState(enabled: true, host: "127.0.0.1", port: 9_090),
+            https: ProxyEndpointState(enabled: true, host: "127.0.0.1", port: 9_090),
+            socks: ProxyEndpointState(enabled: false, host: "", port: 0),
+            pacEnabled: false,
+            pacURL: "",
+            autoDiscoveryEnabled: false,
+            bypassDomains: []
+        )
+        let target = ProxyServiceRestorationState(
+            service: "Wi-Fi",
+            http: ProxyEndpointState(enabled: true, host: "proxy.corp.example", port: 8_080),
+            https: ProxyEndpointState(enabled: true, host: "proxy.corp.example", port: 8_080),
+            socks: ProxyEndpointState(enabled: false, host: "", port: 0),
+            pacEnabled: false,
+            pacURL: "",
+            autoDiscoveryEnabled: false,
+            bypassDomains: ["localhost"]
+        )
+        let entry = ProxyServiceRecoveryJournalEntry(
+            service: "Wi-Fi",
+            stage: .restored,
+            expectedPreStepState: live,
+            target: target
+        )
+        let backup = ProxyBackupMirror(
+            services: [makeServiceBackup()],
+            timestamp: Date(),
+            rockxyPort: 9_090,
+            ownerPID: nil,
+            ownerStartSignature: nil,
+            recoveryPending: true,
+            journal: [entry]
+        )
+
+        let data = try PropertyListEncoder().encode(backup)
+        let decoded = try PropertyListDecoder().decode(ProxyBackupMirror.self, from: data)
+
+        #expect(decoded.journal == [entry])
+        #expect(decoded.journal.first?.stage == .restored)
+    }
+
+    @Test("A backup written before the copy marker existed still decodes, and still counts")
+    func aLegacyCopyKeepsItsMigrationBehaviour() throws {
+        let legacy = LegacyProxyBackupMirror(
+            services: [makeServiceBackup()],
+            timestamp: Date(),
+            rockxyPort: 9_090
+        )
+
+        let data = try PropertyListEncoder().encode(legacy)
+        let decoded = try PropertyListDecoder().decode(ProxyBackupMirror.self, from: data)
+
+        #expect(decoded.copyRole == nil)
+        // An unmarked copy in the compatibility location was written by a build that predates the
+        // marker, so it is the only backup that build ever had — refusing it would strand it.
+        #expect(ProxyBackupCopyPolicy.isRecoveryTruth(
+            role: decoded.copyRole,
+            isAuthoritativeLocation: false
+        ))
+    }
+
+    @Test("A prepared compatibility copy remains a recovery answer")
+    func aCurrentFormatMirrorIsAccepted() throws {
+        let mirror = ProxyBackupMirror(
+            services: [makeServiceBackup()],
+            timestamp: Date(),
+            rockxyPort: 9_090,
+            ownerPID: nil,
+            ownerStartSignature: nil,
+            copyRole: .mirror
+        )
+
+        let data = try PropertyListEncoder().encode(mirror)
+        let decoded = try PropertyListDecoder().decode(ProxyBackupMirror.self, from: data)
+
+        #expect(decoded.copyRole == .mirror)
+        // Mirrors are prepared before the authoritative commit. A surviving copy is therefore the
+        // committed record, or a safe attempt whose failed commit authorized no proxy command.
+        #expect(ProxyBackupCopyPolicy.isRecoveryTruth(
+            role: decoded.copyRole,
+            isAuthoritativeLocation: false
+        ))
+    }
+
+    @Test("The authoritative location is recovery's answer whatever it is marked as")
+    func theAuthoritativeCopyIsAlwaysTruth() {
+        // A file explicitly marked as a mirror never becomes authoritative merely by being moved.
+        #expect(ProxyBackupCopyPolicy.isRecoveryTruth(role: .authoritative, isAuthoritativeLocation: true))
+        #expect(ProxyBackupCopyPolicy.isRecoveryTruth(role: nil, isAuthoritativeLocation: true))
+        #expect(!ProxyBackupCopyPolicy.isRecoveryTruth(role: .mirror, isAuthoritativeLocation: true))
+    }
+
+    @Test("The copy marker survives a plist roundtrip alongside everything else")
+    func theCopyMarkerRoundtrips() throws {
+        let backup = ProxyBackupMirror(
+            services: [makeServiceBackup()],
+            timestamp: Date(),
+            rockxyPort: 9_090,
+            ownerPID: 4_242,
+            ownerStartSignature: "1788787973.748707",
+            recoveryPending: true,
+            copyRole: .authoritative
+        )
+
+        let data = try PropertyListEncoder().encode(backup)
+        let decoded = try PropertyListDecoder().decode(ProxyBackupMirror.self, from: data)
+
+        #expect(decoded.copyRole == .authoritative)
+        #expect(decoded.ownerPID == 4_242)
+        #expect(decoded.recoveryPending)
+    }
+
     // MARK: Private
 
     /// Mirror of CrashRecovery.ServiceProxyBackup — must match the helper tool's struct layout.
@@ -127,7 +244,9 @@ struct HelperProxyBackupOwnerIdentityTests {
             rockxyPort: Int?,
             ownerPID: Int32?,
             ownerStartSignature: String?,
-            recoveryPending: Bool = false
+            recoveryPending: Bool = false,
+            journal: [ProxyServiceRecoveryJournalEntry] = [],
+            copyRole: ProxyBackupCopyRole? = nil
         ) {
             self.services = services
             self.timestamp = timestamp
@@ -135,6 +254,8 @@ struct HelperProxyBackupOwnerIdentityTests {
             self.ownerPID = ownerPID
             self.ownerStartSignature = ownerStartSignature
             self.recoveryPending = recoveryPending
+            self.journal = journal
+            self.copyRole = copyRole
         }
 
         init(from decoder: any Decoder) throws {
@@ -145,6 +266,11 @@ struct HelperProxyBackupOwnerIdentityTests {
             ownerPID = try container.decodeIfPresent(Int32.self, forKey: .ownerPID)
             ownerStartSignature = try container.decodeIfPresent(String.self, forKey: .ownerStartSignature)
             recoveryPending = try container.decodeIfPresent(Bool.self, forKey: .recoveryPending) ?? false
+            journal = (try? container.decodeIfPresent(
+                [ProxyServiceRecoveryJournalEntry].self,
+                forKey: .journal
+            )) ?? []
+            copyRole = try? container.decodeIfPresent(ProxyBackupCopyRole.self, forKey: .copyRole)
         }
 
         // MARK: Internal
@@ -155,6 +281,8 @@ struct HelperProxyBackupOwnerIdentityTests {
         let ownerPID: Int32?
         let ownerStartSignature: String?
         let recoveryPending: Bool
+        let journal: [ProxyServiceRecoveryJournalEntry]
+        let copyRole: ProxyBackupCopyRole?
 
         // MARK: Private
 
@@ -165,6 +293,8 @@ struct HelperProxyBackupOwnerIdentityTests {
             case ownerPID
             case ownerStartSignature
             case recoveryPending
+            case journal
+            case copyRole
         }
     }
 

--- a/RockxyTests/Core/TrafficCapture/ProxyBackupCommitTests.swift
+++ b/RockxyTests/Core/TrafficCapture/ProxyBackupCommitTests.swift
@@ -1,0 +1,219 @@
+import Foundation
+@testable import Rockxy
+import Testing
+
+// Regression tests for the order a proxy backup's two on-disk copies are published in, and for
+// what a current build is allowed to read back from them after an upgrade.
+
+// MARK: - ProxyBackupCommitTests
+
+struct ProxyBackupCommitTests {
+    @Test("The compatibility copies are dealt with before the authoritative record is committed")
+    func compatibilityCopiesArePreparedFirst() throws {
+        var steps: [String] = []
+
+        try ProxyBackupCommit.run(
+            prepareCompatibilityCopies: { steps.append("compatibility") },
+            publishAuthoritative: { steps.append("authoritative") }
+        )
+
+        #expect(steps == ["compatibility", "authoritative"])
+    }
+
+    @Test("A compatibility copy that cannot be prepared stops the commit before it happens")
+    func aFailedCompatibilityCopyBlocksTheCommit() {
+        var committed = false
+
+        #expect(throws: BackupWriteError.self) {
+            try ProxyBackupCommit.run(
+                prepareCompatibilityCopies: { throw BackupWriteError.denied },
+                publishAuthoritative: { committed = true }
+            )
+        }
+
+        // A reported failure has to mean nothing was committed: every caller treats a successful
+        // write as its permission to issue a `networksetup` command.
+        #expect(!committed)
+    }
+
+    @Test("A compatibility copy that cannot be written is removed instead")
+    func anUnwritableCompatibilityCopyIsInvalidated() throws {
+        var exists = true
+
+        let outcome = try ProxyBackupCompatibilityCopy.prepare(
+            publish: { throw BackupWriteError.denied },
+            remove: { exists = false },
+            copyExists: { exists }
+        )
+
+        #expect(outcome == .invalidated)
+    }
+
+    @Test("A compatibility copy that can be neither written nor removed is a pre-commit failure")
+    func aStubbornCompatibilityCopyThrows() {
+        #expect(throws: BackupWriteError.self) {
+            try ProxyBackupCompatibilityCopy.prepare(
+                publish: { throw BackupWriteError.denied },
+                remove: {},
+                copyExists: { true }
+            )
+        }
+    }
+}
+
+// MARK: - ProxyBackupUpgradeTests
+
+/// The upgrade these cover is the one where the marker itself is new: a build that predates it
+/// wrote unmarked bytes to both locations, and a current build reads an unmarked compatibility
+/// copy as truth — correctly, because for that build it was the only backup there was. What must
+/// never happen is that answer surviving into a session where a current-format commit has already
+/// moved on without it.
+struct ProxyBackupUpgradeTests {
+    // MARK: Internal
+
+    @Test("An unmarked compatibility copy is truth only while no current commit has succeeded")
+    func b0BackupIsReadableUntilB1Commits() throws {
+        let disk = BackupDisk()
+        disk.writeUnmarkedLegacyBackupToBothLocations(named: "b0")
+
+        // B0's own backup: nothing current has been committed, so the compatibility copy is the
+        // only record there is and reading it is the honest answer.
+        #expect(disk.load() == "b0")
+
+        try disk.commit(named: "b1")
+
+        // After the commit both copies are current, and the authoritative one is what recovery
+        // reads.
+        #expect(disk.load() == "b1")
+        #expect(disk.role(at: .compatibility) == .mirror)
+    }
+
+    @Test("Losing the authoritative record falls back to the prepared current mirror")
+    func aLostAuthoritativeRecordUsesB1Mirror() throws {
+        let disk = BackupDisk()
+        disk.writeUnmarkedLegacyBackupToBothLocations(named: "b0")
+        try disk.commit(named: "b1")
+
+        disk.remove(.authoritative)
+
+        // The compatibility copy was prepared as B1 before the authoritative commit advanced,
+        // so it is the exact current restore point rather than the older unmarked B0 bytes.
+        #expect(disk.load() == "b1")
+    }
+
+    @Test("A commit that could not convert the compatibility copy never advances")
+    func aBlockedCompatibilityCopyLeavesTheOldCommitInPlace() throws {
+        let disk = BackupDisk()
+        try disk.commit(named: "b1")
+        disk.compatibilityCopyIsWritable = false
+        disk.compatibilityCopyIsRemovable = false
+
+        #expect(throws: BackupWriteError.self) {
+            try disk.commit(named: "b2")
+        }
+
+        // The record on disk is still the one the previous commit published, which is what a
+        // caller that was told "this write failed" has to be able to rely on.
+        #expect(disk.load() == "b1")
+    }
+
+    @Test("Copy roles are accepted only at compatible recovery locations")
+    func copyRolesMatchTheirRecoveryLocations() {
+        #expect(!ProxyBackupCopyPolicy.isRecoveryTruth(role: .mirror, isAuthoritativeLocation: true))
+        #expect(ProxyBackupCopyPolicy.isRecoveryTruth(role: .authoritative, isAuthoritativeLocation: true))
+        #expect(ProxyBackupCopyPolicy.isRecoveryTruth(role: nil, isAuthoritativeLocation: true))
+        #expect(ProxyBackupCopyPolicy.isRecoveryTruth(role: .mirror, isAuthoritativeLocation: false))
+        #expect(!ProxyBackupCopyPolicy.isRecoveryTruth(role: .authoritative, isAuthoritativeLocation: false))
+        #expect(ProxyBackupCopyPolicy.isRecoveryTruth(role: nil, isAuthoritativeLocation: false))
+    }
+
+    // MARK: Private
+
+    /// The two on-disk locations a proxy backup lives at, published and read through the same
+    /// policies the helper uses. Modelling the bytes rather than the filesystem keeps the ordering
+    /// under test deterministic and root-free.
+    private final class BackupDisk {
+        // MARK: Internal
+
+        enum Location {
+            case authoritative
+            case compatibility
+        }
+
+        var compatibilityCopyIsWritable = true
+        var compatibilityCopyIsRemovable = true
+
+        func writeUnmarkedLegacyBackupToBothLocations(named name: String) {
+            authoritative = (name, nil)
+            compatibility = (name, nil)
+        }
+
+        func commit(named name: String) throws {
+            try ProxyBackupCommit.run(
+                prepareCompatibilityCopies: {
+                    try ProxyBackupCompatibilityCopy.prepare(
+                        publish: {
+                            guard compatibilityCopyIsWritable else {
+                                throw BackupWriteError.denied
+                            }
+                            compatibility = (name, .mirror)
+                        },
+                        remove: {
+                            guard compatibilityCopyIsRemovable else {
+                                return
+                            }
+                            compatibility = nil
+                        },
+                        copyExists: { compatibility != nil }
+                    )
+                },
+                publishAuthoritative: { authoritative = (name, .authoritative) }
+            )
+        }
+
+        func remove(_ location: Location) {
+            switch location {
+            case .authoritative:
+                authoritative = nil
+            case .compatibility:
+                compatibility = nil
+            }
+        }
+
+        func role(at location: Location) -> ProxyBackupCopyRole? {
+            switch location {
+            case .authoritative:
+                authoritative?.role
+            case .compatibility:
+                compatibility?.role
+            }
+        }
+
+        /// The loader, in the order the helper reads the locations.
+        func load() -> String? {
+            for (isAuthoritativeLocation, copy) in [(true, authoritative), (false, compatibility)] {
+                guard let copy else {
+                    continue
+                }
+                if ProxyBackupCopyPolicy.isRecoveryTruth(
+                    role: copy.role,
+                    isAuthoritativeLocation: isAuthoritativeLocation
+                ) {
+                    return copy.name
+                }
+            }
+            return nil
+        }
+
+        // MARK: Private
+
+        private var authoritative: (name: String, role: ProxyBackupCopyRole?)?
+        private var compatibility: (name: String, role: ProxyBackupCopyRole?)?
+    }
+}
+
+// MARK: - BackupWriteError
+
+private enum BackupWriteError: Error {
+    case denied
+}

--- a/RockxyTests/Core/TrafficCapture/ProxyOperationGateTests.swift
+++ b/RockxyTests/Core/TrafficCapture/ProxyOperationGateTests.swift
@@ -1,0 +1,355 @@
+import Foundation
+@testable import Rockxy
+import Testing
+
+// Regression tests for the gate that keeps a termination cleanup out of the middle of an enable.
+
+// MARK: - ProxyOperationGateTests
+
+/// Deterministic rather than timing-based: the second thread is only released once the first is
+/// provably inside its operation, so what these observe is the ordering itself.
+struct ProxyOperationGateTests {
+    @Test("A cleanup cannot start while an enable still has commands to write")
+    func operationsDoNotInterleave() {
+        let gate = ProxyOperationGate()
+        let events = EventLog()
+        let enableIsInside = DispatchSemaphore(value: 0)
+        let cleanupHasBeenAsked = DispatchSemaphore(value: 0)
+        let cleanupFinished = DispatchSemaphore(value: 0)
+
+        let enable = Thread {
+            gate.withOperation {
+                events.append("enable:backup-published")
+                enableIsInside.signal()
+                // The cleanup thread is now asking for the gate. Every remaining proxy command of
+                // this enable has to land before it gets in: restoring and clearing the backup
+                // here would leave the user overridden with no restore point at all.
+                cleanupHasBeenAsked.wait()
+                events.append("enable:commands-written")
+            }
+        }
+        let cleanup = Thread {
+            cleanupHasBeenAsked.signal()
+            gate.withOperation {
+                events.append("cleanup:restored")
+            }
+            cleanupFinished.signal()
+        }
+
+        enable.start()
+        enableIsInside.wait()
+        cleanup.start()
+        cleanupFinished.wait()
+
+        #expect(events.entries == [
+            "enable:backup-published",
+            "enable:commands-written",
+            "cleanup:restored",
+        ])
+    }
+
+    @Test("An operation can roll back its own failure without waiting on itself")
+    func nestedOperationsOnOneThreadDoNotDeadlock() {
+        let gate = ProxyOperationGate()
+        let events = EventLog()
+
+        gate.withOperation {
+            events.append("enable")
+            // A failing enable legitimately contains the rollback of its own work. A plain lock
+            // would deadlock here while doing nothing about the cross-thread case the gate exists
+            // for.
+            gate.withOperation {
+                events.append("rollback")
+            }
+        }
+
+        #expect(events.entries == ["enable", "rollback"])
+    }
+
+    @Test("A throwing operation releases the gate")
+    func aThrownErrorDoesNotStrandTheGate() {
+        let gate = ProxyOperationGate()
+
+        #expect(throws: (any Error).self) {
+            try gate.withOperation { throw TestFailure() }
+        }
+
+        // The next operation must not be blocked by the one that failed — the settings still need
+        // putting back.
+        #expect(gate.withOperation { true })
+    }
+}
+
+// MARK: - ProxyAsyncOperationGateTests
+
+struct ProxyAsyncOperationGateTests {
+    @Test("Suspending lifecycle operations cannot overlap")
+    func lifecycleOperationsDoNotInterleave() async {
+        let gate = ProxyAsyncOperationGate()
+        let events = AsyncEventLog()
+        let firstEntered = AsyncLatch()
+        let releaseFirst = AsyncLatch()
+        let secondRequested = AsyncLatch()
+
+        let first = Task {
+            await gate.withOperation {
+                await events.append("first:start")
+                await firstEntered.signal()
+                await releaseFirst.wait()
+                await events.append("first:end")
+            }
+        }
+        await firstEntered.wait()
+
+        let second = Task {
+            await secondRequested.signal()
+            await gate.withOperation {
+                await events.append("second:start")
+            }
+        }
+        await secondRequested.wait()
+        await releaseFirst.signal()
+
+        await first.value
+        await second.value
+        #expect(await events.entries == ["first:start", "first:end", "second:start"])
+    }
+
+    @Test("A throwing async operation releases the lifecycle gate")
+    func aThrownAsyncErrorDoesNotStrandTheGate() async {
+        let gate = ProxyAsyncOperationGate()
+
+        await #expect(throws: (any Error).self) {
+            try await gate.withOperation { throw TestFailure() }
+        }
+
+        #expect(await gate.withOperation { true })
+    }
+}
+
+// MARK: - ProxyOperationSessionPolicyTests
+
+/// The gate orders operations but says nothing about which session they belong to. These cover the
+/// second half of that: work queued while an override was live, let through only once the session
+/// it belonged to is still the one running.
+struct ProxyOperationSessionPolicyTests {
+    @Test("Work queued for the running session runs")
+    func theRunningSessionMayProceed() {
+        #expect(ProxyOperationSessionPolicy.mayRun(
+            queuedGeneration: 7,
+            currentGeneration: 7,
+            overrideIsActive: true
+        ))
+    }
+
+    @Test("Work queued before a cleanup does not run after it")
+    func workFromAnEndedSessionIsRefused() {
+        // The cleanup restored every service and deleted the restore point. Letting this write
+        // through now would put Rockxy's bypass list back on the user's machine with nothing left
+        // on disk to undo it.
+        #expect(!ProxyOperationSessionPolicy.mayRun(
+            queuedGeneration: 7,
+            currentGeneration: 8,
+            overrideIsActive: false
+        ))
+        // And the same when a new session has already started: this write carries the old one's
+        // list, for services the new one may not even cover.
+        #expect(!ProxyOperationSessionPolicy.mayRun(
+            queuedGeneration: 7,
+            currentGeneration: 8,
+            overrideIsActive: true
+        ))
+    }
+
+    @Test("Work is refused while no override is in place, whatever the generation says")
+    func workWithoutAnOverrideIsRefused() {
+        #expect(!ProxyOperationSessionPolicy.mayRun(
+            queuedGeneration: 7,
+            currentGeneration: 7,
+            overrideIsActive: false
+        ))
+    }
+}
+
+// MARK: - ProxyBypassWriteSerializationTests
+
+/// The scenario the gate and the session check exist for together, driven deterministically: a
+/// bypass write that is already queued when a termination cleanup arrives.
+struct ProxyBypassWriteSerializationTests {
+    @Test("A bypass write queued before a cleanup issues no command after it")
+    func aQueuedBypassWriteIsDroppedAfterCleanup() {
+        let session = ProxySessionState()
+        let gate = ProxyOperationGate()
+        let events = EventLog()
+        let cleanupIsInside = DispatchSemaphore(value: 0)
+        let bypassIsWaiting = DispatchSemaphore(value: 0)
+        let bypassFinished = DispatchSemaphore(value: 0)
+
+        // The write is queued while the override is still live, so it carries that session.
+        let queuedGeneration = session.generation
+
+        let cleanup = Thread {
+            gate.withOperation {
+                events.append("cleanup:entered")
+                cleanupIsInside.signal()
+                // The bypass write is now blocked on the gate. Everything this cleanup does —
+                // ending the session, restoring the services, and clearing the restore point —
+                // has to land before it gets in. Ending the session comes first so there is no
+                // post-restore window where queued work can still regard the override as active.
+                bypassIsWaiting.wait()
+                session.end()
+                events.append("cleanup:restored-and-cleared")
+            }
+        }
+        let bypassWrite = Thread {
+            bypassIsWaiting.signal()
+            gate.withOperation {
+                guard ProxyOperationSessionPolicy.mayRun(
+                    queuedGeneration: queuedGeneration,
+                    currentGeneration: session.generation,
+                    overrideIsActive: session.overrideIsActive
+                ) else {
+                    events.append("bypass:skipped")
+                    return
+                }
+                events.append("bypass:commands-written")
+            }
+            bypassFinished.signal()
+        }
+
+        cleanup.start()
+        cleanupIsInside.wait()
+        bypassWrite.start()
+        bypassFinished.wait()
+
+        #expect(events.entries == [
+            "cleanup:entered",
+            "cleanup:restored-and-cleared",
+            "bypass:skipped",
+        ])
+    }
+
+    @Test("A bypass write that reaches the gate first still runs, and the cleanup waits for it")
+    func aBypassWriteThatWinsTheRaceIsNotDropped() {
+        let session = ProxySessionState()
+        let gate = ProxyOperationGate()
+        let events = EventLog()
+        let queuedGeneration = session.generation
+
+        gate.withOperation {
+            guard ProxyOperationSessionPolicy.mayRun(
+                queuedGeneration: queuedGeneration,
+                currentGeneration: session.generation,
+                overrideIsActive: session.overrideIsActive
+            ) else {
+                events.append("bypass:skipped")
+                return
+            }
+            events.append("bypass:commands-written")
+        }
+        gate.withOperation {
+            session.end()
+            events.append("cleanup:restored-and-cleared")
+        }
+
+        #expect(events.entries == ["bypass:commands-written", "cleanup:restored-and-cleared"])
+    }
+
+    @Test("A rollback reached from a confirmation failure serializes without deadlocking")
+    func aRollbackTakesTheGateWithoutDeadlocking() {
+        let gate = ProxyOperationGate()
+        let events = EventLog()
+
+        // The enable has already let go of the gate by the time confirmation fails, so the
+        // rollback takes it for real rather than nesting — and it must still not block on itself
+        // when an enable does contain its own rollback.
+        gate.withOperation { events.append("enable") }
+        gate.withOperation {
+            events.append("rollback")
+            gate.withOperation { events.append("rollback:nested-restore") }
+        }
+
+        #expect(events.entries == ["enable", "rollback", "rollback:nested-restore"])
+    }
+}
+
+// MARK: - ProxySessionState
+
+/// The manager's session bookkeeping, reduced to the two values the gate's callers read.
+private final class ProxySessionState: @unchecked Sendable {
+    // MARK: Internal
+
+    var generation: UInt64 {
+        lock.withLock { currentGeneration }
+    }
+
+    var overrideIsActive: Bool {
+        lock.withLock { isActive }
+    }
+
+    func end() {
+        lock.withLock {
+            isActive = false
+            currentGeneration &+= 1
+        }
+    }
+
+    // MARK: Private
+
+    private let lock = NSLock()
+    private var currentGeneration: UInt64 = 1
+    private var isActive = true
+}
+
+// MARK: - EventLog
+
+/// Orders observations made from two threads.
+private final class EventLog: @unchecked Sendable {
+    // MARK: Internal
+
+    var entries: [String] {
+        lock.withLock { recorded }
+    }
+
+    func append(_ event: String) {
+        lock.withLock { recorded.append(event) }
+    }
+
+    // MARK: Private
+
+    private let lock = NSLock()
+    private var recorded: [String] = []
+}
+
+// MARK: - Async Test Support
+
+private actor AsyncEventLog {
+    private(set) var entries: [String] = []
+
+    func append(_ event: String) {
+        entries.append(event)
+    }
+}
+
+private actor AsyncLatch {
+    private var isSignaled = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func wait() async {
+        guard !isSignaled else {
+            return
+        }
+        await withCheckedContinuation { waiters.append($0) }
+    }
+
+    func signal() {
+        isSignaled = true
+        let pending = waiters
+        waiters.removeAll()
+        pending.forEach { $0.resume() }
+    }
+}
+
+// MARK: - TestFailure
+
+private struct TestFailure: Error {}

--- a/RockxyTests/Core/TrafficCapture/SystemProxyBackupCompatibilityTests.swift
+++ b/RockxyTests/Core/TrafficCapture/SystemProxyBackupCompatibilityTests.swift
@@ -95,6 +95,45 @@ struct SystemProxyBackupCompatibilityTests {
 
         #expect(decoded.rockxyPort == 9_090)
         #expect(decoded.recoveryPending == false)
+        #expect(decoded.ownerPID == nil)
+        #expect(decoded.ownerStartSignature == nil)
+    }
+
+    @Test("A direct backup belongs only to the exact process instance that created it")
+    func directBackupOwnerIdentityIsExact() {
+        let backup = DirectProxyBackup(
+            services: [],
+            timestamp: Date(),
+            rockxyPort: 9_090,
+            ownerPID: 4_242,
+            ownerStartSignature: "start-a"
+        )
+
+        #expect(DirectProxyBackupOwnerPolicy.belongsToSession(
+            backup,
+            processIdentifier: 4_242,
+            processStartSignature: "start-a"
+        ))
+        #expect(!DirectProxyBackupOwnerPolicy.belongsToSession(
+            backup,
+            processIdentifier: 4_243,
+            processStartSignature: "start-b"
+        ))
+        #expect(!DirectProxyBackupOwnerPolicy.belongsToSession(
+            backup,
+            processIdentifier: 4_242,
+            processStartSignature: "start-b"
+        ))
+        #expect(DirectProxyBackupOwnerPolicy.ownerIsLive(
+            backup,
+            processIsAlive: { $0 == 4_242 },
+            liveStartSignature: { _ in "start-a" }
+        ))
+        #expect(!DirectProxyBackupOwnerPolicy.ownerIsLive(
+            backup,
+            processIsAlive: { $0 == 4_242 },
+            liveStartSignature: { _ in "start-b" }
+        ))
     }
 
     // MARK: Private
@@ -114,5 +153,313 @@ struct SystemProxyBackupCompatibilityTests {
         let services: [DirectServiceBackup]
         let timestamp: Date
         let rockxyPort: Int
+    }
+}
+
+// MARK: - ProxyBackupExtensionTests
+
+/// What survives an override attempt extending a backup it did not write. This is the moment a
+/// reclaim used to lose the record of the override it was reclaiming — after which nothing on the
+/// machine could prove those settings were Rockxy's, and the service was abandoned rather than
+/// undone.
+struct ProxyBackupExtensionTests {
+    // MARK: Internal
+
+    @Test("Adding a service keeps every record the backup already held")
+    func addingAServiceKeepsThePriorJournal() {
+        let existing = DirectProxyBackup(
+            services: [serviceBackup(service: "Wi-Fi")],
+            timestamp: Date(timeIntervalSince1970: 1_000),
+            rockxyPort: 9_090,
+            ownerPID: 4_242,
+            ownerStartSignature: "start-a",
+            recoveryPending: true,
+            journal: [applicationEntry(service: "Wi-Fi", port: 9_090)]
+        )
+
+        let extended = DirectProxyBackup.extending(
+            existing,
+            with: [serviceBackup(service: "Ethernet")],
+            rockxyPort: 9_090,
+            now: Date(timeIntervalSince1970: 2_000)
+        )
+
+        #expect(extended.services.map(\.service) == ["Wi-Fi", "Ethernet"])
+        #expect(extended.journal == existing.journal)
+        #expect(extended.recoveryPending)
+        #expect(extended.timestamp == existing.timestamp)
+        #expect(extended.ownerPID == 4_242)
+        #expect(extended.ownerStartSignature == "start-a")
+    }
+
+    @Test("Taking the same services on a different port keeps every record too")
+    func changingThePortKeepsThePriorJournal() {
+        let existing = DirectProxyBackup(
+            services: [serviceBackup(service: "Wi-Fi")],
+            timestamp: Date(timeIntervalSince1970: 1_000),
+            rockxyPort: 9_090,
+            journal: [applicationEntry(service: "Wi-Fi", port: 9_090)]
+        )
+
+        let extended = DirectProxyBackup.extending(
+            existing,
+            with: [],
+            rockxyPort: 9_091,
+            now: Date(timeIntervalSince1970: 2_000)
+        )
+
+        #expect(extended.rockxyPort == 9_091)
+        // The record still names the port its own commands were issued on, which is what a later
+        // attempt compares the live settings against.
+        #expect(extended.journal.first?.appliedOverridePort == 9_090)
+        #expect(extended.journal == existing.journal)
+    }
+
+    @Test("A first attempt starts with no record and no recovery under way")
+    func aFirstAttemptStartsClean() {
+        let created = DirectProxyBackup.extending(
+            nil,
+            with: [serviceBackup(service: "Wi-Fi")],
+            rockxyPort: 9_090,
+            now: Date(timeIntervalSince1970: 2_000),
+            ownerPID: 4_242,
+            ownerStartSignature: "start-a"
+        )
+
+        #expect(created.journal.isEmpty)
+        #expect(!created.recoveryPending)
+        #expect(created.timestamp == Date(timeIntervalSince1970: 2_000))
+        #expect(created.ownerPID == 4_242)
+        #expect(created.ownerStartSignature == "start-a")
+    }
+
+    @Test("Nothing recorded is dropped on the way through")
+    func carriedForwardKeepsBothHalves() {
+        let journal = [applicationEntry(service: "Wi-Fi", port: 9_090)]
+        let carried = ProxyBackupExtension.carriedForward(journal: journal, recoveryPending: true)
+
+        #expect(carried.journal == journal)
+        #expect(carried.recoveryPending)
+
+        let fresh = ProxyBackupExtension.carriedForward(journal: nil, recoveryPending: nil)
+        #expect(fresh.journal.isEmpty)
+        #expect(!fresh.recoveryPending)
+    }
+
+    // MARK: Private
+
+    private func serviceBackup(service: String) -> DirectServiceBackup {
+        DirectServiceBackup(
+            service: service,
+            httpEnabled: false,
+            httpHost: "",
+            httpPort: 0,
+            httpsEnabled: false,
+            httpsHost: "",
+            httpsPort: 0,
+            socksEnabled: false,
+            socksHost: "",
+            socksPort: 0,
+            pacEnabled: false,
+            pacURL: "",
+            autoDiscoveryEnabled: false,
+            bypassDomains: []
+        )
+    }
+
+    private func applicationEntry(service: String, port: Int) -> ProxyServiceRecoveryJournalEntry {
+        let captured = ProxyServiceRestorationState(
+            service: service,
+            http: ProxyEndpointState(enabled: false, host: "", port: 0),
+            https: ProxyEndpointState(enabled: false, host: "", port: 0),
+            socks: ProxyEndpointState(enabled: false, host: "", port: 0),
+            pacEnabled: false,
+            pacURL: "",
+            autoDiscoveryEnabled: false,
+            bypassDomains: []
+        )
+        return ProxyServiceRecoveryJournalEntry(
+            overrideApplicationFor: captured,
+            stage: .applying,
+            port: port
+        )
+    }
+}
+
+// MARK: - DirectProxyBackupJournalCompatibilityTests
+
+/// The recovery journal is additive: a backup written before it existed still decodes, and one
+/// written with it round-trips so a retry can read the intent the previous attempt recorded.
+struct DirectProxyBackupJournalCompatibilityTests {
+    // MARK: Internal
+
+    @Test("Direct backups written before the journal existed decode with no journal")
+    func legacyDirectBackupDecodesWithoutJournal() throws {
+        let legacy = LegacyPendingDirectProxyBackup(
+            services: [makeServiceBackup()],
+            timestamp: Date(),
+            rockxyPort: 9_090,
+            recoveryPending: true
+        )
+
+        let data = try PropertyListEncoder().encode(legacy)
+        let decoded = try PropertyListDecoder().decode(DirectProxyBackup.self, from: data)
+
+        #expect(decoded.recoveryPending)
+        #expect(decoded.journal.isEmpty)
+        #expect(decoded.services.map(\.service) == ["Wi-Fi"])
+    }
+
+    @Test("A journal round-trips with the backup that carries it")
+    func journalRoundtripsWithTheBackup() throws {
+        let live = restorationState(host: "127.0.0.1", port: 9_090, enabled: true)
+        let target = restorationState(host: "proxy.corp.example", port: 8_080, enabled: true)
+        let entry = ProxyServiceRecoveryJournalEntry(
+            service: "Wi-Fi",
+            stage: .inFlight,
+            expectedPreStepState: live,
+            target: target
+        )
+        let backup = DirectProxyBackup(
+            services: [makeServiceBackup()],
+            timestamp: Date(),
+            rockxyPort: 9_090,
+            recoveryPending: true,
+            journal: [entry]
+        )
+
+        let data = try PropertyListEncoder().encode(backup)
+        let decoded = try PropertyListDecoder().decode(DirectProxyBackup.self, from: data)
+
+        #expect(decoded.journal == [entry])
+        #expect(decoded.journal.first?.stage == .inFlight)
+    }
+
+    @Test("A journal this build cannot read costs the backup its journal, never its services")
+    func unreadableJournalKeepsTheRestorePoint() throws {
+        let unreadable = DirectProxyBackupWithForeignJournal(
+            services: [makeServiceBackup()],
+            timestamp: Date(),
+            rockxyPort: 9_090,
+            recoveryPending: true,
+            journal: ["not a journal entry"]
+        )
+
+        let data = try PropertyListEncoder().encode(unreadable)
+        let decoded = try PropertyListDecoder().decode(DirectProxyBackup.self, from: data)
+
+        #expect(decoded.services.map(\.service) == ["Wi-Fi"])
+        #expect(decoded.journal.isEmpty)
+        #expect(decoded.recoveryPending)
+    }
+
+    @Test("One unreadable journal record never costs the records beside it")
+    func oneUnreadableRecordKeepsTheOthers() throws {
+        let live = restorationState(host: "127.0.0.1", port: 9_090, enabled: true)
+        let target = restorationState(host: "proxy.corp.example", port: 8_080, enabled: true)
+        let good = ProxyServiceRecoveryJournalEntry(
+            service: "Wi-Fi",
+            stage: .inFlight,
+            expectedPreStepState: live,
+            target: target
+        )
+        let mixed = DirectProxyBackupWithMixedJournal(
+            services: [makeServiceBackup()],
+            timestamp: Date(),
+            rockxyPort: 9_090,
+            recoveryPending: true,
+            readableEntry: good
+        )
+
+        let data = try PropertyListEncoder().encode(mixed)
+        let decoded = try PropertyListDecoder().decode(DirectProxyBackup.self, from: data)
+
+        // The unusable record is dropped and nothing else is. A service whose record is still
+        // good keeps the evidence that authorizes its restore.
+        #expect(decoded.journal == [good])
+        #expect(decoded.services.map(\.service) == ["Wi-Fi"])
+    }
+
+    // MARK: Private
+
+    /// A backup whose journal holds one record this build cannot read beside one it can.
+    private struct DirectProxyBackupWithMixedJournal: Encodable {
+        // MARK: Internal
+
+        let services: [DirectServiceBackup]
+        let timestamp: Date
+        let rockxyPort: Int
+        let recoveryPending: Bool
+        let readableEntry: ProxyServiceRecoveryJournalEntry
+
+        func encode(to encoder: any Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(services, forKey: .services)
+            try container.encode(timestamp, forKey: .timestamp)
+            try container.encode(rockxyPort, forKey: .rockxyPort)
+            try container.encode(recoveryPending, forKey: .recoveryPending)
+            var journal = container.nestedUnkeyedContainer(forKey: .journal)
+            try journal.encode("not a journal entry")
+            try journal.encode(readableEntry)
+        }
+
+        // MARK: Private
+
+        private enum CodingKeys: String, CodingKey {
+            case services
+            case timestamp
+            case rockxyPort
+            case recoveryPending
+            case journal
+        }
+    }
+
+    /// The direct backup shape from before the recovery journal was added.
+    private struct LegacyPendingDirectProxyBackup: Codable {
+        let services: [DirectServiceBackup]
+        let timestamp: Date
+        let rockxyPort: Int
+        let recoveryPending: Bool
+    }
+
+    /// A backup whose journal key holds something this build's decoder cannot make sense of.
+    private struct DirectProxyBackupWithForeignJournal: Codable {
+        let services: [DirectServiceBackup]
+        let timestamp: Date
+        let rockxyPort: Int
+        let recoveryPending: Bool
+        let journal: [String]
+    }
+
+    private func makeServiceBackup(service: String = "Wi-Fi") -> DirectServiceBackup {
+        DirectServiceBackup(
+            service: service,
+            httpEnabled: true,
+            httpHost: "proxy.corp.example",
+            httpPort: 8_080,
+            httpsEnabled: true,
+            httpsHost: "secure.corp.example",
+            httpsPort: 8_443,
+            socksEnabled: false,
+            socksHost: "",
+            socksPort: 0,
+            pacEnabled: false,
+            pacURL: "",
+            autoDiscoveryEnabled: false,
+            bypassDomains: ["localhost"]
+        )
+    }
+
+    private func restorationState(host: String, port: Int, enabled: Bool) -> ProxyServiceRestorationState {
+        ProxyServiceRestorationState(
+            service: "Wi-Fi",
+            http: ProxyEndpointState(enabled: enabled, host: host, port: port),
+            https: ProxyEndpointState(enabled: enabled, host: host, port: port),
+            socks: ProxyEndpointState(enabled: false, host: "", port: 0),
+            pacEnabled: false,
+            pacURL: "",
+            autoDiscoveryEnabled: false,
+            bypassDomains: ["localhost"]
+        )
     }
 }

--- a/RockxyTests/Core/TrafficCapture/SystemProxyManagerTests.swift
+++ b/RockxyTests/Core/TrafficCapture/SystemProxyManagerTests.swift
@@ -52,8 +52,11 @@ struct SystemProxyManagerTests {
             .noActiveNetworkService,
             .proxyActivationNotConfirmed(port: 8_888),
             .proxyRestoreFailed,
+            .proxySessionInUse,
             .previousHelperUnavailable,
             .unexpectedOutput("bad"),
+            .directProxyWatchdogUnavailable(reason: "no start signature"),
+            .overrideRollbackIncomplete(reason: "networksetup exited non-zero"),
         ]
 
         for error in cases {
@@ -273,28 +276,91 @@ struct SystemProxyManagerTests {
         ) == false)
     }
 
-    @Test("direct proxy watchdog exits once backup is gone")
-    func directProxyWatchdogExitsWhenBackupRemoved() {
-        #expect(SystemProxyManager.directProxyWatchdogAction(
-            parentAlive: true,
-            backupExists: false
-        ) == .exit)
+    @Test("a direct override is refused when its watchdog cannot be armed")
+    func directWatchdogPreflightRequiresBothHalves() {
+        // Resolved before any service is mutated. An override applied without a live watchdog is
+        // only noticed at the next launch, and one armed against a bare identifier watches
+        // whatever process later inherits it.
+        #expect(SystemProxyManager.directWatchdogPreflightIsSatisfied(
+            executableIsAvailable: true,
+            parentStartSignature: "1699999999.123456"
+        ))
+        #expect(!SystemProxyManager.directWatchdogPreflightIsSatisfied(
+            executableIsAvailable: false,
+            parentStartSignature: "1699999999.123456"
+        ))
+        #expect(!SystemProxyManager.directWatchdogPreflightIsSatisfied(
+            executableIsAvailable: true,
+            parentStartSignature: nil
+        ))
+        #expect(!SystemProxyManager.directWatchdogPreflightIsSatisfied(
+            executableIsAvailable: true,
+            parentStartSignature: ""
+        ))
     }
 
-    @Test("direct proxy watchdog keeps waiting while parent is alive")
-    func directProxyWatchdogWaitsForParentExit() {
-        #expect(SystemProxyManager.directProxyWatchdogAction(
-            parentAlive: true,
-            backupExists: true
-        ) == .wait)
+    @Test("an override that could not be applied reports whether its rollback finished")
+    func failedOverrideReportsAnIncompleteRollback() {
+        #expect(SystemProxyManager.directOverrideAttemptOutcome(
+            applySucceeded: true,
+            rollbackSucceeded: false
+        ) == .enabled)
+        #expect(SystemProxyManager.directOverrideAttemptOutcome(
+            applySucceeded: false,
+            rollbackSucceeded: true
+        ) == .rolledBack)
+        // A rollback that could not finish keeps the backup and reports the failure: the services
+        // still overridden have no other way back, so the rollback's answer is never discarded in
+        // favour of the original apply error alone.
+        #expect(SystemProxyManager.directOverrideAttemptOutcome(
+            applySucceeded: false,
+            rollbackSucceeded: false
+        ) == .rollbackIncomplete)
     }
 
-    @Test("direct proxy watchdog restores after parent exits with backup present")
-    func directProxyWatchdogRestoresOnParentExit() {
-        #expect(SystemProxyManager.directProxyWatchdogAction(
-            parentAlive: false,
-            backupExists: true
-        ) == .restore)
+    @Test("the watchdog is armed before the first proxy command, never after")
+    func watchdogIsArmedBeforeAnyProxyMutation() {
+        var steps: [DirectOverrideApplicationStep] = []
+        let failure = DirectOverrideApplication.run(
+            persistBackup: { steps.append(.persistBackup) },
+            armWatchdog: { steps.append(.armWatchdog) },
+            mutateServices: { steps.append(.mutateServices) }
+        )
+
+        // A process that dies between the first proxy command and the watchdog submission leaves
+        // an override behind with nothing watching it, so the order is the guarantee.
+        #expect(steps == [.persistBackup, .armWatchdog, .mutateServices])
+        #expect(failure == nil)
+    }
+
+    @Test("a watchdog that cannot be armed stops the attempt before any service is mutated")
+    func watchdogFailureLeavesEverySettingUntouched() {
+        var mutated = false
+        let failure = DirectOverrideApplication.run(
+            persistBackup: {},
+            armWatchdog: { throw DirectOverrideStepError.failed },
+            mutateServices: { mutated = true }
+        )
+
+        #expect(!mutated)
+        #expect(failure?.step == .armWatchdog)
+    }
+
+    @Test("a backup that cannot be published stops the attempt before the watchdog is armed")
+    func backupFailureStopsBeforeArming() {
+        var armed = false
+        var mutated = false
+        let failure = DirectOverrideApplication.run(
+            persistBackup: { throw DirectOverrideStepError.failed },
+            armWatchdog: { armed = true },
+            mutateServices: { mutated = true }
+        )
+
+        // The watchdog watches the backup file. Arming one with no restore point behind it would
+        // give it nothing to act on.
+        #expect(!armed)
+        #expect(!mutated)
+        #expect(failure?.step == .persistBackup)
     }
 
     @Test("direct restore clears backup only after commands succeed and proxy ownership is gone")
@@ -419,27 +485,6 @@ struct SystemProxyManagerTests {
         #expect(MainContentCoordinator.proxyOverridePort(for: .none) == nil)
         #expect(MainContentCoordinator.proxyOverridePort(for: .direct(backup: backup)) == 9_090)
         #expect(MainContentCoordinator.proxyOverridePort(for: .helper(port: 8_888)) == 8_888)
-    }
-
-    @Test("direct proxy watchdog launchctl submission uses helper entrypoint and backup path")
-    func directProxyWatchdogSubmitArguments() {
-        let arguments = SystemProxyManager.directWatchdogSubmitArguments(
-            label: "com.amunx.rockxy.community.direct-proxy-watchdog",
-            executablePath: "/tmp/RockxyHelperTool",
-            parentPID: 4_242,
-            backupPath: "/tmp/proxy-backup-direct.plist"
-        )
-
-        #expect(arguments == [
-            "submit",
-            "-l",
-            "com.amunx.rockxy.community.direct-proxy-watchdog",
-            "--",
-            "/tmp/RockxyHelperTool",
-            "--rockxy-direct-proxy-watchdog",
-            "4242",
-            "/tmp/proxy-backup-direct.plist",
-        ])
     }
 
     // MARK: - Network Service Parsing Logic
@@ -834,4 +879,10 @@ private actor ActivationProbeCounter {
         attempts += 1
         return attempts >= succeedsOnAttempt
     }
+}
+
+// MARK: - DirectOverrideStepError
+
+private enum DirectOverrideStepError: Error {
+    case failed
 }

--- a/RockxyTests/Shared/DirectProxyRecoveryRunnerTests.swift
+++ b/RockxyTests/Shared/DirectProxyRecoveryRunnerTests.swift
@@ -1,0 +1,255 @@
+import Foundation
+@testable import Rockxy
+import Testing
+
+// Regression tests for the per-service recovery loop the app and the shipped watchdog binary both
+// run. The states it leaves behind are only ever observed after a crash, so they are exercised
+// here rather than left to be discovered there.
+
+// MARK: - DirectProxyRecoveryRunnerTests
+
+struct DirectProxyRecoveryRunnerTests {
+    // MARK: Internal
+
+    @Test("The record reaches disk before the first command and again once they have all landed")
+    func theJournalBracketsEveryService() {
+        let machine = RecoveryMachine(live: [service: ProxyRecoveryJournalFixtures.rockxyOverride])
+
+        let result = machine.run(entries: [restoreEntry()])
+
+        // The commit is the permission to issue a command, so it comes first; the completion is
+        // recorded after, which is what keeps a death from that point on from looking like a
+        // command that never ran.
+        #expect(machine.steps == [
+            "publish:inFlight",
+            "proxyState:Wi-Fi",
+            "bypassDomains:Wi-Fi",
+            "publish:restored",
+        ])
+        #expect(result.allSucceeded)
+        #expect(result.attemptedServices == [service])
+        #expect(result.failedServices.isEmpty)
+    }
+
+    @Test("A record that cannot be stored issues no command for that service")
+    func anUnrecordableServiceIsNeverWritten() {
+        let machine = RecoveryMachine(live: [service: ProxyRecoveryJournalFixtures.rockxyOverride])
+        machine.failPublishing = true
+
+        let result = machine.run(entries: [restoreEntry()])
+
+        // An unrecorded write is precisely what a later attempt has no way to reason about, so
+        // the service is deferred with its restore point intact instead.
+        #expect(machine.steps == ["publish:inFlight"])
+        #expect(result.attemptedServices.isEmpty)
+        #expect(result.deferredServices == [service])
+        #expect(result.allSucceeded)
+    }
+
+    @Test("The bypass list is not written when the proxy state failed")
+    func aFailedProxyStateStopsBeforeTheBypassList() {
+        let machine = RecoveryMachine(live: [service: ProxyRecoveryJournalFixtures.rockxyOverride])
+        machine.failProxyState = true
+
+        let result = machine.run(entries: [restoreEntry()])
+
+        // A restored bypass list beside a half-written proxy state is a shape no prefix of the
+        // sequence produces, and recovery reads those as somebody else's.
+        #expect(!machine.steps.contains("bypassDomains:Wi-Fi"))
+        #expect(!machine.steps.contains("publish:restored"))
+        #expect(!result.allSucceeded)
+        #expect(result.failedServices == [service])
+        #expect(result.attemptedServices == [service])
+    }
+
+    @Test("A service the user changed since the plan leaves recovery before anything is written")
+    func aChangedServiceIsDroppedDurably() {
+        // The plan was made for every service at once; this one is re-read immediately before its
+        // own first command, which is what lets a change made in between be seen in time.
+        let machine = RecoveryMachine(live: [service: ProxyRecoveryJournalFixtures.replacing(
+            ProxyRecoveryJournalFixtures.rockxyOverride,
+            https: ProxyEndpointState(enabled: true, host: "vpn.example", port: 3_128)
+        )])
+
+        let result = machine.run(entries: [restoreEntry()])
+
+        #expect(machine.steps == ["publish:"])
+        #expect(result.attemptedServices.isEmpty)
+        #expect(result.journal.isEmpty)
+        // Its entry comes off disk before the loop moves on, so a process that dies straight
+        // afterwards cannot come back and write over the change.
+        #expect(result.retention.services.isEmpty)
+        #expect(machine.published.last?.services.isEmpty == true)
+    }
+
+    @Test("A service changed while its journal is committed receives no recovery command")
+    func aChangeDuringCommitIsRechecked() {
+        let machine = RecoveryMachine(live: [service: ProxyRecoveryJournalFixtures.rockxyOverride])
+        machine.stateAfterFirstPublish = ProxyRecoveryJournalFixtures.replacing(
+            ProxyRecoveryJournalFixtures.rockxyOverride,
+            https: ProxyEndpointState(enabled: true, host: "vpn.example", port: 3_128)
+        )
+
+        let result = machine.run(entries: [restoreEntry()])
+
+        #expect(machine.steps == ["publish:inFlight"])
+        #expect(!result.allSucceeded)
+        #expect(result.failedServices == [service])
+        #expect(!machine.steps.contains("proxyState:Wi-Fi"))
+    }
+
+    @Test("A service whose settings could not be read keeps its restore point and its stage")
+    func anUnreadableServiceIsDeferred() {
+        let machine = RecoveryMachine(live: [:])
+
+        let result = machine.run(entries: [restoreEntry()])
+
+        #expect(result.deferredServices == [service])
+        #expect(result.attemptedServices.isEmpty)
+        #expect(result.retention.services == [service])
+        #expect(result.journal.first?.stage == .pending)
+    }
+
+    @Test("One service failing does not stop the next from being restored")
+    func servicesAreAnsweredIndependently() {
+        let machine = RecoveryMachine(live: [
+            service: ProxyRecoveryJournalFixtures.rockxyOverride,
+            "Ethernet": ProxyRecoveryJournalFixtures.renamed(
+                ProxyRecoveryJournalFixtures.rockxyOverride,
+                to: "Ethernet"
+            ),
+        ])
+        machine.failProxyStateFor = [service]
+
+        let result = machine.run(
+            entries: [restoreEntry(), restoreEntry(service: "Ethernet")],
+            services: [service, "Ethernet"]
+        )
+
+        #expect(result.failedServices == [service])
+        #expect(result.attemptedServices == [service, "Ethernet"])
+        #expect(!result.allSucceeded)
+        #expect(machine.steps.contains("bypassDomains:Ethernet"))
+    }
+
+    // MARK: Private
+
+    private let service = ProxyRecoveryJournalFixtures.service
+
+    private func restoreEntry(service: String = ProxyRecoveryJournalFixtures.service) -> ProxyServiceRecoveryJournalEntry {
+        let pre = ProxyRecoveryJournalFixtures.renamed(ProxyRecoveryJournalFixtures.rockxyOverride, to: service)
+        let target = ProxyRecoveryJournalFixtures.renamed(ProxyRecoveryJournalFixtures.capturedSettings, to: service)
+        return ProxyServiceRecoveryJournalEntry(
+            service: service,
+            stage: .pending,
+            expectedPreStepState: pre,
+            target: target
+        )
+    }
+}
+
+// MARK: - RecoveryMachine
+
+/// A recovery run with the disk and `networksetup` replaced, so the ordering the loop produces is
+/// what the test observes.
+private final class RecoveryMachine {
+    // MARK: Lifecycle
+
+    init(live: [String: ProxyServiceRestorationState]) {
+        self.live = live
+    }
+
+    // MARK: Internal
+
+    var steps: [String] = []
+    var published: [DirectProxyBackup] = []
+    var failPublishing = false
+    var failProxyState = false
+    var failProxyStateFor: Set<String> = []
+    var stateAfterFirstPublish: ProxyServiceRestorationState?
+
+    func run(
+        entries: [ProxyServiceRecoveryJournalEntry],
+        services: [String] = [ProxyRecoveryJournalFixtures.service]
+    )
+        -> DirectProxyRecoveryResult
+    {
+        let backup = DirectProxyBackup(
+            services: services.map(Self.serviceBackup(for:)),
+            timestamp: Date(timeIntervalSince1970: 0),
+            rockxyPort: ProxyRecoveryJournalFixtures.rockxyPort,
+            recoveryPending: true,
+            journal: entries
+        )
+
+        return DirectProxyRecoveryRunner.run(
+            entriesToRestore: entries,
+            backup: backup,
+            journal: entries,
+            retention: ProxyBackupRetention(authorized: services, preserved: []),
+            deferredServices: [],
+            effects: DirectProxyRecoveryEffects(
+                readState: { [weak self] in self?.live[$0] },
+                publishBackup: { [weak self] backup in
+                    guard let self else {
+                        return
+                    }
+                    let stages = backup.journal.map(\.stage.rawValue).joined(separator: ",")
+                    steps.append("publish:\(stages)")
+                    if failPublishing {
+                        throw MachineFailure()
+                    }
+                    published.append(backup)
+                    if let stateAfterFirstPublish {
+                        live[stateAfterFirstPublish.service] = stateAfterFirstPublish
+                        self.stateAfterFirstPublish = nil
+                    }
+                },
+                restoreProxyState: { [weak self] entry in
+                    guard let self else {
+                        return
+                    }
+                    steps.append("proxyState:\(entry.service)")
+                    if failProxyState || failProxyStateFor.contains(entry.service) {
+                        throw MachineFailure()
+                    }
+                },
+                restoreBypassDomains: { [weak self] entry in
+                    self?.steps.append("bypassDomains:\(entry.service)")
+                },
+                log: { _ in }
+            )
+        )
+    }
+
+    // MARK: Private
+
+    private var live: [String: ProxyServiceRestorationState]
+
+    private static func serviceBackup(for service: String) -> DirectServiceBackup {
+        let captured = ProxyRecoveryJournalFixtures.renamed(
+            ProxyRecoveryJournalFixtures.capturedSettings,
+            to: service
+        )
+        return DirectServiceBackup(
+            service: service,
+            httpEnabled: captured.http.enabled,
+            httpHost: captured.http.host,
+            httpPort: captured.http.port,
+            httpsEnabled: captured.https.enabled,
+            httpsHost: captured.https.host,
+            httpsPort: captured.https.port,
+            socksEnabled: captured.socks.enabled,
+            socksHost: captured.socks.host,
+            socksPort: captured.socks.port,
+            pacEnabled: captured.pacEnabled,
+            pacURL: captured.pacURL,
+            autoDiscoveryEnabled: captured.autoDiscoveryEnabled,
+            bypassDomains: captured.bypassDomains
+        )
+    }
+}
+
+// MARK: - MachineFailure
+
+private struct MachineFailure: Error {}

--- a/RockxyTests/Shared/DirectProxyWatchdogRuntimeTests.swift
+++ b/RockxyTests/Shared/DirectProxyWatchdogRuntimeTests.swift
@@ -1,0 +1,236 @@
+import Foundation
+@testable import Rockxy
+import Testing
+
+// Regression tests for the direct-mode watchdog: the invocation the app submits, the loop the
+// shipped helper binary runs, and the swap that replaces one watcher with another.
+
+// MARK: - DirectProxyWatchdogInvocationTests
+
+/// The app formats the invocation and the helper binary parses it back, in two different
+/// processes. These cover both halves against each other, because a field either side counted
+/// differently would arm a watcher that silently watches the wrong thing.
+struct DirectProxyWatchdogInvocationTests {
+    @Test("What the app submits is exactly what the watchdog reads back")
+    func formattingAndParsingAgree() {
+        let arguments = DirectProxyWatchdogInvocation.watchArguments(
+            executablePath: "/tmp/RockxyHelperTool",
+            parentPID: 4_242,
+            backupPath: "/tmp/proxy-backup-direct.plist",
+            parentStartSignature: "1788787973.748707"
+        )
+
+        #expect(DirectProxyWatchdogInvocation.parse(arguments: arguments) == .watch(
+            parentPID: 4_242,
+            backupPath: "/tmp/proxy-backup-direct.plist",
+            parentStartSignature: "1788787973.748707"
+        ))
+    }
+
+    @Test("The launchctl submission carries the entrypoint, backup path, and parent identity")
+    func submissionCarriesTheWholeInvocation() {
+        let arguments = SystemProxyManager.directWatchdogSubmitArguments(
+            label: "com.amunx.rockxy.community.direct-proxy-watchdog",
+            executablePath: "/tmp/RockxyHelperTool",
+            parentPID: 4_242,
+            parentStartSignature: "1788787973.748707",
+            backupPath: "/tmp/proxy-backup-direct.plist"
+        )
+
+        // The start signature travels beside the identifier so the watcher can tell the process
+        // that took the override from whatever later inherits its identifier.
+        #expect(arguments == [
+            "submit",
+            "-l",
+            "com.amunx.rockxy.community.direct-proxy-watchdog",
+            "--",
+            "/tmp/RockxyHelperTool",
+            "--rockxy-direct-proxy-watchdog",
+            "4242",
+            "/tmp/proxy-backup-direct.plist",
+            "1788787973.748707",
+        ])
+    }
+
+    @Test("An invocation with no parent identity is consumed but never watched")
+    func anUnidentifiableParentIsNotWatched() {
+        // Waiting on a bare identifier would keep watching whatever process later reuses it, so
+        // the invocation is consumed and the backup is left for launch-time recovery instead.
+        #expect(DirectProxyWatchdogInvocation.parse(arguments: [
+            "/tmp/RockxyHelperTool",
+            "--rockxy-direct-proxy-watchdog",
+            "4242",
+            "/tmp/proxy-backup-direct.plist",
+        ]) == .unidentifiableParent)
+        #expect(DirectProxyWatchdogInvocation.parse(arguments: [
+            "/tmp/RockxyHelperTool",
+            "--rockxy-direct-proxy-watchdog",
+            "4242",
+            "/tmp/proxy-backup-direct.plist",
+            "",
+        ]) == .unidentifiableParent)
+        #expect(DirectProxyWatchdogInvocation.parse(arguments: [
+            "/tmp/RockxyHelperTool",
+            "--rockxy-direct-proxy-watchdog",
+            "0",
+            "/tmp/proxy-backup-direct.plist",
+            "1788787973.748707",
+        ]) == .unidentifiableParent)
+    }
+
+    @Test("A launch that is not a watchdog request is left alone")
+    func aPlainLaunchIsNotAWatchdog() {
+        #expect(DirectProxyWatchdogInvocation.parse(arguments: ["/tmp/RockxyHelperTool"]) == .notAWatchdog)
+        #expect(DirectProxyWatchdogInvocation.parse(arguments: []) == .notAWatchdog)
+        #expect(
+            DirectProxyWatchdogInvocation.parse(arguments: ["/tmp/RockxyHelperTool", "--something-else"])
+                == .notAWatchdog
+        )
+    }
+}
+
+// MARK: - DirectProxyWatchdogRuntimeTests
+
+/// The loop the shipped helper binary runs. It is exercised here directly rather than through a
+/// second implementation, so what these cover is the ordering the watchdog actually ships with.
+struct DirectProxyWatchdogRuntimeTests {
+    @Test("The watchdog exits once the backup is gone, even while the parent is still running")
+    func aResolvedSessionEndsTheWatch() {
+        var restores = 0
+        let outcome = DirectProxyWatchdogRuntime.watch(
+            parentIsLive: { true },
+            backupExists: { false },
+            restore: { restores += 1 },
+            waitBeforeNextPoll: { Issue.record("A resolved session must not be polled again") }
+        )
+
+        #expect(outcome == .exit)
+        #expect(restores == 0)
+    }
+
+    @Test("The watchdog waits while the parent is alive and restores as soon as it is not")
+    func theParentIsWatchedUntilItGoes() {
+        var polls = 0
+        var restores = 0
+        let outcome = DirectProxyWatchdogRuntime.watch(
+            parentIsLive: { polls < 3 },
+            backupExists: { restores == 0 },
+            restore: { restores += 1 },
+            waitBeforeNextPoll: { polls += 1 }
+        )
+
+        #expect(outcome == .restore)
+        #expect(polls == 3)
+        #expect(restores == 1)
+    }
+
+    @Test("A failed recovery keeps the watchdog alive until the backup is resolved")
+    func aRetainedBackupIsRetried() {
+        var restores = 0
+        var waits = 0
+        let outcome = DirectProxyWatchdogRuntime.watch(
+            parentIsLive: { false },
+            backupExists: { restores < 2 },
+            restore: { restores += 1 },
+            waitBeforeNextPoll: { waits += 1 }
+        )
+
+        #expect(outcome == .restore)
+        #expect(restores == 2)
+        #expect(waits == 1)
+    }
+
+    @Test("A backup that disappears mid-watch ends the loop without writing anything")
+    func aBackupClearedByAnotherProcessStopsTheWatch() {
+        var polls = 0
+        var restores = 0
+        let outcome = DirectProxyWatchdogRuntime.watch(
+            parentIsLive: { true },
+            backupExists: { polls < 2 },
+            restore: { restores += 1 },
+            waitBeforeNextPoll: { polls += 1 }
+        )
+
+        #expect(outcome == .exit)
+        #expect(restores == 0)
+    }
+
+    @Test("The backup is what decides, not the parent")
+    func theActionPolicyChecksTheBackupFirst() {
+        #expect(DirectProxyWatchdogPolicy.action(parentAlive: true, backupExists: false) == .exit)
+        #expect(DirectProxyWatchdogPolicy.action(parentAlive: false, backupExists: false) == .exit)
+        #expect(DirectProxyWatchdogPolicy.action(parentAlive: true, backupExists: true) == .wait)
+        #expect(DirectProxyWatchdogPolicy.action(parentAlive: false, backupExists: true) == .restore)
+    }
+}
+
+// MARK: - DirectProxyWatchdogInstallationTests
+
+/// Replacing the watcher is the moment an override can end up unwatched. These cover the ordering
+/// that keeps it covered throughout.
+struct DirectProxyWatchdogInstallationTests {
+    @Test("A submit that fails leaves the previous watcher in place and removes nothing")
+    func aFailedSubmitKeepsTheOldWatcher() {
+        var removed: [String] = []
+        let outcome = DirectProxyWatchdogInstallation.install(
+            newLabel: "watchdog.new",
+            supersededLabel: "watchdog.old",
+            submit: { _ in throw TestFailure() },
+            remove: { removed.append($0) }
+        )
+
+        // Removing first and submitting after is what could leave the override with no watcher at
+        // all the moment this throws.
+        #expect(removed.isEmpty)
+        #expect(!outcome.isInstalled)
+        #expect(outcome.activeLabel == "watchdog.old")
+    }
+
+    @Test("The superseded watcher is only removed once its replacement is running")
+    func theOldWatcherIsRemovedAfterTheNewOneIsUp() {
+        var steps: [String] = []
+        let outcome = DirectProxyWatchdogInstallation.install(
+            newLabel: "watchdog.new",
+            supersededLabel: "watchdog.old",
+            submit: { steps.append("submit:\($0)") },
+            remove: { steps.append("remove:\($0)") }
+        )
+
+        #expect(steps == ["submit:watchdog.new", "remove:watchdog.old"])
+        #expect(outcome.isInstalled)
+        #expect(outcome.activeLabel == "watchdog.new")
+    }
+
+    @Test("A first arming submits without removing anything")
+    func aFirstArmingRemovesNothing() {
+        var steps: [String] = []
+        let outcome = DirectProxyWatchdogInstallation.install(
+            newLabel: "watchdog.new",
+            supersededLabel: nil,
+            submit: { steps.append("submit:\($0)") },
+            remove: { steps.append("remove:\($0)") }
+        )
+
+        #expect(steps == ["submit:watchdog.new"])
+        #expect(outcome.activeLabel == "watchdog.new")
+    }
+
+    @Test("A stubborn old job does not unseat the watcher that already replaced it")
+    func aFailedRemovalStillReportsTheNewWatcher() {
+        let outcome = DirectProxyWatchdogInstallation.install(
+            newLabel: "watchdog.new",
+            supersededLabel: "watchdog.old",
+            submit: { _ in },
+            remove: { _ in throw TestFailure() }
+        )
+
+        // The replacement is already running, so a job that would not go away is a stray process
+        // rather than a gap in cover — and it exits itself once the backup is resolved.
+        #expect(outcome.isInstalled)
+        #expect(outcome.activeLabel == "watchdog.new")
+    }
+}
+
+// MARK: - TestFailure
+
+private struct TestFailure: Error {}

--- a/RockxyTests/Shared/HelperLifecyclePolicyTests.swift
+++ b/RockxyTests/Shared/HelperLifecyclePolicyTests.swift
@@ -1,0 +1,338 @@
+import Foundation
+@testable import Rockxy
+import Testing
+
+// Regression tests for when the privileged helper may exit, what an uninstall may tear down, and
+// which process a proxy override is recorded for.
+
+// MARK: - HelperIdleExitSequenceTests
+
+/// Exercised at the seam rather than against a real timer: the failure this guards against is an
+/// exit landing between two other steps, and a timing test would only observe that by luck.
+struct HelperIdleExitSequenceTests {
+    @Test("An idle helper with nothing running exits while still holding the barrier")
+    func anIdleHelperExits() {
+        let gate = HelperPrivilegedMutationGate()
+        var released = 0
+
+        let decision = HelperIdleExitSequence.run(
+            proxyIsOverridden: { false },
+            acquireExitBarrier: { gate.beginProcessExitBarrier() },
+            release: { gate.release($0); released += 1 }
+        )
+
+        #expect(decision == .exit)
+        // The barrier is deliberately not released: nothing may start between deciding to exit
+        // and the process actually going away.
+        #expect(released == 0)
+        #expect(gate.isBusy)
+    }
+
+    @Test("A mutation already in flight defers the exit and keeps the gate with its owner")
+    func aBusyGateDefersTheExit() {
+        let gate = HelperPrivilegedMutationGate()
+        let heldByAMutation = gate.tryAcquire()
+        var released = 0
+
+        let decision = HelperIdleExitSequence.run(
+            proxyIsOverridden: { false },
+            acquireExitBarrier: { gate.beginProcessExitBarrier() },
+            release: { gate.release($0); released += 1 }
+        )
+
+        // A timer event that has already been dequeued cannot be cancelled, so this is the check
+        // that keeps it from exiting in the middle of somebody else's privileged work.
+        #expect(decision == .deferBusy)
+        #expect(released == 0)
+        #expect(heldByAMutation != nil)
+        #expect(gate.isBusy)
+    }
+
+    @Test("An override that appears after the first check is caught by the second")
+    func anOverrideStartedMidCheckDefersTheExit() {
+        let gate = HelperPrivilegedMutationGate()
+        var reads = 0
+        var released = 0
+
+        let decision = HelperIdleExitSequence.run(
+            proxyIsOverridden: {
+                reads += 1
+                // Nothing was overridden when the timer fired; by the time the barrier is held,
+                // something is. Reading once would have exited with the override in place and
+                // nothing left alive to restore it.
+                return reads > 1
+            },
+            acquireExitBarrier: { gate.beginProcessExitBarrier() },
+            release: { gate.release($0); released += 1 }
+        )
+
+        #expect(decision == .deferOverridden)
+        #expect(reads == 2)
+        // The barrier is handed back on every path that does not exit, so a deferred check leaves
+        // the helper exactly as it found it.
+        #expect(released == 1)
+        #expect(!gate.isBusy)
+    }
+
+    @Test("An override already in place is refused without taking the gate at all")
+    func anExistingOverrideNeverTakesTheGate() {
+        var acquisitions = 0
+
+        let decision = HelperIdleExitSequence.run(
+            proxyIsOverridden: { true },
+            acquireExitBarrier: {
+                acquisitions += 1
+                return nil
+            },
+            release: { _ in }
+        )
+
+        #expect(decision == .deferOverridden)
+        #expect(acquisitions == 0)
+    }
+}
+
+// MARK: - HelperUninstallPreparationTests
+
+/// Stopping the watchdog and clearing the backup together remove the last two things that could
+/// put the user's settings back, so these cover that neither happens until the restore has.
+struct HelperUninstallPreparationTests {
+    @Test("Nothing is torn down until the restore has succeeded")
+    func teardownFollowsASuccessfulRestore() {
+        var steps: [String] = []
+
+        let prepared = HelperUninstallPreparation.run(
+            restore: { steps.append("restore") },
+            stopWatchdog: { steps.append("stopWatchdog") },
+            clearBackup: { steps.append("clearBackup") }
+        )
+
+        #expect(prepared)
+        #expect(steps == ["restore", "stopWatchdog", "clearBackup"])
+    }
+
+    @Test("A restore that throws keeps the backup and the watchdog and reports failure")
+    func aFailedRestoreTearsDownNothing() {
+        var steps: [String] = []
+
+        let prepared = HelperUninstallPreparation.run(
+            restore: {
+                steps.append("restore")
+                throw TestFailure()
+            },
+            stopWatchdog: { steps.append("stopWatchdog") },
+            clearBackup: { steps.append("clearBackup") }
+        )
+
+        // A failed uninstall must not become a permanent override with no way back: the restore
+        // point and the watcher are the two things that could still fix it.
+        #expect(!prepared)
+        #expect(steps == ["restore"])
+    }
+}
+
+// MARK: - HelperOwnerBindingPolicyTests
+
+/// The owner identifier arrives in the message, so on its own it is a claim. These cover that the
+/// helper acts on the connection it authenticated instead.
+struct HelperOwnerBindingPolicyTests {
+    @Test("A request naming its own connection is the one identity the helper acts on")
+    func aMatchingConnectionIsAuthorized() {
+        #expect(HelperOwnerBindingPolicy.authorizedOwnerPID(
+            boundConnectionPID: 4_242,
+            requestedOwnerPID: 4_242
+        ) == 4_242)
+    }
+
+    @Test("A request naming some other process is refused outright")
+    func aMismatchedOwnerIsRejected() {
+        // Without this, a caller could have the helper arm a watchdog on a process it does not
+        // own — or record that process as the session holding the user's proxy settings.
+        #expect(HelperOwnerBindingPolicy.authorizedOwnerPID(
+            boundConnectionPID: 4_242,
+            requestedOwnerPID: 4_243
+        ) == nil)
+        #expect(HelperOwnerBindingPolicy.authorizedOwnerPID(
+            boundConnectionPID: 4_242,
+            requestedOwnerPID: 1
+        ) == nil)
+    }
+
+    @Test("A request with no usable identifier on either side is refused")
+    func anUnidentifiableRequestIsRejected() {
+        #expect(HelperOwnerBindingPolicy.authorizedOwnerPID(
+            boundConnectionPID: nil,
+            requestedOwnerPID: 4_242
+        ) == nil)
+        #expect(HelperOwnerBindingPolicy.authorizedOwnerPID(
+            boundConnectionPID: 0,
+            requestedOwnerPID: 0
+        ) == nil)
+        #expect(HelperOwnerBindingPolicy.authorizedOwnerPID(
+            boundConnectionPID: 4_242,
+            requestedOwnerPID: 0
+        ) == nil)
+        #expect(HelperOwnerBindingPolicy.authorizedOwnerPID(
+            boundConnectionPID: 4_242,
+            requestedOwnerPID: -1
+        ) == nil)
+    }
+}
+
+// MARK: - HelperBoundProcessIdentityPolicyTests
+
+struct HelperBoundProcessIdentityPolicyTests {
+    @Test("A connection remains valid only for the process instance accepted by the listener")
+    func exactProcessIdentityIsRequired() {
+        #expect(HelperBoundProcessIdentityPolicy.isCurrent(
+            boundPID: 4_242,
+            boundStartSignature: "start-a",
+            liveStartSignature: "start-a"
+        ))
+        #expect(!HelperBoundProcessIdentityPolicy.isCurrent(
+            boundPID: 4_242,
+            boundStartSignature: "start-a",
+            liveStartSignature: "start-b"
+        ))
+        #expect(!HelperBoundProcessIdentityPolicy.isCurrent(
+            boundPID: 4_242,
+            boundStartSignature: "start-a",
+            liveStartSignature: nil
+        ))
+    }
+
+    @Test("A delayed mutation must still own the active backup")
+    func existingSessionIdentityIsRequired() {
+        #expect(HelperBoundProcessIdentityPolicy.ownsProxySession(
+            boundPID: 4_242,
+            boundStartSignature: "start-a",
+            liveStartSignature: "start-a",
+            recordedOwnerPID: 4_242,
+            recordedOwnerStartSignature: "start-a",
+            hasBackedUpServices: true
+        ))
+        #expect(!HelperBoundProcessIdentityPolicy.ownsProxySession(
+            boundPID: 4_242,
+            boundStartSignature: "start-a",
+            liveStartSignature: "start-a",
+            recordedOwnerPID: nil,
+            recordedOwnerStartSignature: nil,
+            hasBackedUpServices: true
+        ))
+        #expect(!HelperBoundProcessIdentityPolicy.ownsProxySession(
+            boundPID: 4_242,
+            boundStartSignature: "start-a",
+            liveStartSignature: "start-a",
+            recordedOwnerPID: 4_242,
+            recordedOwnerStartSignature: "start-a",
+            hasBackedUpServices: false
+        ))
+    }
+
+    @Test("An existing backup can only be extended by its exact owner session")
+    func recordedSessionCannotBeTakenOver() {
+        #expect(HelperBoundProcessIdentityPolicy.recordedSessionBelongsToCaller(
+            recordedOwnerPID: 4_242,
+            recordedOwnerStartSignature: "start-a",
+            callerPID: 4_242,
+            callerStartSignature: "start-a"
+        ))
+        #expect(!HelperBoundProcessIdentityPolicy.recordedSessionBelongsToCaller(
+            recordedOwnerPID: 4_242,
+            recordedOwnerStartSignature: "start-a",
+            callerPID: 4_243,
+            callerStartSignature: "start-b"
+        ))
+        #expect(!HelperBoundProcessIdentityPolicy.recordedSessionBelongsToCaller(
+            recordedOwnerPID: nil,
+            recordedOwnerStartSignature: nil,
+            callerPID: 4_243,
+            callerStartSignature: "start-b"
+        ))
+    }
+
+    @Test("A live session can only be restored by its exact owner")
+    func liveSessionRestoreIsOwnerBound() {
+        #expect(HelperBoundProcessIdentityPolicy.mayRestoreSession(
+            ownerSessionIsLive: true,
+            recordedOwnerPID: 4_242,
+            recordedOwnerStartSignature: "start-a",
+            callerPID: 4_242,
+            callerStartSignature: "start-a"
+        ))
+        #expect(!HelperBoundProcessIdentityPolicy.mayRestoreSession(
+            ownerSessionIsLive: true,
+            recordedOwnerPID: 4_242,
+            recordedOwnerStartSignature: "start-a",
+            callerPID: 4_243,
+            callerStartSignature: "start-b"
+        ))
+        #expect(HelperBoundProcessIdentityPolicy.mayRestoreSession(
+            ownerSessionIsLive: false,
+            recordedOwnerPID: 4_242,
+            recordedOwnerStartSignature: "start-a",
+            callerPID: 4_243,
+            callerStartSignature: "start-b"
+        ))
+    }
+}
+
+// MARK: - HelperOverrideResidencyPolicyTests
+
+/// The idle timer's question, and why the routed service's status is only half of it.
+struct HelperOverrideResidencyPolicyTests {
+    @Test("A live override on the routed service keeps the helper up")
+    func aRoutedOverrideKeepsTheHelper() {
+        #expect(HelperOverrideResidencyPolicy.overrideNeedsHelper(
+            routedServiceIsOverridden: true,
+            unresolvedBackupExists: false
+        ))
+    }
+
+    @Test("An override left on a secondary service keeps the helper up too")
+    func anUnresolvedBackupKeepsTheHelper() {
+        // The routed service reads clean, so the status alone reports this machine as idle. The
+        // services actually left changed are named by the restore point still on disk, and exiting
+        // would take away the only process that could put them back.
+        #expect(HelperOverrideResidencyPolicy.overrideNeedsHelper(
+            routedServiceIsOverridden: false,
+            unresolvedBackupExists: true
+        ))
+    }
+
+    @Test("Nothing overridden and no restore point left means the helper may exit")
+    func aResolvedMachineReleasesTheHelper() {
+        #expect(!HelperOverrideResidencyPolicy.overrideNeedsHelper(
+            routedServiceIsOverridden: false,
+            unresolvedBackupExists: false
+        ))
+    }
+
+    @Test("A partial override still defers the idle exit through the same sequence")
+    func aPartialOverrideDefersTheIdleExit() {
+        var barriersTaken = 0
+
+        let decision = HelperIdleExitSequence.run(
+            proxyIsOverridden: {
+                HelperOverrideResidencyPolicy.overrideNeedsHelper(
+                    routedServiceIsOverridden: false,
+                    unresolvedBackupExists: true
+                )
+            },
+            acquireExitBarrier: {
+                barriersTaken += 1
+                return nil
+            },
+            release: { _ in }
+        )
+
+        #expect(decision == .deferOverridden)
+        // The refusal happens before the gate is touched at all, which is what keeps the common
+        // case cheap.
+        #expect(barriersTaken == 0)
+    }
+}
+
+// MARK: - TestFailure
+
+private struct TestFailure: Error {}

--- a/RockxyTests/Shared/HelperProxyRateLimitPolicyTests.swift
+++ b/RockxyTests/Shared/HelperProxyRateLimitPolicyTests.swift
@@ -1,0 +1,159 @@
+import Foundation
+@testable import Rockxy
+import Testing
+
+// Regression tests for the system proxy override rate limit and for evaluating it inside the
+// privileged mutation gate rather than beside it.
+
+// MARK: - HelperProxyRateLimitPolicyTests
+
+struct HelperProxyRateLimitPolicyTests {
+    @Test("The first request of a session is never rate limited")
+    func firstRequestIsAllowed() {
+        #expect(!HelperProxyRateLimitPolicy.isRateLimited(
+            lastChange: nil,
+            now: Date(timeIntervalSince1970: 1_000),
+            interval: 2.0
+        ))
+    }
+
+    @Test("A request inside the interval is refused and one on the boundary is not")
+    func intervalBoundaryIsExclusive() {
+        let lastChange = Date(timeIntervalSince1970: 1_000)
+
+        #expect(HelperProxyRateLimitPolicy.isRateLimited(
+            lastChange: lastChange,
+            now: lastChange.addingTimeInterval(1.999),
+            interval: 2.0
+        ))
+        #expect(!HelperProxyRateLimitPolicy.isRateLimited(
+            lastChange: lastChange,
+            now: lastChange.addingTimeInterval(2.0),
+            interval: 2.0
+        ))
+        #expect(!HelperProxyRateLimitPolicy.isRateLimited(
+            lastChange: lastChange,
+            now: lastChange.addingTimeInterval(30),
+            interval: 2.0
+        ))
+    }
+
+    @Test("A backward wall-clock adjustment does not extend the rate limit")
+    func backwardClockAdjustmentIsAllowed() {
+        let lastChange = Date(timeIntervalSince1970: 1_000)
+
+        #expect(!HelperProxyRateLimitPolicy.isRateLimited(
+            lastChange: lastChange,
+            now: lastChange.addingTimeInterval(-30),
+            interval: 2.0
+        ))
+    }
+}
+
+// MARK: - GatedProxyRateLimitTests
+
+/// Mirrors the shape of the helper's override entry point: the rate-limit read, the mutation, and
+/// the timestamp write all happen inside one `withExclusiveAccess` turn.
+struct GatedProxyRateLimitTests {
+    // MARK: Internal
+
+    @Test("A busy gate refuses the request without reading or advancing the timestamp")
+    func busyGateNeitherReadsNorWritesTheTimestamp() throws {
+        let gate = HelperPrivilegedMutationGate()
+        let recorder = OverrideRecorder(gate: gate)
+
+        let ticket = try #require(gate.tryAcquire())
+        #expect(recorder.override() == .busy)
+        #expect(recorder.appliedCount == 0)
+        #expect(recorder.observedLastChange == nil)
+
+        gate.release(ticket)
+        #expect(recorder.override() == .applied)
+        #expect(recorder.appliedCount == 1)
+    }
+
+    @Test("A second request inside the interval is rate limited, not applied")
+    func repeatRequestIsRateLimited() {
+        let recorder = OverrideRecorder(gate: HelperPrivilegedMutationGate())
+
+        #expect(recorder.override() == .applied)
+        #expect(recorder.override() == .rateLimited)
+        #expect(recorder.appliedCount == 1)
+
+        recorder.rewindLastChange(by: 5)
+        #expect(recorder.override() == .applied)
+        #expect(recorder.appliedCount == 2)
+    }
+
+    @Test("Concurrent requests cannot both see an unset timestamp")
+    func concurrentRequestsSerializeOnTheTimestamp() async {
+        let recorder = OverrideRecorder(gate: HelperPrivilegedMutationGate())
+
+        await withTaskGroup(of: Void.self) { group in
+            for _ in 0 ..< 16 {
+                group.addTask {
+                    // The gate never waits, so a refused caller retries — the point under test is
+                    // that whoever gets in sees a timestamp nobody else is midway through writing.
+                    while recorder.override() == .busy {
+                        continue
+                    }
+                }
+            }
+        }
+
+        // Reading and writing the timestamp in the same guarded turn is what makes exactly one
+        // request the first: reading it outside the gate let several observe the unset value.
+        #expect(recorder.firstRequestCount == 1)
+        #expect(recorder.appliedCount == 1)
+    }
+
+    // MARK: Private
+
+    private enum OverrideResult: Equatable {
+        case applied
+        case rateLimited
+        case busy
+    }
+
+    private final class OverrideRecorder: @unchecked Sendable {
+        // MARK: Lifecycle
+
+        init(gate: HelperPrivilegedMutationGate) {
+            self.gate = gate
+        }
+
+        // MARK: Internal
+
+        private(set) var appliedCount = 0
+        private(set) var firstRequestCount = 0
+        private(set) var observedLastChange: Date?
+
+        func override() -> OverrideResult {
+            gate.withExclusiveAccess { () -> OverrideResult in
+                observedLastChange = lastProxyChangeTime
+                if lastProxyChangeTime == nil {
+                    firstRequestCount += 1
+                }
+                guard !HelperProxyRateLimitPolicy.isRateLimited(
+                    lastChange: lastProxyChangeTime,
+                    now: Date(),
+                    interval: 2.0
+                ) else {
+                    return .rateLimited
+                }
+                appliedCount += 1
+                lastProxyChangeTime = Date()
+                return .applied
+            } ?? .busy
+        }
+
+        func rewindLastChange(by interval: TimeInterval) {
+            lastProxyChangeTime = lastProxyChangeTime?.addingTimeInterval(-interval)
+        }
+
+        // MARK: Private
+
+        private let gate: HelperPrivilegedMutationGate
+        private var lastProxyChangeTime: Date?
+    }
+}

--- a/RockxyTests/Shared/ProxyBackupRecoveryPolicyTests.swift
+++ b/RockxyTests/Shared/ProxyBackupRecoveryPolicyTests.swift
@@ -162,3 +162,200 @@ struct ProxyBackupSubsetTests {
         BackupEntry(service: service)
     }
 }
+
+// MARK: - ProxyOwnerWatchdogPolicyTests
+
+struct ProxyOwnerWatchdogPolicyTests {
+    @Test("The watchdog keeps watching only while the recorded process is still the live one")
+    func matchingIdentityKeepsTheSessionAlive() {
+        #expect(ProxyOwnerWatchdogPolicy.watchedOwnerIsLive(
+            recordedPID: 4_242,
+            recordedStartSignature: "1788787973.748707",
+            processIsAlive: true,
+            liveStartSignature: "1788787973.748707"
+        ))
+    }
+
+    @Test("A reused process identifier is treated as the owner being gone")
+    func recycledIdentifierTriggersRestore() {
+        #expect(!ProxyOwnerWatchdogPolicy.watchedOwnerIsLive(
+            recordedPID: 4_242,
+            recordedStartSignature: "1788787973.748707",
+            processIsAlive: true,
+            liveStartSignature: "1788799999.100000"
+        ))
+        #expect(!ProxyOwnerWatchdogPolicy.watchedOwnerIsLive(
+            recordedPID: 4_242,
+            recordedStartSignature: "1788787973.748707",
+            processIsAlive: true,
+            liveStartSignature: nil
+        ))
+    }
+
+    @Test("An exited owner is gone whatever the signatures say")
+    func exitedOwnerIsNotLive() {
+        #expect(!ProxyOwnerWatchdogPolicy.watchedOwnerIsLive(
+            recordedPID: 4_242,
+            recordedStartSignature: "1788787973.748707",
+            processIsAlive: false,
+            liveStartSignature: "1788787973.748707"
+        ))
+    }
+
+    @Test("A record with no signature never counts as a live session")
+    func missingSignatureIsNeverLive() {
+        // An override is refused outright unless the requesting process can be identified, so a
+        // record with no signature cannot describe a session worth protecting. Reporting it as
+        // live would be the bare-identifier check this policy exists to remove.
+        #expect(!ProxyOwnerWatchdogPolicy.watchedOwnerIsLive(
+            recordedPID: 4_242,
+            recordedStartSignature: nil,
+            processIsAlive: true,
+            liveStartSignature: "1788787973.748707"
+        ))
+        #expect(!ProxyOwnerWatchdogPolicy.watchedOwnerIsLive(
+            recordedPID: 4_242,
+            recordedStartSignature: "",
+            processIsAlive: true,
+            liveStartSignature: "1788787973.748707"
+        ))
+        #expect(!ProxyOwnerWatchdogPolicy.watchedOwnerIsLive(
+            recordedPID: 4_242,
+            recordedStartSignature: nil,
+            processIsAlive: false,
+            liveStartSignature: nil
+        ))
+    }
+
+    @Test("A preserved owner's recorded signature is what the re-armed watchdog compares against")
+    func preservedOwnerCarriesItsSignatureIntoTheWatchdog() {
+        let recordedSignature = "1788787973.748707"
+
+        // Startup recovery preserves the session only when the recorded identity matches the live
+        // one, so the same signature has to survive into the watchdog — otherwise the re-armed
+        // watchdog would be back to trusting a bare identifier.
+        #expect(ProxyBackupOwnerIdentityPolicy.ownerSessionIsLive(
+            recordedOwnerPID: 4_242,
+            recordedStartSignature: recordedSignature,
+            ownerProcessIsAlive: true,
+            liveStartSignature: recordedSignature,
+            ownerPassesCallerValidation: true
+        ))
+        #expect(ProxyOwnerWatchdogPolicy.watchedOwnerIsLive(
+            recordedPID: 4_242,
+            recordedStartSignature: recordedSignature,
+            processIsAlive: true,
+            liveStartSignature: recordedSignature
+        ))
+        #expect(!ProxyOwnerWatchdogPolicy.watchedOwnerIsLive(
+            recordedPID: 4_242,
+            recordedStartSignature: recordedSignature,
+            processIsAlive: true,
+            liveStartSignature: "1788799999.100000"
+        ))
+    }
+}
+
+// MARK: - ProxyOverrideApplicationPolicyTests
+
+/// Applying an override touches several network services with no transaction behind it. These
+/// cover what a partially applied attempt is allowed to report, and what counts as a service it
+/// never wrote to.
+struct ProxyOverrideApplicationPolicyTests {
+    // MARK: Internal
+
+    @Test("A service that still reads exactly as captured was never written to")
+    func unchangedServiceReadsAsUntouched() {
+        #expect(ProxyOverrideApplicationPolicy.serviceIsUntouched(
+            live: captured,
+            captured: captured
+        ))
+    }
+
+    @Test("A service that no longer matches its capture counts as mutated")
+    func changedServiceReadsAsTouched() {
+        let halfApplied = ProxyServiceRestorationState(
+            service: "Wi-Fi",
+            http: ProxyEndpointState(enabled: true, host: "127.0.0.1", port: 9_090),
+            https: captured.https,
+            socks: captured.socks,
+            pacEnabled: captured.pacEnabled,
+            pacURL: captured.pacURL,
+            autoDiscoveryEnabled: captured.autoDiscoveryEnabled,
+            bypassDomains: captured.bypassDomains
+        )
+
+        #expect(!ProxyOverrideApplicationPolicy.serviceIsUntouched(
+            live: halfApplied,
+            captured: captured
+        ))
+    }
+
+    @Test("A service that could not be read is never assumed untouched")
+    func unreadableServiceReadsAsTouched() {
+        // An unreadable state cannot be shown to be unchanged, and assuming it is would leave a
+        // mutated service with no rollback and no restore point.
+        #expect(!ProxyOverrideApplicationPolicy.serviceIsUntouched(
+            live: nil,
+            captured: captured
+        ))
+    }
+
+    @Test("An attempt that configured every service it touched is applied")
+    func fullyConfiguredAttemptIsApplied() {
+        #expect(ProxyOverrideApplicationPolicy.outcome(
+            configuredServices: ["Wi-Fi", "Ethernet"],
+            partiallyAppliedServices: [],
+            unresolvedServices: []
+        ) == .applied)
+    }
+
+    @Test("One half-applied service makes the whole attempt a rollback, not a success")
+    func partialApplicationIsNeverReportedAsSuccess() {
+        #expect(ProxyOverrideApplicationPolicy.outcome(
+            configuredServices: ["Wi-Fi"],
+            partiallyAppliedServices: ["Ethernet"],
+            unresolvedServices: []
+        ) == .rolledBack)
+    }
+
+    @Test("A service the rollback could not put back keeps the failure and the backup")
+    func unresolvedRollbackIsReportedIncomplete() {
+        #expect(ProxyOverrideApplicationPolicy.outcome(
+            configuredServices: ["Wi-Fi"],
+            partiallyAppliedServices: ["Ethernet"],
+            unresolvedServices: ["Ethernet"]
+        ) == .rollbackIncomplete)
+    }
+
+    @Test("A service left overridden outweighs an otherwise clean attempt")
+    func residualOwnershipAfterRollbackIsIncomplete() {
+        #expect(ProxyOverrideApplicationPolicy.outcome(
+            configuredServices: ["Wi-Fi", "Ethernet"],
+            partiallyAppliedServices: [],
+            unresolvedServices: ["Wi-Fi"]
+        ) == .rollbackIncomplete)
+    }
+
+    @Test("An attempt that configured nothing has nothing to report as applied")
+    func nothingConfiguredIsNotApplied() {
+        #expect(ProxyOverrideApplicationPolicy.outcome(
+            configuredServices: [],
+            partiallyAppliedServices: [],
+            unresolvedServices: []
+        ) == .rolledBack)
+    }
+
+    // MARK: Private
+
+    private let captured = ProxyServiceRestorationState(
+        service: "Wi-Fi",
+        http: ProxyEndpointState(enabled: true, host: "proxy.corp.example", port: 8_080),
+        https: ProxyEndpointState(enabled: true, host: "secure.corp.example", port: 8_443),
+        socks: ProxyEndpointState(enabled: false, host: "", port: 0),
+        pacEnabled: false,
+        pacURL: "",
+        autoDiscoveryEnabled: false,
+        bypassDomains: ["localhost"]
+    )
+}

--- a/RockxyTests/Shared/ProxyOverrideApplicationPreflightTests.swift
+++ b/RockxyTests/Shared/ProxyOverrideApplicationPreflightTests.swift
@@ -1,0 +1,255 @@
+import Foundation
+@testable import Rockxy
+import Testing
+
+// Regression tests for the check that runs immediately before a service's first override command:
+// what the capture in a backup still authorizes once the machine has moved on from it.
+
+// MARK: - ProxyOverrideApplicationPreflightTests
+
+struct ProxyOverrideApplicationPreflightTests {
+    // MARK: Internal
+
+    @Test("A service still reading exactly as captured is written from that capture")
+    func aFreshServiceIsWritable() {
+        #expect(
+            ProxyOverrideApplicationPreflight.decision(
+                captured: Fixtures.capturedSettings,
+                live: Fixtures.capturedSettings,
+                priorEntry: nil,
+                port: Fixtures.rockxyPort
+            ) == .apply(baseline: Fixtures.capturedSettings)
+        )
+    }
+
+    @Test("A service changed since it was captured is left with no command issued against it")
+    func aChangedFreshServiceIsAborted() {
+        // The capture was taken moments ago and the user has re-pointed the service since. Writing
+        // now would put the override over a configuration nothing recorded, and leave the rollback
+        // aiming at a snapshot that no longer describes anything on the machine.
+        let userProxy = Fixtures.replacing(
+            Fixtures.capturedSettings,
+            https: ProxyEndpointState(enabled: true, host: "vpn.example", port: 3_128)
+        )
+
+        #expect(
+            ProxyOverrideApplicationPreflight.decision(
+                captured: Fixtures.capturedSettings,
+                live: userProxy,
+                priorEntry: nil,
+                port: Fixtures.rockxyPort
+            ) == .abort
+        )
+    }
+
+    @Test("A reclaim is written from the override already on the machine, not from the capture")
+    func aReclaimBaselinesFromTheLiveOverride() throws {
+        // The previous session's override is still in place, so the sequence about to run starts
+        // there. The record it commits has to say so — while still naming the pre-Rockxy capture
+        // as what a rollback puts back.
+        let rockxyBypass = ["localhost"]
+        let live = try #require(ProxyOverrideTransition.completedState(
+            from: Fixtures.capturedSettings,
+            port: Fixtures.rockxyPort,
+            appliedBypassDomains: rockxyBypass
+        ))
+
+        #expect(
+            ProxyOverrideApplicationPreflight.decision(
+                captured: Fixtures.capturedSettings,
+                live: live,
+                priorEntry: applicationEntry(stage: .applying, appliedBypassDomains: rockxyBypass),
+                port: Fixtures.rockxyPort
+            ) == .apply(baseline: live)
+        )
+    }
+
+    @Test("A reclaim resumes from a sequence that stopped part-way")
+    func aReclaimBaselinesFromAHalfAppliedService() {
+        let halfApplied = Fixtures.replacing(
+            Fixtures.capturedSettings,
+            http: ProxyEndpointState(
+                enabled: true,
+                host: ProxyOverrideTransition.loopbackHost,
+                port: Fixtures.rockxyPort
+            )
+        )
+
+        #expect(
+            ProxyOverrideApplicationPreflight.decision(
+                captured: Fixtures.capturedSettings,
+                live: halfApplied,
+                priorEntry: applicationEntry(stage: .applying),
+                port: Fixtures.rockxyPort
+            ) == .apply(baseline: halfApplied)
+        )
+    }
+
+    @Test("A record whose commands were never issued authorizes no changed state")
+    func anApplicationPendingRecordDoesNotAuthorizeAReclaim() {
+        let halfApplied = Fixtures.replacing(
+            Fixtures.capturedSettings,
+            http: ProxyEndpointState(
+                enabled: true,
+                host: ProxyOverrideTransition.loopbackHost,
+                port: Fixtures.rockxyPort
+            )
+        )
+
+        #expect(
+            ProxyOverrideApplicationPreflight.decision(
+                captured: Fixtures.capturedSettings,
+                live: halfApplied,
+                priorEntry: applicationEntry(stage: .applicationPending),
+                port: Fixtures.rockxyPort
+            ) == .abort
+        )
+    }
+
+    @Test("A foreign configuration is not reclaimable, whatever the record says")
+    func aForeignConfigurationIsAborted() {
+        let foreign = Fixtures.replacing(
+            Fixtures.capturedSettings,
+            http: ProxyEndpointState(enabled: true, host: "10.0.0.9", port: 3_128)
+        )
+
+        #expect(
+            ProxyOverrideApplicationPreflight.decision(
+                captured: Fixtures.capturedSettings,
+                live: foreign,
+                priorEntry: applicationEntry(stage: .applying),
+                port: Fixtures.rockxyPort
+            ) == .abort
+        )
+    }
+
+    @Test("A record describing some other capture is not this attempt's to reclaim from")
+    func aStaleRecordDoesNotAuthorizeAReclaim() throws {
+        let live = try #require(ProxyOverrideTransition.completedState(
+            from: Fixtures.capturedSettings,
+            port: Fixtures.rockxyPort
+        ))
+        let staleRecord = applicationEntry(
+            stage: .applying,
+            captured: Fixtures.replacing(Fixtures.capturedSettings, bypassDomains: ["something.else"])
+        )
+
+        #expect(
+            ProxyOverrideApplicationPreflight.decision(
+                captured: Fixtures.capturedSettings,
+                live: live,
+                priorEntry: staleRecord,
+                port: Fixtures.rockxyPort
+            ) == .abort
+        )
+    }
+
+    @Test("A restore record never authorizes an override to be written over it")
+    func aRestoreRecordDoesNotAuthorizeAnOverride() {
+        // A recovery was part-way through putting the captured settings back when this attempt
+        // arrived. Its states belong to a different command sequence entirely.
+        let midRestore = Fixtures.capturedSettings.withProxyModesDisabled
+
+        #expect(
+            ProxyOverrideApplicationPreflight.decision(
+                captured: Fixtures.capturedSettings,
+                live: midRestore,
+                priorEntry: Fixtures.entry(stage: .inFlight),
+                port: Fixtures.rockxyPort
+            ) == .abort
+        )
+    }
+
+    @Test("A service whose settings could not be read is never written to")
+    func anUnreadableServiceIsAborted() {
+        #expect(
+            ProxyOverrideApplicationPreflight.decision(
+                captured: Fixtures.capturedSettings,
+                live: nil,
+                priorEntry: applicationEntry(stage: .applying),
+                port: Fixtures.rockxyPort
+            ) == .abort
+        )
+    }
+
+    @Test("A record naming another service authorizes nothing here")
+    func aMismatchedServiceIsAborted() {
+        #expect(
+            ProxyOverrideApplicationPreflight.decision(
+                captured: Fixtures.capturedSettings,
+                live: Fixtures.renamed(Fixtures.capturedSettings, to: "Ethernet"),
+                priorEntry: applicationEntry(stage: .applying),
+                port: Fixtures.rockxyPort
+            ) == .abort
+        )
+    }
+
+    @Test("An override with no usable port is refused before anything is read")
+    func anUnusablePortIsAborted() {
+        #expect(
+            ProxyOverrideApplicationPreflight.decision(
+                captured: Fixtures.capturedSettings,
+                live: Fixtures.capturedSettings,
+                priorEntry: nil,
+                port: 0
+            ) == .abort
+        )
+    }
+
+    @Test("The record a reclaim commits restores the original capture from the live baseline")
+    func theCommittedRecordKeepsTheOriginalTarget() throws {
+        let live = try #require(ProxyOverrideTransition.completedState(
+            from: Fixtures.capturedSettings,
+            port: Fixtures.rockxyPort
+        ))
+        guard case let .apply(baseline) = ProxyOverrideApplicationPreflight.decision(
+            captured: Fixtures.capturedSettings,
+            live: live,
+            priorEntry: applicationEntry(stage: .applying),
+            port: Fixtures.rockxyPort
+        ) else {
+            Issue.record("expected the reclaim to be writable")
+            return
+        }
+
+        let committed = ProxyServiceRecoveryJournalEntry(
+            overrideApplicationFor: Fixtures.capturedSettings,
+            baseline: baseline,
+            stage: .applying,
+            port: Fixtures.rockxyPort
+        )
+
+        // The sequence starts at what is live, and the rollback still puts the user's own
+        // configuration back rather than the override this attempt is reclaiming.
+        #expect(committed.expectedPreStepState == live)
+        #expect(committed.target == Fixtures.capturedSettings)
+        // And the record still describes the backup on disk, so the planner keeps reading it.
+        #expect(committed.describesRestore(of: Fixtures.capturedSettings))
+        // A crash after this commit but before the first command still has the prior override live.
+        // That is a reclaim to roll back, not an untouched fresh service whose restore point may go.
+        #expect(ProxyOverrideApplicationRecoveryPolicy.continuation(
+            for: committed,
+            live: live,
+            ownedPort: Fixtures.rockxyPort
+        ) == .rollBack(baseline: live))
+    }
+
+    // MARK: Private
+
+    private typealias Fixtures = ProxyRecoveryJournalFixtures
+
+    private func applicationEntry(
+        stage: ProxyRecoveryStage,
+        captured: ProxyServiceRestorationState = ProxyRecoveryJournalFixtures.capturedSettings,
+        appliedBypassDomains: [String]? = nil
+    )
+        -> ProxyServiceRecoveryJournalEntry
+    {
+        ProxyServiceRecoveryJournalEntry(
+            overrideApplicationFor: captured,
+            stage: stage,
+            port: ProxyRecoveryJournalFixtures.rockxyPort,
+            appliedBypassDomains: appliedBypassDomains
+        )
+    }
+}

--- a/RockxyTests/Shared/ProxyOverrideSessionCompletionPolicyTests.swift
+++ b/RockxyTests/Shared/ProxyOverrideSessionCompletionPolicyTests.swift
@@ -1,0 +1,166 @@
+import Foundation
+@testable import Rockxy
+import Testing
+
+// Regression tests for what a helper launch may leave alone when the app process recorded in a
+// backup is still running.
+
+// MARK: - ProxyOverrideSessionCompletionPolicyTests
+
+/// A live owner is not on its own a reason to preserve a session. The override it took either
+/// finished on every service or it did not, and a sequence that stopped part-way left a shape that
+/// is neither Rockxy's nor the user's — with the process that would have finished it already past
+/// the point of doing so.
+struct ProxyOverrideSessionCompletionPolicyTests {
+    // MARK: Internal
+
+    @Test("A session whose override finished exactly as recorded is left alone")
+    func aFullyAppliedSessionIsPreserved() throws {
+        let finished = try #require(ProxyOverrideTransition.completedState(
+            from: Fixtures.capturedSettings,
+            port: Fixtures.rockxyPort,
+            appliedBypassDomains: rockxyBypass
+        ))
+
+        #expect(ProxyOverrideSessionCompletionPolicy.sessionIsFullyApplied(
+            services: [Fixtures.service],
+            journal: [applicationEntry(stage: .applying, appliedBypassDomains: rockxyBypass)],
+            liveStates: [Fixtures.service: finished],
+            ownedPort: Fixtures.rockxyPort
+        ))
+    }
+
+    @Test("A sequence that stopped part-way is recovered even though its owner is alive")
+    func aPartialPrefixIsNotPreserved() {
+        let halfApplied = Fixtures.replacing(
+            Fixtures.capturedSettings,
+            http: ProxyEndpointState(
+                enabled: true,
+                host: ProxyOverrideTransition.loopbackHost,
+                port: Fixtures.rockxyPort
+            )
+        )
+
+        #expect(!ProxyOverrideSessionCompletionPolicy.sessionIsFullyApplied(
+            services: [Fixtures.service],
+            journal: [applicationEntry(stage: .applying)],
+            liveStates: [Fixtures.service: halfApplied],
+            ownedPort: Fixtures.rockxyPort
+        ))
+    }
+
+    @Test("A record whose commands were never issued is not a finished session")
+    func anApplicationPendingRecordIsNotPreserved() {
+        // Whether the service is untouched or already overridden, nothing was recorded as issued
+        // under this record, so nothing about it says the session finished.
+        for live in [Fixtures.capturedSettings, Fixtures.rockxyOverride] {
+            #expect(!ProxyOverrideSessionCompletionPolicy.sessionIsFullyApplied(
+                services: [Fixtures.service],
+                journal: [applicationEntry(stage: .applicationPending)],
+                liveStates: [Fixtures.service: live],
+                ownedPort: Fixtures.rockxyPort
+            ))
+        }
+    }
+
+    @Test("A service the override never reached takes the whole session out of preservation")
+    func anUntouchedServiceIsNotPreserved() {
+        #expect(!ProxyOverrideSessionCompletionPolicy.sessionIsFullyApplied(
+            services: [Fixtures.service],
+            journal: [applicationEntry(stage: .applying)],
+            liveStates: [Fixtures.service: Fixtures.capturedSettings],
+            ownedPort: Fixtures.rockxyPort
+        ))
+    }
+
+    @Test("A restore already under way is never a finished override")
+    func aRestoreRecordIsNotPreserved() {
+        #expect(!ProxyOverrideSessionCompletionPolicy.sessionIsFullyApplied(
+            services: [Fixtures.service],
+            journal: [Fixtures.entry(stage: .inFlight)],
+            liveStates: [Fixtures.service: Fixtures.rockxyOverride],
+            ownedPort: Fixtures.rockxyPort
+        ))
+    }
+
+    @Test("One service the journal says nothing about takes the whole session out of preservation")
+    func anUnrecordedServiceIsNotPreserved() throws {
+        let finished = try #require(ProxyOverrideTransition.completedState(
+            from: Fixtures.capturedSettings,
+            port: Fixtures.rockxyPort
+        ))
+        let secondary = Fixtures.renamed(finished, to: "Ethernet")
+
+        #expect(!ProxyOverrideSessionCompletionPolicy.sessionIsFullyApplied(
+            services: [Fixtures.service, "Ethernet"],
+            journal: [applicationEntry(stage: .applying)],
+            liveStates: [Fixtures.service: finished, "Ethernet": secondary],
+            ownedPort: Fixtures.rockxyPort
+        ))
+    }
+
+    @Test("A service whose settings could not be read is not proof of anything")
+    func anUnreadableServiceIsNotPreserved() {
+        #expect(!ProxyOverrideSessionCompletionPolicy.sessionIsFullyApplied(
+            services: [Fixtures.service],
+            journal: [applicationEntry(stage: .applying)],
+            liveStates: [:],
+            ownedPort: Fixtures.rockxyPort
+        ))
+    }
+
+    @Test("A backup covering no service at all is never preserved")
+    func anEmptyBackupIsNotPreserved() {
+        #expect(!ProxyOverrideSessionCompletionPolicy.sessionIsFullyApplied(
+            services: [],
+            journal: [],
+            liveStates: [:],
+            ownedPort: Fixtures.rockxyPort
+        ))
+    }
+
+    @Test("A backup written before the journal keeps the older ownership answer")
+    func aLegacyBackupFallsBackToOwnership() {
+        // There is no record to read a partial application out of, so tearing the session down
+        // would be condemning a live session on evidence this build simply does not have. The
+        // answer decides nothing but whether to write nothing.
+        #expect(ProxyOverrideSessionCompletionPolicy.sessionIsFullyApplied(
+            services: [Fixtures.service],
+            journal: [],
+            liveStates: [Fixtures.service: Fixtures.rockxyOverride],
+            ownedPort: Fixtures.rockxyPort
+        ))
+        #expect(!ProxyOverrideSessionCompletionPolicy.sessionIsFullyApplied(
+            services: [Fixtures.service],
+            journal: [],
+            liveStates: [Fixtures.service: Fixtures.capturedSettings],
+            ownedPort: Fixtures.rockxyPort
+        ))
+        #expect(!ProxyOverrideSessionCompletionPolicy.sessionIsFullyApplied(
+            services: [Fixtures.service],
+            journal: [],
+            liveStates: [Fixtures.service: Fixtures.rockxyOverride],
+            ownedPort: nil
+        ))
+    }
+
+    // MARK: Private
+
+    private typealias Fixtures = ProxyRecoveryJournalFixtures
+
+    private let rockxyBypass = ["localhost", "127.0.0.1"]
+
+    private func applicationEntry(
+        stage: ProxyRecoveryStage,
+        appliedBypassDomains: [String]? = nil
+    )
+        -> ProxyServiceRecoveryJournalEntry
+    {
+        ProxyServiceRecoveryJournalEntry(
+            overrideApplicationFor: ProxyRecoveryJournalFixtures.capturedSettings,
+            stage: stage,
+            port: ProxyRecoveryJournalFixtures.rockxyPort,
+            appliedBypassDomains: appliedBypassDomains
+        )
+    }
+}

--- a/RockxyTests/Shared/ProxyRecoveryJournalTests.swift
+++ b/RockxyTests/Shared/ProxyRecoveryJournalTests.swift
@@ -1,0 +1,2085 @@
+import Foundation
+@testable import Rockxy
+import Testing
+
+// Regression tests for the per-service recovery journal in the shared recovery layer: what a
+// retry is allowed to write after a partial restore, a crash, or a user change.
+
+// MARK: - ProxyRecoveryJournalFixtures
+
+/// Shared shapes for the journal tests: the override Rockxy leaves on a service, and the corporate
+/// configuration a restore has to put back.
+enum ProxyRecoveryJournalFixtures {
+    // MARK: Internal
+
+    static let service = "Wi-Fi"
+    static let rockxyPort = 9_090
+
+    /// The strict loopback override Rockxy writes, with the SOCKS endpoint and PAC URL the user
+    /// already had left switched off but otherwise untouched.
+    static let rockxyOverride = ProxyServiceRestorationState(
+        service: service,
+        http: ProxyEndpointState(enabled: true, host: "127.0.0.1", port: rockxyPort),
+        https: ProxyEndpointState(enabled: true, host: "127.0.0.1", port: rockxyPort),
+        socks: ProxyEndpointState(enabled: false, host: "socks.corp.example", port: 1_080),
+        pacEnabled: false,
+        pacURL: "https://proxy.corp.example/config.pac",
+        autoDiscoveryEnabled: false,
+        bypassDomains: ["*.corp.internal"]
+    )
+
+    /// Everything the user had configured before Rockxy took the route: both web proxies, SOCKS,
+    /// PAC, auto discovery, and a bypass list.
+    static let capturedSettings = ProxyServiceRestorationState(
+        service: service,
+        http: ProxyEndpointState(enabled: true, host: "proxy.corp.example", port: 8_080),
+        https: ProxyEndpointState(enabled: true, host: "secure.corp.example", port: 8_443),
+        socks: ProxyEndpointState(enabled: true, host: "socks.corp.example", port: 1_080),
+        pacEnabled: true,
+        pacURL: "https://proxy.corp.example/config.pac",
+        autoDiscoveryEnabled: true,
+        bypassDomains: ["*.corp.internal", "localhost"]
+    )
+
+    static var restoredSettings: ProxyServiceRestorationState {
+        ProxyServiceRestorationState.expectedRestorationResult(
+            target: capturedSettings,
+            from: rockxyOverride
+        )
+    }
+
+    static func entry(
+        stage: ProxyRecoveryStage,
+        pre: ProxyServiceRestorationState = rockxyOverride,
+        target: ProxyServiceRestorationState = capturedSettings
+    )
+        -> ProxyServiceRecoveryJournalEntry
+    {
+        ProxyServiceRecoveryJournalEntry(
+            service: pre.service,
+            stage: stage,
+            expectedPreStepState: pre,
+            target: target
+        )
+    }
+
+    static func renamed(
+        _ state: ProxyServiceRestorationState,
+        to service: String
+    )
+        -> ProxyServiceRestorationState
+    {
+        ProxyServiceRestorationState(
+            service: service,
+            http: state.http,
+            https: state.https,
+            socks: state.socks,
+            pacEnabled: state.pacEnabled,
+            pacURL: state.pacURL,
+            autoDiscoveryEnabled: state.autoDiscoveryEnabled,
+            bypassDomains: state.bypassDomains
+        )
+    }
+
+    static func replacing(
+        _ state: ProxyServiceRestorationState,
+        http: ProxyEndpointState? = nil,
+        https: ProxyEndpointState? = nil,
+        socks: ProxyEndpointState? = nil,
+        pacEnabled: Bool? = nil,
+        pacURL: String? = nil,
+        autoDiscoveryEnabled: Bool? = nil,
+        bypassDomains: [String]? = nil
+    )
+        -> ProxyServiceRestorationState
+    {
+        ProxyServiceRestorationState(
+            service: state.service,
+            http: http ?? state.http,
+            https: https ?? state.https,
+            socks: socks ?? state.socks,
+            pacEnabled: pacEnabled ?? state.pacEnabled,
+            pacURL: pacURL ?? state.pacURL,
+            autoDiscoveryEnabled: autoDiscoveryEnabled ?? state.autoDiscoveryEnabled,
+            bypassDomains: bypassDomains ?? state.bypassDomains
+        )
+    }
+}
+
+// MARK: - ProxyRestorationStateTests
+
+struct ProxyRestorationStateTests {
+    // MARK: Internal
+
+    @Test("A completed restore reproduces every captured proxy mode")
+    func restorationResultCoversEveryProxyMode() {
+        let restored = Fixtures.restoredSettings
+
+        #expect(restored.http == Fixtures.capturedSettings.http)
+        #expect(restored.https == Fixtures.capturedSettings.https)
+        #expect(restored.socks == Fixtures.capturedSettings.socks)
+        #expect(restored.pacEnabled)
+        #expect(restored.pacURL == "https://proxy.corp.example/config.pac")
+        #expect(restored.autoDiscoveryEnabled)
+        #expect(restored.bypassDomains == ["*.corp.internal", "localhost"])
+    }
+
+    @Test("A captured protocol with no endpoint is only switched off, never re-pointed")
+    func restorationLeavesUnnamedEndpointsWhereTheyAre() {
+        let target = Fixtures.replacing(
+            Fixtures.capturedSettings,
+            http: ProxyEndpointState(enabled: false, host: "", port: 0),
+            socks: ProxyEndpointState(enabled: false, host: "", port: 0),
+            pacEnabled: false,
+            autoDiscoveryEnabled: false
+        )
+
+        let restored = ProxyServiceRestorationState.expectedRestorationResult(
+            target: target,
+            from: Fixtures.rockxyOverride
+        )
+
+        // `networksetup` has no command that clears a stored endpoint, so the override's host and
+        // port survive with the mode off — expecting the empty snapshot back would report a
+        // finished restore as unfinished forever.
+        #expect(restored.http == ProxyEndpointState(enabled: false, host: "127.0.0.1", port: 9_090))
+        #expect(restored.socks == ProxyEndpointState(enabled: false, host: "socks.corp.example", port: 1_080))
+        #expect(!restored.pacEnabled)
+        #expect(restored.pacURL == Fixtures.rockxyOverride.pacURL)
+        #expect(!restored.autoDiscoveryEnabled)
+    }
+
+    @Test("Switching every mode off keeps the endpoints, the PAC URL, and the bypass list")
+    func disablingModesPreservesStoredValues() {
+        let disabled = Fixtures.rockxyOverride.withProxyModesDisabled
+
+        #expect(!disabled.http.enabled)
+        #expect(disabled.http.host == "127.0.0.1")
+        #expect(disabled.http.port == 9_090)
+        #expect(!disabled.https.enabled)
+        #expect(!disabled.socks.enabled)
+        #expect(disabled.socks.host == "socks.corp.example")
+        #expect(!disabled.pacEnabled)
+        #expect(disabled.pacURL == Fixtures.rockxyOverride.pacURL)
+        #expect(!disabled.autoDiscoveryEnabled)
+        #expect(disabled.bypassDomains == Fixtures.rockxyOverride.bypassDomains)
+    }
+
+    @Test("The ownership projection reads the loopback override and a global bypass")
+    func overrideProjectionMatchesOwnership() {
+        #expect(ProxyOverrideOwnership.isOwnedByRockxy(
+            Fixtures.rockxyOverride.overrideState,
+            port: Fixtures.rockxyPort
+        ))
+        #expect(!ProxyOverrideOwnership.isOwnedByRockxy(
+            Fixtures.replacing(Fixtures.rockxyOverride, bypassDomains: ["*"]).overrideState,
+            port: Fixtures.rockxyPort
+        ))
+        #expect(!ProxyOverrideOwnership.isOwnedByRockxy(
+            Fixtures.capturedSettings.overrideState,
+            port: Fixtures.rockxyPort
+        ))
+    }
+
+    @Test("A journal entry survives a plist roundtrip")
+    func journalEntryRoundtrips() throws {
+        let entry = Fixtures.entry(stage: .inFlight)
+
+        let data = try PropertyListEncoder().encode([entry])
+        let decoded = try PropertyListDecoder().decode([ProxyServiceRecoveryJournalEntry].self, from: data)
+
+        #expect(decoded == [entry])
+        #expect(decoded.first?.stage == .inFlight)
+    }
+
+    @Test("networksetup's empty bypass sentence parses as no bypass domains")
+    func bypassOutputParsing() {
+        #expect(ProxyBypassDomainOutput.parse(
+            "There aren't any bypass domains set on Wi-Fi.\n"
+        ).isEmpty)
+        #expect(ProxyBypassDomainOutput.parse("*.corp.internal\nlocalhost\n\n") == [
+            "*.corp.internal",
+            "localhost",
+        ])
+    }
+
+    // MARK: Private
+
+    private typealias Fixtures = ProxyRecoveryJournalFixtures
+}
+
+// MARK: - ProxyServiceRecoveryPolicyTests
+
+struct ProxyServiceRecoveryPolicyTests {
+    // MARK: Internal
+
+    @Test("Before any command runs, only the exact recorded override authorizes a write")
+    func pendingRequiresTheRecordedOverride() {
+        let entry = Fixtures.entry(stage: .pending)
+
+        #expect(ProxyServiceRecoveryPolicy.continuation(
+            for: entry,
+            live: Fixtures.rockxyOverride
+        ) == .restore)
+        #expect(ProxyServiceRecoveryPolicy.continuation(
+            for: entry,
+            live: Fixtures.rockxyOverride.withProxyModesDisabled
+        ) == .abandon)
+    }
+
+    @Test("A user change between retries takes the service out of automatic recovery")
+    func userChangeBetweenRetriesIsNeverOverwritten() {
+        let userProxy = Fixtures.replacing(
+            Fixtures.rockxyOverride,
+            http: ProxyEndpointState(enabled: true, host: "10.0.0.5", port: 3_128),
+            https: ProxyEndpointState(enabled: true, host: "10.0.0.5", port: 3_128)
+        )
+
+        for stage in [ProxyRecoveryStage.pending, .inFlight, .restored] {
+            #expect(ProxyServiceRecoveryPolicy.continuation(
+                for: Fixtures.entry(stage: stage),
+                live: userProxy
+            ) == .abandon)
+        }
+    }
+
+    @Test("A bypass list the user edited between retries is not written over")
+    func userBypassChangeIsNeverOverwritten() {
+        let userBypass = Fixtures.replacing(
+            Fixtures.rockxyOverride,
+            bypassDomains: ["*.staging.internal"]
+        )
+
+        #expect(ProxyServiceRecoveryPolicy.continuation(
+            for: Fixtures.entry(stage: .inFlight),
+            live: userBypass
+        ) == .abandon)
+    }
+
+    @Test("An interrupted sequence is resumed at every point it can stop")
+    func partialCommandStatesAreResumed() {
+        let entry = Fixtures.entry(stage: .inFlight)
+        let disabled = Fixtures.rockxyOverride.withProxyModesDisabled
+        let restored = Fixtures.restoredSettings
+
+        // Stopped right after every mode was switched off.
+        #expect(ProxyServiceRecoveryPolicy.continuation(for: entry, live: disabled) == .restore)
+        // HTTP written back, HTTPS not reached yet.
+        #expect(ProxyServiceRecoveryPolicy.continuation(
+            for: entry,
+            live: Fixtures.replacing(disabled, http: restored.http)
+        ) == .restore)
+        // Stopped between writing the HTTP endpoint and switching it on.
+        #expect(ProxyServiceRecoveryPolicy.continuation(
+            for: entry,
+            live: Fixtures.replacing(disabled, http: restored.http.disabled)
+        ) == .restore)
+        // SOCKS and PAC written back, auto discovery and bypass not reached yet.
+        #expect(ProxyServiceRecoveryPolicy.continuation(
+            for: entry,
+            live: Fixtures.replacing(
+                disabled,
+                http: restored.http,
+                https: restored.https,
+                socks: restored.socks,
+                pacEnabled: true
+            )
+        ) == .restore)
+        // Everything but the bypass list.
+        #expect(ProxyServiceRecoveryPolicy.continuation(
+            for: entry,
+            live: Fixtures.replacing(restored, bypassDomains: Fixtures.rockxyOverride.bypassDomains)
+        ) == .restore)
+    }
+
+    @Test("A host from one step beside a port from another is not a state any step produced")
+    func mixedHostAndPortIsTreatedAsForeign() {
+        #expect(ProxyServiceRecoveryPolicy.continuation(
+            for: Fixtures.entry(stage: .inFlight),
+            live: Fixtures.replacing(
+                Fixtures.rockxyOverride,
+                http: ProxyEndpointState(enabled: true, host: "127.0.0.1", port: 8_080)
+            )
+        ) == .abandon)
+    }
+
+    @Test("A process that died between the commands and the journal update writes nothing again")
+    func completedCommandsWithoutAJournalUpdateAreNotReplayed() {
+        // The entry never advanced past `inFlight`, but the settings are already the restored
+        // ones, so the sequence completed and there is nothing left to write.
+        #expect(ProxyServiceRecoveryPolicy.continuation(
+            for: Fixtures.entry(stage: .inFlight),
+            live: Fixtures.restoredSettings
+        ) == .complete)
+    }
+
+    @Test("A recorded completion whose settings did not land is retried")
+    func recordedCompletionThatDidNotLandIsRetried() {
+        #expect(ProxyServiceRecoveryPolicy.continuation(
+            for: Fixtures.entry(stage: .restored),
+            live: Fixtures.rockxyOverride
+        ) == .restore)
+        #expect(ProxyServiceRecoveryPolicy.continuation(
+            for: Fixtures.entry(stage: .restored),
+            live: Fixtures.restoredSettings
+        ) == .complete)
+    }
+
+    @Test("Settings that could not be read defer the service instead of guessing")
+    func unreadableServiceIsDeferred() {
+        #expect(ProxyServiceRecoveryPolicy.continuation(
+            for: Fixtures.entry(stage: .inFlight),
+            live: nil
+        ) == .retryLater)
+    }
+
+    @Test("A record that names a different service never authorizes a write")
+    func mismatchedServiceIsAbandoned() {
+        let otherService = ProxyServiceRestorationState(
+            service: "Ethernet",
+            http: Fixtures.rockxyOverride.http,
+            https: Fixtures.rockxyOverride.https,
+            socks: Fixtures.rockxyOverride.socks,
+            pacEnabled: false,
+            pacURL: "",
+            autoDiscoveryEnabled: false,
+            bypassDomains: []
+        )
+
+        #expect(ProxyServiceRecoveryPolicy.continuation(
+            for: Fixtures.entry(stage: .inFlight),
+            live: otherService
+        ) == .abandon)
+    }
+
+    // MARK: Private
+
+    private typealias Fixtures = ProxyRecoveryJournalFixtures
+}
+
+// MARK: - ProxyRestoreTransitionTests
+
+/// The restore is a fixed, ordered list of `networksetup` commands. These pin down that the
+/// states it can be observed in are exactly the prefixes of that list — no more, so a foreign
+/// change is caught, and no fewer, so an interrupted restore is still resumed.
+struct ProxyRestoreTransitionTests {
+    // MARK: Internal
+
+    @Test("The reachable states start at the recorded settings and end at the finished restore")
+    func transitionsSpanTheWholeStep() {
+        let states = ProxyRestoreTransition.reachableStates(
+            from: Fixtures.rockxyOverride,
+            target: Fixtures.capturedSettings
+        )
+
+        #expect(states.first == Fixtures.rockxyOverride)
+        #expect(states.last == Fixtures.restoredSettings)
+    }
+
+    @Test("Every state the ordered commands pass through authorizes the restore to continue")
+    func everyOrderedPrefixIsResumable() {
+        let entry = Fixtures.entry(stage: .inFlight)
+        let states = ProxyRestoreTransition.reachableStates(
+            from: Fixtures.rockxyOverride,
+            target: Fixtures.capturedSettings
+        )
+
+        for state in states {
+            let continuation = ProxyServiceRecoveryPolicy.continuation(for: entry, live: state)
+            let expected: ProxyRecoveryContinuation = state == Fixtures.restoredSettings
+                ? .complete
+                : .restore
+            #expect(continuation == expected)
+        }
+    }
+
+    @Test("The commands are walked in the order the restore issues them")
+    func statesFollowTheCommandOrder() {
+        let disabled = Fixtures.rockxyOverride.withProxyModesDisabled
+        let restored = Fixtures.restoredSettings
+        let states = ProxyRestoreTransition.reachableStates(
+            from: Fixtures.rockxyOverride,
+            target: Fixtures.capturedSettings
+        )
+
+        // HTTP is switched off before HTTPS is, and the bypass list is not written until every
+        // other command has run.
+        let httpOff = Fixtures.replacing(Fixtures.rockxyOverride, http: Fixtures.rockxyOverride.http.disabled)
+        #expect(index(of: httpOff, in: states) < index(of: disabled, in: states))
+        #expect(index(of: disabled, in: states) < index(of: restored, in: states))
+
+        // Each endpoint is written before the next protocol is touched.
+        let httpWritten = Fixtures.replacing(disabled, http: restored.http)
+        let httpsWritten = Fixtures.replacing(httpWritten, https: restored.https)
+        #expect(index(of: httpWritten, in: states) < index(of: httpsWritten, in: states))
+    }
+
+    @Test("Setting an endpoint leaves its own mode uncertain and nothing else")
+    func endpointWritesBranchOnlyOnTheirOwnMode() {
+        let disabled = Fixtures.rockxyOverride.withProxyModesDisabled
+        let restored = Fixtures.restoredSettings
+        let entry = Fixtures.entry(stage: .inFlight)
+
+        // `networksetup` does not define what writing an endpoint does to that mode's on/off
+        // flag, so both answers are accepted at that command.
+        #expect(ProxyServiceRecoveryPolicy.continuation(
+            for: entry,
+            live: Fixtures.replacing(disabled, http: restored.http.disabled)
+        ) == .restore)
+        #expect(ProxyServiceRecoveryPolicy.continuation(
+            for: entry,
+            live: Fixtures.replacing(disabled, http: restored.http)
+        ) == .restore)
+
+        // The uncertainty does not spread: an HTTPS mode that is on while its endpoint is still
+        // the override's is not something any command produced.
+        #expect(ProxyServiceRecoveryPolicy.continuation(
+            for: entry,
+            live: Fixtures.replacing(disabled, http: restored.http, https: Fixtures.rockxyOverride.https)
+        ) == .abandon)
+    }
+
+    @Test("A field combination no ordered prefix produces belongs to whoever wrote it")
+    func impossibleCombinationsAreForeign() {
+        let entry = Fixtures.entry(stage: .inFlight)
+        let restored = Fixtures.restoredSettings
+
+        // The bypass list is written last, so it cannot be the restore's while HTTP and HTTPS
+        // are still exactly as the override left them.
+        #expect(ProxyServiceRecoveryPolicy.continuation(
+            for: entry,
+            live: Fixtures.replacing(
+                Fixtures.rockxyOverride,
+                bypassDomains: Fixtures.capturedSettings.bypassDomains
+            )
+        ) == .abandon)
+
+        // PAC is switched on after every endpoint has been written back.
+        #expect(ProxyServiceRecoveryPolicy.continuation(
+            for: entry,
+            live: Fixtures.replacing(Fixtures.rockxyOverride, pacEnabled: true)
+        ) == .abandon)
+
+        // Auto discovery comes after PAC, which comes after the endpoints.
+        #expect(ProxyServiceRecoveryPolicy.continuation(
+            for: entry,
+            live: Fixtures.replacing(Fixtures.rockxyOverride, autoDiscoveryEnabled: true)
+        ) == .abandon)
+
+        // A restored bypass list beside a half-written set of endpoints is not a prefix either.
+        #expect(ProxyServiceRecoveryPolicy.continuation(
+            for: entry,
+            live: Fixtures.replacing(
+                Fixtures.rockxyOverride.withProxyModesDisabled,
+                http: restored.http,
+                bypassDomains: restored.bypassDomains
+            )
+        ) == .abandon)
+    }
+
+    @Test("A capture with no PAC and no auto discovery never passes through switching them on")
+    func skippedCommandsAreNotReachable() {
+        let target = Fixtures.replacing(
+            Fixtures.capturedSettings,
+            pacEnabled: false,
+            autoDiscoveryEnabled: false
+        )
+        let entry = Fixtures.entry(stage: .inFlight, target: target)
+
+        #expect(ProxyServiceRecoveryPolicy.continuation(
+            for: entry,
+            live: Fixtures.replacing(
+                ProxyServiceRestorationState.expectedRestorationResult(
+                    target: target,
+                    from: Fixtures.rockxyOverride
+                ),
+                pacEnabled: true
+            )
+        ) == .abandon)
+    }
+
+    // MARK: Private
+
+    private typealias Fixtures = ProxyRecoveryJournalFixtures
+
+    private func index(
+        of state: ProxyServiceRestorationState,
+        in states: [ProxyServiceRestorationState]
+    )
+        -> Int
+    {
+        states.firstIndex(of: state) ?? -1
+    }
+}
+
+// MARK: - ProxyOverrideTransitionTests
+
+/// Applying the override is a fixed seven-command sequence. These cover what that buys: a service
+/// this process stopped part-way through can be proven to be its own work, and anything else
+/// cannot.
+struct ProxyOverrideTransitionTests {
+    // MARK: Internal
+
+    @Test("The reachable states start at the captured settings and end at the finished override")
+    func transitionSpansTheWholeApply() {
+        let states = ProxyOverrideTransition.reachableStates(
+            from: Fixtures.capturedSettings,
+            port: Fixtures.rockxyPort
+        )
+
+        #expect(states.first == Fixtures.capturedSettings)
+        guard let final = states.last else {
+            Issue.record("the override sequence produced no states")
+            return
+        }
+        let loopback = ProxyEndpointState(enabled: true, host: "127.0.0.1", port: Fixtures.rockxyPort)
+        #expect(final.http == loopback)
+        #expect(final.https == loopback)
+        #expect(!final.socks.enabled)
+        #expect(!final.pacEnabled)
+        #expect(!final.autoDiscoveryEnabled)
+        // The bypass list is not part of the sequence: applying the override never writes it.
+        #expect(final.bypassDomains == Fixtures.capturedSettings.bypassDomains)
+        #expect(ProxyOverrideOwnership.isOwnedByRockxy(final.overrideState, port: Fixtures.rockxyPort))
+    }
+
+    @Test("The commands are walked in the order the override issues them")
+    func statesFollowTheCommandOrder() {
+        let states = ProxyOverrideTransition.reachableStates(
+            from: Fixtures.capturedSettings,
+            port: Fixtures.rockxyPort
+        )
+        let loopback = ProxyEndpointState(enabled: true, host: "127.0.0.1", port: Fixtures.rockxyPort)
+
+        let httpWritten = index(of: Fixtures.replacing(
+            Fixtures.capturedSettings,
+            http: loopback.disabled
+        ), in: states)
+        let httpOn = index(of: Fixtures.replacing(Fixtures.capturedSettings, http: loopback), in: states)
+        let httpsOn = index(of: Fixtures.replacing(
+            Fixtures.capturedSettings,
+            http: loopback,
+            https: loopback
+        ), in: states)
+        let socksOff = index(of: Fixtures.replacing(
+            Fixtures.capturedSettings,
+            http: loopback,
+            https: loopback,
+            socks: Fixtures.capturedSettings.socks.disabled
+        ), in: states)
+
+        #expect(httpWritten != nil)
+        #expect(httpOn != nil)
+        #expect(httpsOn != nil)
+        #expect(socksOff != nil)
+        if let httpWritten, let httpOn, let httpsOn, let socksOff {
+            #expect(httpWritten < httpOn)
+            #expect(httpOn < httpsOn)
+            #expect(httpsOn < socksOff)
+        }
+    }
+
+    @Test("Setting an endpoint leaves its own mode uncertain and nothing else")
+    func endpointWritesBranchOnlyOnTheirOwnMode() {
+        let states = ProxyOverrideTransition.reachableStates(
+            from: Fixtures.capturedSettings,
+            port: Fixtures.rockxyPort
+        )
+        let loopback = ProxyEndpointState(enabled: true, host: "127.0.0.1", port: Fixtures.rockxyPort)
+
+        // `networksetup` does not define what writing an endpoint does to that mode's flag, so
+        // both answers are reachable — at that one command, for that one field.
+        #expect(states.contains(Fixtures.replacing(Fixtures.capturedSettings, http: loopback.disabled)))
+        #expect(states.contains(Fixtures.replacing(Fixtures.capturedSettings, http: loopback)))
+        // The HTTPS endpoint is not written until two commands later, so it cannot be loopback
+        // while HTTP is still undecided.
+        #expect(!states.contains(Fixtures.replacing(
+            Fixtures.capturedSettings,
+            http: loopback.disabled,
+            https: loopback
+        )))
+    }
+
+    @Test("A field combination no ordered prefix produces belongs to whoever wrote it")
+    func arbitraryForeignStatesAreRejected() {
+        let loopback = ProxyEndpointState(enabled: true, host: "127.0.0.1", port: Fixtures.rockxyPort)
+        let foreignStates: [ProxyServiceRestorationState] = [
+            // Another proxy app on both protocols.
+            Fixtures.replacing(
+                Fixtures.capturedSettings,
+                http: ProxyEndpointState(enabled: true, host: "10.0.0.5", port: 3_128),
+                https: ProxyEndpointState(enabled: true, host: "10.0.0.5", port: 3_128)
+            ),
+            // Rockxy's host on somebody else's port.
+            Fixtures.replacing(
+                Fixtures.capturedSettings,
+                http: ProxyEndpointState(enabled: true, host: "127.0.0.1", port: 4_444)
+            ),
+            // The override applied, with the bypass list edited underneath it.
+            Fixtures.replacing(
+                Fixtures.capturedSettings,
+                http: loopback,
+                https: loopback,
+                socks: Fixtures.capturedSettings.socks.disabled,
+                pacEnabled: false,
+                autoDiscoveryEnabled: false,
+                bypassDomains: ["*"]
+            ),
+            // The last command's effect without the ones before it.
+            Fixtures.replacing(Fixtures.capturedSettings, autoDiscoveryEnabled: false),
+        ]
+
+        for foreign in foreignStates {
+            #expect(!ProxyOverrideTransition.isReachedByApplying(
+                foreign,
+                from: Fixtures.capturedSettings,
+                port: Fixtures.rockxyPort
+            ))
+        }
+    }
+
+    @Test("A record for one service never explains another service's settings")
+    func aRenamedStateIsNotReachable() {
+        #expect(!ProxyOverrideTransition.isReachedByApplying(
+            Fixtures.renamed(Fixtures.capturedSettings, to: "Ethernet"),
+            from: Fixtures.capturedSettings,
+            port: Fixtures.rockxyPort
+        ))
+    }
+
+    @Test("A backup that cannot name its port proves nothing beyond the captured settings")
+    func anUnknownPortProvesNothing() {
+        let states = ProxyOverrideTransition.reachableStates(from: Fixtures.capturedSettings, port: 0)
+
+        #expect(states == [Fixtures.capturedSettings])
+    }
+
+    // MARK: Private
+
+    private typealias Fixtures = ProxyRecoveryJournalFixtures
+
+    private func index(
+        of state: ProxyServiceRestorationState,
+        in states: [ProxyServiceRestorationState]
+    )
+        -> Int?
+    {
+        states.firstIndex(of: state)
+    }
+}
+
+// MARK: - ProxyBackupRetentionTests
+
+/// A rollback that covers only the services one failed attempt touched must never be the moment
+/// an untouched service loses the only restore point it has.
+struct ProxyBackupRetentionTests {
+    @Test("Entries this attempt may not write stay in the backup for its whole run")
+    func preservedEntriesAreNeverAbsent() {
+        var retention = ProxyBackupRetention(
+            authorized: ["Wi-Fi", "Ethernet"],
+            preserved: ["USB LAN", "Thunderbolt Bridge"]
+        )
+
+        #expect(retention.services == ["Wi-Fi", "Ethernet", "USB LAN", "Thunderbolt Bridge"])
+
+        // A service the attempt finished with leaves. Every write from here on still carries the
+        // preserved entries, because they were never this attempt's to delete.
+        retention.drop("Wi-Fi")
+        #expect(retention.services == ["Ethernet", "USB LAN", "Thunderbolt Bridge"])
+
+        retention.drop("Ethernet")
+        #expect(retention.services == ["USB LAN", "Thunderbolt Bridge"])
+    }
+
+    @Test("A preserved entry is never dropped, whatever the attempt decides about its own work")
+    func preservedEntriesCannotBeDropped() {
+        var retention = ProxyBackupRetention(authorized: ["Wi-Fi"], preserved: ["USB LAN"])
+
+        retention.drop("USB LAN")
+
+        #expect(retention.services.contains("USB LAN"))
+        #expect(retention.preservedServices == ["USB LAN"])
+    }
+
+    @Test("With nothing preserved the retained set is exactly the authorized one")
+    func wholeBackupRestoreIsUnchanged() {
+        var retention = ProxyBackupRetention(authorized: ["Wi-Fi", "Ethernet"], preserved: [])
+
+        retention.drop("Wi-Fi")
+
+        #expect(retention.services == ["Ethernet"])
+    }
+
+    @Test("An entry this attempt captured for a service it never touched does not outlive it")
+    func freshlyCapturedUntouchedEntriesAreNotKept() {
+        // The attempt found a restore point for USB LAN already on disk and captured one for
+        // Thunderbolt Bridge itself. Both are preserved while it runs, because a crash in
+        // between must never be the moment an untouched service loses its only restore point.
+        let retention = ProxyBackupRetention(
+            authorized: ["Wi-Fi", "Ethernet"],
+            preserved: ["USB LAN", "Thunderbolt Bridge"],
+            preAttemptServices: ["USB LAN"]
+        )
+
+        #expect(retention.services == ["Wi-Fi", "Ethernet", "USB LAN", "Thunderbolt Bridge"])
+
+        // Once it has finished, only the entry that predates it may stay. Thunderbolt Bridge was
+        // never overridden, so its snapshot describes settings nobody changed — keeping it is
+        // what would let the next enable write it back over whatever the user has set since.
+        #expect(retention.preservedServicesPredatingAttempt == ["USB LAN"])
+        #expect(retention.retainedAfterAttempt(unresolvedServices: []) == ["USB LAN"])
+    }
+
+    @Test("A rollback that could not finish keeps the touched services and the older entries")
+    func anIncompleteRollbackKeepsBothKinds() {
+        let retention = ProxyBackupRetention(
+            authorized: ["Wi-Fi", "Ethernet"],
+            preserved: ["USB LAN", "Thunderbolt Bridge"],
+            preAttemptServices: ["USB LAN"]
+        )
+
+        #expect(
+            retention.retainedAfterAttempt(unresolvedServices: ["Wi-Fi"]) == ["Wi-Fi", "USB LAN"]
+        )
+    }
+
+    @Test("An attempt that captured nothing keeps every preserved entry")
+    func anAttemptThatCapturedNothingKeepsEverything() {
+        // No pre-attempt set is recorded when the caller captured nothing, which is the case for
+        // a plain disable or a launch-time recovery: every entry it sees predates it.
+        let retention = ProxyBackupRetention(authorized: ["Wi-Fi"], preserved: ["USB LAN"])
+
+        #expect(retention.preservedServicesPredatingAttempt == ["USB LAN"])
+        #expect(retention.retainedAfterAttempt(unresolvedServices: []) == ["USB LAN"])
+    }
+}
+
+// MARK: - ProxyOverrideApplicationRecoveryPolicyTests
+
+/// A crash in the middle of the seven-command override leaves a service that is neither Rockxy's
+/// nor the user's. These cover what the durable record of that attempt does and does not
+/// authorize once a relaunch or a watchdog reads it back.
+struct ProxyOverrideApplicationRecoveryPolicyTests {
+    // MARK: Internal
+
+    @Test("A service no command reached is reported as untouched, not rolled back")
+    func aServiceNoCommandReachedIsUntouched() {
+        // The record is written before the first command, so `applying` on its own proves
+        // nothing: the settings still reading exactly as captured is what proves nothing landed.
+        #expect(
+            ProxyOverrideApplicationRecoveryPolicy.continuation(
+                for: applicationEntry(stage: .applying),
+                live: ProxyRecoveryJournalFixtures.capturedSettings,
+                ownedPort: ProxyRecoveryJournalFixtures.rockxyPort
+            ) == .untouched
+        )
+    }
+
+    @Test("Every point the override sequence stops at authorizes the rollback")
+    func everyOrderedPrefixIsRolledBack() {
+        let states = ProxyOverrideTransition.reachableStates(
+            from: ProxyRecoveryJournalFixtures.capturedSettings,
+            port: ProxyRecoveryJournalFixtures.rockxyPort
+        )
+
+        for live in states where live != ProxyRecoveryJournalFixtures.capturedSettings {
+            let continuation = ProxyOverrideApplicationRecoveryPolicy.continuation(
+                for: applicationEntry(stage: .applying),
+                live: live,
+                ownedPort: ProxyRecoveryJournalFixtures.rockxyPort
+            )
+            // The baseline a rollback starts from is what is live now, not what was captured:
+            // the restore it is about to run has to record the state it actually begins at.
+            #expect(continuation == .rollBack(baseline: live))
+        }
+    }
+
+    @Test("Strict ownership alone would miss a service stopped after its first command")
+    func halfAppliedServiceIsNotOwnedButIsStillRecoverable() {
+        // Only the HTTP endpoint was written. `isOwnedByRockxy` requires both web proxies on the
+        // loopback port, so it reports this service as nobody's — which is exactly why the
+        // record has to carry the authorization instead.
+        let halfApplied = ProxyRecoveryJournalFixtures.replacing(
+            ProxyRecoveryJournalFixtures.capturedSettings,
+            http: ProxyEndpointState(
+                enabled: true,
+                host: ProxyOverrideTransition.loopbackHost,
+                port: ProxyRecoveryJournalFixtures.rockxyPort
+            )
+        )
+
+        #expect(!ProxyOverrideOwnership.isOwnedByRockxy(
+            halfApplied.overrideState,
+            port: ProxyRecoveryJournalFixtures.rockxyPort
+        ))
+        #expect(
+            ProxyOverrideApplicationRecoveryPolicy.continuation(
+                for: applicationEntry(stage: .applying),
+                live: halfApplied,
+                ownedPort: ProxyRecoveryJournalFixtures.rockxyPort
+            ) == .rollBack(baseline: halfApplied)
+        )
+    }
+
+    @Test("A captured bypass of * survives the override and still authorizes the rollback")
+    func aCapturedGlobalBypassIsHandled() {
+        // Applying the override never writes the bypass list, so a user who had `*` still has it
+        // afterwards — and `isOwnedByRockxy` refuses a global bypass outright. The record covers
+        // the case without loosening that refusal anywhere else.
+        let captured = ProxyRecoveryJournalFixtures.replacing(
+            ProxyRecoveryJournalFixtures.capturedSettings,
+            bypassDomains: ["*"]
+        )
+        let live = ProxyRecoveryJournalFixtures.replacing(
+            ProxyRecoveryJournalFixtures.rockxyOverride,
+            bypassDomains: ["*"]
+        )
+
+        #expect(ProxyOverrideTransition.isReachedByApplying(
+            live,
+            from: captured,
+            port: ProxyRecoveryJournalFixtures.rockxyPort
+        ))
+        #expect(!ProxyOverrideOwnership.isOwnedByRockxy(
+            live.overrideState,
+            port: ProxyRecoveryJournalFixtures.rockxyPort
+        ))
+        #expect(
+            ProxyOverrideApplicationRecoveryPolicy.continuation(
+                for: applicationEntry(stage: .applying, captured: captured),
+                live: live,
+                ownedPort: ProxyRecoveryJournalFixtures.rockxyPort
+            ) == .rollBack(baseline: live)
+        )
+    }
+
+    @Test("A finished override whose bypass list Rockxy replaced is recoverable from the record of it")
+    func aBypassListWrittenAfterTheOverrideIsStillOwned() {
+        // The bounded bypass list is written after the seven commands, so this shape is not one of
+        // their prefixes. The record names the list before that command runs, which is what puts
+        // the finished shape back inside the sequence rather than outside it.
+        let rockxyBypass = ["localhost", "127.0.0.1"]
+        let live = ProxyRecoveryJournalFixtures.replacing(
+            ProxyRecoveryJournalFixtures.rockxyOverride,
+            bypassDomains: rockxyBypass
+        )
+
+        #expect(
+            ProxyOverrideApplicationRecoveryPolicy.continuation(
+                for: applicationEntry(stage: .applying, appliedBypassDomains: rockxyBypass),
+                live: live,
+                ownedPort: ProxyRecoveryJournalFixtures.rockxyPort
+            ) == .rollBack(baseline: live)
+        )
+    }
+
+    @Test("A bypass list no record names is not Rockxy's to undo, whatever the web proxies say")
+    func anUnrecordedBypassListIsAbandoned() {
+        // Both web proxies point at Rockxy's loopback port, which is all the ownership projection
+        // ever asked for — and on that alone the whole captured snapshot used to be written back
+        // over a bypass list nothing had shown was Rockxy's.
+        let live = ProxyRecoveryJournalFixtures.replacing(
+            ProxyRecoveryJournalFixtures.rockxyOverride,
+            bypassDomains: ["intranet.corp.example"]
+        )
+
+        #expect(ProxyOverrideOwnership.isOwnedByRockxy(
+            live.overrideState,
+            port: ProxyRecoveryJournalFixtures.rockxyPort
+        ))
+        #expect(
+            ProxyOverrideApplicationRecoveryPolicy.continuation(
+                for: applicationEntry(stage: .applying),
+                live: live,
+                ownedPort: ProxyRecoveryJournalFixtures.rockxyPort
+            ) == .abandon
+        )
+    }
+
+    @Test("A bypass list edited after the override is not the one the record names")
+    func aUserEditedBypassListIsAbandoned() {
+        let rockxyBypass = ["localhost", "127.0.0.1"]
+        let live = ProxyRecoveryJournalFixtures.replacing(
+            ProxyRecoveryJournalFixtures.rockxyOverride,
+            bypassDomains: rockxyBypass + ["intranet.corp.example"]
+        )
+
+        // Not a global bypass, so the projection still calls this service Rockxy's. The record
+        // names the exact list, and this is not it.
+        #expect(ProxyOverrideOwnership.isOwnedByRockxy(
+            live.overrideState,
+            port: ProxyRecoveryJournalFixtures.rockxyPort
+        ))
+        #expect(
+            ProxyOverrideApplicationRecoveryPolicy.continuation(
+                for: applicationEntry(stage: .applying, appliedBypassDomains: rockxyBypass),
+                live: live,
+                ownedPort: ProxyRecoveryJournalFixtures.rockxyPort
+            ) == .abandon
+        )
+    }
+
+    @Test("A SOCKS endpoint changed while the mode is off is not something the override wrote")
+    func aChangedDisabledSocksEndpointIsAbandoned() {
+        // Applying the override switches SOCKS off and never touches its host or port. The
+        // projection only reads the on/off flag, so a re-pointed endpoint was invisible to it —
+        // and restoring the captured snapshot would have written over it.
+        let live = ProxyRecoveryJournalFixtures.replacing(
+            ProxyRecoveryJournalFixtures.rockxyOverride,
+            socks: ProxyEndpointState(enabled: false, host: "socks.vpn.example", port: 1_081),
+            bypassDomains: ProxyRecoveryJournalFixtures.capturedSettings.bypassDomains
+        )
+
+        #expect(ProxyOverrideOwnership.isOwnedByRockxy(
+            live.overrideState,
+            port: ProxyRecoveryJournalFixtures.rockxyPort
+        ))
+        #expect(
+            ProxyOverrideApplicationRecoveryPolicy.continuation(
+                for: applicationEntry(stage: .applying),
+                live: live,
+                ownedPort: ProxyRecoveryJournalFixtures.rockxyPort
+            ) == .abandon
+        )
+    }
+
+    @Test("A PAC URL changed while PAC is off is not something the override wrote")
+    func aChangedPACURLIsAbandoned() {
+        let live = ProxyRecoveryJournalFixtures.replacing(
+            ProxyRecoveryJournalFixtures.rockxyOverride,
+            pacURL: "https://vpn.example/other.pac",
+            bypassDomains: ProxyRecoveryJournalFixtures.capturedSettings.bypassDomains
+        )
+
+        #expect(ProxyOverrideOwnership.isOwnedByRockxy(
+            live.overrideState,
+            port: ProxyRecoveryJournalFixtures.rockxyPort
+        ))
+        #expect(
+            ProxyOverrideApplicationRecoveryPolicy.continuation(
+                for: applicationEntry(stage: .applying),
+                live: live,
+                ownedPort: ProxyRecoveryJournalFixtures.rockxyPort
+            ) == .abandon
+        )
+    }
+
+    @Test("The exact state the whole sequence ends at is what authorizes the rollback")
+    func theExactCompletedStateIsRolledBack() throws {
+        let rockxyBypass = ["localhost"]
+        let completed = try #require(ProxyOverrideTransition.completedState(
+            from: ProxyRecoveryJournalFixtures.capturedSettings,
+            port: ProxyRecoveryJournalFixtures.rockxyPort,
+            appliedBypassDomains: rockxyBypass
+        ))
+
+        #expect(completed.bypassDomains == rockxyBypass)
+        #expect(completed.socks == ProxyRecoveryJournalFixtures.capturedSettings.socks.disabled)
+        #expect(completed.pacURL == ProxyRecoveryJournalFixtures.capturedSettings.pacURL)
+        #expect(
+            ProxyOverrideApplicationRecoveryPolicy.continuation(
+                for: applicationEntry(stage: .applying, appliedBypassDomains: rockxyBypass),
+                live: completed,
+                ownedPort: ProxyRecoveryJournalFixtures.rockxyPort
+            ) == .rollBack(baseline: completed)
+        )
+    }
+
+    @Test("A configuration the override could not have produced is left to whoever wrote it")
+    func aForeignConfigurationIsAbandoned() {
+        let foreign = ProxyRecoveryJournalFixtures.replacing(
+            ProxyRecoveryJournalFixtures.capturedSettings,
+            http: ProxyEndpointState(enabled: true, host: "10.0.0.9", port: 3_128)
+        )
+
+        #expect(
+            ProxyOverrideApplicationRecoveryPolicy.continuation(
+                for: applicationEntry(stage: .applying),
+                live: foreign,
+                ownedPort: ProxyRecoveryJournalFixtures.rockxyPort
+            ) == .abandon
+        )
+    }
+
+    @Test("A service whose settings could not be read is deferred rather than guessed at")
+    func anUnreadableServiceIsDeferred() {
+        #expect(
+            ProxyOverrideApplicationRecoveryPolicy.continuation(
+                for: applicationEntry(stage: .applying),
+                live: nil,
+                ownedPort: ProxyRecoveryJournalFixtures.rockxyPort
+            ) == .retryLater
+        )
+    }
+
+    @Test("A record whose commands were never issued authorizes no changed state")
+    func applicationPendingDoesNotAuthorizeAPrefix() {
+        let halfApplied = ProxyRecoveryJournalFixtures.replacing(
+            ProxyRecoveryJournalFixtures.capturedSettings,
+            http: ProxyEndpointState(
+                enabled: true,
+                host: ProxyOverrideTransition.loopbackHost,
+                port: ProxyRecoveryJournalFixtures.rockxyPort
+            )
+        )
+
+        // No command was issued under this record, so both a half-applied shape and a complete
+        // override belong to something else. Strict ownership only proves a completed Rockxy
+        // shape; it does not prove this pending attempt produced it.
+        #expect(
+            ProxyOverrideApplicationRecoveryPolicy.continuation(
+                for: applicationEntry(stage: .applicationPending),
+                live: halfApplied,
+                ownedPort: ProxyRecoveryJournalFixtures.rockxyPort
+            ) == .abandon
+        )
+        #expect(
+            ProxyOverrideApplicationRecoveryPolicy.continuation(
+                for: applicationEntry(stage: .applicationPending),
+                live: ProxyRecoveryJournalFixtures.rockxyOverride,
+                ownedPort: ProxyRecoveryJournalFixtures.rockxyPort
+            ) == .abandon
+        )
+    }
+
+    @Test("A record that names a different service never authorizes a write")
+    func aMismatchedServiceIsAbandoned() {
+        #expect(
+            ProxyOverrideApplicationRecoveryPolicy.continuation(
+                for: applicationEntry(stage: .applying),
+                live: ProxyRecoveryJournalFixtures.renamed(
+                    ProxyRecoveryJournalFixtures.rockxyOverride,
+                    to: "Ethernet"
+                ),
+                ownedPort: ProxyRecoveryJournalFixtures.rockxyPort
+            ) == .abandon
+        )
+    }
+
+    @Test("A restore record is never read as an override record")
+    func aRestoreRecordAuthorizesNothingHere() {
+        #expect(
+            ProxyOverrideApplicationRecoveryPolicy.continuation(
+                for: ProxyRecoveryJournalFixtures.entry(stage: .inFlight),
+                live: ProxyRecoveryJournalFixtures.rockxyOverride,
+                ownedPort: ProxyRecoveryJournalFixtures.rockxyPort
+            ) == .abandon
+        )
+        // And the reverse: the restore policy refuses an override record outright, because the
+        // states it authorizes come from a different command sequence on a different port.
+        #expect(
+            ProxyServiceRecoveryPolicy.continuation(
+                for: applicationEntry(stage: .applying),
+                live: ProxyRecoveryJournalFixtures.rockxyOverride
+            ) == .abandon
+        )
+    }
+
+    @Test("An override record survives a plist roundtrip with the port it was written for")
+    func anOverrideRecordRoundtrips() throws {
+        let entry = applicationEntry(stage: .applying)
+
+        let data = try PropertyListEncoder().encode([entry])
+        let decoded = try PropertyListDecoder().decode([ProxyServiceRecoveryJournalEntry].self, from: data)
+
+        #expect(decoded == [entry])
+        #expect(decoded.first?.appliedOverridePort == ProxyRecoveryJournalFixtures.rockxyPort)
+        #expect(decoded.first?.stage == .applying)
+    }
+
+    @Test("A record written before the port existed still decodes, and authorizes nothing on its own")
+    func aRecordWithoutAPortDecodes() throws {
+        let portless = ProxyServiceRecoveryJournalEntry(
+            service: ProxyRecoveryJournalFixtures.service,
+            stage: .applying,
+            expectedPreStepState: ProxyRecoveryJournalFixtures.capturedSettings,
+            target: ProxyRecoveryJournalFixtures.capturedSettings
+        )
+
+        #expect(portless.appliedOverridePort == nil)
+        #expect(portless.appliedBypassDomains == nil)
+
+        let finished = try #require(ProxyOverrideTransition.completedState(
+            from: ProxyRecoveryJournalFixtures.capturedSettings,
+            port: ProxyRecoveryJournalFixtures.rockxyPort
+        ))
+
+        // With no port on the record and none from the backup, there is nothing to compare a
+        // half-applied shape against, so the service keeps its restore point instead.
+        #expect(
+            ProxyOverrideApplicationRecoveryPolicy.continuation(
+                for: portless,
+                live: finished,
+                ownedPort: nil
+            ) == .abandon
+        )
+        // The port the backup records stands in for it, which is what keeps an older record
+        // usable rather than merely readable.
+        #expect(
+            ProxyOverrideApplicationRecoveryPolicy.continuation(
+                for: portless,
+                live: finished,
+                ownedPort: ProxyRecoveryJournalFixtures.rockxyPort
+            ) == .rollBack(baseline: finished)
+        )
+    }
+
+    // MARK: Private
+
+    private func applicationEntry(
+        stage: ProxyRecoveryStage,
+        captured: ProxyServiceRestorationState = ProxyRecoveryJournalFixtures.capturedSettings,
+        port: Int = ProxyRecoveryJournalFixtures.rockxyPort,
+        appliedBypassDomains: [String]? = nil
+    )
+        -> ProxyServiceRecoveryJournalEntry
+    {
+        ProxyServiceRecoveryJournalEntry(
+            overrideApplicationFor: captured,
+            stage: stage,
+            port: port,
+            appliedBypassDomains: appliedBypassDomains
+        )
+    }
+}
+
+// MARK: - ProxyBypassUpdatePreflightTests
+
+struct ProxyBypassUpdatePreflightTests {
+    @Test("A bypass update keeps both sides of its per-service crash window recoverable")
+    func repeatedUpdateRetainsItsPreviousExactState() throws {
+        let oldDomains = ["localhost"]
+        let newDomains = ["localhost", "127.0.0.1"]
+        let stable = ProxyServiceRecoveryJournalEntry(
+            overrideApplicationFor: ProxyRecoveryJournalFixtures.capturedSettings,
+            stage: .applying,
+            port: ProxyRecoveryJournalFixtures.rockxyPort,
+            appliedBypassDomains: oldDomains
+        )
+        let oldLive = try #require(ProxyOverrideTransition.completedState(
+            from: ProxyRecoveryJournalFixtures.capturedSettings,
+            port: ProxyRecoveryJournalFixtures.rockxyPort,
+            appliedBypassDomains: oldDomains
+        ))
+        let pending = stable.recordingAppliedBypassDomains(
+            newDomains,
+            from: oldLive.bypassDomains
+        )
+        let newLive = try #require(ProxyOverrideTransition.completedState(
+            from: ProxyRecoveryJournalFixtures.capturedSettings,
+            port: ProxyRecoveryJournalFixtures.rockxyPort,
+            appliedBypassDomains: newDomains
+        ))
+
+        #expect(ProxyBypassUpdatePreflight.decision(
+            entry: pending,
+            live: oldLive,
+            ownedPort: ProxyRecoveryJournalFixtures.rockxyPort,
+            requestedDomains: newDomains
+        ) == .apply(baseline: oldLive))
+        #expect(ProxyBypassUpdatePreflight.decision(
+            entry: pending,
+            live: newLive,
+            ownedPort: ProxyRecoveryJournalFixtures.rockxyPort,
+            requestedDomains: newDomains
+        ) == .unchanged)
+        #expect(ProxyOverrideApplicationRecoveryPolicy.continuation(
+            for: pending,
+            live: oldLive,
+            ownedPort: ProxyRecoveryJournalFixtures.rockxyPort
+        ) == .rollBack(baseline: oldLive))
+        #expect(ProxyOverrideApplicationRecoveryPolicy.continuation(
+            for: pending,
+            live: newLive,
+            ownedPort: ProxyRecoveryJournalFixtures.rockxyPort
+        ) == .rollBack(baseline: newLive))
+
+        let completed = pending.completingAppliedBypassUpdate(at: newDomains)
+        #expect(completed.previousAppliedBypassDomains == nil)
+        #expect(completed.appliedBypassDomains == newDomains)
+        let stabilizedOldSide = pending.completingAppliedBypassUpdate(at: oldDomains)
+        #expect(stabilizedOldSide.previousAppliedBypassDomains == nil)
+        #expect(stabilizedOldSide.appliedBypassDomains == oldDomains)
+    }
+
+    @Test("A bypass update refuses a service whose other proxy fields moved")
+    func foreignStateIsNotWritten() throws {
+        let domains = ["localhost"]
+        let entry = ProxyServiceRecoveryJournalEntry(
+            overrideApplicationFor: ProxyRecoveryJournalFixtures.capturedSettings,
+            stage: .applying,
+            port: ProxyRecoveryJournalFixtures.rockxyPort,
+            appliedBypassDomains: domains
+        )
+        let live = try #require(ProxyOverrideTransition.completedState(
+            from: ProxyRecoveryJournalFixtures.capturedSettings,
+            port: ProxyRecoveryJournalFixtures.rockxyPort,
+            appliedBypassDomains: domains
+        ))
+        let foreign = ProxyRecoveryJournalFixtures.replacing(
+            live,
+            pacURL: "https://other.example/config.pac"
+        )
+
+        #expect(ProxyBypassUpdatePreflight.decision(
+            entry: entry,
+            live: foreign,
+            ownedPort: ProxyRecoveryJournalFixtures.rockxyPort,
+            requestedDomains: ["127.0.0.1"]
+        ) == .abort)
+    }
+}
+
+// MARK: - ProxyOverrideApplicationPlanningTests
+
+/// The planner is where an override record turns into a restore. These cover that hand-off, which
+/// is what makes a crash mid-override recoverable from a relaunch or a watchdog rather than only
+/// from inside the process that caused it.
+struct ProxyOverrideApplicationPlanningTests {
+    @Test("A half-applied service is planned for rollback from what is live, not from the capture")
+    func aHalfAppliedServiceIsPlannedFromLive() {
+        let halfApplied = ProxyRecoveryJournalFixtures.replacing(
+            ProxyRecoveryJournalFixtures.capturedSettings,
+            http: ProxyEndpointState(
+                enabled: true,
+                host: ProxyOverrideTransition.loopbackHost,
+                port: ProxyRecoveryJournalFixtures.rockxyPort
+            )
+        )
+
+        let plan = ProxyRecoveryPlanner.plan(
+            targets: [ProxyRecoveryJournalFixtures.capturedSettings],
+            journal: [ProxyServiceRecoveryJournalEntry(
+                overrideApplicationFor: ProxyRecoveryJournalFixtures.capturedSettings,
+                stage: .applying,
+                port: ProxyRecoveryJournalFixtures.rockxyPort
+            )],
+            liveStates: [ProxyRecoveryJournalFixtures.service: halfApplied],
+            ownedPort: ProxyRecoveryJournalFixtures.rockxyPort
+        )
+
+        #expect(plan.entriesToRestore.count == 1)
+        // A `pending` restore record: no restore command has been issued yet, and the state it
+        // begins from is the half-applied one a later retry would have to recognise.
+        #expect(plan.entriesToRestore.first?.stage == .pending)
+        #expect(plan.entriesToRestore.first?.expectedPreStepState == halfApplied)
+        #expect(plan.entriesToRestore.first?.target == ProxyRecoveryJournalFixtures.capturedSettings)
+        #expect(plan.abandonedServices.isEmpty)
+    }
+
+    @Test("A service the override never reached leaves recovery with its entry dropped")
+    func anUntouchedServiceLeavesRecovery() {
+        let plan = ProxyRecoveryPlanner.plan(
+            targets: [ProxyRecoveryJournalFixtures.capturedSettings],
+            journal: [ProxyServiceRecoveryJournalEntry(
+                overrideApplicationFor: ProxyRecoveryJournalFixtures.capturedSettings,
+                stage: .applying,
+                port: ProxyRecoveryJournalFixtures.rockxyPort
+            )],
+            liveStates: [
+                ProxyRecoveryJournalFixtures.service: ProxyRecoveryJournalFixtures.capturedSettings,
+            ],
+            ownedPort: ProxyRecoveryJournalFixtures.rockxyPort
+        )
+
+        #expect(plan.entriesToRestore.isEmpty)
+        #expect(plan.completedServices == [ProxyRecoveryJournalFixtures.service])
+        #expect(plan.servicesKeepingBackup.isEmpty)
+    }
+
+    @Test("A user change after the crash keeps its settings and its restore point")
+    func aUserChangeAfterTheCrashIsNeverOverwritten() {
+        let userConfiguration = ProxyRecoveryJournalFixtures.replacing(
+            ProxyRecoveryJournalFixtures.capturedSettings,
+            https: ProxyEndpointState(enabled: true, host: "vpn.example", port: 3_128)
+        )
+
+        let plan = ProxyRecoveryPlanner.plan(
+            targets: [ProxyRecoveryJournalFixtures.capturedSettings],
+            journal: [ProxyServiceRecoveryJournalEntry(
+                overrideApplicationFor: ProxyRecoveryJournalFixtures.capturedSettings,
+                stage: .applying,
+                port: ProxyRecoveryJournalFixtures.rockxyPort
+            )],
+            liveStates: [ProxyRecoveryJournalFixtures.service: userConfiguration],
+            ownedPort: ProxyRecoveryJournalFixtures.rockxyPort
+        )
+
+        #expect(plan.entriesToRestore.isEmpty)
+        #expect(plan.abandonedServices == [ProxyRecoveryJournalFixtures.service])
+    }
+
+    @Test("A service whose full state could not be read is deferred with its backup intact")
+    func anUnreadableServiceKeepsItsRestorePoint() {
+        let plan = ProxyRecoveryPlanner.plan(
+            targets: [ProxyRecoveryJournalFixtures.capturedSettings],
+            journal: [ProxyServiceRecoveryJournalEntry(
+                overrideApplicationFor: ProxyRecoveryJournalFixtures.capturedSettings,
+                stage: .applicationPending,
+                port: ProxyRecoveryJournalFixtures.rockxyPort
+            )],
+            liveStates: [:],
+            ownedPort: ProxyRecoveryJournalFixtures.rockxyPort
+        )
+
+        #expect(plan.entriesToRestore.isEmpty)
+        #expect(plan.deferredServices == [ProxyRecoveryJournalFixtures.service])
+        #expect(plan.servicesKeepingBackup == [ProxyRecoveryJournalFixtures.service])
+    }
+
+    @Test("An override record that describes some other capture is not this backup's to act on")
+    func aStaleOverrideRecordIsNotTrusted() {
+        // The record names the same service but a different capture, so it belongs to an earlier
+        // attempt. The service falls back to the proof any unrecorded service has to give.
+        let plan = ProxyRecoveryPlanner.plan(
+            targets: [ProxyRecoveryJournalFixtures.capturedSettings],
+            journal: [ProxyServiceRecoveryJournalEntry(
+                overrideApplicationFor: ProxyRecoveryJournalFixtures.replacing(
+                    ProxyRecoveryJournalFixtures.capturedSettings,
+                    bypassDomains: ["something.else"]
+                ),
+                stage: .applying,
+                port: ProxyRecoveryJournalFixtures.rockxyPort
+            )],
+            liveStates: [
+                ProxyRecoveryJournalFixtures.service: ProxyRecoveryJournalFixtures.rockxyOverride,
+            ],
+            ownedPort: ProxyRecoveryJournalFixtures.rockxyPort
+        )
+
+        #expect(plan.entriesToRestore.count == 1)
+        #expect(plan.entriesToRestore.first?.expectedPreStepState == ProxyRecoveryJournalFixtures.rockxyOverride)
+    }
+}
+
+// MARK: - ProxyJournaledServiceRestoreTests
+
+/// The `inFlight` record is the permission to issue a command, not a note about one that already
+/// ran. These cover that order in both directions.
+struct ProxyJournaledServiceRestoreTests {
+    @Test("The record is committed before the first rollback command runs")
+    func theRecordIsCommittedFirst() {
+        var steps: [String] = []
+        let attempt = ProxyJournaledServiceRestore.run(
+            commitInFlight: { steps.append("commit") },
+            restore: {
+                steps.append("restore")
+                return .restored
+            }
+        )
+
+        #expect(steps == ["commit", "restore"])
+        guard case .issued = attempt else {
+            Issue.record("expected the commands to be issued")
+            return
+        }
+    }
+
+    @Test("A record that could not be committed issues no command at all")
+    func aFailedCommitIssuesNothing() {
+        var restoreRan = false
+        let attempt = ProxyJournaledServiceRestore.run(
+            commitInFlight: { throw RestoreStepError.failed },
+            restore: {
+                restoreRan = true
+                return .restored
+            }
+        )
+
+        // An unrecorded write is exactly the case a resumed attempt has no way to reason about:
+        // it would believe a command may have run when none did.
+        #expect(!restoreRan)
+        guard case .notIssued = attempt else {
+            Issue.record("expected no command to be issued")
+            return
+        }
+    }
+
+    @Test("A failed command is reported as the step it stopped at")
+    func aFailedCommandIsReported() {
+        let attempt = ProxyJournaledServiceRestore.run(
+            commitInFlight: {},
+            restore: { .failed(step: .proxyState, error: RestoreStepError.failed) }
+        )
+
+        guard case let .issued(outcome) = attempt else {
+            Issue.record("expected the commands to be issued")
+            return
+        }
+        #expect(outcome.failedStep == .proxyState)
+    }
+}
+
+// MARK: - ProxyRecoveryPlannerTests
+
+struct ProxyRecoveryPlannerTests {
+    // MARK: Internal
+
+    @Test("A first attempt baselines a service the live settings still prove is Rockxy's")
+    func firstAttemptBaselinesAServiceRockxyStillOwns() {
+        let plan = ProxyRecoveryPlanner.plan(
+            targets: [Fixtures.capturedSettings],
+            journal: [],
+            liveStates: [Fixtures.service: Fixtures.rockxyOverride],
+            ownedPort: Fixtures.rockxyPort
+        )
+
+        #expect(plan.entriesToRestore.map(\.service) == [Fixtures.service])
+        // The entry is handed back — and persisted — at `pending`. Nothing has been issued for
+        // this service yet, and only the command that is about to run may advance it.
+        #expect(plan.entriesToRestore.first?.stage == .pending)
+        #expect(plan.entriesToRestore.first?.expectedPreStepState == Fixtures.rockxyOverride)
+        #expect(plan.entriesToRestore.first?.expectedPostStepState == Fixtures.restoredSettings)
+        #expect(plan.abandonedServices.isEmpty)
+        #expect(plan.completedServices.isEmpty)
+        #expect(plan.deferredServices.isEmpty)
+    }
+
+    @Test("A first attempt never baselines settings that are not Rockxy's own override")
+    func firstAttemptDoesNotBaselineAForeignState() {
+        // The user (or another proxy app) configured this service while capture was running. It
+        // is readable, and on a first attempt there is no record to contradict it — which is
+        // exactly the state that used to be adopted as "where the restore begins" and then
+        // written over with a snapshot the user never asked for.
+        let userProxy = Fixtures.replacing(
+            Fixtures.rockxyOverride,
+            http: ProxyEndpointState(enabled: true, host: "10.0.0.5", port: 3_128),
+            https: ProxyEndpointState(enabled: true, host: "10.0.0.5", port: 3_128),
+            bypassDomains: ["*.staging.internal"]
+        )
+
+        let plan = ProxyRecoveryPlanner.plan(
+            targets: [Fixtures.capturedSettings],
+            journal: [],
+            liveStates: [Fixtures.service: userProxy],
+            ownedPort: Fixtures.rockxyPort
+        )
+
+        #expect(plan.entriesToRestore.isEmpty)
+        #expect(plan.deferredServices == [Fixtures.service])
+        #expect(plan.servicesKeepingBackup == [Fixtures.service])
+    }
+
+    @Test("A legacy ownership projection cannot overwrite fields the override never changed")
+    func legacyProjectionDoesNotAuthorizeAFullRestore() {
+        let foreignStates = [
+            Fixtures.replacing(Fixtures.rockxyOverride, bypassDomains: ["intranet.example"]),
+            Fixtures.replacing(
+                Fixtures.rockxyOverride,
+                socks: ProxyEndpointState(enabled: false, host: "new-socks.example", port: 10_80)
+            ),
+            Fixtures.replacing(Fixtures.rockxyOverride, pacURL: "https://config.example/new.pac"),
+        ]
+
+        for live in foreignStates {
+            // All three still satisfy the narrow HTTP/HTTPS ownership projection. None equals the
+            // complete state of the recorded override sequence, so restoring a full captured
+            // snapshot would overwrite a field this backup cannot prove it changed.
+            #expect(ProxyOverrideOwnership.isOwnedByRockxy(
+                live.overrideState,
+                port: Fixtures.rockxyPort
+            ))
+            let plan = ProxyRecoveryPlanner.plan(
+                targets: [Fixtures.capturedSettings],
+                journal: [],
+                liveStates: [Fixtures.service: live],
+                ownedPort: Fixtures.rockxyPort
+            )
+            #expect(plan.entriesToRestore.isEmpty)
+            #expect(plan.deferredServices == [Fixtures.service])
+        }
+    }
+
+    @Test("A half-applied override is not proof of ownership either")
+    func firstAttemptDoesNotBaselineAPartiallyOverriddenState() {
+        // HTTP points at Rockxy but HTTPS never got there. Nothing about this shape says who
+        // wrote it, so it is not a starting point recovery may claim.
+        let halfApplied = Fixtures.replacing(
+            Fixtures.rockxyOverride,
+            https: ProxyEndpointState(enabled: false, host: "secure.corp.example", port: 8_443)
+        )
+
+        let plan = ProxyRecoveryPlanner.plan(
+            targets: [Fixtures.capturedSettings],
+            journal: [],
+            liveStates: [Fixtures.service: halfApplied],
+            ownedPort: Fixtures.rockxyPort
+        )
+
+        #expect(plan.entriesToRestore.isEmpty)
+        #expect(plan.deferredServices == [Fixtures.service])
+    }
+
+    @Test("An override on another port is not this backup's to restore")
+    func aDifferentPortIsNotBaselined() {
+        let plan = ProxyRecoveryPlanner.plan(
+            targets: [Fixtures.capturedSettings],
+            journal: [],
+            liveStates: [Fixtures.service: Fixtures.rockxyOverride],
+            ownedPort: Fixtures.rockxyPort + 1
+        )
+
+        #expect(plan.entriesToRestore.isEmpty)
+        #expect(plan.deferredServices == [Fixtures.service])
+    }
+
+    @Test("A backup that cannot name its port baselines nothing")
+    func anUnknownPortBaselinesNothing() {
+        let plan = ProxyRecoveryPlanner.plan(
+            targets: [Fixtures.capturedSettings],
+            journal: [],
+            liveStates: [Fixtures.service: Fixtures.rockxyOverride],
+            ownedPort: nil
+        )
+
+        #expect(plan.entriesToRestore.isEmpty)
+        #expect(plan.deferredServices == [Fixtures.service])
+    }
+
+    @Test("Every state the override's own commands pass through may be undone by the process that wrote it")
+    func aHalfAppliedOverrideIsBaselinedFromItsOwnTransition() {
+        // An override that stopped part-way leaves a shape strict ownership does not recognise.
+        // Refusing it a baseline would strand exactly the service that most needs putting back —
+        // but only the states the override sequence really produces earn one.
+        let prefixes = ProxyOverrideTransition.reachableStates(
+            from: Fixtures.capturedSettings,
+            port: Fixtures.rockxyPort
+        )
+        .dropFirst()
+
+        for halfApplied in prefixes {
+            let plan = ProxyRecoveryPlanner.plan(
+                targets: [Fixtures.capturedSettings],
+                journal: [],
+                liveStates: [Fixtures.service: halfApplied],
+                ownedPort: Fixtures.rockxyPort,
+                locallyMutatedServices: [Fixtures.service]
+            )
+
+            #expect(plan.entriesToRestore.map(\.service) == [Fixtures.service])
+            #expect(plan.entriesToRestore.first?.expectedPreStepState == halfApplied)
+            #expect(plan.deferredServices.isEmpty)
+        }
+    }
+
+    @Test("Having touched a service is not on its own a licence to write over what is there now")
+    func aTouchedServiceWithAForeignStateIsNeverOverwritten() {
+        // A service is recorded as touched before its first command runs. If that command failed
+        // and somebody else changed the service in the meantime, the live settings are not a
+        // state the override sequence produces — and the change stays exactly where it is.
+        let foreign = Fixtures.replacing(
+            Fixtures.capturedSettings,
+            http: ProxyEndpointState(enabled: true, host: "10.0.0.5", port: 3_128),
+            https: ProxyEndpointState(enabled: true, host: "10.0.0.5", port: 3_128)
+        )
+
+        let plan = ProxyRecoveryPlanner.plan(
+            targets: [Fixtures.capturedSettings],
+            journal: [],
+            liveStates: [Fixtures.service: foreign],
+            ownedPort: Fixtures.rockxyPort,
+            locallyMutatedServices: [Fixtures.service]
+        )
+
+        #expect(plan.entriesToRestore.isEmpty)
+        #expect(plan.abandonedServices.isEmpty)
+        // Deferred, not abandoned: the restore point survives for an attempt that can prove
+        // something about this service.
+        #expect(plan.deferredServices == [Fixtures.service])
+    }
+
+    @Test("A first override command that changed nothing leaves the service alone")
+    func aTouchedServiceThatWasNeverMutatedIsNotWritten() {
+        // The very first command failed, so the service still reads exactly as it was captured.
+        // There is nothing to undo, and issuing the restore anyway would write settings onto a
+        // service this attempt never changed.
+        let plan = ProxyRecoveryPlanner.plan(
+            targets: [Fixtures.capturedSettings],
+            journal: [],
+            liveStates: [Fixtures.service: Fixtures.capturedSettings],
+            ownedPort: Fixtures.rockxyPort,
+            locallyMutatedServices: [Fixtures.service]
+        )
+
+        #expect(plan.entriesToRestore.isEmpty)
+        #expect(plan.completedServices == [Fixtures.service])
+        #expect(plan.deferredServices.isEmpty)
+    }
+
+    @Test("A service this process did not write is judged on ownership alone")
+    func anUntouchedServiceGetsNoTransitionProof() {
+        let halfApplied = Fixtures.replacing(
+            Fixtures.capturedSettings,
+            http: ProxyEndpointState(enabled: true, host: "127.0.0.1", port: Fixtures.rockxyPort)
+        )
+
+        let plan = ProxyRecoveryPlanner.plan(
+            targets: [Fixtures.capturedSettings],
+            journal: [],
+            liveStates: [Fixtures.service: halfApplied],
+            ownedPort: Fixtures.rockxyPort
+        )
+
+        #expect(plan.entriesToRestore.isEmpty)
+        #expect(plan.deferredServices == [Fixtures.service])
+    }
+
+    @Test("One user-changed service does not strand the ones that still need recovery")
+    func partiallyRestoredServicesAreNotAbandonedWithTheChangedOne() {
+        let changed = renamed(Fixtures.rockxyOverride, to: "Ethernet")
+        let userProxy = ProxyRecoveryJournalFixtures.replacing(
+            changed,
+            http: ProxyEndpointState(enabled: true, host: "10.0.0.5", port: 3_128),
+            https: ProxyEndpointState(enabled: true, host: "10.0.0.5", port: 3_128)
+        )
+        let done = renamed(Fixtures.rockxyOverride, to: "USB LAN")
+
+        let plan = ProxyRecoveryPlanner.plan(
+            targets: [
+                Fixtures.capturedSettings,
+                renamed(Fixtures.capturedSettings, to: "Ethernet"),
+                renamed(Fixtures.capturedSettings, to: "USB LAN"),
+                renamed(Fixtures.capturedSettings, to: "Thunderbolt Bridge"),
+            ],
+            journal: [
+                Fixtures.entry(stage: .inFlight),
+                Fixtures.entry(stage: .inFlight, pre: changed, target: renamed(
+                    Fixtures.capturedSettings,
+                    to: "Ethernet"
+                )),
+                Fixtures.entry(stage: .restored, pre: done, target: renamed(
+                    Fixtures.capturedSettings,
+                    to: "USB LAN"
+                )),
+            ],
+            liveStates: [
+                Fixtures.service: Fixtures.rockxyOverride.withProxyModesDisabled,
+                "Ethernet": userProxy,
+                "USB LAN": ProxyServiceRestorationState.expectedRestorationResult(
+                    target: renamed(Fixtures.capturedSettings, to: "USB LAN"),
+                    from: done
+                ),
+            ],
+            ownedPort: Fixtures.rockxyPort
+        )
+
+        #expect(plan.entriesToRestore.map(\.service) == [Fixtures.service])
+        #expect(plan.abandonedServices == ["Ethernet"])
+        #expect(plan.completedServices == ["USB LAN"])
+        #expect(plan.deferredServices == ["Thunderbolt Bridge"])
+        // A finished or foreign service leaves recovery; an unreadable one keeps its restore point.
+        #expect(plan.servicesKeepingBackup == [Fixtures.service, "Thunderbolt Bridge"])
+    }
+
+    @Test("A record that no longer describes the backup on disk is never trusted")
+    func staleJournalRecordIsNeverTrusted() {
+        let staleTarget = ProxyRecoveryJournalFixtures.replacing(
+            Fixtures.capturedSettings,
+            http: ProxyEndpointState(enabled: true, host: "old.corp.example", port: 3_128)
+        )
+        // The record describes a different restore than the backup asks for, so it says nothing
+        // about what the live settings mean. With a live state that proves nothing either, the
+        // service keeps its restore point rather than acquiring a baseline.
+        let userProxy = Fixtures.replacing(
+            Fixtures.rockxyOverride,
+            http: ProxyEndpointState(enabled: true, host: "10.0.0.5", port: 3_128),
+            https: ProxyEndpointState(enabled: true, host: "10.0.0.5", port: 3_128)
+        )
+
+        let plan = ProxyRecoveryPlanner.plan(
+            targets: [Fixtures.capturedSettings],
+            journal: [Fixtures.entry(stage: .restored, target: staleTarget)],
+            liveStates: [Fixtures.service: userProxy],
+            ownedPort: Fixtures.rockxyPort
+        )
+
+        #expect(plan.entriesToRestore.isEmpty)
+        #expect(plan.deferredServices == [Fixtures.service])
+        #expect(plan.abandonedServices.isEmpty)
+        #expect(plan.servicesKeepingBackup == [Fixtures.service])
+    }
+
+    @Test("A stale record does not stop a service Rockxy provably still owns from recovering")
+    func staleJournalRecordIsReplacedOnlyByProvenOwnership() {
+        let staleTarget = ProxyRecoveryJournalFixtures.replacing(
+            Fixtures.capturedSettings,
+            http: ProxyEndpointState(enabled: true, host: "old.corp.example", port: 3_128)
+        )
+
+        let plan = ProxyRecoveryPlanner.plan(
+            targets: [Fixtures.capturedSettings],
+            journal: [Fixtures.entry(stage: .restored, target: staleTarget)],
+            liveStates: [Fixtures.service: Fixtures.rockxyOverride],
+            ownedPort: Fixtures.rockxyPort
+        )
+
+        // The service still carries the strict override, and no restore can produce that shape
+        // once it has started — so nothing has been written to this service yet and a fresh
+        // baseline is the truth, not a guess. The stale record itself is discarded.
+        #expect(plan.entriesToRestore.map(\.service) == [Fixtures.service])
+        #expect(plan.entriesToRestore.first?.stage == .pending)
+        #expect(plan.entriesToRestore.first?.target == Fixtures.capturedSettings)
+        #expect(plan.entriesToRestore.first?.expectedPreStepState == Fixtures.rockxyOverride)
+    }
+
+    @Test("A service with neither a record nor a readable state keeps its restore point")
+    func unreadableServiceWithoutARecordIsDeferred() {
+        let plan = ProxyRecoveryPlanner.plan(
+            targets: [Fixtures.capturedSettings],
+            journal: [],
+            liveStates: [:],
+            ownedPort: Fixtures.rockxyPort
+        )
+
+        #expect(plan.entriesToRestore.isEmpty)
+        #expect(plan.deferredServices == [Fixtures.service])
+        #expect(plan.abandonedServices.isEmpty)
+    }
+
+    @Test("A pending backup with no readable journal still recovers the services Rockxy owns")
+    func pendingBackupWithoutAJournalRecoversStrictlyOwnedServices() {
+        // A backup written before the journal existed — or one whose journal this build could not
+        // read — arrives with no records at all. The services that still carry the strict
+        // override are provably Rockxy's, so they recover; the one the user re-pointed does not.
+        let userProxy = Fixtures.renamed(
+            Fixtures.replacing(
+                Fixtures.rockxyOverride,
+                http: ProxyEndpointState(enabled: true, host: "10.0.0.5", port: 3_128),
+                https: ProxyEndpointState(enabled: true, host: "10.0.0.5", port: 3_128)
+            ),
+            to: "USB LAN"
+        )
+
+        let plan = ProxyRecoveryPlanner.plan(
+            targets: [
+                Fixtures.capturedSettings,
+                Fixtures.renamed(Fixtures.capturedSettings, to: "Ethernet"),
+                Fixtures.renamed(Fixtures.capturedSettings, to: "USB LAN"),
+            ],
+            journal: [],
+            liveStates: [
+                Fixtures.service: Fixtures.rockxyOverride,
+                "Ethernet": Fixtures.renamed(Fixtures.rockxyOverride, to: "Ethernet"),
+                "USB LAN": userProxy,
+            ],
+            ownedPort: Fixtures.rockxyPort
+        )
+
+        #expect(plan.entriesToRestore.map(\.service) == [Fixtures.service, "Ethernet"])
+        #expect(plan.entriesToRestore.allSatisfy { $0.stage == .pending })
+        #expect(plan.deferredServices == ["USB LAN"])
+        #expect(plan.abandonedServices.isEmpty)
+    }
+
+    @Test("One unusable record does not stop the services whose records are still good")
+    func oneUnusableRecordDoesNotBlockTheOthers() {
+        let ethernetTarget = Fixtures.renamed(Fixtures.capturedSettings, to: "Ethernet")
+        let ethernetOverride = Fixtures.renamed(Fixtures.rockxyOverride, to: "Ethernet")
+        let staleEthernetTarget = ProxyRecoveryJournalFixtures.replacing(
+            ethernetTarget,
+            https: ProxyEndpointState(enabled: true, host: "old.corp.example", port: 3_128)
+        )
+        let ethernetUserProxy = ProxyRecoveryJournalFixtures.replacing(
+            ethernetOverride,
+            http: ProxyEndpointState(enabled: true, host: "10.0.0.5", port: 3_128),
+            https: ProxyEndpointState(enabled: true, host: "10.0.0.5", port: 3_128)
+        )
+
+        let plan = ProxyRecoveryPlanner.plan(
+            targets: [Fixtures.capturedSettings, ethernetTarget],
+            journal: [
+                Fixtures.entry(stage: .inFlight),
+                Fixtures.entry(
+                    stage: .inFlight,
+                    pre: ethernetOverride,
+                    target: staleEthernetTarget
+                ),
+            ],
+            liveStates: [
+                Fixtures.service: Fixtures.rockxyOverride,
+                "Ethernet": ethernetUserProxy,
+            ],
+            ownedPort: Fixtures.rockxyPort
+        )
+
+        #expect(plan.entriesToRestore.map(\.service) == [Fixtures.service])
+        #expect(plan.deferredServices == ["Ethernet"])
+        #expect(plan.abandonedServices.isEmpty)
+        #expect(plan.servicesKeepingBackup == [Fixtures.service, "Ethernet"])
+    }
+
+    @Test("A service the restore never reached stays pending, and a prefix match cannot claim it")
+    func untouchedServiceStaysPendingAcrossACrash() {
+        let ethernetTarget = Fixtures.renamed(Fixtures.capturedSettings, to: "Ethernet")
+        let ethernetOverride = Fixtures.renamed(Fixtures.rockxyOverride, to: "Ethernet")
+
+        // Both services are planned and persisted together, each at the stage it was planned at.
+        let plan = ProxyRecoveryPlanner.plan(
+            targets: [Fixtures.capturedSettings, ethernetTarget],
+            journal: [],
+            liveStates: [
+                Fixtures.service: Fixtures.rockxyOverride,
+                "Ethernet": ethernetOverride,
+            ],
+            ownedPort: Fixtures.rockxyPort
+        )
+        #expect(plan.entriesToRestore.map(\.stage) == [.pending, .pending])
+
+        // Wi-Fi is advanced to `inFlight` immediately before its first command; the process then
+        // dies while writing it. Ethernet was never issued a command, so its record is still
+        // `pending` on disk.
+        let persistedJournal = plan.entriesToRestore.map {
+            $0.service == Fixtures.service ? $0.advanced(to: .inFlight) : $0
+        }
+        #expect(persistedJournal.map(\.stage) == [.inFlight, .pending])
+
+        // The user then switches Ethernet's proxies off — which happens to be the very first
+        // shape Ethernet's own restore would have passed through. A record that claimed the
+        // commands had started would read that as its own interrupted work and write over it.
+        let userDisabledEthernet = ethernetOverride.withProxyModesDisabled
+        let ethernetEntry = persistedJournal[1]
+
+        #expect(ProxyServiceRecoveryPolicy.continuation(
+            for: ethernetEntry,
+            live: userDisabledEthernet
+        ) == .abandon)
+        // The same live settings against a record that claimed the commands had started would be
+        // written over instead, which is exactly what persisting every service as in-flight up
+        // front used to do.
+        #expect(ProxyServiceRecoveryPolicy.continuation(
+            for: ethernetEntry.advanced(to: .inFlight),
+            live: userDisabledEthernet
+        ) == .restore)
+    }
+
+    @Test("A service deferred on the first attempt is not baselined from a foreign state later")
+    func previouslyDeferredServiceStaysDeferred() {
+        let ethernetTarget = Fixtures.renamed(Fixtures.capturedSettings, to: "Ethernet")
+        let ethernetOverride = Fixtures.renamed(Fixtures.rockxyOverride, to: "Ethernet")
+
+        // First attempt: Ethernet could not be read, so it was deferred and only Wi-Fi entered
+        // the journal.
+        let firstAttempt = ProxyRecoveryPlanner.plan(
+            targets: [Fixtures.capturedSettings, ethernetTarget],
+            journal: [],
+            liveStates: [Fixtures.service: Fixtures.rockxyOverride],
+            ownedPort: Fixtures.rockxyPort
+        )
+        #expect(firstAttempt.entriesToRestore.map(\.service) == [Fixtures.service])
+        #expect(firstAttempt.deferredServices == ["Ethernet"])
+
+        // Second attempt: Ethernet reads fine now, but what it reads is somebody else's proxy.
+        // Recording that as where its restore begins is what would put the user's own settings
+        // under a snapshot they never asked for.
+        let ethernetUserProxy = ProxyRecoveryJournalFixtures.replacing(
+            ethernetOverride,
+            http: ProxyEndpointState(enabled: true, host: "10.0.0.5", port: 3_128),
+            https: ProxyEndpointState(enabled: true, host: "10.0.0.5", port: 3_128)
+        )
+        let secondAttempt = ProxyRecoveryPlanner.plan(
+            targets: [Fixtures.capturedSettings, ethernetTarget],
+            journal: firstAttempt.entriesToRestore.map { $0.advanced(to: .inFlight) },
+            liveStates: [
+                Fixtures.service: Fixtures.rockxyOverride.withProxyModesDisabled,
+                "Ethernet": ethernetUserProxy,
+            ],
+            ownedPort: Fixtures.rockxyPort
+        )
+
+        #expect(secondAttempt.entriesToRestore.map(\.service) == [Fixtures.service])
+        #expect(secondAttempt.deferredServices == ["Ethernet"])
+        #expect(secondAttempt.abandonedServices.isEmpty)
+    }
+
+    @Test("A service that changes between planning and its first command is dropped, not written")
+    func serviceChangedAfterPlanningIsDroppedWithoutStrandingTheOther() {
+        let ethernetTarget = Fixtures.renamed(Fixtures.capturedSettings, to: "Ethernet")
+        let ethernetOverride = Fixtures.renamed(Fixtures.rockxyOverride, to: "Ethernet")
+
+        let plan = ProxyRecoveryPlanner.plan(
+            targets: [Fixtures.capturedSettings, ethernetTarget],
+            journal: [],
+            liveStates: [
+                Fixtures.service: Fixtures.rockxyOverride,
+                "Ethernet": ethernetOverride,
+            ],
+            ownedPort: Fixtures.rockxyPort
+        )
+        #expect(plan.entriesToRestore.map(\.service) == [Fixtures.service, "Ethernet"])
+
+        // Wi-Fi is written first. While that is happening the user re-points Ethernet, so the
+        // re-read that runs immediately before Ethernet's first command sees something the plan
+        // never described. Wi-Fi still restores; Ethernet leaves recovery without being touched.
+        let userProxy = ProxyRecoveryJournalFixtures.replacing(
+            ethernetOverride,
+            http: ProxyEndpointState(enabled: true, host: "10.0.0.5", port: 3_128),
+            https: ProxyEndpointState(enabled: true, host: "10.0.0.5", port: 3_128)
+        )
+        let preflight = plan.entriesToRestore.map { entry in
+            ProxyServiceRecoveryPolicy.continuation(
+                for: entry,
+                live: entry.service == "Ethernet" ? userProxy : Fixtures.rockxyOverride
+            )
+        }
+
+        #expect(preflight == [.restore, .abandon])
+
+        // An unreadable service at the same moment keeps its restore point rather than losing it.
+        #expect(ProxyServiceRecoveryPolicy.continuation(
+            for: plan.entriesToRestore[1],
+            live: nil
+        ) == .retryLater)
+    }
+
+    // MARK: Private
+
+    private typealias Fixtures = ProxyRecoveryJournalFixtures
+
+    private func renamed(
+        _ state: ProxyServiceRestorationState,
+        to service: String
+    )
+        -> ProxyServiceRestorationState
+    {
+        ProxyRecoveryJournalFixtures.renamed(state, to: service)
+    }
+}
+
+// MARK: - ProxyServiceRestoreExecutionTests
+
+/// The restore of one service is an ordered sequence, and the bypass list is the last thing in
+/// it. These cover the part of that order a failure has to respect.
+struct ProxyServiceRestoreExecutionTests {
+    @Test("A completed restore writes the proxy state and then the bypass list")
+    func bothStepsRunInOrder() {
+        var steps: [ProxyServiceRestoreStep] = []
+        let outcome = ProxyServiceRestoreExecution.run(
+            proxyState: { steps.append(.proxyState) },
+            bypassDomains: { steps.append(.bypassDomains) }
+        )
+
+        #expect(steps == [.proxyState, .bypassDomains])
+        #expect(outcome.failedStep == nil)
+    }
+
+    @Test("A failed proxy-state command is never followed by the bypass list")
+    func bypassIsNotWrittenAfterAProxyStateFailure() {
+        var bypassWasWritten = false
+        let outcome = ProxyServiceRestoreExecution.run(
+            proxyState: { throw RestoreStepError.failed },
+            bypassDomains: { bypassWasWritten = true }
+        )
+
+        // Writing the bypass list on top of a half-written proxy state leaves a shape no prefix
+        // of the restore sequence produces, and a later attempt has to read those as somebody
+        // else's work — which is how a service loses its automatic recovery.
+        #expect(!bypassWasWritten)
+        #expect(outcome.failedStep == .proxyState)
+        #expect(outcome.error != nil)
+    }
+
+    @Test("A failed bypass write is reported as the step it was")
+    func bypassFailureIsReported() {
+        let outcome = ProxyServiceRestoreExecution.run(
+            proxyState: {},
+            bypassDomains: { throw RestoreStepError.failed }
+        )
+
+        #expect(outcome.failedStep == .bypassDomains)
+    }
+}
+
+// MARK: - RestoreStepError
+
+private enum RestoreStepError: Error {
+    case failed
+}
+
+// MARK: - ProxyBackupFilePublicationTests
+
+/// A journal write is the permission to issue a command. These cover the one property that makes
+/// that safe: a reported failure can never have left the new record on disk.
+struct ProxyBackupFilePublicationTests {
+    // MARK: Internal
+
+    @Test("A published backup is readable and owner-only")
+    func publishedFileIsOwnerOnly() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let url = directory.appendingPathComponent("proxy-backup.plist")
+
+        try ProxyBackupFilePublication.publish(Data("in-flight".utf8), to: url)
+
+        let published = try Data(contentsOf: url)
+        #expect(published == Data("in-flight".utf8))
+        let permissions = try FileManager.default
+            .attributesOfItem(atPath: url.path)[.posixPermissions] as? NSNumber
+        #expect(permissions?.int16Value == 0o600)
+    }
+
+    @Test("A failed commit leaves the previous record exactly where it was")
+    func aFailedCommitPublishesNothing() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let url = directory
+            .appendingPathComponent("missing", isDirectory: true)
+            .appendingPathComponent("proxy-backup.plist")
+
+        #expect(throws: (any Error).self) {
+            try ProxyBackupFilePublication.publish(Data("in-flight".utf8), to: url)
+        }
+
+        // Nothing published, and no half-written temporary left behind for a later read to find.
+        #expect(!FileManager.default.fileExists(atPath: url.path))
+        let leftovers = try FileManager.default.contentsOfDirectory(atPath: directory.path)
+        #expect(leftovers.isEmpty)
+    }
+
+    @Test("An in-flight record replaces a pending one only when the commit succeeds")
+    func aFailedCommitCannotAdvanceTheRecordOnDisk() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let url = directory.appendingPathComponent("proxy-backup.plist")
+        let pendingRecord = try encoded(stage: .pending)
+        try ProxyBackupFilePublication.publish(pendingRecord, to: url)
+
+        // The directory is made unwritable, so the temporary file cannot even be created — the
+        // same shape as any failure before the rename.
+        try FileManager.default.setAttributes([.posixPermissions: 0o500], ofItemAtPath: directory.path)
+        defer {
+            try? FileManager.default.setAttributes(
+                [.posixPermissions: 0o700],
+                ofItemAtPath: directory.path
+            )
+        }
+
+        let inFlightRecord = try encoded(stage: .inFlight)
+        #expect(throws: (any Error).self) {
+            try ProxyBackupFilePublication.publish(inFlightRecord, to: url)
+        }
+
+        // A caller that reads the throw as "no command may have run" must be right: a resumed
+        // attempt still sees `pending`, which authorizes only the exact recorded state.
+        let onDiskData = try Data(contentsOf: url)
+        let onDisk = try PropertyListDecoder()
+            .decode([ProxyServiceRecoveryJournalEntry].self, from: onDiskData)
+        #expect(onDisk.first?.stage == .pending)
+    }
+
+    // MARK: Private
+
+    private func makeTemporaryDirectory() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("rockxy-proxy-backup-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: url,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700]
+        )
+        return url
+    }
+
+    private func encoded(stage: ProxyRecoveryStage) throws -> Data {
+        try PropertyListEncoder().encode([ProxyRecoveryJournalFixtures.entry(stage: stage)])
+    }
+}

--- a/RockxyTests/Shared/RockxyIdentityTests.swift
+++ b/RockxyTests/Shared/RockxyIdentityTests.swift
@@ -92,6 +92,21 @@ struct RockxyIdentityTests {
         #expect(identity.appBundleIdentifier == "com.test.custom.app")
     }
 
+    @Test("The helper resolves direct backups in the app support directory")
+    func helperUsesTheAppSupportDirectorySetting() throws {
+        let projectRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let helperInfoURL = projectRoot.appendingPathComponent("RockxyHelperTool/Info.plist")
+        let data = try Data(contentsOf: helperInfoURL)
+        let plist = try #require(
+            PropertyListSerialization.propertyList(from: data, format: nil) as? [String: Any]
+        )
+
+        #expect(plist["RockxyAppSupportDirectoryName"] as? String == "$(ROCKXY_APP_SUPPORT_DIRECTORY_NAME)")
+    }
+
     // MARK: - Live Config (TEST_HOST = real app process)
 
     @Test("Live displayName resolves to Rockxy")

--- a/Shared/DirectProxyBackup.swift
+++ b/Shared/DirectProxyBackup.swift
@@ -1,0 +1,294 @@
+import Foundation
+
+// The direct-mode proxy backup, shared by the app that writes it and the helper binary that is
+// launched as its watchdog. One definition rather than two: the two processes read and write
+// the same file, so a field either of them decoded differently would be a silent divergence in
+// exactly the record recovery depends on.
+
+// MARK: - ProxyBackupExtension
+
+/// What a backup carries forward when an override attempt extends it.
+///
+/// An attempt that adds a newly enabled service, or takes the same services on a different port,
+/// rewrites the backup. Neither is a reason to forget what any service was already in the middle
+/// of. A journal record dropped here is the only thing that could have told a later attempt which
+/// live states it may still write, so losing it turns an override this backup already covers into
+/// one nothing can prove is Rockxy's — abandoned rather than undone, and left on the user's
+/// machine. The mid-recovery flag travels with it for the same reason: a rewrite that forgot it
+/// would hand every later launch a backup claiming no recovery had ever begun.
+enum ProxyBackupExtension {
+    static func carriedForward(
+        journal: [ProxyServiceRecoveryJournalEntry]?,
+        recoveryPending: Bool?
+    )
+        -> (journal: [ProxyServiceRecoveryJournalEntry], recoveryPending: Bool)
+    {
+        (journal ?? [], recoveryPending ?? false)
+    }
+}
+
+// MARK: - DirectProxyBackup
+
+/// Persistent on-disk backup of the pre-Rockxy proxy state for all services.
+/// Written before any direct-mode mutation; cleared after successful restore.
+struct DirectProxyBackup: Codable {
+    init(
+        services: [DirectServiceBackup],
+        timestamp: Date,
+        rockxyPort: Int,
+        ownerPID: Int32? = nil,
+        ownerStartSignature: String? = nil,
+        recoveryPending: Bool = false,
+        journal: [ProxyServiceRecoveryJournalEntry] = []
+    ) {
+        self.services = services
+        self.timestamp = timestamp
+        self.rockxyPort = rockxyPort
+        self.ownerPID = ownerPID
+        self.ownerStartSignature = ownerStartSignature
+        self.recoveryPending = recoveryPending
+        self.journal = journal
+    }
+
+    /// A backup written before the recovery journal existed decodes with an empty journal, which
+    /// recovery reads as "no step has been recorded for these services yet". A record this build
+    /// cannot read degrades the same way rather than costing the backup its restore point — and
+    /// only that record: the ones beside it are read on their own, so one unusable entry never
+    /// erases the evidence that authorizes an unrelated service's restore.
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        services = try container.decode([DirectServiceBackup].self, forKey: .services)
+        timestamp = try container.decode(Date.self, forKey: .timestamp)
+        rockxyPort = try container.decode(Int.self, forKey: .rockxyPort)
+        ownerPID = try container.decodeIfPresent(Int32.self, forKey: .ownerPID)
+        ownerStartSignature = try container.decodeIfPresent(String.self, forKey: .ownerStartSignature)
+        recoveryPending = try container.decodeIfPresent(Bool.self, forKey: .recoveryPending) ?? false
+        journal = ProxyRecoveryJournalCoding.decodeEntries(from: container, forKey: .journal)
+    }
+
+    let services: [DirectServiceBackup]
+    let timestamp: Date
+    let rockxyPort: Int
+    /// Exact app process that owns this override. Legacy backups decode without an owner and are
+    /// therefore recoverable, never assumed to belong to whichever process happens to launch.
+    let ownerPID: Int32?
+    let ownerStartSignature: String?
+    /// Kept so a build that predates the journal still reads this backup the way it always has.
+    let recoveryPending: Bool
+    /// Per-service recovery intent: the state each step expected to find and the state it leaves
+    /// behind, which is what lets a retry tell an interrupted restore apart from a service the
+    /// user has since changed.
+    let journal: [ProxyServiceRecoveryJournalEntry]
+
+    private enum CodingKeys: String, CodingKey {
+        case services
+        case timestamp
+        case rockxyPort
+        case ownerPID
+        case ownerStartSignature
+        case recoveryPending
+        case journal
+    }
+
+    /// The same backup with individual parts replaced. `recoveryPending` defaults to the flag
+    /// this backup already carries: narrowing a backup is not the same act as starting to write
+    /// one, and only the write may claim recovery has begun.
+    func with(
+        services: [DirectServiceBackup]? = nil,
+        journal: [ProxyServiceRecoveryJournalEntry]? = nil,
+        recoveryPending: Bool? = nil
+    )
+        -> DirectProxyBackup
+    {
+        DirectProxyBackup(
+            services: services ?? self.services,
+            timestamp: timestamp,
+            rockxyPort: rockxyPort,
+            ownerPID: ownerPID,
+            ownerStartSignature: ownerStartSignature,
+            recoveryPending: recoveryPending ?? self.recoveryPending,
+            journal: journal ?? self.journal
+        )
+    }
+}
+
+// MARK: - DirectProxyBackup + Extension
+
+extension DirectProxyBackup {
+    /// The backup covering everything `existing` already held plus the services just captured.
+    ///
+    /// Everything the previous attempt recorded travels with it. See `ProxyBackupExtension` for
+    /// why adding a service or changing the port must never be the moment a record is dropped.
+    static func extending(
+        _ existing: DirectProxyBackup?,
+        with additions: [DirectServiceBackup],
+        rockxyPort: Int,
+        now: Date,
+        ownerPID: Int32? = nil,
+        ownerStartSignature: String? = nil
+    )
+        -> DirectProxyBackup
+    {
+        let carried = ProxyBackupExtension.carriedForward(
+            journal: existing?.journal,
+            recoveryPending: existing?.recoveryPending
+        )
+        return DirectProxyBackup(
+            services: (existing?.services ?? []) + additions,
+            timestamp: existing?.timestamp ?? now,
+            rockxyPort: rockxyPort,
+            ownerPID: existing?.ownerPID ?? ownerPID,
+            ownerStartSignature: existing?.ownerStartSignature ?? ownerStartSignature,
+            recoveryPending: carried.recoveryPending,
+            journal: carried.journal
+        )
+    }
+}
+
+// MARK: - DirectProxyBackupOwnerPolicy
+
+/// Binds one direct-mode restore point to the exact app process that created it.
+enum DirectProxyBackupOwnerPolicy {
+    static func belongsToSession(
+        _ backup: DirectProxyBackup,
+        processIdentifier: Int32,
+        processStartSignature: String?
+    )
+        -> Bool
+    {
+        backup.ownerPID == processIdentifier
+            && ProcessStartIdentity.identifiesSameProcess(
+                recordedPID: backup.ownerPID,
+                recordedStartSignature: backup.ownerStartSignature,
+                liveStartSignature: processStartSignature
+            )
+    }
+
+    static func ownerIsLive(
+        _ backup: DirectProxyBackup,
+        processIsAlive: (Int32) -> Bool,
+        liveStartSignature: (Int32) -> String?
+    )
+        -> Bool
+    {
+        guard let ownerPID = backup.ownerPID, processIsAlive(ownerPID) else {
+            return false
+        }
+        return ProcessStartIdentity.identifiesSameProcess(
+            recordedPID: ownerPID,
+            recordedStartSignature: backup.ownerStartSignature,
+            liveStartSignature: liveStartSignature(ownerPID)
+        )
+    }
+}
+
+// MARK: - DirectServiceBackup
+
+/// Per-service proxy configuration captured before Rockxy overrides it.
+struct DirectServiceBackup: Codable {
+    // MARK: Lifecycle
+
+    init(
+        service: String,
+        httpEnabled: Bool,
+        httpHost: String,
+        httpPort: Int,
+        httpsEnabled: Bool,
+        httpsHost: String,
+        httpsPort: Int,
+        socksEnabled: Bool,
+        socksHost: String,
+        socksPort: Int,
+        pacEnabled: Bool,
+        pacURL: String,
+        autoDiscoveryEnabled: Bool,
+        bypassDomains: [String]
+    ) {
+        self.service = service
+        self.httpEnabled = httpEnabled
+        self.httpHost = httpHost
+        self.httpPort = httpPort
+        self.httpsEnabled = httpsEnabled
+        self.httpsHost = httpsHost
+        self.httpsPort = httpsPort
+        self.socksEnabled = socksEnabled
+        self.socksHost = socksHost
+        self.socksPort = socksPort
+        self.pacEnabled = pacEnabled
+        self.pacURL = pacURL
+        self.autoDiscoveryEnabled = autoDiscoveryEnabled
+        self.bypassDomains = bypassDomains
+    }
+
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        service = try container.decode(String.self, forKey: .service)
+        httpEnabled = try container.decode(Bool.self, forKey: .httpEnabled)
+        httpHost = try container.decode(String.self, forKey: .httpHost)
+        httpPort = try container.decode(Int.self, forKey: .httpPort)
+        httpsEnabled = try container.decode(Bool.self, forKey: .httpsEnabled)
+        httpsHost = try container.decode(String.self, forKey: .httpsHost)
+        httpsPort = try container.decode(Int.self, forKey: .httpsPort)
+        socksEnabled = try container.decodeIfPresent(Bool.self, forKey: .socksEnabled) ?? false
+        socksHost = try container.decodeIfPresent(String.self, forKey: .socksHost) ?? ""
+        socksPort = try container.decodeIfPresent(Int.self, forKey: .socksPort) ?? 0
+        pacEnabled = try container.decodeIfPresent(Bool.self, forKey: .pacEnabled) ?? false
+        pacURL = try container.decodeIfPresent(String.self, forKey: .pacURL) ?? ""
+        autoDiscoveryEnabled = try container.decodeIfPresent(Bool.self, forKey: .autoDiscoveryEnabled) ?? false
+        bypassDomains = try container.decode([String].self, forKey: .bypassDomains)
+    }
+
+    // MARK: Internal
+
+    let service: String
+    let httpEnabled: Bool
+    let httpHost: String
+    let httpPort: Int
+    let httpsEnabled: Bool
+    let httpsHost: String
+    let httpsPort: Int
+    let socksEnabled: Bool
+    let socksHost: String
+    let socksPort: Int
+    let pacEnabled: Bool
+    let pacURL: String
+    let autoDiscoveryEnabled: Bool
+    let bypassDomains: [String]
+
+    // MARK: Private
+
+    private enum CodingKeys: String, CodingKey {
+        case service
+        case httpEnabled
+        case httpHost
+        case httpPort
+        case httpsEnabled
+        case httpsHost
+        case httpsPort
+        case socksEnabled
+        case socksHost
+        case socksPort
+        case pacEnabled
+        case pacURL
+        case autoDiscoveryEnabled
+        case bypassDomains
+    }
+}
+
+// MARK: - DirectServiceBackup + Restoration
+
+extension DirectServiceBackup {
+    /// The captured pre-Rockxy settings for this service, in the shape recovery compares against.
+    var restorationTarget: ProxyServiceRestorationState {
+        ProxyServiceRestorationState(
+            service: service,
+            http: ProxyEndpointState(enabled: httpEnabled, host: httpHost, port: httpPort),
+            https: ProxyEndpointState(enabled: httpsEnabled, host: httpsHost, port: httpsPort),
+            socks: ProxyEndpointState(enabled: socksEnabled, host: socksHost, port: socksPort),
+            pacEnabled: pacEnabled,
+            pacURL: pacURL,
+            autoDiscoveryEnabled: autoDiscoveryEnabled,
+            bypassDomains: bypassDomains
+        )
+    }
+}

--- a/Shared/DirectProxyRecoveryRunner.swift
+++ b/Shared/DirectProxyRecoveryRunner.swift
@@ -1,0 +1,265 @@
+import Foundation
+
+// The per-service loop that writes a direct-mode backup back onto the machine.
+
+// MARK: - DirectProxyRecoveryEvent
+
+/// Something worth reporting that happened to one service during a recovery run. The runner
+/// decides; the caller decides how to say it, because the app and the watchdog log differently.
+enum DirectProxyRecoveryEvent {
+    /// The service's live settings are no longer the ones this recovery planned for, so it left
+    /// recovery untouched.
+    case droppedChangedService(String)
+    /// The service's settings could not be read before its first command, so nothing was written.
+    case deferredUnreadableService(String)
+    /// The record that authorizes this service's commands could not be stored, so no command was
+    /// issued for it.
+    case uncommittedService(service: String, error: any Error)
+    /// A command sequence stopped part-way.
+    case failedStep(service: String, step: ProxyServiceRestoreStep, error: (any Error)?)
+    /// A journal update after the commands had already landed could not be persisted.
+    case backupUpdateFailed(any Error)
+}
+
+// MARK: - DirectProxyRecoveryEffects
+
+/// Everything the recovery loop does to the outside world.
+struct DirectProxyRecoveryEffects {
+    // MARK: Lifecycle
+
+    init(
+        readState: @escaping (String) -> ProxyServiceRestorationState?,
+        publishBackup: @escaping (DirectProxyBackup) throws -> Void,
+        restoreProxyState: @escaping (DirectServiceBackup) throws -> Void,
+        restoreBypassDomains: @escaping (DirectServiceBackup) throws -> Void,
+        log: @escaping (DirectProxyRecoveryEvent) -> Void
+    ) {
+        self.readState = readState
+        self.publishBackup = publishBackup
+        self.restoreProxyState = restoreProxyState
+        self.restoreBypassDomains = restoreBypassDomains
+        self.log = log
+    }
+
+    // MARK: Internal
+
+    /// Reads every proxy field of one service, or nothing at all.
+    let readState: (String) -> ProxyServiceRestorationState?
+    /// Publishes the backup. A throw has to mean the previous record is still the one on disk —
+    /// the loop treats a successful write as its permission to issue a command.
+    let publishBackup: (DirectProxyBackup) throws -> Void
+    let restoreProxyState: (DirectServiceBackup) throws -> Void
+    let restoreBypassDomains: (DirectServiceBackup) throws -> Void
+    let log: (DirectProxyRecoveryEvent) -> Void
+}
+
+// MARK: - DirectProxyRecoveryResult
+
+/// What a recovery run decided, in the shape the caller needs to finish the attempt.
+struct DirectProxyRecoveryResult {
+    var backup: DirectProxyBackup
+    var journal: [ProxyServiceRecoveryJournalEntry]
+    var retention: ProxyBackupRetention
+    var attemptedServices: [String] = []
+    var failedServices: Set<String> = []
+    var deferredServices: [String]
+    var allSucceeded = true
+}
+
+// MARK: - DirectProxyRecoveryRunner
+
+/// Restores the services a recovery plan authorized, one at a time, recording the intent before
+/// each service's first command and its completion after the last.
+///
+/// The plan was made for every service at once, but the services are written one after another.
+/// Re-reading a service immediately before its own first command is what lets a change made while
+/// an earlier service was being restored be seen before anything is overwritten — and a service
+/// that leaves recovery here leaves it durably, because its entry comes off disk before the loop
+/// moves on.
+///
+/// The app and the watchdog binary run this same loop. They differ only in how they reach
+/// `networksetup` and the backup file, which is exactly what `DirectProxyRecoveryEffects`
+/// carries: a second implementation that merely resembled this one would drift, and the shape it
+/// drifted into would only ever be observed after a crash.
+enum DirectProxyRecoveryRunner {
+    // MARK: Internal
+
+    static func run(
+        entriesToRestore: [ProxyServiceRecoveryJournalEntry],
+        backup: DirectProxyBackup,
+        journal: [ProxyServiceRecoveryJournalEntry],
+        retention: ProxyBackupRetention,
+        deferredServices: [String],
+        effects: DirectProxyRecoveryEffects
+    )
+        -> DirectProxyRecoveryResult
+    {
+        var result = DirectProxyRecoveryResult(
+            backup: backup,
+            journal: journal,
+            retention: retention,
+            deferredServices: deferredServices
+        )
+
+        for journalEntry in entriesToRestore {
+            restoreOne(journalEntry: journalEntry, result: &result, effects: effects)
+        }
+
+        return result
+    }
+
+    // MARK: Private
+
+    private static func restoreOne(
+        journalEntry: ProxyServiceRecoveryJournalEntry,
+        result: inout DirectProxyRecoveryResult,
+        effects: DirectProxyRecoveryEffects
+    ) {
+        guard let entry = result.backup.services.first(where: { $0.service == journalEntry.service }) else {
+            return
+        }
+
+        switch ProxyServiceRecoveryPolicy.continuation(
+            for: journalEntry,
+            live: effects.readState(entry.service)
+        ) {
+        case .restore:
+            break
+        case .complete, .abandon:
+            effects.log(.droppedChangedService(entry.service))
+            result.retention.drop(entry.service)
+            result.journal.removeAll { $0.service == entry.service }
+            persistOrKeepPrevious(&result, effects: effects)
+            return
+        case .retryLater:
+            effects.log(.deferredUnreadableService(entry.service))
+            result.deferredServices.append(entry.service)
+            result.journal = advanced(result.journal, service: entry.service, to: journalEntry.stage)
+            persistOrKeepPrevious(&result, effects: effects)
+            return
+        }
+
+        // Only now, and only for this one service, does the record advance to `inFlight`. The
+        // commit is the permission to issue a command: a record that cannot be written means no
+        // command is issued for that service, because an unrecorded write is precisely what a
+        // later attempt has no way to reason about.
+        let inFlightEntry = journalEntry.advanced(to: .inFlight)
+        let inFlightJournal = advanced(result.journal, service: entry.service, to: .inFlight)
+        let pendingBackup = result.backup
+        let retainedServices = result.retention.services
+        var committedBackup: DirectProxyBackup?
+        // The bypass list is the last thing a restore writes, and it is not written at all when
+        // the proxy state failed: a restored bypass list beside a half-written proxy state is a
+        // shape no prefix of the sequence produces, and recovery has to read those as somebody
+        // else's.
+        let attempt = ProxyJournaledServiceRestore.run(
+            commitInFlight: {
+                committedBackup = try published(
+                    pendingBackup,
+                    retaining: retainedServices,
+                    journal: inFlightJournal,
+                    effects: effects
+                )
+            },
+            restore: {
+                switch ProxyServiceRecoveryPolicy.continuation(
+                    for: inFlightEntry,
+                    live: effects.readState(entry.service)
+                ) {
+                case .restore:
+                    break
+                case .complete:
+                    return .restored
+                case .abandon, .retryLater:
+                    return .failed(
+                        step: .proxyState,
+                        error: ProxyRecoveryRevalidationError.stateChangedAfterCommit(
+                            service: entry.service
+                        )
+                    )
+                }
+                return ProxyServiceRestoreExecution.run(
+                    proxyState: { try effects.restoreProxyState(entry) },
+                    bypassDomains: { try effects.restoreBypassDomains(entry) }
+                )
+            }
+        )
+
+        guard case let .issued(outcome) = attempt else {
+            if case let .notIssued(commitError) = attempt {
+                effects.log(.uncommittedService(service: entry.service, error: commitError))
+            }
+            result.deferredServices.append(entry.service)
+            return
+        }
+
+        result.journal = inFlightJournal
+        result.backup = committedBackup ?? result.backup
+        result.attemptedServices.append(entry.service)
+
+        if let failedStep = outcome.failedStep {
+            effects.log(.failedStep(service: entry.service, step: failedStep, error: outcome.error))
+            result.allSucceeded = false
+            result.failedServices.insert(entry.service)
+            return
+        }
+
+        // Every command for this service returned. Recording that now is what keeps a death from
+        // this point on from looking like a command that never ran.
+        result.journal = advanced(result.journal, service: entry.service, to: .restored)
+        persistOrKeepPrevious(&result, effects: effects)
+    }
+
+    /// Rewrites the backup so the services and journal it holds match what the run has decided so
+    /// far. A failed write leaves the previous contents in place, which is safe here because the
+    /// next attempt re-reads every service before it writes one.
+    private static func persistOrKeepPrevious(
+        _ result: inout DirectProxyRecoveryResult,
+        effects: DirectProxyRecoveryEffects
+    ) {
+        do {
+            result.backup = try published(
+                result.backup,
+                retaining: result.retention.services,
+                journal: result.journal,
+                effects: effects
+            )
+        } catch {
+            effects.log(.backupUpdateFailed(error))
+        }
+    }
+
+    /// The same rewrite where a failed write has to reach the caller, because the write is the
+    /// permission to issue a command rather than a record of one that already ran.
+    private static func published(
+        _ backup: DirectProxyBackup,
+        retaining services: [String],
+        journal: [ProxyServiceRecoveryJournalEntry],
+        effects: DirectProxyRecoveryEffects
+    )
+        throws -> DirectProxyBackup
+    {
+        let retainedServices = Set(services)
+        let updated = backup.with(
+            services: ProxyBackupSubset.select(
+                backup.services,
+                services: retainedServices,
+                serviceName: \.service
+            ),
+            journal: ProxyBackupSubset.select(journal, services: retainedServices, serviceName: \.service),
+            recoveryPending: true
+        )
+        try effects.publishBackup(updated)
+        return updated
+    }
+
+    private static func advanced(
+        _ journal: [ProxyServiceRecoveryJournalEntry],
+        service: String,
+        to stage: ProxyRecoveryStage
+    )
+        -> [ProxyServiceRecoveryJournalEntry]
+    {
+        journal.map { $0.service == service ? $0.advanced(to: stage) : $0 }
+    }
+}

--- a/Shared/DirectProxySessionLock.swift
+++ b/Shared/DirectProxySessionLock.swift
@@ -1,0 +1,115 @@
+import Darwin
+import Foundation
+
+// MARK: - DirectProxySessionLock
+
+/// Serializes system-proxy ownership and recovery across app, watchdog, and helper processes.
+///
+/// Atomic replacement keeps one plist internally consistent, but it does not make a
+/// read-capture-publish-mutate sequence atomic. Holding this advisory lock for the complete
+/// sequence prevents two app instances, or an old watchdog and a new app instance, from each
+/// acting on a different generation of the same system-wide proxy configuration.
+enum DirectProxySessionLock {
+    enum LockError: LocalizedError {
+        case timedOut
+
+        var errorDescription: String? {
+            switch self {
+            case .timedOut:
+                "Timed out waiting for another proxy operation to finish"
+            }
+        }
+    }
+
+    static func withExclusiveAccess<T>(
+        backupURL: URL,
+        _ operation: () throws -> T
+    ) throws -> T {
+        _ = backupURL
+        return try withGlobalExclusiveAccess(operation)
+    }
+
+    static func withExclusiveAccess<T>(
+        userID: uid_t,
+        _ operation: () throws -> T
+    ) throws -> T {
+        _ = userID
+        return try withGlobalExclusiveAccess(operation)
+    }
+
+    /// Reports whether any local login account has a direct-mode restore point. Callers hold the
+    /// global lock, so this inventory cannot race a current build publishing or clearing one.
+    static func anyDirectBackupExists() -> Bool {
+        setpwent()
+        defer { endpwent() }
+        while let passwordRecord = getpwent() {
+            let userID = passwordRecord.pointee.pw_uid
+            if let url = directBackupURL(userID: userID),
+               FileManager.default.fileExists(atPath: url.path)
+            {
+                return true
+            }
+        }
+        return false
+    }
+
+    private static func withGlobalExclusiveAccess<T>(_ operation: () throws -> T) throws -> T {
+        // `/Users/Shared` is a stable, root-owned directory readable by every login user. Locking
+        // its descriptor gives all sessions one kernel-backed mutex without creating a mutable
+        // world-writable lock file that another process could unlink and replace.
+        let descriptor = open("/Users/Shared", O_RDONLY | O_CLOEXEC | O_NOFOLLOW)
+        guard descriptor >= 0 else {
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+        }
+        defer { close(descriptor) }
+
+        var status = stat()
+        guard fstat(descriptor, &status) == 0,
+              status.st_uid == 0,
+              status.st_mode & S_IFMT == S_IFDIR
+        else {
+            throw POSIXError(.EPERM)
+        }
+
+        let deadline = ProcessInfo.processInfo.systemUptime + acquisitionTimeout
+        while flock(descriptor, LOCK_EX | LOCK_NB) != 0 {
+            let lockError = errno
+            if lockError == EINTR {
+                continue
+            }
+            guard lockError == EWOULDBLOCK || lockError == EAGAIN else {
+                throw POSIXError(POSIXErrorCode(rawValue: lockError) ?? .EIO)
+            }
+            guard ProcessInfo.processInfo.systemUptime < deadline else {
+                throw LockError.timedOut
+            }
+            Thread.sleep(forTimeInterval: retryInterval)
+        }
+        defer { flock(descriptor, LOCK_UN) }
+
+        return try operation()
+    }
+
+    /// A legitimate proxy mutation may span several `networksetup` commands, so contenders wait
+    /// briefly. The wait is still bounded: a foreign or wedged process can hold an advisory lock,
+    /// and neither app shutdown nor either recovery watchdog may block behind it forever. Recovery
+    /// callers preserve their restore point and retry from their own lifecycle after this throws.
+    private static let acquisitionTimeout: TimeInterval = 5
+    private static let retryInterval: TimeInterval = 0.05
+
+    /// The unprivileged direct-mode restore point for one login user. The privileged helper uses
+    /// this only after authenticating that user's XPC connection and acquiring the same lock.
+    static func directBackupURL(userID: uid_t) -> URL? {
+        guard let passwordRecord = getpwuid(userID) else {
+            return nil
+        }
+        let homeDirectory = String(cString: passwordRecord.pointee.pw_dir)
+        guard !homeDirectory.isEmpty else {
+            return nil
+        }
+        return URL(fileURLWithPath: homeDirectory, isDirectory: true)
+            .appendingPathComponent("Library/Application Support", isDirectory: true)
+            .appendingPathComponent(RockxyIdentity.current.appSupportDirectoryName, isDirectory: true)
+            .appendingPathComponent("proxy-backup-direct.plist")
+    }
+}

--- a/Shared/DirectProxyWatchdogRuntime.swift
+++ b/Shared/DirectProxyWatchdogRuntime.swift
@@ -1,0 +1,197 @@
+import Foundation
+
+// The direct-mode proxy watchdog, in the one form both the process that submits it and the
+// process that runs it agree on.
+
+// MARK: - DirectProxyWatchdogAction
+
+/// What a watchdog poll decides to do next.
+enum DirectProxyWatchdogAction: Equatable {
+    /// The override is still there and its owner is still running. Keep watching.
+    case wait
+    /// The owner is gone and the restore point is still on disk. Put the settings back.
+    case restore
+    /// There is no backup left, so somebody else already resolved this session.
+    case exit
+}
+
+// MARK: - DirectProxyWatchdogPolicy
+
+/// Decides a watchdog poll from the only two facts it has.
+///
+/// The backup is checked first on purpose: once it is gone there is nothing left to restore, and
+/// a watchdog that kept waiting on a live parent would outlive the session it was armed for.
+enum DirectProxyWatchdogPolicy {
+    static func action(parentAlive: Bool, backupExists: Bool) -> DirectProxyWatchdogAction {
+        guard backupExists else {
+            return .exit
+        }
+        return parentAlive ? .wait : .restore
+    }
+}
+
+// MARK: - DirectProxyWatchdogInvocation
+
+/// How the watchdog is asked for on the command line, and what an invocation means.
+///
+/// Formatting and parsing live together because the two halves run in different processes: the
+/// app builds the `launchctl submit` line, and the helper binary reads it back. A field either
+/// side counted differently would arm a watchdog that silently watches the wrong thing.
+enum DirectProxyWatchdogInvocation: Equatable {
+    /// This process was not launched as a watchdog at all.
+    case notAWatchdog
+    /// A watchdog was asked for, but the parent it names cannot be identified. Nothing is
+    /// watched: waiting on a bare identifier would keep watching whatever process later inherits
+    /// it, so the backup is left on disk for the app's own launch-time recovery instead.
+    case unidentifiableParent
+    case watch(parentPID: Int32, backupPath: String, parentStartSignature: String)
+
+    // MARK: Internal
+
+    static let flag = "--rockxy-direct-proxy-watchdog"
+
+    /// The arguments that ask a freshly launched binary to watch `parentPID`.
+    static func watchArguments(
+        executablePath: String,
+        parentPID: Int32,
+        backupPath: String,
+        parentStartSignature: String
+    )
+        -> [String]
+    {
+        [
+            executablePath,
+            flag,
+            String(parentPID),
+            backupPath,
+            parentStartSignature,
+        ]
+    }
+
+    static func parse(arguments: [String]) -> DirectProxyWatchdogInvocation {
+        guard arguments.count >= 2, arguments[1] == flag else {
+            return .notAWatchdog
+        }
+        guard arguments.count >= 5,
+              let parentPID = Int32(arguments[2]),
+              parentPID > 0,
+              !arguments[4].isEmpty
+        else {
+            return .unidentifiableParent
+        }
+        return .watch(
+            parentPID: parentPID,
+            backupPath: arguments[3],
+            parentStartSignature: arguments[4]
+        )
+    }
+}
+
+// MARK: - DirectProxyWatchdogInstallation
+
+/// Replaces the watcher guarding a direct override without ever leaving it unwatched.
+///
+/// `launchctl` will not accept a second job under a label it already knows, so replacing a
+/// watcher used to mean removing the old one first. That order is the bug: a submit that then
+/// fails leaves no watcher at all, and the override this attempt is about to write — or the one
+/// already on the machine — has nothing left to put it back. Submitting under a label nothing is
+/// using yet inverts it, so the old watcher stays effective for exactly as long as the new one is
+/// not, and the superseded job is only removed once its replacement is known installed.
+enum DirectProxyWatchdogInstallation {
+    // MARK: Internal
+
+    enum Outcome {
+        /// The new watcher is running. The superseded label, if there was one, has been asked to
+        /// go away; whether that removal itself succeeded does not change who is watching.
+        case installed(activeLabel: String, supersededLabel: String?)
+        /// Nothing was submitted. Whatever was watching before still is, and the caller must not
+        /// treat the override as watched by anything new.
+        case failed(activeLabel: String?, error: any Error)
+
+        // MARK: Internal
+
+        /// The label of the job actually watching once this call returns, which is what decides
+        /// whether the override is covered.
+        var activeLabel: String? {
+            switch self {
+            case let .installed(activeLabel, _):
+                activeLabel
+            case let .failed(activeLabel, _):
+                activeLabel
+            }
+        }
+
+        var isInstalled: Bool {
+            switch self {
+            case .installed:
+                true
+            case .failed:
+                false
+            }
+        }
+    }
+
+    static func install(
+        newLabel: String,
+        supersededLabel: String?,
+        submit: (String) throws -> Void,
+        remove: (String) throws -> Void
+    )
+        -> Outcome
+    {
+        do {
+            try submit(newLabel)
+        } catch {
+            return .failed(activeLabel: supersededLabel, error: error)
+        }
+
+        if let supersededLabel, supersededLabel != newLabel {
+            // The replacement is already running, so a stubborn old job is a stray process rather
+            // than a gap in cover. It exits on its own as soon as the backup is resolved.
+            try? remove(supersededLabel)
+        }
+        return .installed(activeLabel: newLabel, supersededLabel: supersededLabel)
+    }
+}
+
+// MARK: - DirectProxyWatchdogRuntime
+
+/// The watchdog's polling loop, with every side effect supplied by the caller.
+///
+/// This is the loop the binary in `Contents/Library/HelperTools` actually runs. It is written
+/// against injected effects rather than against `FileManager` and `Thread.sleep` so the shipped
+/// behaviour — the ordering of the checks, when a restore is issued, when the loop ends — is the
+/// behaviour under test, instead of a second copy that only resembles it.
+enum DirectProxyWatchdogRuntime {
+    /// Polls until the session resolves, and reports how it ended.
+    @discardableResult
+    static func watch(
+        parentIsLive: () -> Bool,
+        backupExists: () -> Bool,
+        restore: () -> Void,
+        waitBeforeNextPoll: () -> Void
+    )
+        -> DirectProxyWatchdogAction
+    {
+        while true {
+            switch DirectProxyWatchdogPolicy.action(
+                parentAlive: parentIsLive(),
+                backupExists: backupExists()
+            ) {
+            case .wait:
+                waitBeforeNextPoll()
+            case .restore:
+                restore()
+                guard backupExists() else {
+                    return .restore
+                }
+                // A transient read, publication, or system-command failure leaves the narrowed
+                // backup on disk. Keep the watcher alive and retry instead of turning one failed
+                // attempt into an override with no remaining recovery process.
+                waitBeforeNextPoll()
+            case .exit:
+                return .exit
+            }
+        }
+    }
+}

--- a/Shared/HelperLifecyclePolicy.swift
+++ b/Shared/HelperLifecyclePolicy.swift
@@ -1,0 +1,179 @@
+import Foundation
+
+// Decides when the privileged helper may exit, and what an uninstall is allowed to tear down.
+
+// MARK: - HelperIdleExitDecision
+
+/// What an idle timeout that has already fired is allowed to do.
+enum HelperIdleExitDecision: Equatable {
+    /// Nothing privileged is running and no override is in place. The exit barrier is still held
+    /// when this is returned, so nothing can start between the decision and the exit.
+    case exit
+    /// Another privileged mutation owns the gate. The helper stays up and the timer is rearmed.
+    case deferBusy
+    /// A proxy override is in place, so the process that would restore it has to stay alive.
+    case deferOverridden
+}
+
+// MARK: - HelperIdleExitSequence
+
+/// Serializes the helper's idle exit with every other privileged mutation.
+///
+/// A dispatch timer event that has already been dequeued cannot be cancelled, so an idle check
+/// that merely read the proxy status could reach `exit` while an override or a certificate
+/// operation was half-written — the reply would never arrive and the settings would be left
+/// mid-sequence. Taking the same exclusive gate those mutations take closes that: a busy gate
+/// means the helper is needed, and an empty one cannot be filled while this decision is being
+/// made.
+///
+/// The status is read twice on purpose. The first read is cheap and refuses the common case
+/// without touching the gate; the second happens while the barrier is held, which is what makes
+/// an override that started between them impossible to miss. The barrier is released on every
+/// path that does not exit, so a deferred check leaves the helper exactly as it found it.
+enum HelperIdleExitSequence {
+    static func run(
+        proxyIsOverridden: () -> Bool,
+        acquireExitBarrier: () -> HelperPrivilegedMutationGate.Ticket?,
+        release: (HelperPrivilegedMutationGate.Ticket) -> Void
+    )
+        -> HelperIdleExitDecision
+    {
+        guard !proxyIsOverridden() else {
+            return .deferOverridden
+        }
+        guard let barrier = acquireExitBarrier() else {
+            return .deferBusy
+        }
+        guard !proxyIsOverridden() else {
+            release(barrier)
+            return .deferOverridden
+        }
+        return .exit
+    }
+}
+
+// MARK: - HelperOverrideResidencyPolicy
+
+/// Whether something on this machine still needs the helper process alive.
+///
+/// The routed service's status answers for the common case, and only for it: an override that
+/// stopped on a secondary service leaves the routed one reading clean, so a status check on its
+/// own reports a machine that is still changed as idle — and the helper exits with the only
+/// process that could put those services back. A restore point still on disk names exactly the
+/// services in that position, so it is the second half of the question.
+enum HelperOverrideResidencyPolicy {
+    static func overrideNeedsHelper(
+        routedServiceIsOverridden: Bool,
+        unresolvedBackupExists: Bool
+    )
+        -> Bool
+    {
+        routedServiceIsOverridden || unresolvedBackupExists
+    }
+}
+
+// MARK: - HelperBoundProcessIdentityPolicy
+
+/// Keeps a privileged connection bound to the exact process instance accepted by the listener.
+/// A process identifier can be recycled after that acceptance, so every later mutation must still
+/// match the start signature captured at the same boundary.
+enum HelperBoundProcessIdentityPolicy {
+    static func isCurrent(
+        boundPID: Int32,
+        boundStartSignature: String,
+        liveStartSignature: String?
+    )
+        -> Bool
+    {
+        boundPID > 0
+            && !boundStartSignature.isEmpty
+            && liveStartSignature == boundStartSignature
+    }
+
+    /// A session mutation is also tied to the backup created for this exact connection. This keeps
+    /// a delayed request from changing services after restoration has removed the backup, or from
+    /// acting on a later session owned by another process instance.
+    static func ownsProxySession(
+        boundPID: Int32,
+        boundStartSignature: String,
+        liveStartSignature: String?,
+        recordedOwnerPID: Int32?,
+        recordedOwnerStartSignature: String?,
+        hasBackedUpServices: Bool
+    )
+        -> Bool
+    {
+        hasBackedUpServices
+            && isCurrent(
+                boundPID: boundPID,
+                boundStartSignature: boundStartSignature,
+                liveStartSignature: liveStartSignature
+            )
+            && recordedOwnerPID == boundPID
+            && recordedOwnerStartSignature == boundStartSignature
+    }
+
+    static func recordedSessionBelongsToCaller(
+        recordedOwnerPID: Int32?,
+        recordedOwnerStartSignature: String?,
+        callerPID: Int32,
+        callerStartSignature: String
+    )
+        -> Bool
+    {
+        recordedOwnerPID == callerPID
+            && ProcessStartIdentity.identifiesSameProcess(
+                recordedPID: recordedOwnerPID,
+                recordedStartSignature: recordedOwnerStartSignature,
+                liveStartSignature: callerStartSignature
+            )
+    }
+
+    /// A live session may only be restored by the exact connection that owns it. Once its owner
+    /// is gone, any authenticated app connection may trigger the recovery the helper would run on
+    /// restart anyway.
+    static func mayRestoreSession(
+        ownerSessionIsLive: Bool,
+        recordedOwnerPID: Int32?,
+        recordedOwnerStartSignature: String?,
+        callerPID: Int32,
+        callerStartSignature: String
+    )
+        -> Bool
+    {
+        !ownerSessionIsLive || recordedSessionBelongsToCaller(
+            recordedOwnerPID: recordedOwnerPID,
+            recordedOwnerStartSignature: recordedOwnerStartSignature,
+            callerPID: callerPID,
+            callerStartSignature: callerStartSignature
+        )
+    }
+}
+
+// MARK: - HelperUninstallPreparation
+
+/// Tears down a helper session only once the user's proxy settings are provably back.
+///
+/// Stopping the watchdog and clearing the backup are both irreversible for this machine: together
+/// they remove the last two things that could put the settings back. Doing either before the
+/// restore has succeeded turns a failed uninstall into a permanent override with no restore point
+/// — so a restore that throws leaves both exactly where they are and the caller is told the
+/// preparation did not happen.
+enum HelperUninstallPreparation {
+    static func run(
+        restore: () throws -> Void,
+        stopWatchdog: () -> Void,
+        clearBackup: () -> Void
+    )
+        -> Bool
+    {
+        do {
+            try restore()
+        } catch {
+            return false
+        }
+        stopWatchdog()
+        clearBackup()
+        return true
+    }
+}

--- a/Shared/HelperProxyRateLimitPolicy.swift
+++ b/Shared/HelperProxyRateLimitPolicy.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+// MARK: - HelperProxyRateLimitPolicy
+
+/// Decides whether a system proxy override request arrives too soon after the previous one.
+///
+/// The decision and the timestamp it reads are both taken inside the privileged mutation gate.
+/// Evaluating it outside would let two concurrently delivered XPC requests read the same stale
+/// timestamp — and race on writing the new one — so neither the rate limit nor the stored value
+/// would mean anything.
+enum HelperProxyRateLimitPolicy {
+    static func isRateLimited(
+        lastChange: Date?,
+        now: Date,
+        interval: TimeInterval
+    )
+        -> Bool
+    {
+        guard let lastChange else {
+            return false
+        }
+        let elapsed = now.timeIntervalSince(lastChange)
+        return elapsed >= 0 && elapsed < interval
+    }
+}

--- a/Shared/ProxyBackupRecoveryPolicy.swift
+++ b/Shared/ProxyBackupRecoveryPolicy.swift
@@ -53,6 +53,21 @@ struct ProxyServiceOverrideState: Equatable {
     let pacEnabled: Bool
     let autoDiscoveryEnabled: Bool
     let hasGlobalBypass: Bool
+
+    /// The answer for a service whose settings could not be read: not overridden, by anybody.
+    /// Reporting an unreadable service as owned is how recovery would claim something it cannot
+    /// prove, and every caller that reads ownership needs the same answer for it.
+    static func unreadable(service: String) -> ProxyServiceOverrideState {
+        ProxyServiceOverrideState(
+            service: service,
+            httpEnabled: false,
+            httpHost: "",
+            httpPort: 0,
+            httpsEnabled: false,
+            httpsHost: "",
+            httpsPort: 0
+        )
+    }
 }
 
 // MARK: - ProxyOverrideOwnership
@@ -194,5 +209,283 @@ enum ProxyBackupSubset {
             let service = serviceName(entry)
             return failedServices.contains(service) || stillOwnedServices.contains(service)
         }
+    }
+}
+
+// MARK: - ProxyBackupRetention
+
+/// The services a restore attempt keeps a restore point for while it runs.
+///
+/// An attempt may be authorized to write only part of a backup — the services one failed override
+/// touched, say. The rest is not merely left unwritten: its entries have to stay in the
+/// authoritative backup for the whole run, because a crash or a failed write in between would
+/// otherwise be the moment a service nobody touched lost the only restore point it has. Removing
+/// them and adding them back at the end is the same bug with a smaller window.
+struct ProxyBackupRetention: Equatable {
+    // MARK: Lifecycle
+
+    /// - Parameters:
+    ///   - authorized: entries this attempt may write.
+    ///   - preserved: entries this attempt may not write but must keep for its whole run.
+    ///   - preAttemptServices: the services the backup already held before this attempt captured
+    ///     anything, or nil when the attempt captured nothing and every entry therefore predates
+    ///     it. Only these preserved entries may outlive the attempt.
+    init(authorized: [String], preserved: [String], preAttemptServices: Set<String>? = nil) {
+        authorizedServices = authorized
+        preservedServices = preserved
+        self.preAttemptServices = preAttemptServices
+    }
+
+    // MARK: Internal
+
+    /// Entries this attempt may write, and may stop keeping once it has finished with them.
+    private(set) var authorizedServices: [String]
+    /// Entries this attempt was never authorized to write.
+    let preservedServices: [String]
+    /// The services proven to have had a restore point before this attempt started.
+    let preAttemptServices: Set<String>?
+
+    /// Every service the backup on disk must still hold an entry for while the attempt runs, in
+    /// backup order.
+    var services: [String] {
+        authorizedServices + preservedServices
+    }
+
+    /// The preserved entries that were already on disk when this attempt started.
+    ///
+    /// An entry this very attempt captured for a service it then never touched describes settings
+    /// nobody overrode. Keeping it past the attempt would hand the next enable a snapshot older
+    /// than whatever the user has set in the meantime, and the enable after that would write it
+    /// back over their change.
+    var preservedServicesPredatingAttempt: [String] {
+        guard let preAttemptServices else {
+            return preservedServices
+        }
+        return preservedServices.filter { preAttemptServices.contains($0) }
+    }
+
+    /// Every service the backup must still hold an entry for once the attempt has finished: the
+    /// ones it could not resolve, plus the untouched ones that had a restore point before it
+    /// began.
+    func retainedAfterAttempt(unresolvedServices: [String]) -> [String] {
+        unresolvedServices + preservedServicesPredatingAttempt
+    }
+
+    /// Drops a service this attempt has finished with.
+    ///
+    /// A preserved entry is never dropped here. This attempt was not allowed to write that
+    /// service, so it is not this attempt's to delete mid-run either — whatever it decided about
+    /// its own work.
+    mutating func drop(_ service: String) {
+        authorizedServices.removeAll { $0 == service }
+    }
+}
+
+// MARK: - ProxyBackupCopyRole
+
+/// Which of a backup's on-disk copies a file is.
+///
+/// The marker exists so a current build can tell the record it commits to from the copy it keeps
+/// only for older builds. Without it the two are indistinguishable, and a mirror left behind by a
+/// failed mirror write reads exactly like the truth.
+enum ProxyBackupCopyRole: String, Codable, Equatable {
+    /// The copy whose publication is the commit. Recovery reads this one.
+    case authoritative
+    /// A compatibility copy, prepared before the authoritative commit so an older build can still
+    /// find a backup. It is never recovery's answer in a build that understands this marker.
+    case mirror
+}
+
+// MARK: - ProxyBackupCopyPolicy
+
+/// Decides whether a decoded backup copy may be used as recovery truth.
+///
+/// The authoritative location always may unless it is explicitly marked as a mirror. A secondary
+/// location may be an unmarked legacy backup or a marked compatibility copy. Current writers
+/// prepare that copy before the authoritative publication, so a surviving marked copy is either
+/// the exact committed record or a safe record whose later commit failed and authorized no command.
+enum ProxyBackupCopyPolicy {
+    static func isRecoveryTruth(role: ProxyBackupCopyRole?, isAuthoritativeLocation: Bool) -> Bool {
+        if isAuthoritativeLocation {
+            return role != .mirror
+        }
+        return role == nil || role == .mirror
+    }
+}
+
+// MARK: - ProxyBackupCompatibilityCopy
+
+/// Brings one compatibility copy of a backup into a state a later loader can never misread, or
+/// says plainly that it could not.
+///
+/// A build older than the copy marker wrote unmarked bytes to both locations, and a current build
+/// reads an unmarked compatibility copy as truth — correctly, because for that build it was the
+/// only backup there was. Once a current build commits, those bytes are stale, and leaving them
+/// where they are is what lets them be read back and written onto the user's services the moment
+/// the authoritative record is lost.
+///
+/// Rewriting the copy with the marker is the ordinary answer. Removing it is just as good a one:
+/// a copy that is not there is never read. Only a file that can be neither rewritten nor removed
+/// is a genuine blocker.
+enum ProxyBackupCompatibilityCopy {
+    // MARK: Internal
+
+    enum Outcome: Equatable {
+        /// The marked copy is on disk.
+        case published
+        /// The copy could not be written, but nothing is left at the location either.
+        case invalidated
+    }
+
+    @discardableResult
+    static func prepare(
+        publish: () throws -> Void,
+        remove: () -> Void,
+        copyExists: () -> Bool
+    )
+        throws -> Outcome
+    {
+        do {
+            try publish()
+            return .published
+        } catch {
+            remove()
+            guard copyExists() else {
+                return .invalidated
+            }
+            throw error
+        }
+    }
+}
+
+// MARK: - ProxyBackupCommit
+
+/// Publishes a backup's copies in the one order that cannot leave stale bytes a later loader would
+/// accept.
+///
+/// The compatibility copies are dealt with first and the authoritative record second, because the
+/// authoritative publication *is* the commit. Committing first and mirroring afterwards leaves a
+/// window — the whole rest of the session, if the mirror write failed — in which an unmarked copy
+/// from an older build sits beside a record that has already moved on. Doing the copies first
+/// means an unmarked one can only survive where no commit in the current format ever succeeded,
+/// which is exactly the case where it is the honest answer.
+///
+/// A throw therefore means nothing was committed, which is what every caller that treats a
+/// successful write as its permission to issue a command depends on.
+enum ProxyBackupCommit {
+    static func run(
+        prepareCompatibilityCopies: () throws -> Void,
+        publishAuthoritative: () throws -> Void
+    )
+        throws
+    {
+        try prepareCompatibilityCopies()
+        try publishAuthoritative()
+    }
+}
+
+// MARK: - HelperOwnerBindingPolicy
+
+/// Resolves the app process a privileged proxy request is allowed to act for.
+///
+/// The owner identifier arrives in the message, so on its own it is a claim rather than a fact: a
+/// client could name any process and have the helper arm a watchdog on it — or record it as the
+/// session that owns the user's proxy settings. The connection the request came in on has already
+/// been authenticated, and its peer identifier cannot be chosen by the sender, so that is the only
+/// identity the helper acts on. The parameter is kept, and required to agree, so the wire protocol
+/// is unchanged and a disagreement is refused rather than quietly reinterpreted.
+enum HelperOwnerBindingPolicy {
+    static func authorizedOwnerPID(boundConnectionPID: Int32?, requestedOwnerPID: Int32) -> Int32? {
+        guard let boundConnectionPID, boundConnectionPID > 0, requestedOwnerPID > 0 else {
+            return nil
+        }
+        return boundConnectionPID == requestedOwnerPID ? boundConnectionPID : nil
+    }
+}
+
+// MARK: - ProxyOwnerWatchdogPolicy
+
+/// Decides whether the process a watchdog is watching is still the one it was armed for.
+///
+/// Liveness alone is not identity: the kernel recycles process identifiers, so a bare `kill(pid, 0)`
+/// keeps reporting an owner that exited minutes ago as present. Pairing the identifier with the
+/// recorded kernel start time makes a reused identifier read as what it is — the owner is gone and
+/// the override it left behind has to be restored.
+///
+/// A watchdog is never armed without a start signature: an override that cannot name the process
+/// it belongs to is refused before anything is written. A record with no signature therefore
+/// cannot describe a session worth protecting, and reporting it as live would be exactly the
+/// bare-identifier check this type exists to remove.
+enum ProxyOwnerWatchdogPolicy {
+    static func watchedOwnerIsLive(
+        recordedPID: Int32,
+        recordedStartSignature: String?,
+        processIsAlive: Bool,
+        liveStartSignature: String?
+    )
+        -> Bool
+    {
+        guard processIsAlive else {
+            return false
+        }
+        return ProcessStartIdentity.identifiesSameProcess(
+            recordedPID: recordedPID,
+            recordedStartSignature: recordedStartSignature,
+            liveStartSignature: liveStartSignature
+        )
+    }
+}
+
+// MARK: - ProxyOverrideApplicationPolicy
+
+/// Decides what an override attempt may report once every service it touched has been answered.
+///
+/// Applying an override is a multi-service write with no transaction behind it. A service whose
+/// command sequence stopped part-way is neither Rockxy's nor the user's: strict ownership does
+/// not recognise it, so recovery cannot adopt it, and reporting the attempt as a success would
+/// leave that shape on the machine with nothing watching it. The attempt therefore has to put
+/// back everything it touched and say plainly when it could not.
+enum ProxyOverrideApplicationPolicy {
+    // MARK: Internal
+
+    enum Outcome: Equatable {
+        /// Every service the attempt configured carries the override, and none was left part-way.
+        case applied
+        /// The attempt failed and every service it touched is back on its captured settings.
+        case rolledBack
+        /// The attempt failed and at least one touched service is still changed, so the backup
+        /// has to survive and the failure has to be reported.
+        case rollbackIncomplete
+    }
+
+    /// True when a service whose override sequence failed still reads exactly as it was captured,
+    /// which is the only evidence that nothing was written to it.
+    ///
+    /// A service that could not be read answers false. An unreadable state cannot be shown to be
+    /// unchanged, and treating it as untouched is how a mutated service ends up with no rollback
+    /// and no restore point.
+    static func serviceIsUntouched(
+        live: ProxyServiceRestorationState?,
+        captured: ProxyServiceRestorationState
+    )
+        -> Bool
+    {
+        live == captured
+    }
+
+    static func outcome(
+        configuredServices: [String],
+        partiallyAppliedServices: [String],
+        unresolvedServices: [String]
+    )
+        -> Outcome
+    {
+        guard unresolvedServices.isEmpty else {
+            return .rollbackIncomplete
+        }
+        guard partiallyAppliedServices.isEmpty, !configuredServices.isEmpty else {
+            return .rolledBack
+        }
+        return .applied
     }
 }

--- a/Shared/ProxyOperationGate.swift
+++ b/Shared/ProxyOperationGate.swift
@@ -1,0 +1,104 @@
+import Foundation
+
+// MARK: - ProxyOperationGate
+
+/// Serializes the app's whole proxy operations against each other.
+///
+/// Enabling a direct override, disabling it, and the cleanup a termination signal runs are all
+/// multi-command sequences over the same services and the same backup file. They arrive on
+/// different threads — a signal handler, the main thread at termination, a capture task — so
+/// without a gate the cleanup can read the backup, restore every service, and clear the file
+/// while the enable loop still has proxy commands left to write. The user is then left with an
+/// override and no restore point at all.
+///
+/// The gate is deliberately **blocking** and **reentrant**. Blocking, because refusing a
+/// termination cleanup would leave the override in place with nothing else coming to undo it —
+/// waiting for the enable to finish is the point. Reentrant, because an operation legitimately
+/// contains the rollback of its own failure, and a plain lock would deadlock on that nesting
+/// while doing nothing about the cross-thread case this exists for.
+final class ProxyOperationGate: @unchecked Sendable {
+    // MARK: Internal
+
+    /// Runs `body` with no other proxy operation in progress. Nested calls on the same thread run
+    /// straight through, so a failing enable can roll itself back without waiting on itself.
+    func withOperation<T>(_ body: () throws -> T) rethrows -> T {
+        lock.lock()
+        defer { lock.unlock() }
+        return try body()
+    }
+
+    // MARK: Private
+
+    private let lock = NSRecursiveLock()
+}
+
+// MARK: - ProxyAsyncOperationGate
+
+/// Serializes complete asynchronous proxy lifecycle operations.
+///
+/// Helper-backed enable and restore calls suspend while XPC work is in flight. A blocking lock
+/// cannot safely span those suspension points, but releasing the lock early lets an older disable
+/// continuation clear the state and observer belonging to a newer enable. This gate keeps the
+/// complete asynchronous operation ordered while allowing the executing task to suspend.
+final class ProxyAsyncOperationGate: @unchecked Sendable {
+    // MARK: Internal
+
+    func withOperation<T>(_ body: () async throws -> T) async rethrows -> T {
+        await acquire()
+        defer { release() }
+        return try await body()
+    }
+
+    // MARK: Private
+
+    private let lock = NSLock()
+    private var isHeld = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    private func acquire() async {
+        await withCheckedContinuation { continuation in
+            lock.lock()
+            if isHeld {
+                waiters.append(continuation)
+                lock.unlock()
+            } else {
+                isHeld = true
+                lock.unlock()
+                continuation.resume()
+            }
+        }
+    }
+
+    private func release() {
+        lock.lock()
+        let next = waiters.isEmpty ? nil : waiters.removeFirst()
+        if next == nil {
+            isHeld = false
+        }
+        lock.unlock()
+        next?.resume()
+    }
+}
+
+// MARK: - ProxyOperationSessionPolicy
+
+/// Decides whether proxy work queued for one override session may still run once it reaches the
+/// gate.
+///
+/// The gate serializes operations but says nothing about which session they belong to. A bypass
+/// write queued while an override was live waits behind a disable or a termination cleanup, and
+/// the cleanup restores every service and clears the backup — so by the time the write is let
+/// through, the settings it is about to change are the user's again and nothing on disk could undo
+/// it. The generation is bumped by whatever ends a session, and it is read inside the gate, so
+/// work queued before that point cannot start after it.
+enum ProxyOperationSessionPolicy {
+    static func mayRun(
+        queuedGeneration: UInt64,
+        currentGeneration: UInt64,
+        overrideIsActive: Bool
+    )
+        -> Bool
+    {
+        overrideIsActive && queuedGeneration == currentGeneration
+    }
+}

--- a/Shared/ProxyRecoveryJournal.swift
+++ b/Shared/ProxyRecoveryJournal.swift
@@ -1,0 +1,1440 @@
+import Foundation
+
+// Durable per-service state machine that makes a proxy recovery retry safe to resume.
+
+// MARK: - ProxyBypassDomainOutput
+
+/// Normalizes the bypass list `networksetup` prints, so the value recovery compares is the same
+/// one no matter which process read it. macOS answers with a sentence rather than an empty list
+/// when a service has no bypass domains, and that sentence is not a domain.
+enum ProxyBypassDomainOutput {
+    static let emptyListPrefix = "There aren't any bypass domains"
+
+    static func parse(_ output: String) -> [String] {
+        output.components(separatedBy: "\n")
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty && !$0.hasPrefix(emptyListPrefix) }
+    }
+}
+
+// MARK: - ProxyEndpointState
+
+/// One proxy protocol's configuration on a network service.
+///
+/// `networksetup` writes the endpoint and its on/off state with two separate commands, so a
+/// restore that stops between them leaves the host and port of one step beside the enabled flag
+/// of another. Keeping the three values together lets recovery reason about that gap.
+struct ProxyEndpointState: Codable, Equatable {
+    // MARK: Lifecycle
+
+    init(enabled: Bool, host: String, port: Int) {
+        self.enabled = enabled
+        self.host = host
+        self.port = port
+    }
+
+    // MARK: Internal
+
+    let enabled: Bool
+    let host: String
+    let port: Int
+
+    /// True when a captured endpoint names somewhere to point at. Anything else is never written
+    /// back: the restore only switches that mode off.
+    var isWritable: Bool {
+        !host.isEmpty && port > 0
+    }
+
+    /// The same endpoint with only its on/off state cleared. Every restore switches all proxy
+    /// modes off before it writes anything back, and the stored host and port survive that step.
+    var disabled: ProxyEndpointState {
+        ProxyEndpointState(enabled: false, host: host, port: port)
+    }
+
+    /// The same endpoint with only its on/off state set.
+    func settingEnabled(_ isEnabled: Bool) -> ProxyEndpointState {
+        ProxyEndpointState(enabled: isEnabled, host: host, port: port)
+    }
+}
+
+// MARK: - ProxyServiceRestorationState
+
+/// Every proxy field a restore reads or writes for one network service.
+///
+/// Ownership asks the narrower question of whether a service still carries Rockxy's override.
+/// A retry has to answer something stricter — whether the live settings are still explained by
+/// what recovery itself wrote — and that needs the SOCKS endpoint, the PAC URL, and the bypass
+/// list too, none of which ownership looks at.
+struct ProxyServiceRestorationState: Codable, Equatable {
+    // MARK: Lifecycle
+
+    init(
+        service: String,
+        http: ProxyEndpointState,
+        https: ProxyEndpointState,
+        socks: ProxyEndpointState,
+        pacEnabled: Bool,
+        pacURL: String,
+        autoDiscoveryEnabled: Bool,
+        bypassDomains: [String]
+    ) {
+        self.service = service
+        self.http = http
+        self.https = https
+        self.socks = socks
+        self.pacEnabled = pacEnabled
+        self.pacURL = pacURL
+        self.autoDiscoveryEnabled = autoDiscoveryEnabled
+        self.bypassDomains = bypassDomains
+    }
+
+    // MARK: Internal
+
+    let service: String
+    let http: ProxyEndpointState
+    let https: ProxyEndpointState
+    let socks: ProxyEndpointState
+    let pacEnabled: Bool
+    let pacURL: String
+    let autoDiscoveryEnabled: Bool
+    let bypassDomains: [String]
+
+    /// The ownership-relevant projection of this state, so a single read serves both the
+    /// ownership question and the journal comparison.
+    var overrideState: ProxyServiceOverrideState {
+        ProxyServiceOverrideState(
+            service: service,
+            httpEnabled: http.enabled,
+            httpHost: http.host,
+            httpPort: http.port,
+            httpsEnabled: https.enabled,
+            httpsHost: https.host,
+            httpsPort: https.port,
+            socksEnabled: socks.enabled,
+            pacEnabled: pacEnabled,
+            autoDiscoveryEnabled: autoDiscoveryEnabled,
+            hasGlobalBypass: bypassDomains.contains("*")
+        )
+    }
+
+    /// The shape a service passes through in the middle of a restore: every proxy mode is
+    /// switched off before the captured settings are written back, so the hosts, ports, PAC URL,
+    /// and bypass list still read as they did before the step started.
+    var withProxyModesDisabled: ProxyServiceRestorationState {
+        replacing(
+            http: http.disabled,
+            https: https.disabled,
+            socks: socks.disabled,
+            pacEnabled: false,
+            autoDiscoveryEnabled: false
+        )
+    }
+
+    /// The settings a completed restore actually leaves behind.
+    ///
+    /// This is not the captured snapshot verbatim: a snapshot with no host or no port for a
+    /// protocol only causes that mode to be switched off, so the host and port stay whatever the
+    /// override left there. Comparing against the snapshot instead would report a finished
+    /// restore as unfinished forever.
+    static func expectedRestorationResult(
+        target: ProxyServiceRestorationState,
+        from current: ProxyServiceRestorationState
+    )
+        -> ProxyServiceRestorationState
+    {
+        ProxyServiceRestorationState(
+            service: target.service,
+            http: restoredEndpoint(target: target.http, current: current.http),
+            https: restoredEndpoint(target: target.https, current: current.https),
+            socks: restoredEndpoint(target: target.socks, current: current.socks),
+            pacEnabled: target.pacEnabled,
+            pacURL: target.pacEnabled && !target.pacURL.isEmpty ? target.pacURL : current.pacURL,
+            autoDiscoveryEnabled: target.autoDiscoveryEnabled,
+            bypassDomains: target.bypassDomains
+        )
+    }
+
+    /// The same state with individual fields replaced, used to walk one `networksetup` command
+    /// at a time.
+    func replacing(
+        http: ProxyEndpointState? = nil,
+        https: ProxyEndpointState? = nil,
+        socks: ProxyEndpointState? = nil,
+        pacEnabled: Bool? = nil,
+        pacURL: String? = nil,
+        autoDiscoveryEnabled: Bool? = nil,
+        bypassDomains: [String]? = nil
+    )
+        -> ProxyServiceRestorationState
+    {
+        ProxyServiceRestorationState(
+            service: service,
+            http: http ?? self.http,
+            https: https ?? self.https,
+            socks: socks ?? self.socks,
+            pacEnabled: pacEnabled ?? self.pacEnabled,
+            pacURL: pacURL ?? self.pacURL,
+            autoDiscoveryEnabled: autoDiscoveryEnabled ?? self.autoDiscoveryEnabled,
+            bypassDomains: bypassDomains ?? self.bypassDomains
+        )
+    }
+
+    // MARK: Private
+
+    /// A captured endpoint is written back only when it names both a host and a port. Anything
+    /// else leaves the live endpoint where it is and just turns the mode off.
+    private static func restoredEndpoint(
+        target: ProxyEndpointState,
+        current: ProxyEndpointState
+    )
+        -> ProxyEndpointState
+    {
+        guard target.isWritable else {
+            return current.disabled
+        }
+        return target
+    }
+}
+
+// MARK: - ProxyRestoreTransition
+
+/// The exact sequence of states one service passes through while its captured settings are
+/// written back.
+///
+/// A restore is a fixed, ordered list of `networksetup` commands: every proxy mode is switched
+/// off, each captured endpoint is written and then switched to its captured state, the PAC URL
+/// and PAC state follow, then auto discovery, and the bypass list is written last. Walking that
+/// order produces the complete set of shapes an interrupted restore can leave behind — and,
+/// just as importantly, excludes everything else. A field combination that no prefix of the
+/// sequence produces (a restored bypass list beside an untouched HTTP endpoint, say) belongs to
+/// whoever else wrote it.
+enum ProxyRestoreTransition {
+    /// Every state observable while the restore of `target` runs against a service that starts
+    /// in `pre`, in command order and beginning with `pre` itself.
+    ///
+    /// `networksetup` does not define what writing an endpoint or a PAC URL does to that mode's
+    /// on/off flag, so both answers are treated as reachable — but only at the single command
+    /// that writes it, and only for that one field. The very next command sets the flag
+    /// outright, which is why the uncertainty never spreads into a free choice across fields.
+    static func reachableStates(
+        from pre: ProxyServiceRestorationState,
+        target: ProxyServiceRestorationState
+    )
+        -> [ProxyServiceRestorationState]
+    {
+        var states: [ProxyServiceRestorationState] = [pre]
+        var current = pre
+
+        func commit(_ next: ProxyServiceRestorationState) {
+            current = next
+            states.append(next)
+        }
+
+        // Phase 1 — every proxy mode is switched off, in the order the commands run.
+        commit(current.replacing(http: current.http.disabled))
+        commit(current.replacing(https: current.https.disabled))
+        commit(current.replacing(socks: current.socks.disabled))
+        commit(current.replacing(pacEnabled: false))
+        commit(current.replacing(autoDiscoveryEnabled: false))
+
+        // Phase 2 — each captured endpoint is written, then switched to its captured state.
+        if target.http.isWritable {
+            states.append(current.replacing(http: target.http.disabled))
+            states.append(current.replacing(http: target.http.settingEnabled(true)))
+            commit(current.replacing(http: target.http))
+        }
+        if target.https.isWritable {
+            states.append(current.replacing(https: target.https.disabled))
+            states.append(current.replacing(https: target.https.settingEnabled(true)))
+            commit(current.replacing(https: target.https))
+        }
+        if target.socks.isWritable {
+            states.append(current.replacing(socks: target.socks.disabled))
+            states.append(current.replacing(socks: target.socks.settingEnabled(true)))
+            commit(current.replacing(socks: target.socks))
+        }
+
+        // Phase 3 — the PAC URL, then the PAC state. Neither runs unless the capture had PAC on.
+        if target.pacEnabled {
+            if !target.pacURL.isEmpty {
+                states.append(current.replacing(pacEnabled: false, pacURL: target.pacURL))
+                states.append(current.replacing(pacEnabled: true, pacURL: target.pacURL))
+                current = current.replacing(pacURL: target.pacURL)
+            }
+            commit(current.replacing(pacEnabled: true))
+        }
+
+        // Phase 4 — auto discovery, and only when the capture had it on.
+        if target.autoDiscoveryEnabled {
+            commit(current.replacing(autoDiscoveryEnabled: true))
+        }
+
+        // Phase 5 — the bypass list is always written, and always last.
+        commit(current.replacing(bypassDomains: target.bypassDomains))
+
+        return states
+    }
+}
+
+// MARK: - ProxyOverrideTransition
+
+/// The exact sequence of states one service passes through while Rockxy's loopback override is
+/// written onto it.
+///
+/// Applying the override is a fixed, ordered list of seven `networksetup` commands: the HTTP
+/// endpoint and its state, the HTTPS endpoint and its state, then SOCKS, PAC, and auto discovery
+/// switched off. Walking that order produces every shape an interrupted override can leave
+/// behind — and excludes everything else, which is what turns "this process wrote that service"
+/// from an assertion into proof. A recorded bypass write is the final step of that sequence.
+enum ProxyOverrideTransition {
+    // MARK: Internal
+
+    static let loopbackHost = "127.0.0.1"
+
+    /// Every state observable while the override is applied to a service that starts in
+    /// `captured`, in command order and beginning with `captured` itself.
+    ///
+    /// `networksetup` does not define what writing an endpoint does to that mode's on/off flag,
+    /// so both answers are treated as reachable — but only at the single command that writes the
+    /// endpoint, and only for that one field. The very next command sets the flag outright.
+    ///
+    /// `appliedBypassDomains` is the bounded bypass list Rockxy writes once the override is on,
+    /// taken from the record that says so. It is a separate command, issued after the seven and
+    /// recorded before it runs, so it adds exactly one more state to the end of the sequence —
+    /// and only when a record names the list. Without one the bypass list is not part of what
+    /// this sequence can produce, and a service whose bypass list differs is nobody's to undo.
+    static func reachableStates(
+        from captured: ProxyServiceRestorationState,
+        port: Int,
+        previousAppliedBypassDomains: [String]? = nil,
+        appliedBypassDomains: [String]? = nil
+    )
+        -> [ProxyServiceRestorationState]
+    {
+        guard port > 0 else {
+            return [captured]
+        }
+
+        let endpoint = ProxyEndpointState(enabled: true, host: loopbackHost, port: port)
+        var states: [ProxyServiceRestorationState] = [captured]
+        var current = captured
+
+        func commit(_ next: ProxyServiceRestorationState) {
+            current = next
+            states.append(next)
+        }
+
+        // Commands 1–2 — the HTTP endpoint is written, then switched on. The endpoint write may
+        // or may not have switched the mode on by itself; the switched-on answer is the same
+        // state command 2 produces, so it is only recorded once.
+        states.append(current.replacing(http: endpoint.disabled))
+        commit(current.replacing(http: endpoint))
+
+        // Commands 3–4 — the HTTPS endpoint, in the same two steps.
+        states.append(current.replacing(https: endpoint.disabled))
+        commit(current.replacing(https: endpoint))
+
+        // Commands 5–7 — SOCKS, PAC, and auto discovery are switched off, in that order.
+        commit(current.replacing(socks: current.socks.disabled))
+        commit(current.replacing(pacEnabled: false))
+        commit(current.replacing(autoDiscoveryEnabled: false))
+
+        // A later bypass update records both the state it starts from and the one it intends to
+        // write. Either can be live across a crash between durable publication and the command.
+        if let previousAppliedBypassDomains, previousAppliedBypassDomains != current.bypassDomains {
+            commit(current.replacing(bypassDomains: previousAppliedBypassDomains))
+        }
+
+        // Command 8 — the bounded bypass list, written after the override and only when a record
+        // says which list it is.
+        if let appliedBypassDomains, appliedBypassDomains != current.bypassDomains {
+            commit(current.replacing(bypassDomains: appliedBypassDomains))
+        }
+
+        return states
+    }
+
+    /// The settings a finished override leaves behind: every one of its commands applied, and the
+    /// bypass list a record says followed them.
+    static func completedState(
+        from captured: ProxyServiceRestorationState,
+        port: Int,
+        previousAppliedBypassDomains: [String]? = nil,
+        appliedBypassDomains: [String]? = nil
+    )
+        -> ProxyServiceRestorationState?
+    {
+        guard port > 0 else {
+            return nil
+        }
+        return reachableStates(
+            from: captured,
+            port: port,
+            previousAppliedBypassDomains: previousAppliedBypassDomains,
+            appliedBypassDomains: appliedBypassDomains
+        ).last
+    }
+
+    /// True when the live settings are exactly one of the states applying the override to
+    /// `captured` passes through.
+    ///
+    /// This is the only thing that makes a service Rockxy just wrote safe to undo. A service is
+    /// recorded as touched before its first command runs, so "we touched it" on its own cannot
+    /// tell a command that never mutated anything from a change somebody else made in the
+    /// meantime — and both of those must stay out of an automatic rollback.
+    static func isReachedByApplying(
+        _ live: ProxyServiceRestorationState,
+        from captured: ProxyServiceRestorationState,
+        port: Int,
+        previousAppliedBypassDomains: [String]? = nil,
+        appliedBypassDomains: [String]? = nil
+    )
+        -> Bool
+    {
+        guard live.service == captured.service else {
+            return false
+        }
+        return reachableStates(
+            from: captured,
+            port: port,
+            previousAppliedBypassDomains: previousAppliedBypassDomains,
+            appliedBypassDomains: appliedBypassDomains
+        ).contains(live)
+    }
+}
+
+// MARK: - ProxyBackupFilePublication
+
+/// Publishes a proxy backup so that "the call reported failure" and "the new contents are on
+/// disk" can never both be true.
+///
+/// Writing atomically and then adjusting the file afterwards leaves exactly that gap: the
+/// permission change can fail after the new contents are already visible, and a caller that
+/// reads the thrown error as "nothing was written" would then skip a command a resumed attempt
+/// believes may already have run. Permissions are therefore prepared on the temporary file, and
+/// the rename that publishes it is the single act whose success or failure is the answer.
+enum ProxyBackupFilePublication {
+    // MARK: Internal
+
+    static let ownerOnlyFilePermissions = 0o600
+    static let ownerOnlyDirectoryPermissions = 0o700
+
+    /// Writes `data` to a sibling temporary file with owner-only permissions and renames it over
+    /// `url`. Nothing is observable at `url` unless this returns.
+    static func publish(_ data: Data, to url: URL) throws {
+        let temporaryURL = url
+            .deletingLastPathComponent()
+            .appendingPathComponent(".\(url.lastPathComponent).\(UUID().uuidString).partial")
+
+        do {
+            try data.write(to: temporaryURL, options: .atomic)
+            try FileManager.default.setAttributes(
+                [.posixPermissions: ownerOnlyFilePermissions],
+                ofItemAtPath: temporaryURL.path
+            )
+            // `rename` carries the prepared mode with the contents, so there is nothing left to
+            // do to the published file — and nothing left that can fail after it exists.
+            guard rename(temporaryURL.path, url.path) == 0 else {
+                throw publicationError(url: url, code: errno)
+            }
+        } catch {
+            try? FileManager.default.removeItem(at: temporaryURL)
+            throw error
+        }
+    }
+
+    // MARK: Private
+
+    private static func publicationError(url: URL, code: Int32) -> any Error {
+        NSError(
+            domain: NSPOSIXErrorDomain,
+            code: Int(code),
+            userInfo: [
+                NSLocalizedDescriptionKey:
+                    "Could not publish \(url.lastPathComponent): \(String(cString: strerror(code)))",
+            ]
+        )
+    }
+}
+
+// MARK: - ProxyServiceRestoreStep
+
+/// The two halves of one service's restore, in the order the commands run.
+enum ProxyServiceRestoreStep: String, Equatable {
+    /// Every proxy mode is switched off and the captured endpoints, PAC, and auto discovery are
+    /// written back.
+    case proxyState
+    /// The captured bypass list, which is always the last thing a restore writes.
+    case bypassDomains
+}
+
+// MARK: - ProxyServiceRestoreOutcome
+
+enum ProxyServiceRestoreOutcome {
+    case restored
+    case failed(step: ProxyServiceRestoreStep, error: any Error)
+
+    /// The step that stopped the restore, or nil when every command returned.
+    var failedStep: ProxyServiceRestoreStep? {
+        switch self {
+        case .restored:
+            nil
+        case let .failed(step, _):
+            step
+        }
+    }
+
+    var error: (any Error)? {
+        switch self {
+        case .restored:
+            nil
+        case let .failed(_, error):
+            error
+        }
+    }
+}
+
+enum ProxyRecoveryRevalidationError: LocalizedError {
+    case stateChangedAfterCommit(service: String)
+
+    var errorDescription: String? {
+        switch self {
+        case let .stateChangedAfterCommit(service):
+            "The live proxy settings for \(service) changed while its recovery record was being committed"
+        }
+    }
+}
+
+// MARK: - ProxyServiceRestoreExecution
+
+/// Runs one service's restore in exactly the order `ProxyRestoreTransition` models: the proxy
+/// state first, the bypass list last.
+///
+/// The bypass list is not written when a proxy-state command fails. That ordering is the whole
+/// basis on which a later attempt recognises its own unfinished work, and a service whose bypass
+/// list has been restored beside a half-written proxy state is a shape no prefix of the sequence
+/// produces — which is precisely the shape recovery has to read as somebody else's.
+enum ProxyServiceRestoreExecution {
+    static func run(
+        proxyState: () throws -> Void,
+        bypassDomains: () throws -> Void
+    )
+        -> ProxyServiceRestoreOutcome
+    {
+        do {
+            try proxyState()
+        } catch {
+            return .failed(step: .proxyState, error: error)
+        }
+
+        do {
+            try bypassDomains()
+        } catch {
+            return .failed(step: .bypassDomains, error: error)
+        }
+
+        return .restored
+    }
+}
+
+// MARK: - ProxyJournaledServiceRestore
+
+/// Runs one service's restore only after its `inFlight` record has been committed.
+///
+/// The commit is the permission to issue a command, not a note about one that already ran. If it
+/// fails, not a single command may be sent for that service: an unrecorded write is exactly the
+/// case a resumed attempt has no way to reason about, and it is what turns a half-restored
+/// service into one nobody can prove anything about. Keeping the two in one place is what stops
+/// the order drifting apart in the paths that use it.
+enum ProxyJournaledServiceRestore {
+    // MARK: Internal
+
+    enum Attempt {
+        /// The record could not be committed, so not one command was issued for this service.
+        case notIssued(commitError: any Error)
+        /// The record was committed and the commands ran.
+        case issued(ProxyServiceRestoreOutcome)
+    }
+
+    static func run(
+        commitInFlight: () throws -> Void,
+        restore: () -> ProxyServiceRestoreOutcome
+    )
+        -> Attempt
+    {
+        do {
+            try commitInFlight()
+        } catch {
+            return .notIssued(commitError: error)
+        }
+        return .issued(restore())
+    }
+}
+
+// MARK: - ProxyRecoveryStage
+
+/// How far recovery has got with one network service.
+///
+/// The stage is written to disk before and after the commands it describes, which is what lets a
+/// later attempt tell "the command never ran" apart from "the command completed and the process
+/// died before it could say so".
+enum ProxyRecoveryStage: String, Codable, Equatable {
+    /// Recorded before any command for this service has been issued.
+    case pending
+    /// A command sequence was issued for this service and has not been confirmed complete.
+    case inFlight
+    /// Every command for this service returned without an error.
+    case restored
+    /// Legacy pre-command application record. Current writers commit `.applying` immediately
+    /// before each service's first mutation; this case remains decodable so older backups can be
+    /// handled without treating an unissued command as proof of a changed state.
+    case applicationPending
+    /// Rockxy's override commands were issued for this service and have not been confirmed.
+    /// Recorded immediately before that service's first command.
+    case applying
+
+    /// True for the stages that describe an override being written rather than a restore.
+    ///
+    /// The two kinds of record authorize completely different writes, so they are never read by
+    /// the same policy: an application record says "Rockxy was putting its override on this
+    /// service", which is what lets a relaunch undo a sequence that stopped half-way.
+    var isOverrideApplication: Bool {
+        switch self {
+        case .applicationPending, .applying:
+            true
+        case .pending, .inFlight, .restored:
+            false
+        }
+    }
+}
+
+// MARK: - ProxyServiceRecoveryJournalEntry
+
+/// One service's durable recovery intent: the stage, the state the step expects to find, and the
+/// captured settings that step writes back.
+///
+/// The captured settings are recorded rather than derived so a later attempt can check that the
+/// record still describes the restore the backup on disk asks for. A record that describes some
+/// other restore is stale, and a stale record is never a licence to write.
+struct ProxyServiceRecoveryJournalEntry: Codable, Equatable {
+    // MARK: Lifecycle
+
+    init(
+        service: String,
+        stage: ProxyRecoveryStage,
+        expectedPreStepState: ProxyServiceRestorationState,
+        target: ProxyServiceRestorationState,
+        appliedOverridePort: Int? = nil,
+        previousAppliedBypassDomains: [String]? = nil,
+        appliedBypassDomains: [String]? = nil
+    ) {
+        self.service = service
+        self.stage = stage
+        self.expectedPreStepState = expectedPreStepState
+        self.target = target
+        self.appliedOverridePort = appliedOverridePort
+        self.previousAppliedBypassDomains = previousAppliedBypassDomains
+        self.appliedBypassDomains = appliedBypassDomains
+    }
+
+    /// A record written before an override touches one service.
+    ///
+    /// The captured settings are what a rollback writes back. `baseline` is what the service
+    /// actually reads when the sequence is about to start, and on a fresh service the two are the
+    /// same snapshot. They are not the same on a session reclaiming an override it already holds:
+    /// there the sequence begins at the override already on the machine, while the settings to
+    /// put back are still the ones captured before Rockxy ever touched it. Recording the live
+    /// baseline is what lets a later attempt recognise the sequence this one issued; recording the
+    /// capture as the target is what keeps the rollback aimed at the user's own configuration.
+    ///
+    /// The port travels with them because it is what turns a half-applied service into a shape
+    /// recovery can recognise as Rockxy's own work.
+    init(
+        overrideApplicationFor captured: ProxyServiceRestorationState,
+        baseline: ProxyServiceRestorationState? = nil,
+        stage: ProxyRecoveryStage,
+        port: Int,
+        appliedBypassDomains: [String]? = nil
+    ) {
+        self.init(
+            service: captured.service,
+            stage: stage,
+            expectedPreStepState: baseline ?? captured,
+            target: captured,
+            appliedOverridePort: port,
+            appliedBypassDomains: appliedBypassDomains
+        )
+    }
+
+    /// A record whose port is optional, so a build that predates it still reads every field
+    /// beside it rather than losing the whole entry.
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        service = try container.decode(String.self, forKey: .service)
+        stage = try container.decode(ProxyRecoveryStage.self, forKey: .stage)
+        expectedPreStepState = try container.decode(
+            ProxyServiceRestorationState.self,
+            forKey: .expectedPreStepState
+        )
+        target = try container.decode(ProxyServiceRestorationState.self, forKey: .target)
+        appliedOverridePort = try container.decodeIfPresent(Int.self, forKey: .appliedOverridePort)
+        previousAppliedBypassDomains = try container.decodeIfPresent(
+            [String].self,
+            forKey: .previousAppliedBypassDomains
+        )
+        appliedBypassDomains = try container.decodeIfPresent([String].self, forKey: .appliedBypassDomains)
+    }
+
+    // MARK: Internal
+
+    let service: String
+    let stage: ProxyRecoveryStage
+    /// The settings recorded when this service entered recovery.
+    let expectedPreStepState: ProxyServiceRestorationState
+    /// The captured pre-Rockxy settings this step writes back.
+    let target: ProxyServiceRestorationState
+    /// The loopback port an override record was written for. Only an override application
+    /// carries one; a restore record has no port of its own.
+    let appliedOverridePort: Int?
+    /// The bypass list live immediately before the recorded update. Present only while that
+    /// per-service command may be in flight, so recovery accepts both sides of the transition.
+    let previousAppliedBypassDomains: [String]?
+    /// The bounded bypass list Rockxy wrote onto this service after its override, recorded before
+    /// that command ran. Absent until it does, and absent on a restore record.
+    ///
+    /// Without it the finished override is only recognisable through a projection that reads
+    /// neither the bypass list, nor a switched-off SOCKS endpoint, nor the PAC URL — and a
+    /// configuration that merely points at the loopback port would then authorize writing a whole
+    /// captured snapshot over fields nothing proved were Rockxy's.
+    let appliedBypassDomains: [String]?
+
+    /// The settings a completed step leaves behind.
+    var expectedPostStepState: ProxyServiceRestorationState {
+        ProxyServiceRestorationState.expectedRestorationResult(
+            target: target,
+            from: expectedPreStepState
+        )
+    }
+
+    /// True when this record still describes the restore the backup on disk asks for. Everything
+    /// has to line up: the service it names, the service its states name, and the captured
+    /// settings themselves.
+    func describesRestore(of target: ProxyServiceRestorationState) -> Bool {
+        service == target.service
+            && expectedPreStepState.service == service
+            && self.target == target
+    }
+
+    func advanced(to stage: ProxyRecoveryStage) -> ProxyServiceRecoveryJournalEntry {
+        ProxyServiceRecoveryJournalEntry(
+            service: service,
+            stage: stage,
+            expectedPreStepState: expectedPreStepState,
+            target: target,
+            appliedOverridePort: appliedOverridePort,
+            previousAppliedBypassDomains: previousAppliedBypassDomains,
+            appliedBypassDomains: appliedBypassDomains
+        )
+    }
+
+    /// The same record naming the bypass list about to be written onto this service.
+    ///
+    /// The record has to be committed before that command runs. Recording it afterwards would
+    /// leave the one window where the bypass list on the machine is Rockxy's while nothing on disk
+    /// says so — which is exactly the state a relaunch has to read as somebody else's.
+    func recordingAppliedBypassDomains(
+        _ domains: [String],
+        from previousDomains: [String]
+    )
+        -> ProxyServiceRecoveryJournalEntry
+    {
+        ProxyServiceRecoveryJournalEntry(
+            service: service,
+            stage: stage,
+            expectedPreStepState: expectedPreStepState,
+            target: target,
+            appliedOverridePort: appliedOverridePort,
+            previousAppliedBypassDomains: previousDomains,
+            appliedBypassDomains: domains
+        )
+    }
+
+    /// Clears the in-flight side of a bypass transition at the exact side observed or written.
+    func completingAppliedBypassUpdate(at domains: [String]) -> ProxyServiceRecoveryJournalEntry {
+        ProxyServiceRecoveryJournalEntry(
+            service: service,
+            stage: stage,
+            expectedPreStepState: expectedPreStepState,
+            target: target,
+            appliedOverridePort: appliedOverridePort,
+            appliedBypassDomains: domains
+        )
+    }
+
+    // MARK: Private
+
+    private enum CodingKeys: String, CodingKey {
+        case service
+        case stage
+        case expectedPreStepState
+        case target
+        case appliedOverridePort
+        case previousAppliedBypassDomains
+        case appliedBypassDomains
+    }
+}
+
+// MARK: - ProxyRecoveryContinuation
+
+/// What a retry is allowed to do with one service.
+enum ProxyRecoveryContinuation: Equatable {
+    /// The live settings are still explained by this service's recovery, so writing the captured
+    /// settings back is safe.
+    case restore
+    /// The live settings already are the restored settings. Nothing is written and the service
+    /// leaves recovery.
+    case complete
+    /// The live settings are not something recovery could have produced, so someone else owns
+    /// this service now. It leaves recovery untouched.
+    case abandon
+    /// The live settings could not be read. Nothing is written and the service keeps its restore
+    /// point for a later attempt.
+    case retryLater
+}
+
+// MARK: - ProxyServiceRecoveryPolicy
+
+/// Decides, for one journaled service, whether a retry may still write.
+///
+/// The rule is that recovery only ever overwrites its own work. A service whose live settings
+/// cannot be produced by the recorded step — not before it, not part-way through it, not after it
+/// — has been changed by the user or another tool, and the correct response is to walk away from
+/// it rather than replay a snapshot over the change.
+enum ProxyServiceRecoveryPolicy {
+    // MARK: Internal
+
+    static func continuation(
+        for entry: ProxyServiceRecoveryJournalEntry,
+        live: ProxyServiceRestorationState?
+    )
+        -> ProxyRecoveryContinuation
+    {
+        guard let live else {
+            return .retryLater
+        }
+        guard live.service == entry.service else {
+            return .abandon
+        }
+        if live == entry.expectedPostStepState {
+            return .complete
+        }
+
+        switch entry.stage {
+        case .pending:
+            // No command has been issued, so the only state that authorizes a write is exactly
+            // the one recorded when the service entered recovery.
+            return live == entry.expectedPreStepState ? .restore : .abandon
+        case .inFlight, .restored:
+            // A sequence that was interrupted — or one that completed without the settings
+            // landing — can only have stopped at one of the points its commands pass through.
+            return isExplainedByStep(live, entry: entry) ? .restore : .abandon
+        case .applicationPending, .applying:
+            // An application record does not describe a restore at all: it says the override was
+            // being written, and the states that authorizes are the ones applying it passes
+            // through, on the port that record carries. Recovery turns such a record into a
+            // restore baseline before planning a write, so one reaching here is not the record
+            // this step planned from — and nothing may be written from it.
+            return .abandon
+        }
+    }
+
+    /// True when the live settings are exactly one of the states the recorded step passes
+    /// through, in the order its commands run.
+    static func isExplainedByStep(
+        _ live: ProxyServiceRestorationState,
+        entry: ProxyServiceRecoveryJournalEntry
+    )
+        -> Bool
+    {
+        guard live.service == entry.service else {
+            return false
+        }
+        return ProxyRestoreTransition.reachableStates(
+            from: entry.expectedPreStepState,
+            target: entry.target
+        )
+        .contains(live)
+    }
+}
+
+// MARK: - ProxyOverrideApplicationContinuation
+
+/// What recovery may do with a service an override record names.
+enum ProxyOverrideApplicationContinuation: Equatable {
+    /// The live settings are provably Rockxy's own half-written or finished override, so the
+    /// captured settings may be written back. The baseline is the state the rollback starts
+    /// from, which is what the restore records as its own `expectedPreStepState`.
+    case rollBack(baseline: ProxyServiceRestorationState)
+    /// The live settings are exactly what was captured, so no command of the override landed on
+    /// this service. There is nothing to undo and the record is spent.
+    case untouched
+    /// The live settings are not something applying the override could have produced. Somebody
+    /// else owns this service now and it is left exactly as it is.
+    case abandon
+    /// The live settings could not be read, so nothing is decided and the restore point stays.
+    case retryLater
+}
+
+// MARK: - ProxyOverrideApplicationRecoveryPolicy
+
+/// Decides whether a relaunch, watchdog, or in-process rollback may undo an override this
+/// machine started applying.
+///
+/// A crash in the middle of the seven-command override leaves a service that is neither Rockxy's
+/// nor the user's: the strict ownership test does not recognise it, so without a durable record
+/// of the attempt nothing would ever put it back. The record supplies the missing half — the
+/// settings the override started from and the port it was writing — and authorization is then
+/// exactly the set of shapes that sequence passes through. Nothing wider: a configuration no
+/// prefix produces belongs to whoever wrote it.
+enum ProxyOverrideApplicationRecoveryPolicy {
+    static func continuation(
+        for entry: ProxyServiceRecoveryJournalEntry,
+        live: ProxyServiceRestorationState?,
+        ownedPort: Int?
+    )
+        -> ProxyOverrideApplicationContinuation
+    {
+        guard entry.stage.isOverrideApplication else {
+            return .abandon
+        }
+        guard let live else {
+            return .retryLater
+        }
+        guard live.service == entry.service, entry.expectedPreStepState.service == entry.service else {
+            return .abandon
+        }
+        if live == entry.expectedPreStepState {
+            // A fresh application begins at the captured user state, so equality means no command
+            // landed. A reclaim begins at a prior owned override while its target remains the
+            // original user state; consuming that record as untouched would lose the only restore
+            // point for the override already on the machine.
+            if entry.expectedPreStepState == entry.target {
+                return .untouched
+            }
+            let reclaimPort = entry.appliedOverridePort ?? ownedPort
+            guard entry.stage == .applying, let reclaimPort, reclaimPort > 0 else {
+                return .abandon
+            }
+            return .rollBack(baseline: live)
+        }
+
+        let recordedPort = entry.appliedOverridePort ?? ownedPort
+        guard let recordedPort, recordedPort > 0 else {
+            return .abandon
+        }
+
+        // A record whose commands were never issued authorizes no changed state at all, whatever
+        // the settings happen to look like.
+        guard entry.stage == .applying else {
+            return .abandon
+        }
+
+        // The bounded bypass list Rockxy writes after the override is part of the sequence only
+        // when this record names it, which it does before that command runs. Everything else is
+        // decided by exact equality with a state the sequence passes through.
+        //
+        // An ownership projection would answer here too, and used to. It reads neither the bypass
+        // list, nor the endpoint of a switched-off SOCKS mode, nor the PAC URL — so a service that
+        // merely happens to point at the loopback port authorized writing a whole captured
+        // snapshot over three fields nothing had shown were Rockxy's to touch.
+        guard ProxyOverrideTransition.isReachedByApplying(
+            live,
+            from: entry.expectedPreStepState,
+            port: recordedPort,
+            previousAppliedBypassDomains: entry.previousAppliedBypassDomains,
+            appliedBypassDomains: entry.appliedBypassDomains
+        ) else {
+            return .abandon
+        }
+        return .rollBack(baseline: live)
+    }
+}
+
+// MARK: - ProxyOverrideApplicationDecision
+
+/// What an override attempt may do with one service, decided immediately before its first command.
+enum ProxyOverrideApplicationDecision: Equatable {
+    /// The service may be written. `baseline` is the state the sequence actually starts from, and
+    /// it is what the record committed before the first command has to say.
+    case apply(baseline: ProxyServiceRestorationState)
+    /// The live settings are neither the capture this attempt holds nor anything this machine can
+    /// prove Rockxy produced. Not one command may be issued for the service.
+    case abort
+}
+
+// MARK: - ProxyOverrideApplicationPreflight
+
+/// Decides, for one service and against the settings read right now, whether an override may be
+/// written to it.
+///
+/// The capture a backup holds was taken at some earlier point — moments earlier for a service this
+/// attempt just captured, an entire session earlier for one it is reclaiming. Either way the state
+/// the override is about to start from is a fact about the machine now, not about when the backup
+/// was written, and the two disagree exactly when somebody else has changed the service in
+/// between. Writing then would put Rockxy's override over a configuration nothing recorded, and
+/// leave a rollback aiming at a snapshot that no longer describes anything.
+///
+/// So a fresh service is writable only while it still reads exactly as captured, and a reclaim
+/// only while the record of the earlier session still explains the live settings. Anything else
+/// leaves the service exactly as it is.
+enum ProxyOverrideApplicationPreflight {
+    static func decision(
+        captured: ProxyServiceRestorationState,
+        live: ProxyServiceRestorationState?,
+        priorEntry: ProxyServiceRecoveryJournalEntry?,
+        port: Int
+    )
+        -> ProxyOverrideApplicationDecision
+    {
+        // A service whose settings could not be read cannot be shown to be either, and an
+        // unreadable service is never written to.
+        guard port > 0, let live, live.service == captured.service else {
+            return .abort
+        }
+        if live == captured {
+            return .apply(baseline: live)
+        }
+
+        // The settings moved on from the capture, so the only thing that can still authorize a
+        // write is the durable record of what this machine did to the service itself.
+        guard let priorEntry, priorEntry.describesRestore(of: captured) else {
+            return .abort
+        }
+        switch ProxyOverrideApplicationRecoveryPolicy.continuation(
+            for: priorEntry,
+            live: live,
+            ownedPort: port
+        ) {
+        case let .rollBack(baseline):
+            return .apply(baseline: baseline)
+        case .untouched:
+            // The service is still exactly where the earlier record says its sequence began, and
+            // that baseline was itself proven before anything was written to it.
+            return .apply(baseline: live)
+        case .abandon, .retryLater:
+            return .abort
+        }
+    }
+}
+
+// MARK: - ProxyBypassUpdatePreflight
+
+/// What a per-service bypass update may do after comparing the complete live state with its
+/// durable override record.
+enum ProxyBypassUpdateDecision: Equatable {
+    case apply(baseline: ProxyServiceRestorationState)
+    case unchanged
+    case abort
+}
+
+/// Authorizes a bypass command only for a service whose complete override state is still exactly
+/// one of the two sides of its last recorded bypass transition.
+enum ProxyBypassUpdatePreflight {
+    static func decision(
+        entry: ProxyServiceRecoveryJournalEntry,
+        live: ProxyServiceRestorationState?,
+        ownedPort: Int?,
+        requestedDomains: [String]
+    )
+        -> ProxyBypassUpdateDecision
+    {
+        guard entry.stage == .applying,
+              let live,
+              live.service == entry.service,
+              let port = entry.appliedOverridePort ?? ownedPort,
+              port > 0
+        else {
+            return .abort
+        }
+
+        var expectedStates = [ProxyOverrideTransition.completedState(
+                from: entry.expectedPreStepState,
+                port: port,
+                appliedBypassDomains: entry.appliedBypassDomains
+            )].compactMap { $0 }
+        if let previousDomains = entry.previousAppliedBypassDomains,
+           let previous = ProxyOverrideTransition.completedState(
+               from: entry.expectedPreStepState,
+               port: port,
+               appliedBypassDomains: previousDomains
+           )
+        {
+            expectedStates.append(previous)
+        }
+
+        guard expectedStates.contains(live) else {
+            return .abort
+        }
+        return live.bypassDomains == requestedDomains ? .unchanged : .apply(baseline: live)
+    }
+}
+
+// MARK: - ProxyOverrideSessionCompletionPolicy
+
+/// Whether a backup whose recorded owner is still alive describes a session safe to leave exactly
+/// where it is.
+///
+/// Preserving a session means the helper writes nothing, re-arms the watchdog, and lets its idle
+/// timer run again. That is only defensible when every service the backup covers carries the
+/// finished override — the exact state the record says the sequence ends at. A journal that
+/// stopped part-way describes a service that is neither Rockxy's nor the user's, and a live owner
+/// does not make that shape safe: the sequence that would have finished it has already failed, and
+/// nothing is coming back to finish it. Such a session is recovered immediately instead.
+enum ProxyOverrideSessionCompletionPolicy {
+    // MARK: Internal
+
+    static func sessionIsFullyApplied(
+        services: [String],
+        journal: [ProxyServiceRecoveryJournalEntry],
+        liveStates: [String: ProxyServiceRestorationState],
+        ownedPort: Int?
+    )
+        -> Bool
+    {
+        guard !services.isEmpty else {
+            return false
+        }
+        guard !journal.isEmpty else {
+            // A backup with no record at all predates the journal, so there is no partial
+            // application to read out of it. The older question is the only one available, and it
+            // stays the answer for those backups rather than tearing down a live session this
+            // build simply cannot describe. It decides nothing but whether to write nothing.
+            return legacySessionIsFullyApplied(
+                services: services,
+                liveStates: liveStates,
+                ownedPort: ownedPort
+            )
+        }
+        guard Set(journal.map(\.service)) == Set(services) else {
+            // A service the journal says nothing about is a service nothing proves was finished.
+            return false
+        }
+        return services.allSatisfy { service in
+            guard let entry = journal.first(where: { $0.service == service }),
+                  entry.stage == .applying,
+                  let live = liveStates[service],
+                  let port = entry.appliedOverridePort ?? ownedPort,
+                  let completed = ProxyOverrideTransition.completedState(
+                      from: entry.expectedPreStepState,
+                      port: port,
+                      previousAppliedBypassDomains: entry.previousAppliedBypassDomains,
+                      appliedBypassDomains: entry.appliedBypassDomains
+                  )
+            else {
+                return false
+            }
+            return live == completed
+        }
+    }
+
+    // MARK: Private
+
+    private static func legacySessionIsFullyApplied(
+        services: [String],
+        liveStates: [String: ProxyServiceRestorationState],
+        ownedPort: Int?
+    )
+        -> Bool
+    {
+        guard let ownedPort, ownedPort > 0 else {
+            return false
+        }
+        return services.allSatisfy { service in
+            guard let live = liveStates[service] else {
+                return false
+            }
+            return ProxyOverrideOwnership.isOwnedByRockxy(live.overrideState, port: ownedPort)
+        }
+    }
+}
+
+// MARK: - ProxyRecoveryPlan
+
+/// The verdict for every service a recovery attempt considered.
+struct ProxyRecoveryPlan: Equatable {
+    // MARK: Lifecycle
+
+    init(
+        entriesToRestore: [ProxyServiceRecoveryJournalEntry],
+        completedServices: [String],
+        abandonedServices: [String],
+        deferredServices: [String]
+    ) {
+        self.entriesToRestore = entriesToRestore
+        self.completedServices = completedServices
+        self.abandonedServices = abandonedServices
+        self.deferredServices = deferredServices
+    }
+
+    // MARK: Internal
+
+    /// The services this attempt may write, each at the stage it was recorded at. Re-checking a
+    /// service immediately before its first command uses these, because the recorded stage is
+    /// what says which live states still authorize a write.
+    let entriesToRestore: [ProxyServiceRecoveryJournalEntry]
+    let completedServices: [String]
+    let abandonedServices: [String]
+    let deferredServices: [String]
+
+    /// The services that still need a restore point after this attempt is planned. A deferred
+    /// service has to keep its entry, a completed or abandoned one must not.
+    var servicesKeepingBackup: [String] {
+        entriesToRestore.map(\.service) + deferredServices
+    }
+}
+
+// MARK: - ProxyRecoveryPlanner
+
+/// Turns a backup, its journal, and the live settings into the per-service decisions a recovery
+/// attempt acts on.
+enum ProxyRecoveryPlanner {
+    /// - Parameters:
+    ///   - targets: the captured pre-Rockxy settings, one per service the caller still owns.
+    ///   - journal: whatever a previous attempt recorded; empty on the first attempt.
+    ///   - liveStates: the settings read right now, keyed by service. A service missing from the
+    ///     map could not be read and is deferred rather than guessed at.
+    ///   - ownedPort: the loopback port this backup records as Rockxy's, when one is known. A
+    ///     service with no usable record may only enter recovery when its complete live state
+    ///     still proves Rockxy owns it on exactly that port. Nothing weaker will do: a restore
+    ///     switches every proxy mode off before it writes anything, so a service that still
+    ///     carries the strict override cannot be part-way through one — while a merely readable
+    ///     service may be the user's own configuration, and recording that as "where the restore
+    ///     begins" is how a user's settings end up written over.
+    ///   - locallyMutatedServices: the services this very process has just issued override
+    ///     commands for and has not confirmed. These are not authorized by name — a service is
+    ///     recorded as touched before its first command runs, so the name alone cannot tell an
+    ///     override that never mutated anything from a change somebody else made. What it buys
+    ///     them is the second proof: live settings that are exactly one of the states applying
+    ///     the override passes through, which is the evidence a half-applied service needs to be
+    ///     undone at all.
+    static func plan(
+        targets: [ProxyServiceRestorationState],
+        journal: [ProxyServiceRecoveryJournalEntry],
+        liveStates: [String: ProxyServiceRestorationState],
+        ownedPort: Int?,
+        locallyMutatedServices: Set<String> = []
+    )
+        -> ProxyRecoveryPlan
+    {
+        var entriesToRestore: [ProxyServiceRecoveryJournalEntry] = []
+        var completedServices: [String] = []
+        var abandonedServices: [String] = []
+        var deferredServices: [String] = []
+
+        for target in targets {
+            let live = liveStates[target.service]
+
+            // An override record is answered first and on its own terms. It says the override was
+            // being written to this service, not that a restore was, so the states that authorize
+            // a write are the ones applying it passes through — which is the only evidence a
+            // service left half-overridden by a crash ever has.
+            if let application = overrideApplicationRecord(for: target, journal: journal) {
+                switch ProxyOverrideApplicationRecoveryPolicy.continuation(
+                    for: application,
+                    live: live,
+                    ownedPort: ownedPort
+                ) {
+                case let .rollBack(baseline):
+                    // The rollback starts from what is live now, not from what was captured, so
+                    // the record it writes describes the restore it is actually about to run.
+                    entriesToRestore.append(ProxyServiceRecoveryJournalEntry(
+                        service: target.service,
+                        stage: .pending,
+                        expectedPreStepState: baseline,
+                        target: target
+                    ))
+                case .untouched:
+                    completedServices.append(target.service)
+                case .abandon:
+                    abandonedServices.append(target.service)
+                case .retryLater:
+                    deferredServices.append(target.service)
+                }
+                continue
+            }
+
+            let entry = resolvedEntry(
+                target: target,
+                journal: journal,
+                live: live,
+                ownedPort: ownedPort,
+                isLocallyMutated: locallyMutatedServices.contains(target.service)
+            )
+
+            guard let entry else {
+                // There is no record this attempt may reason from, and nothing it may safely
+                // invent. The restore point survives untouched for a later attempt.
+                deferredServices.append(target.service)
+                continue
+            }
+
+            switch ProxyServiceRecoveryPolicy.continuation(for: entry, live: live) {
+            case .restore:
+                entriesToRestore.append(entry)
+            case .complete:
+                completedServices.append(target.service)
+            case .abandon:
+                abandonedServices.append(target.service)
+            case .retryLater:
+                deferredServices.append(target.service)
+            }
+        }
+
+        return ProxyRecoveryPlan(
+            entriesToRestore: entriesToRestore,
+            completedServices: completedServices,
+            abandonedServices: abandonedServices,
+            deferredServices: deferredServices
+        )
+    }
+
+    /// The override record for this service, when the journal holds one that still describes the
+    /// backup on disk. A record naming some other capture belongs to a different attempt, and a
+    /// stale record is never a licence to write.
+    private static func overrideApplicationRecord(
+        for target: ProxyServiceRestorationState,
+        journal: [ProxyServiceRecoveryJournalEntry]
+    )
+        -> ProxyServiceRecoveryJournalEntry?
+    {
+        journal.first {
+            $0.service == target.service
+                && $0.stage.isOverrideApplication
+                && $0.describesRestore(of: target)
+        }
+    }
+
+    /// The journal record this attempt reasons from, or nil when there is none it may use.
+    ///
+    /// A recorded entry that no longer describes the backup on disk is stale — it belongs to a
+    /// different restore — so it is never trusted. It is not a licence to record whatever is live
+    /// now as "the state recovery started from" either; only the same proof a service with no
+    /// record at all has to give can do that.
+    private static func resolvedEntry(
+        target: ProxyServiceRestorationState,
+        journal: [ProxyServiceRecoveryJournalEntry],
+        live: ProxyServiceRestorationState?,
+        ownedPort: Int?,
+        isLocallyMutated: Bool
+    )
+        -> ProxyServiceRecoveryJournalEntry?
+    {
+        if let recorded = journal.first(where: {
+            $0.service == target.service && !$0.stage.isOverrideApplication
+        }), recorded.describesRestore(of: target) {
+            return recorded
+        }
+
+        guard let live, baselineIsProven(
+            live: live,
+            target: target,
+            ownedPort: ownedPort,
+            isLocallyMutated: isLocallyMutated
+        ) else {
+            return nil
+        }
+
+        return ProxyServiceRecoveryJournalEntry(
+            service: target.service,
+            stage: .pending,
+            expectedPreStepState: live,
+            target: target
+        )
+    }
+
+    /// Whether the live settings themselves prove this service is still Rockxy's, which is the
+    /// only evidence a new baseline may be built on.
+    ///
+    /// There are exactly two proofs. A legacy completed override is one, but only when its entire
+    /// restoration-relevant state equals the end of the known command sequence. A strict ownership
+    /// projection is not enough because it omits the bypass list, the endpoint of disabled SOCKS,
+    /// and the PAC URL. A state earlier in that exact sequence is the other proof, and it is
+    /// available only to the process that just issued those commands — which is what lets an
+    /// override that stopped after its second command be undone while a configuration nobody can
+    /// account for is left exactly where it is.
+    ///
+    /// A backup that cannot name the port it overrode proves nothing about any service, so it
+    /// baselines none of them: the services keep their restore points for an attempt that can.
+    private static func baselineIsProven(
+        live: ProxyServiceRestorationState,
+        target: ProxyServiceRestorationState,
+        ownedPort: Int?,
+        isLocallyMutated: Bool
+    )
+        -> Bool
+    {
+        guard let ownedPort else {
+            return false
+        }
+        guard ownedPort > 0 else {
+            return false
+        }
+        let reachable = ProxyOverrideTransition.reachableStates(
+            from: target,
+            port: ownedPort
+        )
+        if live == reachable.last {
+            return true
+        }
+        guard isLocallyMutated else {
+            return false
+        }
+        return reachable.contains(live)
+    }
+}
+
+// MARK: - ProxyRecoveryJournalCoding
+
+/// Reads a persisted journal without letting one unreadable record cost the others.
+///
+/// A backup's journal is the only thing that tells a retry which services it may still write.
+/// Decoding the array as a whole means a single record this build cannot parse erases the
+/// records beside it, and services with perfectly good entries would silently lose the evidence
+/// that authorizes their restore.
+enum ProxyRecoveryJournalCoding {
+    // MARK: Internal
+
+    static func decodeEntries<Key: CodingKey>(
+        from container: KeyedDecodingContainer<Key>,
+        forKey key: Key
+    )
+        -> [ProxyServiceRecoveryJournalEntry]
+    {
+        guard container.contains(key) else {
+            return []
+        }
+        if let entries = try? container.decode([ProxyServiceRecoveryJournalEntry].self, forKey: key) {
+            return entries
+        }
+        guard let salvaged = try? container.decode([SalvagedEntry].self, forKey: key) else {
+            return []
+        }
+        return salvaged.compactMap(\.entry)
+    }
+
+    // MARK: Private
+
+    /// One journal record that decodes to nothing rather than failing, so the records after it
+    /// are still reached.
+    private struct SalvagedEntry: Decodable {
+        // MARK: Lifecycle
+
+        init(from decoder: any Decoder) throws {
+            entry = try? ProxyServiceRecoveryJournalEntry(from: decoder)
+        }
+
+        // MARK: Internal
+
+        let entry: ProxyServiceRecoveryJournalEntry?
+    }
+}


### PR DESCRIPTION
## Summary

- bind helper and direct proxy sessions to exact process identities and serialize ownership across app instances
- journal proxy mutations before commands, revalidate every restore, and preserve HTTP, HTTPS, SOCKS, PAC, autodiscovery, and bypass settings
- retry crash and forced-termination recovery without discarding unreadable restore points
- harden helper lifecycle, request rate limiting, legacy backup handling, and direct/helper handoff safety
- add regression coverage for partial commands, concurrent lifecycle operations, watchdog recovery, and user changes during restore

## Why

System proxy changes span multiple commands and processes. A crash, partial command failure, duplicate app instance, transient read failure, or helper/direct overlap could otherwise strand a loopback proxy, overwrite newer user settings, or leave recovery without a live owner.

## Validation

- `swiftlint lint --strict --quiet`
- `python3 .github/tools/validate_xcstrings.py`
- focused proxy recovery, watchdog, helper lifecycle, rate-limit, and identity tests
- macOS Debug build-for-testing with code signing disabled

Refs #310
Refs #319

Related to #329