### PR TITLE
fix(replay): preserve WebSocket identity after restore

### DIFF
--- a/Rockxy/Core/Storage/SessionStore.swift
+++ b/Rockxy/Core/Storage/SessionStore.swift
@@ -99,6 +99,7 @@ actor SessionStore {
             Self.txWeb3BlockIdentifier <- transaction.web3RPCInfo?.blockIdentifier,
             Self.txWeb3RequestPayloadSize <- transaction.web3RPCInfo?.requestPayloadSize,
             Self.txWeb3ResponsePayloadSize <- transaction.web3RPCInfo?.responsePayloadSize,
+            Self.txIsWebSocket <- (transaction.webSocketConnection == nil ? 0 : 1),
             Self.txIsPinned <- (transaction.isPinned ? 1 : 0),
             Self.txIsSaved <- (transaction.isSaved ? 1 : 0),
             Self.txComment <- transaction.comment,
@@ -308,6 +309,7 @@ actor SessionStore {
     private static let txWeb3BlockIdentifier = SQLite.Expression<String?>("web3_block_identifier")
     private static let txWeb3RequestPayloadSize = SQLite.Expression<Int?>("web3_request_payload_size")
     private static let txWeb3ResponsePayloadSize = SQLite.Expression<Int?>("web3_response_payload_size")
+    private static let txIsWebSocket = SQLite.Expression<Int>("is_websocket")
     private static let txIsPinned = SQLite.Expression<Int>("is_pinned")
     private static let txIsSaved = SQLite.Expression<Int>("is_saved")
     private static let txComment = SQLite.Expression<String?>("comment")
@@ -468,6 +470,9 @@ actor SessionStore {
                 "ALTER TABLE transactions ADD COLUMN web3_block_identifier TEXT",
                 "ALTER TABLE transactions ADD COLUMN web3_request_payload_size INTEGER",
                 "ALTER TABLE transactions ADD COLUMN web3_response_payload_size INTEGER",
+            ]),
+            (3, [
+                "ALTER TABLE transactions ADD COLUMN is_websocket INTEGER NOT NULL DEFAULT 0",
             ]),
         ]
 
@@ -688,7 +693,7 @@ actor SessionStore {
         transaction.clientApp = row[Self.txClientApp]
 
         let wsFrames = try loadWebSocketFrameDatas(transactionId: id)
-        if !wsFrames.isEmpty {
+        if row[Self.txIsWebSocket] != 0 || !wsFrames.isEmpty {
             transaction.webSocketConnection = WebSocketConnection(
                 upgradeRequest: request,
                 frames: wsFrames

--- a/RockxyTests/Core/Storage/SessionStoreMigrationTests.swift
+++ b/RockxyTests/Core/Storage/SessionStoreMigrationTests.swift
@@ -31,7 +31,7 @@ struct SessionStoreMigrationTests {
         let store = try SessionStore(directory: dir)
         let version = try await store.schemaVersion()
 
-        #expect(version >= 2)
+        #expect(version >= 3)
     }
 
     @Test("Second initialization skips migration")
@@ -57,7 +57,7 @@ struct SessionStoreMigrationTests {
         let store = try SessionStore(directory: dir)
         let version = try await store.schemaVersion()
 
-        #expect(version >= 2)
+        #expect(version >= 3)
     }
 
     @Test("Save and load transaction after migration")
@@ -114,6 +114,28 @@ struct SessionStoreMigrationTests {
         #expect(info.chainHint?.chainID == "0x1")
         #expect(info.requestPayloadSize == transaction.web3RPCInfo?.requestPayloadSize)
         #expect(info.responsePayloadSize == transaction.web3RPCInfo?.responsePayloadSize)
+    }
+
+    @Test("Save and load preserves a zero-frame WebSocket identity")
+    func saveLoadPreservesZeroFrameWebSocketIdentity() async throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let store = try SessionStore(directory: dir)
+        let request = TestFixtures.makeRequest(url: "wss://ws.example.com/empty")
+        let transaction = HTTPTransaction(
+            request: request,
+            state: .completed,
+            webSocketConnection: WebSocketConnection(upgradeRequest: request)
+        )
+
+        try await store.saveTransaction(transaction)
+        let reloadedStore = try SessionStore(directory: dir)
+        let loaded = try #require(try await reloadedStore.loadTransaction(byID: transaction.id))
+
+        #expect(loaded.webSocketConnection != nil)
+        #expect(loaded.webSocketConnection?.frames.isEmpty == true)
+        #expect(!MainContentCoordinator.canReplay(loaded))
     }
 
     @Test("Migrated columns have correct defaults")


### PR DESCRIPTION
## Summary

- persist an explicit WebSocket marker with saved transactions
- restore zero-frame WebSocket sessions without relying on frame rows
- retain frame-based compatibility for sessions written by older database schemas
- keep restored WebSocket handshakes out of HTTP Repeat

## Why

A WebSocket session with no captured frames lost its protocol identity after a project or session reload. The restored transaction was then treated as ordinary HTTP and could incorrectly become eligible for Repeat.

This follow-up addresses the review finding on the pending `develop` to `main` promotion in #348.

## Validation

- `swiftlint lint --strict` on the changed source and test files
- `SessionStoreMigrationTests`: 8 passed, including save/reopen/restore of a zero-frame WebSocket
- `RequestReplayTests`: 6 passed, including rejection of WebSocket sessions
- staged diff and whitespace checks passed
- tracked scope is limited to `SessionStore` and its migration regression tests

Refs #7