### PR TITLE
fix(helper): bound interactive update recovery

### DIFF
--- a/Rockxy/AppDelegate.swift
+++ b/Rockxy/AppDelegate.swift
@@ -88,14 +88,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSUserInterfaceValidat
                     Self.logger.error("Failed to initialize root CA: \(error.localizedDescription)")
                 }
             }
-            // The shared barrier the capture UI also waits on, so startup capture can never run
-            // against a helper that is about to be replaced by the one in this app bundle.
-            await HelperUpdateStartupReconciliation.task.value
+            // Start the shared barrier now, but do not hold independent app services behind the
+            // legacy helper's bounded launchd recovery window. The capture UI awaits this same
+            // task before it can restore an automatic capture session.
+            let helperReconciliation = HelperUpdateStartupReconciliation.task
             await PluginManager.shared.ensureLoadedOnce()
-            guard !RockxyIdentity.isRunningTests else {
-                return
+            if !RockxyIdentity.isRunningTests {
+                await MCPServerCoordinator.shared.startIfEnabled()
             }
-            await MCPServerCoordinator.shared.startIfEnabled()
+            await helperReconciliation.value
         }
     }
 

--- a/Rockxy/Core/ProxyEngine/HelperManager+AppUpdate.swift
+++ b/Rockxy/Core/ProxyEngine/HelperManager+AppUpdate.swift
@@ -347,7 +347,7 @@ struct HelperUpdateStartupRecoveryOrchestrator {
     /// timer — so polling harder would only add noise without bringing its exit forward. The
     /// ladder sums to seven minutes, which clears the five-minute idle timeout with room for the
     /// time the old helper had already been idle before this app was relaunched.
-    var retryDelays: [Duration] = [
+    static let launchRetryDelays: [Duration] = [
         .seconds(5),
         .seconds(10),
         .seconds(15),
@@ -361,6 +361,16 @@ struct HelperUpdateStartupRecoveryOrchestrator {
         .seconds(60),
     ]
 
+    /// An explicit retry follows a completed launch recovery window, so it needs only enough time
+    /// for a fresh launchd/XPC handshake. Keeping this separate prevents a button press from
+    /// holding the UI busy for another seven minutes.
+    static let interactiveRetryDelays: [Duration] = [
+        .seconds(2),
+        .seconds(5),
+        .seconds(8),
+    ]
+
+    var retryDelays: [Duration] = HelperUpdateStartupRecoveryOrchestrator.launchRetryDelays
     var reconcile: () async -> Attempt
     var resetTransport: () async -> Void
     var wait: (Duration) async -> Void
@@ -642,6 +652,28 @@ extension HelperManager {
 
     /// Launch-time reconciliation, owning the busy and notification wrapper.
     func reconcileEmbeddedHelperOnLaunch() async {
+        await reconcileEmbeddedHelperWithRecovery(
+            retryDelays: HelperUpdateStartupRecoveryOrchestrator.launchRetryDelays,
+            reason: "app launch"
+        )
+    }
+
+    /// Retry a failed automatic refresh without repeating the seven-minute launch recovery window.
+    func retryAutomaticHelperRefresh() async {
+        // The startup pass may have left a refused XPC proxy cached. The recovery orchestrator
+        // resets between attempts; an explicit retry also needs a fresh first attempt.
+        HelperConnection.shared.resetConnection()
+        HelperConnection.shared.invalidateSigningCache()
+        await reconcileEmbeddedHelperWithRecovery(
+            retryDelays: HelperUpdateStartupRecoveryOrchestrator.interactiveRetryDelays,
+            reason: "user retry"
+        )
+    }
+
+    private func reconcileEmbeddedHelperWithRecovery(
+        retryDelays: [Duration],
+        reason: String
+    ) async {
         let previousStatus = status
         let previousReachable = isReachable
         let previousInfo = installedInfo
@@ -668,7 +700,7 @@ extension HelperManager {
             return
         }
 
-        let orchestrator = HelperUpdateStartupRecoveryOrchestrator(
+        var orchestrator = HelperUpdateStartupRecoveryOrchestrator(
             reconcile: { [weak self] in
                 guard let self else {
                     return HelperUpdateStartupRecoveryOrchestrator.Attempt(
@@ -676,7 +708,7 @@ extension HelperManager {
                         registrationIsEnabled: false
                     )
                 }
-                let outcome = await reconcileEmbeddedHelper(reason: "app launch")
+                let outcome = await reconcileEmbeddedHelper(reason: reason)
                 return HelperUpdateStartupRecoveryOrchestrator.Attempt(
                     outcome: outcome,
                     registrationIsEnabled: Self.registrationIsEnabled()
@@ -689,6 +721,7 @@ extension HelperManager {
             wait: { try? await Task.sleep(for: $0) },
             log: { Self.appUpdateLogger.info("\($0, privacy: .public)") }
         )
+        orchestrator.retryDelays = retryDelays
 
         if case let .recoveryExhausted(outcome) = await orchestrator.run() {
             // The registration is untouched and `reconcileEmbeddedHelper` has already published

--- a/Rockxy/ViewModels/WelcomeViewModel.swift
+++ b/Rockxy/ViewModels/WelcomeViewModel.swift
@@ -309,7 +309,7 @@ final class WelcomeViewModel {
         defer { activeAction = nil }
 
         if helperAutomaticRefreshRecoveryPending {
-            await HelperManager.shared.reconcileEmbeddedHelperOnLaunch()
+            await HelperManager.shared.retryAutomaticHelperRefresh()
         } else {
             await HelperManager.shared.retryConnection()
         }

--- a/Rockxy/Views/Settings/AdvancedProxySettingsView.swift
+++ b/Rockxy/Views/Settings/AdvancedProxySettingsView.swift
@@ -675,7 +675,7 @@ struct AdvancedProxySettingsView: View {
             case .unreachable:
                 if helperManager.automaticRefreshRecoveryPending {
                     Button(String(localized: "Retry Automatic Update", bundle: RockxyLocalization.bundle)) {
-                        Task { await helperManager.reconcileEmbeddedHelperOnLaunch() }
+                        Task { await helperManager.retryAutomaticHelperRefresh() }
                     }
                     .disabled(helperManager.isBusy)
                 } else {

--- a/Rockxy/Views/Settings/AdvancedSettingsTab.swift
+++ b/Rockxy/Views/Settings/AdvancedSettingsTab.swift
@@ -137,7 +137,7 @@ struct AdvancedSettingsTab: View {
                                         localized: "Retry Automatic Update",
                                         bundle: RockxyLocalization.bundle
                                     )) {
-                                        Task { await helperManager.reconcileEmbeddedHelperOnLaunch() }
+                                        Task { await helperManager.retryAutomaticHelperRefresh() }
                                     }
                                     .disabled(helperManager.isBusy)
                                 } else {

--- a/RockxyTests/Core/ProxyEngine/HelperUpdateReconciliationTests.swift
+++ b/RockxyTests/Core/ProxyEngine/HelperUpdateReconciliationTests.swift
@@ -259,6 +259,24 @@ struct HelperUpdateStartupRecoveryTests {
         // Sparse, not a poll loop: a rejected connection never resets that timer, so hammering it
         // would add noise without bringing the exit forward.
         #expect(orchestrator.retryDelays.allSatisfy { $0 >= .seconds(5) })
+        #expect(orchestrator.retryDelays == HelperUpdateStartupRecoveryOrchestrator.launchRetryDelays)
+    }
+
+    @Test("an explicit retry is short, bounded, and preserves the registration on exhaustion")
+    func interactiveRecoveryIsShortAndBounded() async {
+        let recovery = ScriptedStartupRecovery(attempts: [
+            .init(outcome: .blocked(.unreachable), registrationIsEnabled: true),
+        ])
+        var orchestrator = recovery.orchestrator
+        orchestrator.retryDelays = HelperUpdateStartupRecoveryOrchestrator.interactiveRetryDelays
+
+        let outcome = await orchestrator.run()
+        let window = orchestrator.retryDelays.reduce(Duration.zero, +)
+
+        #expect(outcome == .recoveryExhausted(.blocked(.unreachable)))
+        #expect(window < .seconds(30))
+        #expect(recovery.waits == HelperUpdateStartupRecoveryOrchestrator.interactiveRetryDelays)
+        #expect(recovery.transportResetCount == orchestrator.retryDelays.count)
     }
 
     @Test("approval, absence, signing, package, protocol and legacy results never wait")
@@ -509,6 +527,9 @@ struct HelperUpdatePlanTests {
         )))
         #expect(!HelperManager.embeddedHelperSigningAllowsRefresh(.certificateChainUnavailable))
         #expect(!HelperManager.embeddedHelperSigningAllowsRefresh(.appSignatureInvalid(detail: "invalid")))
+        #expect(!HelperManager.embeddedHelperSigningAllowsRefresh(.runningCodeChanged(detail: "replaced")))
+        #expect(!HelperManager.embeddedHelperSigningAllowsRefresh(.helperBinaryNotFound))
+        #expect(!HelperManager.embeddedHelperSigningAllowsRefresh(.diagnosticError(detail: "error")))
     }
 }
 


### PR DESCRIPTION
## Summary

- keep plugin loading and the local MCP service responsive while launch-time helper reconciliation continues
- preserve the full launch recovery window, but bound explicit retry actions to a short transport-reset sequence
- strengthen fail-closed signing diagnostic coverage

## Validation

- `swiftlint lint --strict`
- focused helper update and startup recovery tests
- signed Debug build

Refs #319

Follow-up for #342.